### PR TITLE
Add field on documentation when create table from yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ It's possible to map serializable classes straight to tables in your database. T
 
     class: Company
     table: company
+    fields:
       name: String
       foundedDate: DateTime?
       employees: List<Employee>
@@ -128,6 +129,7 @@ For performance reasons, you may want to add indexes to your database tables. Yo
 
     class: Company
     table: company
+    fields:
       name: String
       foundedDate: DateTime?
       employees: List<Employee>


### PR DESCRIPTION
When I'm following the documentation, I encounter this error 
```
Error on line 3, column 7: Mapping values are not allowed here. Did you miss a colon earlier?
```
I think because we need to add fields after the table.