### PR TITLE
Use default ports for Postgres and Redis

### DIFF
--- a/examples/auth_example/auth_example_server/config/development.yaml
+++ b/examples/auth_example/auth_example_server/config/development.yaml
@@ -30,7 +30,7 @@ webServer:
 # This is the database setup for your server.
 database:
   host: localhost
-  port: 8090
+  port: 5432
   name: auth_example
   user: postgres
 
@@ -38,4 +38,4 @@ database:
 redis:
   enabled: false
   host: localhost
-  port: 8091
+  port: 6379

--- a/examples/auth_example/auth_example_server/docker-compose.yaml
+++ b/examples/auth_example/auth_example_server/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:14.1
     ports:
-      - '8090:5432'
+      - '5432:5432'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: auth_example
@@ -14,7 +14,7 @@ services:
   redis:
     image: redis:6.2.6
     ports:
-      - '8091:6379'
+      - '6379:6379'
     command: redis-server --requirepass "V7YogaG9K2rnIpS1odXIKrqsW8kkfddt"
     environment:
       - REDIS_REPLICATION_MODE=master

--- a/examples/chat/chat_server/config/development.yaml
+++ b/examples/chat/chat_server/config/development.yaml
@@ -30,7 +30,7 @@ webServer:
 # This is the database setup for your server.
 database:
   host: localhost
-  port: 8090
+  port: 5432
   name: chat
   user: postgres
 
@@ -38,4 +38,4 @@ database:
 redis:
   enabled: false
   host: localhost
-  port: 8091
+  port: 6379

--- a/examples/chat/chat_server/docker-compose.yaml
+++ b/examples/chat/chat_server/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:14.1
     ports:
-      - '8090:5432'
+      - '5432:5432'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: chat

--- a/templates/serverpod_templates/projectname_server/config/development.yaml
+++ b/templates/serverpod_templates/projectname_server/config/development.yaml
@@ -30,7 +30,7 @@ webServer:
 # This is the database setup for your server.
 database:
   host: localhost
-  port: 8090
+  port: 5432
   name: projectname
   user: postgres
 
@@ -38,4 +38,4 @@ database:
 redis:
   enabled: false
   host: localhost
-  port: 8091
+  port: 6379

--- a/templates/serverpod_templates/projectname_server/docker-compose.yaml
+++ b/templates/serverpod_templates/projectname_server/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:14.1
     ports:
-      - '8090:5432'
+      - '5432:5432'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: projectname
@@ -14,7 +14,7 @@ services:
   redis:
     image: redis:6.2.6
     ports:
-      - '8091:6379'
+      - '6379:6379'
     command: redis-server --requirepass "REDIS_PASSWORD"
     environment:
       - REDIS_REPLICATION_MODE=master

--- a/templates/serverpod_templates/projectname_server/setup-tables
+++ b/templates/serverpod_templates/projectname_server/setup-tables
@@ -6,12 +6,12 @@ docker-compose up --build --detach
 
 if command -v netstat &> /dev/null
 then
-  while ! netstat -tna | grep 'LISTEN' | grep -q '.8090'; do
+  while ! netstat -tna | grep 'LISTEN' | grep -q '.5432'; do
     echo "Waiting for Postgres..."
     sleep 2 # time in seconds, tune it as needed
   done
 else
-  while ! ss -tulpn | grep LISTEN | grep :8090; do
+  while ! ss -tulpn | grep LISTEN | grep :5432; do
     echo "Waiting for Postgres..."
     sleep 2
   done

--- a/templates/serverpod_templates/projectname_server/setup-tables.cmd
+++ b/templates/serverpod_templates/projectname_server/setup-tables.cmd
@@ -5,7 +5,7 @@ echo Starting docker
 docker-compose up --build --detach
 
 :LOOP
-netstat -o -n -a | >nul findstr "8090" && (
+netstat -o -n -a | >nul findstr "5432" && (
     echo Waiting for Postgres...
     timeout /t 2 /nobreak > NUL
     goto :PORT_FOUND

--- a/tests/serverpod_test_server/config/development.yaml
+++ b/tests/serverpod_test_server/config/development.yaml
@@ -18,11 +18,11 @@ webServer:
 
 database:
   host: localhost
-  port: 8090
+  port: 5432
   name: serverpod_test
   user: postgres
 
 redis:
   enabled: true
   host: localhost
-  port: 8091
+  port: 6379

--- a/tests/serverpod_test_server/docker-local/docker-compose.yml
+++ b/tests/serverpod_test_server/docker-local/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:14.1
     ports:
-      - '8090:5432'
+      - '5432:5432'
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: serverpod_test
@@ -14,7 +14,7 @@ services:
   redis:
     image: redis:6.2.6
     ports:
-      - '8091:6379'
+      - '6379:6379'
     command: redis-server --requirepass password
     environment:
       - REDIS_REPLICATION_MODE=master

--- a/tools/serverpod_cli/bin/create/create.dart
+++ b/tools/serverpod_cli/bin/create/create.dart
@@ -15,8 +15,8 @@ const _defaultPorts = <String, int>{
   'Serverpod API': 8080,
   'Serverpod insights API': 8081,
   'Serverpod Relic web server': 8082,
-  'PostgreSQL server': 8090,
-  'Redis server': 8091,
+  'PostgreSQL server': 5432,
+  'Redis server': 6379,
 };
 
 Future<void> performCreate(


### PR DESCRIPTION
Partially closes https://github.com/serverpod/serverpod/issues/523

### **The use of custom ports for development is a choice I understand. However, looking at the terraform used for deploying to AWS I saw that the production ports are the default `5432` and `6379`. It seems this custom port for development only seems like it may not be necessary.**

I'm making this PR as the first step to closing https://github.com/serverpod/serverpod/issues/523. I'm interested in helping to modify the `create`  command if someone really wants to use a non-standard port for their development servers.

I started modifying the `serverpod_cli.dart` and `create.dart` files to add the custom port flag. However, I wanted to split this into two PRs based on the contribution docs. 


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update cointains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes. This will only happen for newly created Serverpod projects since other projects have already copied the template files.
