### PR TITLE
fix: Description of supported types for generated classes; float -> double

### DIFF
--- a/templates/serverpod_templates/projectname_server/lib/src/protocol/example_class.yaml
+++ b/templates/serverpod_templates/projectname_server/lib/src/protocol/example_class.yaml
@@ -14,7 +14,7 @@ class: Example
 #table: example
 
 # The fields (and columns if connected to the database) of the class. Supported
-# types are `bool`, `int`, `float`, `String`, `DateTime`, and any other
+# types are `bool`, `int`, `double`, `String`, `DateTime`, and any other
 # generated classes. You can also add lists of objects and types have support
 # for null safety. Eg. `List<int>?` or `List<MyOtherClass?>`.
 fields:


### PR DESCRIPTION
I used github.dev, so the PR template wasn't automatically used. The change I've made is as trivial as they get though, so I don't see the need to add more information.