### PR TITLE
Migrated auth_firebase_flutter from FlutterFire UI to firebase_ui_auth

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
@@ -30,11 +30,9 @@ Future<UserInfo?> signInWithFirebase({
 
                   try {
                     var idToken = await user.getIdToken();
-                    var serverResponse =
-                        await caller.firebase.authenticate(idToken);
+                    var serverResponse = await caller.firebase.authenticate(idToken);
 
-                    if (!serverResponse.success &&
-                        serverResponse.userInfo != null) {
+                    if (!serverResponse.success && serverResponse.userInfo != null) {
                       // Failed to sign in.
                       completer.complete(null);
                       return;

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
@@ -3,13 +3,13 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:serverpod_auth_client/module.dart';
 import 'package:serverpod_auth_shared_flutter/serverpod_auth_shared_flutter.dart';
-import 'package:flutterfire_ui/auth.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 /// Attempts to Sign in with Firebase. If successful, a [UserInfo] is returned.
 /// If the attempt is not a success, null is returned.
 Future<UserInfo?> signInWithFirebase({
   required Caller caller,
-  required List<ProviderConfiguration> providerConfigs,
+  required List<AuthProvider> authProviders,
   required BuildContext context,
   bool debug = false,
 }) async {
@@ -20,7 +20,7 @@ Future<UserInfo?> signInWithFirebase({
       MaterialPageRoute(
         builder: (context) {
           return SignInScreen(
-            providerConfigs: providerConfigs,
+            providers: authProviders,
             actions: [
               AuthStateChangeAction<SignedIn>((context, state) async {
                 if (state.user == null) {
@@ -35,7 +35,7 @@ Future<UserInfo?> signInWithFirebase({
 
                     if (!serverResponse.success &&
                         serverResponse.userInfo != null) {
-                      // Faild to sign in.
+                      // Failed to sign in.
                       completer.complete(null);
                       return;
                     }

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
@@ -30,9 +30,11 @@ Future<UserInfo?> signInWithFirebase({
 
                   try {
                     var idToken = await user.getIdToken();
-                    var serverResponse = await caller.firebase.authenticate(idToken);
+                    var serverResponse =
+                        await caller.firebase.authenticate(idToken);
 
-                    if (!serverResponse.success && serverResponse.userInfo != null) {
+                    if (!serverResponse.success &&
+                        serverResponse.userInfo != null) {
                       // Failed to sign in.
                       completer.complete(null);
                       return;

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/signin_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutterfire_ui/auth.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:serverpod_auth_client/module.dart';
 
@@ -20,14 +20,14 @@ class SignInWithFirebaseButton extends StatelessWidget {
   /// The style of the button.
   final ButtonStyle? style;
 
-  /// List of Firebase sign in configurations.
-  final List<ProviderConfiguration> providerConfigs;
+  /// List of Firebase auth provider.
+  final List<AuthProvider> authProviders;
 
   /// Creates a new Sign in with Firebase button.
   const SignInWithFirebaseButton({
     Key? key,
     required this.caller,
-    required this.providerConfigs,
+    required this.authProviders,
     this.onSignedIn,
     this.onFailure,
     this.style,
@@ -46,7 +46,7 @@ class SignInWithFirebaseButton extends StatelessWidget {
       onPressed: () {
         signInWithFirebase(
           caller: caller,
-          providerConfigs: providerConfigs,
+          authProviders: authProviders,
           context: context,
         ).then((UserInfo? userInfo) {
           // Notify the parent.

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
@@ -14,52 +14,55 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  firebase_auth: ^4.2.6
-  firebase_core: ^2.5.0
-  firebase_ui_auth: ^1.1.10
+  firebase_auth: ^4.2.9
+  firebase_core: ^2.7.0
+  firebase_ui_auth: ^1.1.14
   flutter:
     sdk: flutter
-  material_design_icons_flutter: ">=5.0.6996 <6.0.0"
-  serverpod_auth_client:
+  material_design_icons_flutter: ">=5.0.6996 <6.0.7096"
+  serverpod_auth_client: #^1.0.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter:
+  serverpod_auth_shared_flutter: #^1.0.0
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lints: ^2.0.0
+  lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
+
 # The following section is specific to Flutter.
-flutter: null
-# To add assets to your package, add an assets section, like this:
-# assets:
-#   - images/a_dot_burr.jpeg
-#   - images/a_dot_ham.jpeg
-#
-# For details regarding assets in packages, see
-# https://flutter.dev/assets-and-images/#from-packages
-#
-# An image asset can refer to one or more resolution-specific "variants", see
-# https://flutter.dev/assets-and-images/#resolution-aware.
-# To add custom fonts to your package, add a fonts section here,
-# in this "flutter" section. Each entry in this list should have a
-# "family" key with the font family name, and a "fonts" key with a
-# list giving the asset and other descriptors for the font. For
-# example:
-# fonts:
-#   - family: Schyler
-#     fonts:
-#       - asset: fonts/Schyler-Regular.ttf
-#       - asset: fonts/Schyler-Italic.ttf
-#         style: italic
-#   - family: Trajan Pro
-#     fonts:
-#       - asset: fonts/TrajanPro.ttf
-#       - asset: fonts/TrajanPro_Bold.ttf
-#         weight: 700
-#
-# For details regarding fonts in packages, see
-# https://flutter.dev/custom-fonts/#from-packages
+flutter:
+
+  # To add assets to your package, add an assets section, like this:
+  # assets:
+  #   - images/a_dot_burr.jpeg
+  #   - images/a_dot_ham.jpeg
+  #
+  # For details regarding assets in packages, see
+  # https://flutter.dev/assets-and-images/#from-packages
+  #
+  # An image asset can refer to one or more resolution-specific "variants", see
+  # https://flutter.dev/assets-and-images/#resolution-aware.
+
+  # To add custom fonts to your package, add a fonts section here,
+  # in this "flutter" section. Each entry in this list should have a
+  # "family" key with the font family name, and a "fonts" key with a
+  # list giving the asset and other descriptors for the font. For
+  # example:
+  # fonts:
+  #   - family: Schyler
+  #     fonts:
+  #       - asset: fonts/Schyler-Regular.ttf
+  #       - asset: fonts/Schyler-Italic.ttf
+  #         style: italic
+  #   - family: Trajan Pro
+  #     fonts:
+  #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts in packages, see
+  # https://flutter.dev/custom-fonts/#from-packages

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
@@ -14,15 +14,15 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  firebase_auth: ^4.1.2
-  firebase_core: ^2.2.0
+  firebase_auth: ^4.2.6
+  firebase_core: ^2.5.0
+  firebase_ui_auth: ^1.1.10
   flutter:
     sdk: flutter
-  flutterfire_ui: ^0.4.3+20
-  material_design_icons_flutter: ">=5.0.6996 < 6.0.0"
-  serverpod_auth_client: #^1.0.0
+  material_design_icons_flutter: ">=5.0.6996 <6.0.0"
+  serverpod_auth_client:
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^1.0.0
+  serverpod_auth_shared_flutter:
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:
@@ -32,37 +32,34 @@ dev_dependencies:
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
 # The following section is specific to Flutter.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages
+flutter: null
+# To add assets to your package, add an assets section, like this:
+# assets:
+#   - images/a_dot_burr.jpeg
+#   - images/a_dot_ham.jpeg
+#
+# For details regarding assets in packages, see
+# https://flutter.dev/assets-and-images/#from-packages
+#
+# An image asset can refer to one or more resolution-specific "variants", see
+# https://flutter.dev/assets-and-images/#resolution-aware.
+# To add custom fonts to your package, add a fonts section here,
+# in this "flutter" section. Each entry in this list should have a
+# "family" key with the font family name, and a "fonts" key with a
+# list giving the asset and other descriptors for the font. For
+# example:
+# fonts:
+#   - family: Schyler
+#     fonts:
+#       - asset: fonts/Schyler-Regular.ttf
+#       - asset: fonts/Schyler-Italic.ttf
+#         style: italic
+#   - family: Trajan Pro
+#     fonts:
+#       - asset: fonts/TrajanPro.ttf
+#       - asset: fonts/TrajanPro_Bold.ttf
+#         weight: 700
+#
+# For details regarding fonts in packages, see
+# https://flutter.dev/custom-fonts/#from-packages

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
@@ -13,12 +13,12 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
-  firebase_auth: ^4.1.2
-  firebase_core: ^2.2.0
+  firebase_auth: ^4.2.9
+  firebase_core: ^2.7.0
+  firebase_ui_auth: ^1.1.14
   flutter:
     sdk: flutter
-  flutterfire_ui: ^0.4.3+20
-  material_design_icons_flutter: ">=5.0.6996 < 6.0.0"
+  material_design_icons_flutter: ">=5.0.6996 <6.0.7096"
   serverpod_auth_client: #^VERSION
     path: ../serverpod_auth_client
   serverpod_auth_shared_flutter: #^VERSION
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lints: ^2.0.0
+  lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Migrated the serverpod_auth_firebase_flutter from FlutterFire UI to firebase_ui_auth.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

SignInWithFirebase need now `List<AuthProvider> authProviders` instead of `  required List<ProviderConfiguration> providerConfigs`.
