### PR TITLE
feat: allow docs in protocol files

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
@@ -10,6 +10,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 class ObjectFieldScopes extends _i1.SerializableEntity {
   ObjectFieldScopes({
+    /// The database ID.
     this.id,
     required this.normal,
     this.api,
@@ -27,6 +28,7 @@ class ObjectFieldScopes extends _i1.SerializableEntity {
     );
   }
 
+  /// The database ID.
   int? id;
 
   String normal;

--- a/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
@@ -10,7 +10,6 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 class ObjectFieldScopes extends _i1.SerializableEntity {
   ObjectFieldScopes({
-    /// The database ID.
     this.id,
     required this.normal,
     this.api,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
@@ -11,6 +11,7 @@ import 'dart:typed_data' as _i2;
 
 class ObjectWithByteData extends _i1.SerializableEntity {
   ObjectWithByteData({
+    /// The database ID.
     this.id,
     required this.byteData,
   });
@@ -26,6 +27,7 @@ class ObjectWithByteData extends _i1.SerializableEntity {
     );
   }
 
+  /// The database ID.
   int? id;
 
   _i2.ByteData byteData;

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
@@ -11,7 +11,6 @@ import 'dart:typed_data' as _i2;
 
 class ObjectWithByteData extends _i1.SerializableEntity {
   ObjectWithByteData({
-    /// The database ID.
     this.id,
     required this.byteData,
   });

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
@@ -10,7 +10,6 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 class ObjectWithDuration extends _i1.SerializableEntity {
   ObjectWithDuration({
-    /// The database ID.
     this.id,
     required this.duration,
   });

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
@@ -10,6 +10,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 class ObjectWithDuration extends _i1.SerializableEntity {
   ObjectWithDuration({
+    /// The database ID.
     this.id,
     required this.duration,
   });
@@ -25,6 +26,7 @@ class ObjectWithDuration extends _i1.SerializableEntity {
     );
   }
 
+  /// The database ID.
   int? id;
 
   Duration duration;

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
@@ -11,6 +11,7 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithEnum extends _i1.SerializableEntity {
   ObjectWithEnum({
+    /// The database ID.
     this.id,
     required this.testEnum,
     this.nullableEnum,
@@ -38,6 +39,7 @@ class ObjectWithEnum extends _i1.SerializableEntity {
     );
   }
 
+  /// The database ID.
   int? id;
 
   _i2.TestEnum testEnum;

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
@@ -11,7 +11,6 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithEnum extends _i1.SerializableEntity {
   ObjectWithEnum({
-    /// The database ID.
     this.id,
     required this.testEnum,
     this.nullableEnum,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
@@ -11,6 +11,7 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithObject extends _i1.SerializableEntity {
   ObjectWithObject({
+    /// The database ID.
     this.id,
     required this.data,
     this.nullableData,
@@ -43,6 +44,7 @@ class ObjectWithObject extends _i1.SerializableEntity {
     );
   }
 
+  /// The database ID.
   int? id;
 
   _i2.SimpleData data;

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
@@ -11,7 +11,6 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithObject extends _i1.SerializableEntity {
   ObjectWithObject({
-    /// The database ID.
     this.id,
     required this.data,
     this.nullableData,

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
@@ -8,9 +8,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
+/// Just some simple data.
 class SimpleData extends _i1.SerializableEntity {
   SimpleData({
+    /// The database ID.
     this.id,
+
+    /// The only field of [SimpleData]
+    ///
+    /// Second Value Extra Text
     required this.num,
   });
 
@@ -24,8 +30,12 @@ class SimpleData extends _i1.SerializableEntity {
     );
   }
 
+  /// The database ID.
   int? id;
 
+  /// The only field of [SimpleData]
+  ///
+  /// Second Value Extra Text
   int num;
 
   @override

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
@@ -11,12 +11,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 /// Just some simple data.
 class SimpleData extends _i1.SerializableEntity {
   SimpleData({
-    /// The database ID.
     this.id,
-
-    /// The only field of [SimpleData]
-    ///
-    /// Second Value Extra Text
     required this.num,
   });
 

--- a/tests/serverpod_test_client/lib/src/protocol/test_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/test_enum.dart
@@ -8,8 +8,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
+/// Just an test enum.
 enum TestEnum with _i1.SerializableEntity {
+  /// The first value of [TestEnum].
   one,
+
+  /// Second Value
+  ///
+  /// Second Value Extra Text
   two,
   three;
 

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -11,6 +11,7 @@ import 'dart:typed_data' as _i2;
 
 class Types extends _i1.SerializableEntity {
   Types({
+    /// The database ID.
     this.id,
     this.anInt,
     this.aBool,
@@ -43,6 +44,7 @@ class Types extends _i1.SerializableEntity {
     );
   }
 
+  /// The database ID.
   int? id;
 
   int? anInt;

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -11,7 +11,6 @@ import 'dart:typed_data' as _i2;
 
 class Types extends _i1.SerializableEntity {
   Types({
-    /// The database ID.
     this.id,
     this.anInt,
     this.aBool,

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -10,6 +10,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 class ObjectFieldScopes extends _i1.TableRow {
   ObjectFieldScopes({
+    /// The database ID.
     int? id,
     required this.normal,
     this.api,
@@ -203,6 +204,7 @@ typedef ObjectFieldScopesExpressionBuilder = _i1.Expression Function(
 class ObjectFieldScopesTable extends _i1.Table {
   ObjectFieldScopesTable() : super(tableName: 'object_field_scopes');
 
+  /// The database ID.
   final id = _i1.ColumnInt('id');
 
   final normal = _i1.ColumnString('normal');

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -10,7 +10,6 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 class ObjectFieldScopes extends _i1.TableRow {
   ObjectFieldScopes({
-    /// The database ID.
     int? id,
     required this.normal,
     this.api,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -11,7 +11,6 @@ import 'dart:typed_data' as _i2;
 
 class ObjectWithByteData extends _i1.TableRow {
   ObjectWithByteData({
-    /// The database ID.
     int? id,
     required this.byteData,
   }) : super(id);

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -11,6 +11,7 @@ import 'dart:typed_data' as _i2;
 
 class ObjectWithByteData extends _i1.TableRow {
   ObjectWithByteData({
+    /// The database ID.
     int? id,
     required this.byteData,
   }) : super(id);
@@ -188,6 +189,7 @@ typedef ObjectWithByteDataExpressionBuilder = _i1.Expression Function(
 class ObjectWithByteDataTable extends _i1.Table {
   ObjectWithByteDataTable() : super(tableName: 'object_with_bytedata');
 
+  /// The database ID.
   final id = _i1.ColumnInt('id');
 
   final byteData = _i1.ColumnByteData('byteData');

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -10,7 +10,6 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 class ObjectWithDuration extends _i1.TableRow {
   ObjectWithDuration({
-    /// The database ID.
     int? id,
     required this.duration,
   }) : super(id);

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -10,6 +10,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 class ObjectWithDuration extends _i1.TableRow {
   ObjectWithDuration({
+    /// The database ID.
     int? id,
     required this.duration,
   }) : super(id);
@@ -187,6 +188,7 @@ typedef ObjectWithDurationExpressionBuilder = _i1.Expression Function(
 class ObjectWithDurationTable extends _i1.Table {
   ObjectWithDurationTable() : super(tableName: 'object_with_duration');
 
+  /// The database ID.
   final id = _i1.ColumnInt('id');
 
   final duration = _i1.ColumnDuration('duration');

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -11,6 +11,7 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithEnum extends _i1.TableRow {
   ObjectWithEnum({
+    /// The database ID.
     int? id,
     required this.testEnum,
     this.nullableEnum,
@@ -232,6 +233,7 @@ typedef ObjectWithEnumExpressionBuilder = _i1.Expression Function(
 class ObjectWithEnumTable extends _i1.Table {
   ObjectWithEnumTable() : super(tableName: 'object_with_enum');
 
+  /// The database ID.
   final id = _i1.ColumnInt('id');
 
   final testEnum = _i1.ColumnEnum<_i2.TestEnum>('testEnum');

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -11,7 +11,6 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithEnum extends _i1.TableRow {
   ObjectWithEnum({
-    /// The database ID.
     int? id,
     required this.testEnum,
     this.nullableEnum,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -11,6 +11,7 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithObject extends _i1.TableRow {
   ObjectWithObject({
+    /// The database ID.
     int? id,
     required this.data,
     this.nullableData,
@@ -245,6 +246,7 @@ typedef ObjectWithObjectExpressionBuilder = _i1.Expression Function(
 class ObjectWithObjectTable extends _i1.Table {
   ObjectWithObjectTable() : super(tableName: 'object_with_object');
 
+  /// The database ID.
   final id = _i1.ColumnInt('id');
 
   final data = _i1.ColumnSerializable('data');

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -11,7 +11,6 @@ import 'protocol.dart' as _i2;
 
 class ObjectWithObject extends _i1.TableRow {
   ObjectWithObject({
-    /// The database ID.
     int? id,
     required this.data,
     this.nullableData,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -11,12 +11,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Just some simple data.
 class SimpleData extends _i1.TableRow {
   SimpleData({
-    /// The database ID.
     int? id,
-
-    /// The only field of [SimpleData]
-    ///
-    /// Second Value Extra Text
     required this.num,
   }) : super(id);
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -8,9 +8,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
+/// Just some simple data.
 class SimpleData extends _i1.TableRow {
   SimpleData({
+    /// The database ID.
     int? id,
+
+    /// The only field of [SimpleData]
+    ///
+    /// Second Value Extra Text
     required this.num,
   }) : super(id);
 
@@ -26,6 +32,9 @@ class SimpleData extends _i1.TableRow {
 
   static final t = SimpleDataTable();
 
+  /// The only field of [SimpleData]
+  ///
+  /// Second Value Extra Text
   int num;
 
   @override
@@ -185,8 +194,12 @@ typedef SimpleDataExpressionBuilder = _i1.Expression Function(SimpleDataTable);
 class SimpleDataTable extends _i1.Table {
   SimpleDataTable() : super(tableName: 'simple_data');
 
+  /// The database ID.
   final id = _i1.ColumnInt('id');
 
+  /// The only field of [SimpleData]
+  ///
+  /// Second Value Extra Text
   final num = _i1.ColumnInt('num');
 
   @override

--- a/tests/serverpod_test_server/lib/src/generated/test_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/test_enum.dart
@@ -8,8 +8,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
+/// Just an test enum.
 enum TestEnum with _i1.SerializableEntity {
+  /// The first value of [TestEnum].
   one,
+
+  /// Second Value
+  ///
+  /// Second Value Extra Text
   two,
   three;
 

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -11,7 +11,6 @@ import 'dart:typed_data' as _i2;
 
 class Types extends _i1.TableRow {
   Types({
-    /// The database ID.
     int? id,
     this.anInt,
     this.aBool,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -11,6 +11,7 @@ import 'dart:typed_data' as _i2;
 
 class Types extends _i1.TableRow {
   Types({
+    /// The database ID.
     int? id,
     this.anInt,
     this.aBool,
@@ -252,6 +253,7 @@ typedef TypesExpressionBuilder = _i1.Expression Function(TypesTable);
 class TypesTable extends _i1.Table {
   TypesTable() : super(tableName: 'types');
 
+  /// The database ID.
   final id = _i1.ColumnInt('id');
 
   final anInt = _i1.ColumnInt('anInt');

--- a/tests/serverpod_test_server/lib/src/protocol/simple_data.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/simple_data.yaml
@@ -1,4 +1,10 @@
+### Just some simple data.
 class: SimpleData
 table: simple_data
 fields:
+  # No Documentation (1)
+  ### The only field of [SimpleData]
+  # No Documentation (2)
+  ###
+  ### Second Value Extra Text
   num: int

--- a/tests/serverpod_test_server/lib/src/protocol/test_enum.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/test_enum.yaml
@@ -1,5 +1,12 @@
+### Just an test enum.
 enum: TestEnum
 values:
+  ### The first value of [TestEnum].
   - one
+  # No Documentation (1)
+  ### Second Value
+  # No Documentation (2)
+  ###
+  ### Second Value Extra Text
   - two
   - three

--- a/tools/serverpod_cli/bin/generator/class_analyzer.dart
+++ b/tools/serverpod_cli/bin/generator/class_analyzer.dart
@@ -140,11 +140,10 @@ class ClassAnalyzer {
     var docsExtractor = YamlDocumentationExtractor(yaml);
 
     if (documentContents.nodes['class'] != null) {
-      return _analyzeClassFile(
-          documentContents, docsExtractor.getDocumentation);
+      return _analyzeClassFile(documentContents, docsExtractor);
     }
     if (documentContents.nodes['enum'] != null) {
-      return _analyzeEnumFile(documentContents, docsExtractor.getDocumentation);
+      return _analyzeEnumFile(documentContents, docsExtractor);
     }
 
     collector.addError(SourceSpanException(
@@ -154,8 +153,8 @@ class ClassAnalyzer {
     return null;
   }
 
-  ProtocolFileDefinition? _analyzeClassFile(YamlMap documentContents,
-      List<String>? Function(SourceLocation keyStart) docsExtractor) {
+  ProtocolFileDefinition? _analyzeClassFile(
+      YamlMap documentContents, YamlDocumentationExtractor docsExtractor) {
     if (!_containsOnlyValidKeys(
       documentContents,
       {'class', 'table', 'fields', 'indexes'},
@@ -172,8 +171,8 @@ class ClassAnalyzer {
       ));
       return null;
     }
-    var classDocumentation =
-        docsExtractor(documentContents.key('class')!.span.start);
+    var classDocumentation = docsExtractor
+        .getDocumentation(documentContents.key('class')!.span.start);
 
     var className = classNameNode.value;
     if (className is! String) {
@@ -253,7 +252,8 @@ class ClassAnalyzer {
         ));
         continue;
       }
-      var fieldDocumentation = docsExtractor(fieldNameNode.span.start);
+      var fieldDocumentation =
+          docsExtractor.getDocumentation(fieldNameNode.span.start);
       var fieldName = fieldNameNode.value;
       if (fieldName is! String) {
         collector.addError(SourceSpanException(
@@ -526,8 +526,8 @@ class ClassAnalyzer {
     );
   }
 
-  ProtocolFileDefinition? _analyzeEnumFile(YamlMap documentContents,
-      List<String>? Function(SourceLocation keyStart) docsExtractor) {
+  ProtocolFileDefinition? _analyzeEnumFile(
+      YamlMap documentContents, YamlDocumentationExtractor docsExtractor) {
     if (!_containsOnlyValidKeys(
       documentContents,
       {'enum', 'values'},
@@ -544,8 +544,8 @@ class ClassAnalyzer {
       ));
       return null;
     }
-    var enumDocumentation =
-        docsExtractor(documentContents.key('enum')!.span.start);
+    var enumDocumentation = docsExtractor
+        .getDocumentation(documentContents.key('enum')!.span.start);
 
     var className = classNameNode.value;
     if (className is! String) {
@@ -609,7 +609,8 @@ class ClassAnalyzer {
       }
       var start = valueNode.span.start;
       // 2 is the length of '- ' in '- enumValue'
-      var valueDocumentation = docsExtractor(SourceLocation(start.offset - 2,
+      var valueDocumentation = docsExtractor.getDocumentation(SourceLocation(
+          start.offset - 2,
           column: start.column - 2,
           line: start.line,
           sourceUrl: start.sourceUrl));

--- a/tools/serverpod_cli/bin/generator/class_analyzer.dart
+++ b/tools/serverpod_cli/bin/generator/class_analyzer.dart
@@ -581,7 +581,7 @@ class ClassAnalyzer {
       ));
       return null;
     }
-    var values = <EnumValue>[];
+    var values = <EnumValueDefinition>[];
     for (var valueNode in valuesNode.nodes) {
       if (valueNode is! YamlScalar) {
         collector.addError(SourceSpanException(
@@ -615,7 +615,7 @@ class ClassAnalyzer {
           line: start.line,
           sourceUrl: start.sourceUrl));
 
-      values.add(EnumValue(value, valueDocumentation));
+      values.add(EnumValueDefinition(value, valueDocumentation));
     }
 
     return EnumDefinition(

--- a/tools/serverpod_cli/bin/generator/class_generator_dart.dart
+++ b/tools/serverpod_cli/bin/generator/class_generator_dart.dart
@@ -95,7 +95,6 @@ class ClassGeneratorDart extends ClassGenerator {
                   c.optionalParameters.add(Parameter((p) {
                     p.named = true;
                     p.name = 'id';
-                    p.docs.addAll(field.documentation ?? []);
                     p.type = TypeReference(
                       (t) => t
                         ..symbol = 'int'
@@ -108,7 +107,6 @@ class ClassGeneratorDart extends ClassGenerator {
                     p.required = !field.type.nullable;
                     p.toThis = true;
                     p.name = field.name;
-                    p.docs.addAll(field.documentation ?? []);
                   }));
                 }
               }

--- a/tools/serverpod_cli/bin/generator/class_generator_dart.dart
+++ b/tools/serverpod_cli/bin/generator/class_generator_dart.dart
@@ -2,7 +2,7 @@ import 'package:code_builder/code_builder.dart';
 
 import 'class_generator.dart';
 import 'config.dart';
-import 'protocol_definition.dart' hide EnumValue;
+import 'protocol_definition.dart';
 import 'types.dart';
 
 String serverpodUrl(bool serverCode) {

--- a/tools/serverpod_cli/bin/generator/protocol_definition.dart
+++ b/tools/serverpod_cli/bin/generator/protocol_definition.dart
@@ -120,7 +120,7 @@ class ClassDefinition extends ProtocolFileDefinition {
 }
 
 class EnumDefinition extends ProtocolFileDefinition {
-  List<EnumValue> values;
+  List<EnumValueDefinition> values;
   final List<String>? documentation;
 
   EnumDefinition({
@@ -132,9 +132,9 @@ class EnumDefinition extends ProtocolFileDefinition {
   });
 }
 
-class EnumValue {
+class EnumValueDefinition {
   final String name;
   final List<String>? documentation;
 
-  EnumValue(this.name, [this.documentation]);
+  EnumValueDefinition(this.name, [this.documentation]);
 }

--- a/tools/serverpod_cli/bin/generator/protocol_definition.dart
+++ b/tools/serverpod_cli/bin/generator/protocol_definition.dart
@@ -106,6 +106,7 @@ class ClassDefinition extends ProtocolFileDefinition {
   final String? tableName;
   final List<FieldDefinition> fields;
   final List<IndexDefinition>? indexes;
+  final List<String>? documentation;
 
   ClassDefinition({
     required super.fileName,
@@ -114,16 +115,26 @@ class ClassDefinition extends ProtocolFileDefinition {
     this.tableName,
     this.indexes,
     super.subDir,
+    this.documentation,
   });
 }
 
 class EnumDefinition extends ProtocolFileDefinition {
-  List<String> values;
+  List<EnumValue> values;
+  final List<String>? documentation;
 
   EnumDefinition({
     required super.fileName,
     required super.className,
     required this.values,
     super.subDir,
+    this.documentation,
   });
+}
+
+class EnumValue {
+  final String name;
+  final List<String>? documentation;
+
+  EnumValue(this.name, [this.documentation]);
 }

--- a/tools/serverpod_cli/bin/generator/types.dart
+++ b/tools/serverpod_cli/bin/generator/types.dart
@@ -4,7 +4,6 @@ import 'package:code_builder/code_builder.dart';
 import 'package:source_span/source_span.dart';
 import 'package:path/path.dart' as p;
 
-import '../util/extensions.dart';
 import 'class_generator_dart.dart';
 import 'config.dart';
 import 'protocol_definition.dart';

--- a/tools/serverpod_cli/bin/util/extensions.dart
+++ b/tools/serverpod_cli/bin/util/extensions.dart
@@ -1,3 +1,5 @@
+import 'package:yaml/yaml.dart';
+
 extension NullableString on String? {
   /// Add [other] to [this], if and only if [this] is not [null].
   String? operator +(String other) {
@@ -7,5 +9,14 @@ extension NullableString on String? {
     } else {
       return '${this!}$other';
     }
+  }
+}
+
+extension KeyExposingYamlMap on YamlMap {
+  YamlScalar? key(String keyName) {
+    return nodes.keys.firstWhere(
+      (element) => element.value == keyName,
+      orElse: () => null,
+    );
   }
 }

--- a/tools/serverpod_cli/bin/util/yaml_docs.dart
+++ b/tools/serverpod_cli/bin/util/yaml_docs.dart
@@ -1,0 +1,22 @@
+import 'package:source_span/source_span.dart';
+
+class YamlDocumentationExtractor {
+  final List<String> lines;
+
+  YamlDocumentationExtractor(String yaml) : lines = yaml.split('\n');
+
+  List<String>? getDocumentation(SourceLocation keyStart) {
+    var documentation = <String>[];
+    var docStartExp = RegExp('^${''.padLeft(keyStart.column)}###(.*)');
+    for (var i = keyStart.line - 1; i >= 0; i--) {
+      var line = lines[i];
+      var match = docStartExp.firstMatch(line);
+      if (match != null) {
+        documentation.insert(0, '///${match.group(1) ?? ''}');
+      } else if (line.isNotEmpty && RegExp(r'^\ *?[^#]*$').hasMatch(line)) {
+        break;
+      }
+    }
+    return documentation.isNotEmpty ? documentation : null;
+  }
+}


### PR DESCRIPTION
This PR allows documenting generated files in the protocol yaml files.

Examples:
```yaml
### Some documentation goes here.
class: Foo

fields:
  ### Documentation for a field.
  foo: int
  ### Another field.
  ###
  ### Multiple lines
  bar: String
```
```yaml
### Some documentation goes here.
enum: Foo

values:
  ### Documentation for a value.
  - foo
  ### Another value
  - bar
```
The number of spaces in front of `###` is important.
(For enum values the doccumentation has to start two columns before the value name starts.)

Closes #548 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Not breaking.