### PR TITLE
fix: don't need to run setup-tables script manually in windows

### DIFF
--- a/tools/serverpod_cli/bin/create/create.dart
+++ b/tools/serverpod_cli/bin/create/create.dart
@@ -353,8 +353,8 @@ Future<void> performCreate(
   }
 
   if (dockerConfigured && template != 'module') {
+    await CommandLineTools.createTables(projectDir, name);
     if (Platform.isWindows) {
-      await CommandLineTools.cleanupForWindows(projectDir, name);
       printwwln('');
       printww('====================');
       printww('SERVERPOD CREATED :D');
@@ -362,13 +362,11 @@ Future<void> performCreate(
       printwwln('All setup. You are ready to rock!');
       printwwln('Start your Serverpod by running:');
       stdout.writeln('  \$ cd .\\${p.join(name, '${name}_server')}\\');
-      stdout.writeln('  \$ .\\setup-tables.cmd');
       stdout.writeln('  \$ docker-compose up --build --detach');
       stdout.writeln('  \$ dart .\\bin\\main.dart');
       printww('');
     } else {
       // Create tables
-      await CommandLineTools.createTables(projectDir, name);
       printwwln('');
       printwwln('SERVERPOD CREATED 🥳');
       printwwln('All setup. You are ready to rock!');

--- a/tools/serverpod_cli/bin/util/command_line_tools.dart
+++ b/tools/serverpod_cli/bin/util/command_line_tools.dart
@@ -59,12 +59,12 @@ class CommandLineTools {
       print(result.stdout);
     }
 
+    var setupTablesScript = p.join(
+        serverPath, Platform.isWindows ? 'setup-tables.cmd' : 'setup-tables');
     var process = await Process.start(
       /// Windows has an issue with running batch file directly without the complete path.
       /// Related ticket: https://github.com/dart-lang/sdk/issues/31291
-      Platform.isWindows
-          ? p.join(serverPath, 'setup-tables.cmd')
-          : './setup-tables',
+      setupTablesScript,
       [],
       workingDirectory: serverPath,
     );
@@ -73,34 +73,8 @@ class CommandLineTools {
     unawaited(stderr.addStream(process.stderr));
 
     var exitCode = await process.exitCode;
+    File(setupTablesScript).deleteSync();
     print('Completed table setup exit code: $exitCode');
-
-    print('Cleaning up');
-    result = await Process.run(
-      'rm',
-      ['setup-tables'],
-      workingDirectory: serverPath,
-    );
-    print(result.stdout);
-
-    result = await Process.run(
-      'rm',
-      ['setup-tables.cmd'],
-      workingDirectory: serverPath,
-    );
-    print(result.stdout);
-  }
-
-  static Future<void> cleanupForWindows(Directory dir, String name) async {
-    var serverPath = p.join(dir.path, '${name}_server');
-    print('Cleaning up');
-    var file = File(p.join(serverPath, 'setup-tables'));
-    try {
-      await file.delete();
-    } catch (e) {
-      print('Failed cleanup: $e');
-      print('file: $file');
-    }
   }
 }
 


### PR DESCRIPTION
We don't need to run `setup-tables.cmd` manually in windows.

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the document follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

# Results

<details>
<summary> Windows Logs </summary>

```console
PS C:\Users\yaswa> serverpod create hey
Building package executable...
Built serverpod_cli:serverpod_cli.
WARNING! Windows is not officially supported yet. Things may or may not work as expected.

Development mode. Using templates from: F:\Projects\serverpod\templates\serverpod_templates
SERVERPOD_HOME is set to F:\Projects\serverpod
Creating project hey...
  C:\Users\yaswa\hey\hey_server\analysis_options.yaml
  C:\Users\yaswa\hey\hey_server\aws\scripts\appspec.yml
  C:\Users\yaswa\hey\hey_server\aws\scripts\install_dependencies
  C:\Users\yaswa\hey\hey_server\aws\scripts\run_serverpod
  C:\Users\yaswa\hey\hey_server\aws\scripts\start_server
  C:\Users\yaswa\hey\hey_server\aws\terraform\balancers-staging.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\balancers.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\cloudfront-web-staging.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\cloudfront-web.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\code-deploy.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\config.auto.tfvars
  C:\Users\yaswa\hey\hey_server\aws\terraform\database.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\gitignore
  C:\Users\yaswa\hey\hey_server\aws\terraform\init-script.sh
  C:\Users\yaswa\hey\hey_server\aws\terraform\instances.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\main.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\redis.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\staging.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\storage.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\variables.tf
  C:\Users\yaswa\hey\hey_server\aws\terraform\vpc.tf
  C:\Users\yaswa\hey\hey_server\bin\main.dart
  C:\Users\yaswa\hey\hey_server\CHANGELOG.md
  C:\Users\yaswa\hey\hey_server\config\development.yaml
  C:\Users\yaswa\hey\hey_server\config\generator.yaml
  C:\Users\yaswa\hey\hey_server\config\passwords.yaml
  C:\Users\yaswa\hey\hey_server\config\production.yaml
  C:\Users\yaswa\hey\hey_server\config\staging.yaml
  C:\Users\yaswa\hey\hey_server\docker-compose.yaml
  C:\Users\yaswa\hey\hey_server\generated\protocol.yaml
  C:\Users\yaswa\hey\hey_server\generated\tables-serverpod.pgsql
  C:\Users\yaswa\hey\hey_server\generated\tables.pgsql
  C:\Users\yaswa\hey\hey_server\gitignore
  C:\Users\yaswa\hey\hey_server\lib\server.dart
  C:\Users\yaswa\hey\hey_server\lib\src\endpoints\example_endpoint.dart
  C:\Users\yaswa\hey\hey_server\lib\src\future_calls\example_future_call.dart
  C:\Users\yaswa\hey\hey_server\lib\src\generated\endpoints.dart
  C:\Users\yaswa\hey\hey_server\lib\src\generated\example_class.dart
  C:\Users\yaswa\hey\hey_server\lib\src\generated\protocol.dart
  C:\Users\yaswa\hey\hey_server\lib\src\protocol\example_class.yaml
  C:\Users\yaswa\hey\hey_server\lib\src\web\routes\root.dart
  C:\Users\yaswa\hey\hey_server\lib\src\web\widgets\default_page_widget.dart
  C:\Users\yaswa\hey\hey_server\pubspec.yaml
  C:\Users\yaswa\hey\hey_server\README.md
  C:\Users\yaswa\hey\hey_server\setup-tables
  C:\Users\yaswa\hey\hey_server\setup-tables.cmd
  C:\Users\yaswa\hey\hey_server\web\static\serverpod-logo.svg
  C:\Users\yaswa\hey\hey_server\web\static\style.css
  C:\Users\yaswa\hey\hey_server\web\templates\default.html
  C:\Users\yaswa\hey\hey_client\analysis_options.yaml
  C:\Users\yaswa\hey\hey_client\CHANGELOG.md
  C:\Users\yaswa\hey\hey_client\gitignore
  C:\Users\yaswa\hey\hey_client\lib\projectname_client.dart
  C:\Users\yaswa\hey\hey_client\lib\src\protocol\client.dart
  C:\Users\yaswa\hey\hey_client\lib\src\protocol\example_class.dart
  C:\Users\yaswa\hey\hey_client\lib\src\protocol\protocol.dart
  C:\Users\yaswa\hey\hey_client\pubspec.yaml
  C:\Users\yaswa\hey\hey_client\README.md
  C:\Users\yaswa\hey\hey_flutter\analysis_options.yaml
  C:\Users\yaswa\hey\hey_flutter\gitignore
  C:\Users\yaswa\hey\hey_flutter\lib\main.dart
  C:\Users\yaswa\hey\hey_flutter\pubspec.yaml
  C:\Users\yaswa\hey\hey_flutter\README.md
  C:\Users\yaswa\hey\hey_flutter\test\widget_test.dart
  C:\Users\yaswa\hey\.github\workflows\deployment-aws.yml

Running `dart pub get` in C:\Users\yaswa\hey\hey_server
Resolving dependencies...
+ args 2.3.1
+ async 2.10.0
+ buffer 1.1.1
+ collection 1.17.0
+ crypto 3.0.2
+ executor 2.2.2
+ http 0.13.5
+ http_parser 4.0.2
+ lints 1.0.1 (2.0.1 available)
+ meta 1.8.0
+ mustache_template 2.0.0
+ path 1.8.3
+ pedantic 1.11.1
+ postgres 2.5.2
+ postgres_pool 2.1.5
+ redis 3.1.0
+ retry 3.1.0
+ sasl_scram 0.1.1
+ saslprep 1.0.2
+ serverpod 0.9.21
+ serverpod_client 0.9.21
+ serverpod_serialization 0.9.21
+ serverpod_service_client 0.9.21
+ serverpod_shared 0.9.21
+ source_span 1.9.1
+ stack_trace 1.11.0
+ stream_channel 2.1.1
+ string_scanner 1.2.0
+ synchronized 3.0.0+3
+ system_resources 1.6.0
+ term_glyph 1.2.1
+ typed_data 1.3.1
+ unorm_dart 0.2.0
+ vm_service 9.4.0
+ web_socket_channel 2.2.0
+ yaml 3.1.1
Changed 36 dependencies!

Running `dart pub get` in C:\Users\yaswa\hey\hey_client
Resolving dependencies...
+ async 2.10.0
+ collection 1.17.0
+ crypto 3.0.2
+ http 0.13.5
+ http_parser 4.0.2
+ meta 1.8.0
+ path 1.8.3
+ serverpod_client 0.9.21
+ serverpod_serialization 0.9.21
+ source_span 1.9.1
+ stream_channel 2.1.1
+ string_scanner 1.2.0
+ term_glyph 1.2.1
+ typed_data 1.3.1
+ web_socket_channel 2.2.0
+ yaml 3.1.1
Changed 16 dependencies!

Running `flutter create .` in C:\Users\yaswa\hey\hey_flutter
Recreating project ....
  .idea\libraries\Dart_SDK.xml (created)
  .idea\libraries\KotlinJavaRuntime.xml (created)
  .idea\modules.xml (created)
  .idea\runConfigurations\main_dart.xml (created)
  .idea\workspace.xml (created)
  android\app\build.gradle (created)
  android\app\src\main\kotlin\com\example\hey_flutter\MainActivity.kt (created)
  android\build.gradle (created)
  android\hey_flutter_android.iml (created)
  android\.gitignore (created)
  android\app\src\debug\AndroidManifest.xml (created)
  android\app\src\main\AndroidManifest.xml (created)
  android\app\src\main\res\drawable\launch_background.xml (created)
  android\app\src\main\res\drawable-v21\launch_background.xml (created)
  android\app\src\main\res\mipmap-hdpi\ic_launcher.png (created)
  android\app\src\main\res\mipmap-mdpi\ic_launcher.png (created)
  android\app\src\main\res\mipmap-xhdpi\ic_launcher.png (created)
  android\app\src\main\res\mipmap-xxhdpi\ic_launcher.png (created)
  android\app\src\main\res\mipmap-xxxhdpi\ic_launcher.png (created)
  android\app\src\main\res\values\styles.xml (created)
  android\app\src\main\res\values-night\styles.xml (created)
  android\app\src\profile\AndroidManifest.xml (created)
  android\gradle\wrapper\gradle-wrapper.properties (created)
  android\gradle.properties (created)
  android\settings.gradle (created)
  ios\Runner\AppDelegate.swift (created)
  ios\Runner\Runner-Bridging-Header.h (created)
  ios\Runner.xcodeproj\project.pbxproj (created)
  ios\Runner.xcodeproj\xcshareddata\xcschemes\Runner.xcscheme (created)
  ios\.gitignore (created)
  ios\Flutter\AppFrameworkInfo.plist (created)
  ios\Flutter\Debug.xcconfig (created)
  ios\Flutter\Release.xcconfig (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Contents.json (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-1024x1024@1x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-20x20@1x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-20x20@2x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-20x20@3x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-29x29@1x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-29x29@2x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-29x29@3x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-40x40@1x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-40x40@2x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-40x40@3x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-60x60@2x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-60x60@3x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-76x76@1x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-76x76@2x.png (created)
  ios\Runner\Assets.xcassets\AppIcon.appiconset\Icon-App-83.5x83.5@2x.png (created)
  ios\Runner\Assets.xcassets\LaunchImage.imageset\Contents.json (created)
  ios\Runner\Assets.xcassets\LaunchImage.imageset\LaunchImage.png (created)
  ios\Runner\Assets.xcassets\LaunchImage.imageset\LaunchImage@2x.png (created)
  ios\Runner\Assets.xcassets\LaunchImage.imageset\LaunchImage@3x.png (created)
  ios\Runner\Assets.xcassets\LaunchImage.imageset\README.md (created)
  ios\Runner\Base.lproj\LaunchScreen.storyboard (created)
  ios\Runner\Base.lproj\Main.storyboard (created)
  ios\Runner\Info.plist (created)
  ios\Runner.xcodeproj\project.xcworkspace\contents.xcworkspacedata (created)
  ios\Runner.xcodeproj\project.xcworkspace\xcshareddata\IDEWorkspaceChecks.plist (created)
  ios\Runner.xcodeproj\project.xcworkspace\xcshareddata\WorkspaceSettings.xcsettings (created)
  ios\Runner.xcworkspace\contents.xcworkspacedata (created)
  ios\Runner.xcworkspace\xcshareddata\IDEWorkspaceChecks.plist (created)
  ios\Runner.xcworkspace\xcshareddata\WorkspaceSettings.xcsettings (created)
  linux\.gitignore (created)
  linux\CMakeLists.txt (created)
  linux\flutter\CMakeLists.txt (created)
  linux\main.cc (created)
  linux\my_application.cc (created)
  linux\my_application.h (created)
  macos\.gitignore (created)
  macos\Flutter\Flutter-Debug.xcconfig (created)
  macos\Flutter\Flutter-Release.xcconfig (created)
  macos\Runner\AppDelegate.swift (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_1024.png (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_128.png (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_16.png (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_256.png (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_32.png (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_512.png (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\app_icon_64.png (created)
  macos\Runner\Assets.xcassets\AppIcon.appiconset\Contents.json (created)
  macos\Runner\Base.lproj\MainMenu.xib (created)
  macos\Runner\Configs\AppInfo.xcconfig (created)
  macos\Runner\Configs\Debug.xcconfig (created)
  macos\Runner\Configs\Release.xcconfig (created)
  macos\Runner\Configs\Warnings.xcconfig (created)
  macos\Runner\DebugProfile.entitlements (created)
  macos\Runner\Info.plist (created)
  macos\Runner\MainFlutterWindow.swift (created)
  macos\Runner\Release.entitlements (created)
  macos\Runner.xcodeproj\project.pbxproj (created)
  macos\Runner.xcodeproj\project.xcworkspace\xcshareddata\IDEWorkspaceChecks.plist (created)
  macos\Runner.xcodeproj\xcshareddata\xcschemes\Runner.xcscheme (created)
  macos\Runner.xcworkspace\contents.xcworkspacedata (created)
  macos\Runner.xcworkspace\xcshareddata\IDEWorkspaceChecks.plist (created)
  hey_flutter.iml (created)
  web\favicon.png (created)
  web\icons\Icon-192.png (created)
  web\icons\Icon-512.png (created)
  web\icons\Icon-maskable-192.png (created)
  web\icons\Icon-maskable-512.png (created)
  web\index.html (created)
  web\manifest.json (created)
  windows\.gitignore (created)
  windows\CMakeLists.txt (created)
  windows\flutter\CMakeLists.txt (created)
  windows\runner\CMakeLists.txt (created)
  windows\runner\flutter_window.cpp (created)
  windows\runner\flutter_window.h (created)
  windows\runner\main.cpp (created)
  windows\runner\resource.h (created)
  windows\runner\resources\app_icon.ico (created)
  windows\runner\runner.exe.manifest (created)
  windows\runner\Runner.rc (created)
  windows\runner\utils.cpp (created)
  windows\runner\utils.h (created)
  windows\runner\win32_window.cpp (created)
  windows\runner\win32_window.h (created)
Running "flutter pub get" in hey_flutter...                      2,105ms
Wrote 121 files.

All done!
In order to run your application, type:

  $ cd .
  $ flutter run

Your application code is in .\lib\main.dart.


Setting up Docker and default database tables in C:\Users\yaswa\hey\hey_server
If you run serverpod create for the first time, this can take a few minutes as Docker is downloading the images for
Postgres. If you get stuck at this step, make sure that you have the latest version of Docker Desktop and that it is
currently running.
Starting docker
Network hey_server_default  Creating
Network hey_server_default  Created
Volume "hey_server_hey_data"  Creating
Volume "hey_server_hey_data"  Created
Container hey_server-postgres-1  Creating
Container hey_server-redis-1  Creating
Container hey_server-postgres-1  Created
Container hey_server-redis-1  Created
Container hey_server-redis-1  Starting
Container hey_server-postgres-1  Starting
Container hey_server-postgres-1  Started
Container hey_server-redis-1  Started
Waiting for Postgres...
Postgres is ready
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
ALTER TABLE
CREATE TABLE
ALTER TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE INDEX
ALTER TABLE
Stopping docker
Container hey_server-redis-1  Stopping
Container hey_server-postgres-1  Stopping
Container hey_server-redis-1  Stopped
Container hey_server-postgres-1  Stopped
Completed table setup exit code: 0
Cleaning up
Completed cleanup exit code: 0
Cleaning up


====================
SERVERPOD CREATED :D
====================

All setup. You are ready to rock!

Start your Serverpod by running:

  $ cd .\hey\hey_server\
  $ docker-compose up --build --detach
  $ dart .\bin\main.dart
```
</details>

<details>
<summary> MacOS Logs </summary>

```console
➜  ~ serverpod create hey
Development mode. Using templates from: /Users/mr.minnu/.serverpod/templates/serverpod_templates
SERVERPOD_HOME is set to /Users/mr.minnu/.serverpod
Creating project hey...
  /Users/mr.minnu/hey/hey_server/generated/tables-serverpod.pgsql
  /Users/mr.minnu/hey/hey_server/generated/protocol.yaml
  /Users/mr.minnu/hey/hey_server/generated/tables.pgsql
  /Users/mr.minnu/hey/hey_server/docker-compose.yaml
  /Users/mr.minnu/hey/hey_server/bin/main.dart
  /Users/mr.minnu/hey/hey_server/CHANGELOG.md
  /Users/mr.minnu/hey/hey_server/setup-tables.cmd
  /Users/mr.minnu/hey/hey_server/config/generator.yaml
  /Users/mr.minnu/hey/hey_server/config/staging.yaml
  /Users/mr.minnu/hey/hey_server/config/production.yaml
  /Users/mr.minnu/hey/hey_server/config/development.yaml
  /Users/mr.minnu/hey/hey_server/config/passwords.yaml
  /Users/mr.minnu/hey/hey_server/web/static/css/style.css
  /Users/mr.minnu/hey/hey_server/web/static/images/background.svg
  /Users/mr.minnu/hey/hey_server/web/static/images/serverpod-logo.svg
  /Users/mr.minnu/hey/hey_server/web/templates/default.html
  /Users/mr.minnu/hey/hey_server/README.md
  /Users/mr.minnu/hey/hey_server/pubspec.yaml
  /Users/mr.minnu/hey/hey_server/setup-tables
  /Users/mr.minnu/hey/hey_server/lib/server.dart
  /Users/mr.minnu/hey/hey_server/lib/src/generated/endpoints.dart
  /Users/mr.minnu/hey/hey_server/lib/src/generated/protocol.dart
  /Users/mr.minnu/hey/hey_server/lib/src/generated/example.dart
  /Users/mr.minnu/hey/hey_server/lib/src/endpoints/example_endpoint.dart
  /Users/mr.minnu/hey/hey_server/lib/src/future_calls/example_future_call.dart
  /Users/mr.minnu/hey/hey_server/lib/src/web/routes/root.dart
  /Users/mr.minnu/hey/hey_server/lib/src/web/widgets/default_page_widget.dart
  /Users/mr.minnu/hey/hey_server/lib/src/protocol/example.yaml
  /Users/mr.minnu/hey/hey_server/analysis_options.yaml
  /Users/mr.minnu/hey/hey_server/aws/terraform/cloudfront-web.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/cloudfront-web-staging.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/staging.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/config.auto.tfvars
  /Users/mr.minnu/hey/hey_server/aws/terraform/main.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/storage.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/init-script.sh
  /Users/mr.minnu/hey/hey_server/aws/terraform/redis.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/balancers.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/database.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/variables.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/code-deploy.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/instances.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/balancers-staging.tf
  /Users/mr.minnu/hey/hey_server/aws/terraform/gitignore
  /Users/mr.minnu/hey/hey_server/aws/terraform/vpc.tf
  /Users/mr.minnu/hey/hey_server/aws/scripts/start_server
  /Users/mr.minnu/hey/hey_server/aws/scripts/appspec.yml
  /Users/mr.minnu/hey/hey_server/aws/scripts/run_serverpod
  /Users/mr.minnu/hey/hey_server/aws/scripts/install_dependencies
  /Users/mr.minnu/hey/hey_server/gitignore
  /Users/mr.minnu/hey/hey_client/CHANGELOG.md
  /Users/mr.minnu/hey/hey_client/README.md
  /Users/mr.minnu/hey/hey_client/pubspec.yaml
  /Users/mr.minnu/hey/hey_client/lib/projectname_client.dart
  /Users/mr.minnu/hey/hey_client/lib/src/protocol/client.dart
  /Users/mr.minnu/hey/hey_client/lib/src/protocol/protocol.dart
  /Users/mr.minnu/hey/hey_client/lib/src/protocol/example.dart
  /Users/mr.minnu/hey/hey_client/analysis_options.yaml
  /Users/mr.minnu/hey/hey_client/gitignore
  /Users/mr.minnu/hey/hey_flutter/test/widget_test.dart
  /Users/mr.minnu/hey/hey_flutter/README.md
  /Users/mr.minnu/hey/hey_flutter/pubspec.yaml
  /Users/mr.minnu/hey/hey_flutter/lib/main.dart
  /Users/mr.minnu/hey/hey_flutter/analysis_options.yaml
  /Users/mr.minnu/hey/hey_flutter/gitignore
  /Users/mr.minnu/hey/.github/workflows/deployment-aws.yml

Running `dart pub get` in /Users/mr.minnu/hey/hey_server
Resolving dependencies...
+ args 2.3.1
+ async 2.10.0
+ buffer 1.1.1
+ collection 1.17.0
+ crypto 3.0.2
+ executor 2.2.2
+ http 0.13.5
+ http_parser 4.0.2
+ lints 2.0.1
+ meta 1.8.0
+ mustache_template 2.0.0
+ path 1.8.3
+ pedantic 1.11.1
+ postgres 2.5.2
+ postgres_pool 2.1.5
+ redis 3.1.0
+ retry 3.1.0
+ sasl_scram 0.1.1
+ saslprep 1.0.2
+ serverpod 0.9.21
+ serverpod_client 0.9.21
+ serverpod_serialization 0.9.21
+ serverpod_service_client 0.9.21
+ serverpod_shared 0.9.21
+ source_span 1.9.1
+ stack_trace 1.11.0
+ stream_channel 2.1.1
+ string_scanner 1.2.0
+ synchronized 3.0.0+3
+ system_resources 1.6.0
+ term_glyph 1.2.1
+ typed_data 1.3.1
+ unorm_dart 0.2.0
+ vm_service 9.4.0
+ web_socket_channel 2.2.0
+ yaml 3.1.1
Changed 36 dependencies!

Running `dart pub get` in /Users/mr.minnu/hey/hey_client
Resolving dependencies...
+ async 2.10.0
+ collection 1.17.0
+ crypto 3.0.2
+ http 0.13.5
+ http_parser 4.0.2
+ meta 1.8.0
+ path 1.8.3
+ serverpod_client 0.9.21
+ serverpod_serialization 0.9.21
+ source_span 1.9.1
+ stream_channel 2.1.1
+ string_scanner 1.2.0
+ term_glyph 1.2.1
+ typed_data 1.3.1
+ web_socket_channel 2.2.0
+ yaml 3.1.1
Changed 16 dependencies!

Running `flutter create .` in /Users/mr.minnu/hey/hey_flutter

┌─────────────────────────────────────────────────────────┐
│ A new version of Flutter is available!                  │
│                                                         │
│ To update to the latest version, run "flutter upgrade". │
└─────────────────────────────────────────────────────────┘
Signing iOS app for device deployment using developer identity: "Apple Development: dhananjaya@springlogix.com (U58CK2895J)"
Recreating project ....
  windows/runner/flutter_window.cpp (created)
  windows/runner/utils.h (created)
  windows/runner/utils.cpp (created)
  windows/runner/runner.exe.manifest (created)
  windows/runner/CMakeLists.txt (created)
  windows/runner/win32_window.h (created)
  windows/runner/Runner.rc (created)
  windows/runner/win32_window.cpp (created)
  windows/runner/resources/app_icon.ico (created)
  windows/runner/main.cpp (created)
  windows/runner/resource.h (created)
  windows/runner/flutter_window.h (created)
  windows/flutter/CMakeLists.txt (created)
  windows/.gitignore (created)
  windows/CMakeLists.txt (created)
  ios/Runner.xcworkspace/contents.xcworkspacedata (created)
  ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist (created)
  ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings (created)
  ios/Runner/Info.plist (created)
  ios/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage@2x.png (created)
  ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md (created)
  ios/Runner/Assets.xcassets/LaunchImage.imageset/Contents.json (created)
  ios/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage@3x.png (created)
  ios/Runner/Assets.xcassets/LaunchImage.imageset/LaunchImage.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-29x29@1x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@3x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-29x29@2x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-60x60@3x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-83.5x83.5@2x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-1024x1024@1x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-40x40@2x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-40x40@1x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-76x76@1x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-76x76@2x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-40x40@3x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-29x29@3x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-60x60@2x.png (created)
  ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@1x.png (created)
  ios/Runner/Base.lproj/LaunchScreen.storyboard (created)
  ios/Runner/Base.lproj/Main.storyboard (created)
  ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata (created)
  ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist (created)
  ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings (created)
  ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme (created)
  ios/Flutter/Debug.xcconfig (created)
  ios/Flutter/Release.xcconfig (created)
  ios/Flutter/AppFrameworkInfo.plist (created)
  ios/.gitignore (created)
  hey_flutter.iml (created)
  web/favicon.png (created)
  web/index.html (created)
  web/manifest.json (created)
  web/icons/Icon-maskable-512.png (created)
  web/icons/Icon-192.png (created)
  web/icons/Icon-maskable-192.png (created)
  web/icons/Icon-512.png (created)
  macos/Runner.xcworkspace/contents.xcworkspacedata (created)
  macos/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_32.png (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_16.png (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_256.png (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_64.png (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_512.png (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_128.png (created)
  macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_1024.png (created)
  macos/Runner/DebugProfile.entitlements (created)
  macos/Runner/Base.lproj/MainMenu.xib (created)
  macos/Runner/MainFlutterWindow.swift (created)
  macos/Runner/Configs/Debug.xcconfig (created)
  macos/Runner/Configs/Release.xcconfig (created)
  macos/Runner/Configs/Warnings.xcconfig (created)
  macos/Runner/Configs/AppInfo.xcconfig (created)
  macos/Runner/AppDelegate.swift (created)
  macos/Runner/Info.plist (created)
  macos/Runner/Release.entitlements (created)
  macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist (created)
  macos/Runner.xcodeproj/project.pbxproj (created)
  macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme (created)
  macos/Flutter/Flutter-Debug.xcconfig (created)
  macos/Flutter/Flutter-Release.xcconfig (created)
  macos/.gitignore (created)
  android/app/src/profile/AndroidManifest.xml (created)
  android/app/src/main/res/mipmap-mdpi/ic_launcher.png (created)
  android/app/src/main/res/mipmap-hdpi/ic_launcher.png (created)
  android/app/src/main/res/drawable/launch_background.xml (created)
  android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png (created)
  android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png (created)
  android/app/src/main/res/values-night/styles.xml (created)
  android/app/src/main/res/values/styles.xml (created)
  android/app/src/main/res/drawable-v21/launch_background.xml (created)
  android/app/src/main/res/mipmap-xhdpi/ic_launcher.png (created)
  android/app/src/main/AndroidManifest.xml (created)
  android/app/src/debug/AndroidManifest.xml (created)
  android/gradle/wrapper/gradle-wrapper.properties (created)
  android/gradle.properties (created)
  android/.gitignore (created)
  android/settings.gradle (created)
  android/app/build.gradle (created)
  android/app/src/main/kotlin/com/example/hey_flutter/MainActivity.kt (created)
  android/build.gradle (created)
  android/hey_flutter_android.iml (created)
  ios/Runner/Runner-Bridging-Header.h (created)
  ios/Runner/AppDelegate.swift (created)
  ios/Runner.xcodeproj/project.pbxproj (created)
  .idea/runConfigurations/main_dart.xml (created)
  .idea/libraries/Dart_SDK.xml (created)
  .idea/libraries/KotlinJavaRuntime.xml (created)
  .idea/modules.xml (created)
  .idea/workspace.xml (created)
  linux/main.cc (created)
  linux/my_application.h (created)
  linux/my_application.cc (created)
  linux/flutter/CMakeLists.txt (created)
  linux/.gitignore (created)
  linux/CMakeLists.txt (created)
Running "flutter pub get" in hey_flutter...
Resolving dependencies...
+ args 2.3.1
+ async 2.10.0
+ boolean_selector 2.1.1
+ characters 1.2.1
+ clock 1.1.1
+ collection 1.17.0
+ connectivity_plus 2.3.9 (3.0.2 available)
+ connectivity_plus_linux 1.3.1
+ connectivity_plus_macos 1.2.6
+ connectivity_plus_platform_interface 1.2.3
+ connectivity_plus_web 1.2.5
+ connectivity_plus_windows 1.2.2
+ crypto 3.0.2
+ cupertino_icons 1.0.5
+ dbus 0.7.8
+ fake_async 1.3.1
+ ffi 2.0.1
+ flutter 0.0.0 from sdk flutter
+ flutter_lints 2.0.1
+ flutter_test 0.0.0 from sdk flutter
+ flutter_web_plugins 0.0.0 from sdk flutter
+ hey_client 0.0.0 from path ../hey_client
+ http 0.13.5
+ http_parser 4.0.2
+ js 0.6.5 (0.6.6 available)
+ lints 2.0.1
+ matcher 0.12.13 (0.12.14 available)
+ material_color_utilities 0.2.0
+ meta 1.8.0
+ nm 0.5.0
+ path 1.8.2 (1.8.3 available)
+ petitparser 5.1.0
+ plugin_platform_interface 2.1.3
+ serverpod_client 0.9.21
+ serverpod_flutter 0.9.21
+ serverpod_serialization 0.9.21
+ sky_engine 0.0.99 from sdk flutter
+ source_span 1.9.1
+ stack_trace 1.11.0
+ stream_channel 2.1.1
+ string_scanner 1.2.0
+ term_glyph 1.2.1
+ test_api 0.4.16 (0.4.17 available)
+ typed_data 1.3.1
+ vector_math 2.1.4
+ web_socket_channel 2.2.0
+ xml 6.2.2
+ yaml 3.1.1
Changed 48 dependencies!
Wrote 121 files.

All done!
You can find general documentation for Flutter at: https://docs.flutter.dev/
Detailed API documentation is available at: https://api.flutter.dev/
If you prefer video documentation, consider: https://www.youtube.com/c/flutterdev

In order to run your application, type:

  $ cd .
  $ flutter run

Your application code is in ./lib/main.dart.


Setting up Docker and default database tables in /Users/mr.minnu/hey/hey_server
If you run serverpod create for the first time, this can take a few minutes as
Docker is downloading the images for Postgres. If you get stuck at this step,
make sure that you have the latest version of Docker Desktop and that it is
currently running.

Starting docker
Volume "hey_server_hey_data"  Creating
Volume "hey_server_hey_data"  Created
Container hey_server-postgres-1  Creating
Container hey_server-redis-1  Creating
Container hey_server-postgres-1  Created
Container hey_server-redis-1  Created
Container hey_server-redis-1  Starting
Container hey_server-postgres-1  Starting
Container hey_server-postgres-1  Started
Container hey_server-redis-1  Started
Postgres is ready
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE TABLE
ALTER TABLE
CREATE INDEX
ALTER TABLE
CREATE TABLE
ALTER TABLE
ALTER TABLE
CREATE TABLE
ALTER TABLE
CREATE INDEX
ALTER TABLE
Stopping docker
Container hey_server-redis-1  Stopping
Container hey_server-postgres-1  Stopping
Container hey_server-postgres-1  Stopped
Container hey_server-redis-1  Stopped
Completed table setup exit code: 0


SERVERPOD CREATED 🥳

All setup. You are ready to rock!

Start your Serverpod by running:

  $ cd hey/hey_server
  $ docker-compose up --build --detach
  $ dart bin/main.dart

```

</details>