### PR TITLE
Added fvm support and docker checks

### DIFF
--- a/tests/serverpod_test_server/docker/setup-tables
+++ b/tests/serverpod_test_server/docker/setup-tables
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # Reset tables
-docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test < ../../docker/reset_db.pgsql
+docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test <../../docker/reset_db.pgsql
 
 # Create tables in database container
-docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test < ../../../packages/serverpod/generated/tables.pgsql
-docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test < ../../../modules/serverpod_auth/serverpod_auth_server/generated/tables.pgsql
-docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test < ../generated/tables.pgsql
-docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test < ../../serverpod_test_module/serverpod_test_module_server/generated/tables.pgsql
+docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test <../../../packages/serverpod/generated/tables.pgsql
+docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test <../../../modules/serverpod_auth/serverpod_auth_server/generated/tables.pgsql
+docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test <../generated/tables.pgsql
+docker-compose run postgres env PGPASSWORD="password" psql -h postgres -p 5432 -U postgres -d serverpod_test <../../serverpod_test_module/serverpod_test_module_server/generated/tables.pgsql

--- a/tools/serverpod_cli/bin/create/command_line_tools.dart
+++ b/tools/serverpod_cli/bin/create/command_line_tools.dart
@@ -4,17 +4,35 @@ import 'dart:io';
 import '../util/print.dart';
 
 class CommandLineTools {
+  static late String flutterCommand;
+
   static Future<void> dartPubGet(Directory dir) async {
     print('Running `dart pub get` in ${dir.path}');
-    var result =
-        await Process.run('dart', ['pub', 'get'], workingDirectory: dir.path);
+    var result = await Process.run(
+      'dart',
+      ['pub', 'get'],
+      workingDirectory: dir.path,
+    );
     print(result.stdout);
   }
 
   static Future<void> flutterCreate(Directory dir) async {
-    print('Running `flutter create` in ${dir.path}');
-    var result = await Process.run('flutter', ['create', '.'],
-        workingDirectory: dir.path);
+    print('Running `$flutterCommand create` in ${dir.path}');
+
+    if (!dir.existsSync()) {
+      print('Directory ${dir.path} doesn\'t exists');
+      exit(1);
+    }
+
+    var result = await Process.run(
+      flutterCommand,
+      [
+        if (flutterCommand == 'fvm') 'flutter',
+        'create',
+        '.',
+      ],
+      workingDirectory: dir.path,
+    );
     print(result.stdout);
   }
 

--- a/tools/serverpod_cli/bin/create/create.dart
+++ b/tools/serverpod_cli/bin/create/create.dart
@@ -23,26 +23,17 @@ Future<void> performCreate(
     }
   }
 
-  // Check that docker is installed
-  var dockerInstalled = await CommandLineTools.existsCommand('docker');
-
-  if (!portsAvailable || !dockerInstalled) {
+  if (!portsAvailable) {
     var strIssue =
         'There are some issues with your setup that will prevent your Serverpod project from running out of the box and without further configuration. You can still create this project by passing -f to "serverpod create".';
     var strIssuePorts =
         'By default your server will run on port 8080 and 8081 and Postgres and Redis will run on 8090 and 8091. One or more of these ports are currently in use. The most likely reason is that you have another Serverpod project running, but it can also be another service. You can either stop the other service and run this command again, or you can create the project with the -f flag added and manually configure the ports in the config/development.yaml and docker-compose.yaml files.';
-    var strIssueDocker =
-        'You do not have Docker installed. Serverpod uses Docker to run Postgres and Redis. It\'s recommended that you install Docker Desktop from https://www.docker.com/get-started but you can also install and configure Postgres and Redis manually and run this command with the -f added.';
 
     printww(strIssue);
 
     if (!portsAvailable) {
       printww('');
       printww(strIssuePorts);
-    }
-    if (!dockerInstalled) {
-      printww('');
-      printww(strIssueDocker);
     }
     if (!force) {
       return;
@@ -282,19 +273,17 @@ Future<void> performCreate(
         'Unknown template: $template (valid options are "server" or "module")');
   }
 
-  if (dockerInstalled) {
-    await CommandLineTools.createTables(projectDir, name);
+  await CommandLineTools.createTables(projectDir, name);
 
-    printww('');
-    printww('');
-    printww('All setup. You are ready to rock!');
-    printww('');
-    printww('Start Postgres and Redis by running:');
-    stdout.writeln('    cd $name/${name}_server');
-    stdout.writeln('    docker-compose up --build --detach');
-    printww('');
-    printww('Then start your Serverpod server by running:');
-    stdout.writeln('    dart bin/main.dart');
-    printww('');
-  }
+  printww('');
+  printww('');
+  printww('All setup. You are ready to rock!');
+  printww('');
+  printww('Start Postgres and Redis by running:');
+  stdout.writeln('    cd $name/${name}_server');
+  stdout.writeln('    docker-compose up --build --detach');
+  printww('');
+  printww('Then start your Serverpod server by running:');
+  stdout.writeln('    dart bin/main.dart');
+  printww('');
 }

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -14,7 +14,6 @@ import 'generator/generator.dart';
 import 'internal_tools/generate_pubspecs.dart';
 import 'run/runner.dart';
 import 'shared/environment.dart';
-import 'util/print.dart';
 
 const cmdCreate = 'create';
 const cmdGenerate = 'generate';
@@ -45,7 +44,7 @@ void main(List<String> args) async {
   // Check that docker is running
   if (Process.runSync('docker', ['ps']).exitCode != 0) {
     print(
-      'Failed to run serverpod. Docker is not running',
+      'Failed to run serverpod. Docker must be running',
     );
     return;
   }

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:colorize/colorize.dart';
 
@@ -12,6 +14,7 @@ import 'generator/generator.dart';
 import 'internal_tools/generate_pubspecs.dart';
 import 'run/runner.dart';
 import 'shared/environment.dart';
+import 'util/print.dart';
 
 const cmdCreate = 'create';
 const cmdGenerate = 'generate';
@@ -32,16 +35,41 @@ final Analytics _analytics = Analytics();
 
 void main(List<String> args) async {
   // Check that required tools are installed
+  if (!await CommandLineTools.existsCommand('docker')) {
+    print(
+      'Failed to run serverpod. You need to have docker installed',
+    );
+    return;
+  }
+
+  // Check that docker is running
+  if (Process.runSync('docker', ['ps']).exitCode != 0) {
+    print(
+      'Failed to run serverpod. Docker is not running',
+    );
+    return;
+  }
+
   if (!await CommandLineTools.existsCommand('dart')) {
     print(
-        'Failed to run serverpod. You need to have dart installed and in your \$PATH');
+      'Failed to run serverpod. You need to have dart installed and in your \$PATH',
+    );
     return;
   }
-  if (!await CommandLineTools.existsCommand('flutter')) {
+
+  var commands = await Future.wait([
+    CommandLineTools.existsCommand('flutter'),
+    CommandLineTools.existsCommand('fvm')
+  ]);
+
+  if (commands.every((exists) => !exists)) {
     print(
-        'Failed to run serverpod. You need to have flutter installed and in your \$PATH');
+      'Failed to run serverpod. You need to have flutter or fvm installed and in your \$PATH',
+    );
     return;
   }
+
+  CommandLineTools.flutterCommand = commands[0] ? 'flutter' : 'fvm';
 
   if (!loadEnvironmentVars()) {
     return;


### PR DESCRIPTION
When using serverpod with fvm it fails with `Failed to run serverpod. You need to have flutter installed and in your $PATH` even if it's aliased as `alias flutter="fvm flutter"`.

I added it's support and a check at the head of the script to check if docker is installed and running