### PR TITLE
Allow custom ports for DBs in serverpod create

### DIFF
--- a/tools/serverpod_cli/bin/create/create.dart
+++ b/tools/serverpod_cli/bin/create/create.dart
@@ -11,24 +11,29 @@ import '../util/print.dart';
 import 'copier.dart';
 import 'port_checker.dart';
 
-const _defaultPorts = <String, int>{
-  'Serverpod API': 8080,
-  'Serverpod insights API': 8081,
-  'Serverpod Relic web server': 8082,
-  'PostgreSQL server': 8090,
-  'Redis server': 8091,
-};
+const _defaultPostgresPort = '8090';
+const _defaultRedisPort = '8091';
 
 Future<void> performCreate(
   String name,
   bool verbose,
   String template,
   bool force,
+  int postgresPort,
+  int redisPort,
 ) async {
+  var defaultPorts = <String, int>{
+    'Serverpod API': 8080,
+    'Serverpod insights API': 8081,
+    'Serverpod Relic web server': 8082,
+    'PostgreSQL server': postgresPort,
+    'Redis server': redisPort,
+  };
+
   // Check we are set to create a new project
   var usedPorts = <String, int>{};
-  for (var serverDescription in _defaultPorts.keys) {
-    var port = _defaultPorts[serverDescription]!;
+  for (var serverDescription in defaultPorts.keys) {
+    var port = defaultPorts[serverDescription]!;
 
     var available = await isNetworkPortAvailable(port);
     if (!available) {
@@ -45,7 +50,7 @@ Future<void> performCreate(
     var strIssue =
         'There are some issues with your setup that will prevent your Serverpod project from running out of the box and without further configuration. You can still create this project by passing -f to "serverpod create" and manually configure your Serverpod.';
     var strIssuePorts =
-        'One or more network ports Serverpod want to use are not available. The most likely reason is that you have another Serverpod project running, but it can also be another service.';
+        'One or more network ports Serverpod want to use are not available. The most likely reason is that you have another Serverpod project running, but it can also be another service. You can either stop the other service or change the ports used by Serverpod by passing the --postgresPort flag to "serverpod create".';
     var strIssueDocker =
         'You do not have Docker installed or it is not running. Serverpod uses Docker to run Postgres and Redis. It\'s recommended that you install Docker Desktop from https://www.docker.com/get-started but you can also install and configure Postgres and Redis manually and run this command with the -f flag added.';
 
@@ -140,6 +145,14 @@ Future<void> performCreate(
         Replacement(
           slotName: 'SERVICE_SECRET_PRODUCTION',
           replacement: generateRandomString(),
+        ),
+        Replacement(
+          slotName: _defaultPostgresPort,
+          replacement: postgresPort.toString(),
+        ),
+        Replacement(
+          slotName: _defaultRedisPort,
+          replacement: redisPort.toString(),
         ),
         Replacement(
           slotName: 'DB_PASSWORD',

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -115,6 +115,20 @@ Future<void> _main(List<String> args) async {
     help:
         'Template to use when creating a new project, valid options are "server" or "module"',
   );
+  createParser.addOption(
+    'postgresPort',
+    abbr: 'p',
+    defaultsTo: '8090',
+    mandatory: false,
+    help: 'Port to use for the postgres database',
+  );
+  createParser.addOption(
+    'redisPort',
+    abbr: 'r',
+    defaultsTo: '8091',
+    mandatory: false,
+    help: 'Port to use for the redis database',
+  );
   parser.addCommand(cmdCreate, createParser);
 
   // "generate" command
@@ -177,6 +191,8 @@ Future<void> _main(List<String> args) async {
       bool verbose = results.command!['verbose'];
       String template = results.command!['template'];
       bool force = results.command!['force'];
+      int pgPort = int.parse(results.command!['postgresPort']);
+      int redisPort = int.parse(results.command!['redisPort']);
 
       if (name == 'server' || name == 'module' || name == 'create') {
         _printUsage(parser);
@@ -186,7 +202,7 @@ Future<void> _main(List<String> args) async {
 
       var re = RegExp(r'^[a-z0-9_]+$');
       if (results.arguments.length > 1 && re.hasMatch(name)) {
-        await performCreate(name, verbose, template, force);
+        await performCreate(name, verbose, template, force, pgPort, redisPort);
         _analytics.cleanUp();
         return;
       }


### PR DESCRIPTION
## Closes https://github.com/serverpod/serverpod/issues/523

[Adds the ability to customize DB ports](https://github.com/serverpod/serverpod/pull/532/commits/46d9599d0bc71a0fe21b82630face83a061dacb0) 

This will allow users with busy ports on 8090 and 8091 to use serverpod
without the `-f` option when creating a new project.

This is the simplest way to allow a user to eject from these ports
while keeping the ability to run the "Templates" as individual
projects.
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update cointains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
