### PR TITLE
fix: Generated enums don't respect their subdirectories

### DIFF
--- a/tools/serverpod_cli/bin/generator/class_analyzer.dart
+++ b/tools/serverpod_cli/bin/generator/class_analyzer.dart
@@ -627,6 +627,7 @@ class ClassAnalyzer {
       className: className,
       values: values,
       documentation: enumDocumentation,
+      subDir: subDirectory,
     );
   }
 


### PR DESCRIPTION
The subdirectory has not been passed to the `EnumDefinition`.

Fix #628 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

*none*