### PR TITLE
Support "unread message" indicator for ephemeral chats

### DIFF
--- a/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_view.dart
+++ b/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_view.dart
@@ -170,6 +170,12 @@ class _ChatViewState extends State<ChatView>
         // Trigger another build.
         setState(() {});
       });
+    } else if (_scrollController.offset ==
+        _scrollController.position.maxScrollExtent) {
+      // we are already at the bottom, mark messages as read
+      WidgetsBinding.instance!.addPostFrameCallback((_) {
+        widget.controller.markLastMessageRead();
+      });
     }
 
     return Opacity(


### PR DESCRIPTION
Adds a dummy ID to every ephemeral chat message, such that we can keep track of the read count and show an indicator accordingly.