### PR TITLE
Generate enums instead of classes for enums specified by the protocol

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_fail_reason.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_fail_reason.dart
@@ -8,51 +8,40 @@
 
 import 'package:serverpod_client/serverpod_client.dart';
 
-class AuthenticationFailReason extends SerializableEntity {
+enum AuthenticationFailReason with SerializableEntity {
+  invalidCredentials,
+  userCreationDenied,
+  internalError,
+  tooManyFailedAttempts,
+  ;
+
+  static String get _className => 'AuthenticationFailReason';
+
   @override
-  String get className => 'AuthenticationFailReason';
+  String get className => _className;
 
-  late final int _index;
-  int get index => _index;
-
-  AuthenticationFailReason._internal(this._index);
-
-  AuthenticationFailReason.fromSerialization(
+  factory AuthenticationFailReason.fromSerialization(
       Map<String, dynamic> serialization) {
-    var data = unwrapSerializationData(serialization);
-    _index = data['index'];
+    var data = SerializableEntity.unwrapSerializationDataForClassName(
+        _className, serialization);
+    switch (data['index']) {
+      case 0:
+        return AuthenticationFailReason.invalidCredentials;
+      case 1:
+        return AuthenticationFailReason.userCreationDenied;
+      case 2:
+        return AuthenticationFailReason.internalError;
+      case 3:
+        return AuthenticationFailReason.tooManyFailedAttempts;
+      default:
+        throw Exception('Invalid $_className index $data[\'index\']');
+    }
   }
 
   @override
   Map<String, dynamic> serialize() {
     return wrapSerializationData({
-      'index': _index,
+      'index': index,
     });
-  }
-
-  static final invalidCredentials = AuthenticationFailReason._internal(0);
-  static final userCreationDenied = AuthenticationFailReason._internal(1);
-  static final internalError = AuthenticationFailReason._internal(2);
-  static final tooManyFailedAttempts = AuthenticationFailReason._internal(3);
-
-  @override
-  int get hashCode => _index.hashCode;
-  @override
-  bool operator ==(other) =>
-      other is AuthenticationFailReason && other._index == _index;
-
-  static final values = <AuthenticationFailReason>[
-    invalidCredentials,
-    userCreationDenied,
-    internalError,
-    tooManyFailedAttempts,
-  ];
-
-  String get name {
-    if (this == invalidCredentials) return 'invalidCredentials';
-    if (this == userCreationDenied) return 'userCreationDenied';
-    if (this == internalError) return 'internalError';
-    if (this == tooManyFailedAttempts) return 'tooManyFailedAttempts';
-    throw const FormatException();
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_fail_reason.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_fail_reason.dart
@@ -8,51 +8,40 @@
 
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-class AuthenticationFailReason extends SerializableEntity {
+enum AuthenticationFailReason with SerializableEntity {
+  invalidCredentials,
+  userCreationDenied,
+  internalError,
+  tooManyFailedAttempts,
+  ;
+
+  static String get _className => 'AuthenticationFailReason';
+
   @override
-  String get className => 'AuthenticationFailReason';
+  String get className => _className;
 
-  late final int _index;
-  int get index => _index;
-
-  AuthenticationFailReason._internal(this._index);
-
-  AuthenticationFailReason.fromSerialization(
+  factory AuthenticationFailReason.fromSerialization(
       Map<String, dynamic> serialization) {
-    var data = unwrapSerializationData(serialization);
-    _index = data['index'];
+    var data = SerializableEntity.unwrapSerializationDataForClassName(
+        _className, serialization);
+    switch (data['index']) {
+      case 0:
+        return AuthenticationFailReason.invalidCredentials;
+      case 1:
+        return AuthenticationFailReason.userCreationDenied;
+      case 2:
+        return AuthenticationFailReason.internalError;
+      case 3:
+        return AuthenticationFailReason.tooManyFailedAttempts;
+      default:
+        throw Exception('Invalid $_className index $data[\'index\']');
+    }
   }
 
   @override
   Map<String, dynamic> serialize() {
     return wrapSerializationData({
-      'index': _index,
+      'index': index,
     });
-  }
-
-  static final invalidCredentials = AuthenticationFailReason._internal(0);
-  static final userCreationDenied = AuthenticationFailReason._internal(1);
-  static final internalError = AuthenticationFailReason._internal(2);
-  static final tooManyFailedAttempts = AuthenticationFailReason._internal(3);
-
-  @override
-  int get hashCode => _index.hashCode;
-  @override
-  bool operator ==(other) =>
-      other is AuthenticationFailReason && other._index == _index;
-
-  static final values = <AuthenticationFailReason>[
-    invalidCredentials,
-    userCreationDenied,
-    internalError,
-    tooManyFailedAttempts,
-  ];
-
-  String get name {
-    if (this == invalidCredentials) return 'invalidCredentials';
-    if (this == userCreationDenied) return 'userCreationDenied';
-    if (this == internalError) return 'internalError';
-    if (this == tooManyFailedAttempts) return 'tooManyFailedAttempts';
-    throw const FormatException();
   }
 }

--- a/packages/serverpod/lib/src/generated/log_level.dart
+++ b/packages/serverpod/lib/src/generated/log_level.dart
@@ -8,52 +8,42 @@
 
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-class LogLevel extends SerializableEntity {
+enum LogLevel with SerializableEntity {
+  debug,
+  info,
+  warning,
+  error,
+  fatal,
+  ;
+
+  static String get _className => 'LogLevel';
+
   @override
-  String get className => 'LogLevel';
+  String get className => _className;
 
-  late final int _index;
-  int get index => _index;
-
-  LogLevel._internal(this._index);
-
-  LogLevel.fromSerialization(Map<String, dynamic> serialization) {
-    var data = unwrapSerializationData(serialization);
-    _index = data['index'];
+  factory LogLevel.fromSerialization(Map<String, dynamic> serialization) {
+    var data = SerializableEntity.unwrapSerializationDataForClassName(
+        _className, serialization);
+    switch (data['index']) {
+      case 0:
+        return LogLevel.debug;
+      case 1:
+        return LogLevel.info;
+      case 2:
+        return LogLevel.warning;
+      case 3:
+        return LogLevel.error;
+      case 4:
+        return LogLevel.fatal;
+      default:
+        throw Exception('Invalid $_className index $data[\'index\']');
+    }
   }
 
   @override
   Map<String, dynamic> serialize() {
     return wrapSerializationData({
-      'index': _index,
+      'index': index,
     });
-  }
-
-  static final debug = LogLevel._internal(0);
-  static final info = LogLevel._internal(1);
-  static final warning = LogLevel._internal(2);
-  static final error = LogLevel._internal(3);
-  static final fatal = LogLevel._internal(4);
-
-  @override
-  int get hashCode => _index.hashCode;
-  @override
-  bool operator ==(other) => other is LogLevel && other._index == _index;
-
-  static final values = <LogLevel>[
-    debug,
-    info,
-    warning,
-    error,
-    fatal,
-  ];
-
-  String get name {
-    if (this == debug) return 'debug';
-    if (this == info) return 'info';
-    if (this == warning) return 'warning';
-    if (this == error) return 'error';
-    if (this == fatal) return 'fatal';
-    throw const FormatException();
   }
 }

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -34,13 +34,19 @@ abstract class SerializableEntity {
     };
   }
 
-  /// Unwraps class information, and only returns the data part.
-  Map<String, dynamic> unwrapSerializationData(
-      Map<String, dynamic> serialization) {
+  /// Unwraps class information after checking the class name, and only returns the data part.
+  static Map<String, dynamic> unwrapSerializationDataForClassName(
+      String className, Map<String, dynamic> serialization) {
     if (serialization['class'] != className) throw const FormatException();
     if (serialization['data'] == null) throw const FormatException();
 
     return serialization['data'];
+  }
+
+  /// Unwraps class information, and only returns the data part.
+  Map<String, dynamic> unwrapSerializationData(
+      Map<String, dynamic> serialization) {
+    return unwrapSerializationDataForClassName(className, serialization);
   }
 
   @override

--- a/packages/serverpod_service_client/lib/src/protocol/log_level.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_level.dart
@@ -8,52 +8,42 @@
 
 import 'package:serverpod_client/serverpod_client.dart';
 
-class LogLevel extends SerializableEntity {
+enum LogLevel with SerializableEntity {
+  debug,
+  info,
+  warning,
+  error,
+  fatal,
+  ;
+
+  static String get _className => 'LogLevel';
+
   @override
-  String get className => 'LogLevel';
+  String get className => _className;
 
-  late final int _index;
-  int get index => _index;
-
-  LogLevel._internal(this._index);
-
-  LogLevel.fromSerialization(Map<String, dynamic> serialization) {
-    var data = unwrapSerializationData(serialization);
-    _index = data['index'];
+  factory LogLevel.fromSerialization(Map<String, dynamic> serialization) {
+    var data = SerializableEntity.unwrapSerializationDataForClassName(
+        _className, serialization);
+    switch (data['index']) {
+      case 0:
+        return LogLevel.debug;
+      case 1:
+        return LogLevel.info;
+      case 2:
+        return LogLevel.warning;
+      case 3:
+        return LogLevel.error;
+      case 4:
+        return LogLevel.fatal;
+      default:
+        throw Exception('Invalid $_className index $data[\'index\']');
+    }
   }
 
   @override
   Map<String, dynamic> serialize() {
     return wrapSerializationData({
-      'index': _index,
+      'index': index,
     });
-  }
-
-  static final debug = LogLevel._internal(0);
-  static final info = LogLevel._internal(1);
-  static final warning = LogLevel._internal(2);
-  static final error = LogLevel._internal(3);
-  static final fatal = LogLevel._internal(4);
-
-  @override
-  int get hashCode => _index.hashCode;
-  @override
-  bool operator ==(other) => other is LogLevel && other._index == _index;
-
-  static final values = <LogLevel>[
-    debug,
-    info,
-    warning,
-    error,
-    fatal,
-  ];
-
-  String get name {
-    if (this == debug) return 'debug';
-    if (this == info) return 'info';
-    if (this == warning) return 'warning';
-    if (this == error) return 'error';
-    if (this == fatal) return 'fatal';
-    throw const FormatException();
   }
 }

--- a/tools/serverpod_cli/bin/generator/class_generator_dart.dart
+++ b/tools/serverpod_cli/bin/generator/class_generator_dart.dart
@@ -340,63 +340,42 @@ class ClassGeneratorDart extends ClassGenerator {
       out += 'import \'package:serverpod_client/serverpod_client.dart\';\n';
     }
 
-    out += 'class $enumName extends SerializableEntity {\n';
-    out += '  @override\n';
-    out += '  String get className => \'$enumName\';\n';
-    out += '\n';
-    out += '  late final int _index;\n';
-    out += '  int get index => _index;\n';
-    out += '\n';
+    out += 'enum $enumName with SerializableEntity {\n';
+    for (var value in enumDefinition.values) {
+      out += '  $value,\n';
+    }
+    out += ';\n';
 
-    // Internal constructor
-    out += '  $enumName._internal(this._index); \n';
+    out += '  static String get _className => \'$enumName\';\n';
+    out += '\n';
+    out += '  @override\n';
+    out += '  String get className => _className;\n';
     out += '\n';
 
     // Serialization
     out +=
-        '  $enumName.fromSerialization(Map<String, dynamic> serialization) {\n';
-    out += '    var data = unwrapSerializationData(serialization);\n';
-    out += '    _index = data[\'index\'];\n';
+        '  factory $enumName.fromSerialization(Map<String, dynamic> serialization) {\n';
+    out +=
+        '    var data = SerializableEntity.unwrapSerializationDataForClassName(_className, serialization);\n';
+    out += '    switch (data[\'index\']) {\n';
+    var i = 0;
+    for (var value in enumDefinition.values) {
+      out += '      case $i:\n';
+      out += '        return $enumName.$value;\n';
+      i += 1;
+    }
+    out += '      default:\n';
+    out +=
+        '        throw Exception(\'Invalid \$_className index \$data[\\\'index\\\']\');\n';
+    out += '    }\n';
     out += '  }\n';
     out += '\n';
 
     out += '  @override\n';
     out += '  Map<String, dynamic> serialize() {\n';
     out += '    return wrapSerializationData({\n';
-    out += '      \'index\': _index,\n';
+    out += '      \'index\': index,\n';
     out += '    });\n';
-    out += '  }\n';
-
-    // Values
-    var i = 0;
-    for (var value in enumDefinition.values) {
-      out += '  static final $value = $enumName._internal($i);\n';
-      i += 1;
-    }
-
-    out += '\n';
-
-    out += '  @override\n';
-    out += '  int get hashCode => _index.hashCode;\n';
-    out += '  @override\n';
-    out +=
-        '  bool operator == (other) => other is $enumName && other._index == _index;\n';
-
-    out += '\n';
-
-    out += '  static final values = <$enumName>[\n';
-    for (var value in enumDefinition.values) {
-      out += '    $value,\n';
-    }
-    out += '  ];\n';
-
-    out += '\n';
-
-    out += '  String get name {\n';
-    for (var value in enumDefinition.values) {
-      out += '    if (this == $value) return \'$value\';\n';
-    }
-    out += '    throw const FormatException();\n';
     out += '  }\n';
 
     out += '}\n';


### PR DESCRIPTION
Currently, enums specified in the protocol are generated as classes.

In my opinion it is more elegant and user/developer friendly to generate dart enums instead.

#307

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
~~- [ ] I added new tests to check the change I am making.~~ // Nothing to test, I think.
~~- [ ] All existing and new tests are passing.~~
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

*I am not sure if it should be considered to be a breaking change since it should never happen...*

### Before:

When deserializing an enum with an id the code does not know,  a new object with `name => FormatException()`
 would have been created.

### After:

When deserializing an enum with an id the code does not know, an `Exception('Invalid ... index ...')` is thrown.