### PR TITLE
Initialize SystemResources before making use of .cpuLoadAvg()

### DIFF
--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/server/health_check.dart';
+import 'package:system_resources/system_resources.dart';
 
 /// Performs health checks on the server once a minute, typically this class
 /// is managed internally by Serverpod. Writes results to the database.
@@ -18,8 +19,9 @@ class HealthCheckManager {
   HealthCheckManager(this._pod);
 
   /// Starts the health check manager.
-  void start() {
+  Future<void> start() async {
     _running = true;
+    await SystemResources.init();
     _scheduleNextCheck();
   }
 

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -350,7 +350,7 @@ class Serverpod {
       _futureCallManager.start();
 
       // Start health check manager
-      _healthCheckManager.start();
+      await _healthCheckManager.start();
     }, (e, stackTrace) {
       // Last resort error handling
       // TODO: Log to database?

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -349,7 +349,7 @@ class Serverpod {
       // Start future calls
       _futureCallManager.start();
 
-      // Start health check managager
+      // Start health check manager
       _healthCheckManager.start();
     }, (e, stackTrace) {
       // Last resort error handling


### PR DESCRIPTION
Added missing call to initialize SystemResources class. This is due to a recent change found here https://github.com/jonasroussel/system_resources/commit/e66d68ab228228be108712f4e0e3eb99fe9345c7

_List which issues are fixed by this PR. You must list at least one issue._
I found myself running into an error related to health check, complaining that it needs to be initialized. This happened to me after I fixed another issue first: https://github.com/serverpod/serverpod/issues/271
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] ~~I added new tests to check the change I am making.~~ Not relevant for this minor change IMO.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._

No breaking changes.