### PR TITLE
fix: removed `netstat` and used `lsof` for mac and unix

### DIFF
--- a/templates/serverpod_templates/projectname_server/setup-tables
+++ b/templates/serverpod_templates/projectname_server/setup-tables
@@ -4,18 +4,10 @@
 echo "Starting docker"
 docker-compose up --build --detach
 
-if command -v netstat &> /dev/null
-then
-  while ! netstat -tna | grep 'LISTEN' | grep -q '.8090'; do
-    echo "Waiting for Postgres..."
-    sleep 2 # time in seconds, tune it as needed
-  done
-else
-  while ! ss -tulpn | grep LISTEN | grep :8090; do
-    echo "Waiting for Postgres..."
-    sleep 2
-  done
-fi
+while lsof -Pi :8090 -sTCP:LISTEN -t >/dev/null ; do
+  echo "Waiting for Postgres..."
+  sleep 2 # time in seconds, tune it as needed
+done
 
 sleep 2
 


### PR DESCRIPTION
As for the [UNIX resources](https://dougvitale.wordpress.com/2011/12/21/deprecated-linux-networking-commands-and-their-replacements/#netstat), `netstat` was deprecated. There was a replacement for that with `ss` or we can use `lsof`.

Some discussions : https://unix.stackexchange.com/questions/278474/why-is-netstat-deprecated
## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update cointains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

## Breaking changes

_No breaking changes_

