### PR TITLE
fix: issue-286  Changed the sample comment given for accessing futur…

### DIFF
--- a/packages/serverpod/example/example_server/lib/src/future_calls/example_future_call.dart
+++ b/packages/serverpod/example/example_server/lib/src/future_calls/example_future_call.dart
@@ -7,7 +7,7 @@ import 'package:serverpod/serverpod.dart';
 //
 //  To add a future call to your server, you need to register it in the
 //  `server.dart` file. Schedule the call using the
-//  `session.server.futureCallWithDelay` or `session.server.futureCallAtTime`
+//  `session.serverpod.futureCallWithDelay` or `session.serverpod.futureCallAtTime`
 //  methods. You can optionally pass a serializable object together with the
 //  call.
 

--- a/templates/serverpod_templates/projectname_server/lib/src/future_calls/example_future_call.dart
+++ b/templates/serverpod_templates/projectname_server/lib/src/future_calls/example_future_call.dart
@@ -7,7 +7,7 @@ import 'package:serverpod/serverpod.dart';
 //
 //  To add a future call to your server, you need to register it in the
 //  `server.dart` file. Schedule the call using the
-//  `session.server.futureCallWithDelay` or `session.server.futureCallAtTime`
+//  `session.serverpod.futureCallWithDelay` or `session.serverpod.futureCallAtTime`
 //  methods. You can optionally pass a serializable object together with the
 //  call.
 


### PR DESCRIPTION
## Description
As per issue https://github.com/serverpod/serverpod/issues/286, The sample comment given in the example_future_call.dart file to access the future function in endpoint was given wrong. So i have change the comment

##  List of the issues solved
https://github.com/serverpod/serverpod/issues/286

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
_No breaking changes were made_

