### PR TITLE
fix: Fix import of generics in subdirectories

### DIFF
--- a/tools/serverpod_cli/bin/generator/types.dart
+++ b/tools/serverpod_cli/bin/generator/types.dart
@@ -149,7 +149,8 @@ class TypeDefinition {
         }
         t.isNullable = nullable ?? this.nullable;
         t.symbol = className;
-        t.types.addAll(generics.map((e) => e.reference(serverCode)));
+        t.types.addAll(generics
+            .map((e) => e.reference(serverCode, subDirectory: subDirectory)));
       },
     );
   }


### PR DESCRIPTION
Fixes a small oversight by me. (Imports of generics in sub-directories are not calculated properly.)

Fix #622 
Fix #545 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

*None*