### PR TITLE
feat: Add Support for UUIDs

### DIFF
--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -300,6 +300,32 @@ class ColumnDuration extends Column {
   }
 }
 
+/// A [Column] holding an [uuid](https://www.postgresql.org/docs/current/datatype-uuid.html).
+class ColumnUUID extends Column {
+  /// Creates a new [Column], this is typically done in generated code only.
+  ColumnUUID(String name) : super(name, int);
+
+  /// Creates an [Expression] checking if the value in the column equals the
+  /// specified value.
+  Expression equals(String? value) {
+    if (value == null) {
+      return Expression('"$columnName" IS NULL');
+    } else {
+      return Expression('"$columnName" = $value');
+    }
+  }
+
+  /// Creates an [Expression] checking if the value in the column does not equal
+  /// the specified value.
+  Expression notEquals(String? value) {
+    if (value == null) {
+      return Expression('"$columnName" IS NOT NULL');
+    } else {
+      return Expression('"$columnName" != $value');
+    }
+  }
+}
+
 /// A [Column] holding an [SerializableEntity]. The entity will be stored in the
 /// database as a json column.
 class ColumnSerializable extends Column {

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
@@ -1,0 +1,47 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+class ObjectWithUuid extends _i1.SerializableEntity {
+  ObjectWithUuid({
+    this.id,
+    required this.uuid,
+    this.uuidNullable,
+  });
+
+  factory ObjectWithUuid.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ObjectWithUuid(
+      id: serializationManager.deserialize<int?>(jsonSerialization['id']),
+      uuid: serializationManager.deserialize<String>(jsonSerialization['uuid']),
+      uuidNullable: serializationManager
+          .deserialize<String?>(jsonSerialization['uuidNullable']),
+    );
+  }
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  int? id;
+
+  String uuid;
+
+  String? uuidNullable;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -15,18 +15,19 @@ import 'object_with_duration.dart' as _i5;
 import 'object_with_enum.dart' as _i6;
 import 'object_with_maps.dart' as _i7;
 import 'object_with_object.dart' as _i8;
-import 'simple_data.dart' as _i9;
-import 'simple_data_list.dart' as _i10;
-import 'test_enum.dart' as _i11;
-import 'types.dart' as _i12;
-import 'protocol.dart' as _i13;
-import 'dart:typed_data' as _i14;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i15;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i16;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i17;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i18;
-import 'package:serverpod_test_module_client/module.dart' as _i19;
-import 'package:serverpod_auth_client/module.dart' as _i20;
+import 'object_with_uuid.dart' as _i9;
+import 'simple_data.dart' as _i10;
+import 'simple_data_list.dart' as _i11;
+import 'test_enum.dart' as _i12;
+import 'types.dart' as _i13;
+import 'protocol.dart' as _i14;
+import 'dart:typed_data' as _i15;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i16;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i17;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i18;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i19;
+import 'package:serverpod_test_module_client/module.dart' as _i20;
+import 'package:serverpod_auth_client/module.dart' as _i21;
 export 'nullability.dart';
 export 'object_field_scopes.dart';
 export 'object_with_bytedata.dart';
@@ -34,6 +35,7 @@ export 'object_with_duration.dart';
 export 'object_with_enum.dart';
 export 'object_with_maps.dart';
 export 'object_with_object.dart';
+export 'object_with_uuid.dart';
 export 'simple_data.dart';
 export 'simple_data_list.dart';
 export 'test_enum.dart';
@@ -79,17 +81,20 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i8.ObjectWithObject) {
       return _i8.ObjectWithObject.fromJson(data, this) as T;
     }
-    if (t == _i9.SimpleData) {
-      return _i9.SimpleData.fromJson(data, this) as T;
+    if (t == _i9.ObjectWithUuid) {
+      return _i9.ObjectWithUuid.fromJson(data, this) as T;
     }
-    if (t == _i10.SimpleDataList) {
-      return _i10.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i10.SimpleData) {
+      return _i10.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i11.TestEnum) {
-      return _i11.TestEnum.fromJson(data) as T;
+    if (t == _i11.SimpleDataList) {
+      return _i11.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i12.Types) {
-      return _i12.Types.fromJson(data, this) as T;
+    if (t == _i12.TestEnum) {
+      return _i12.TestEnum.fromJson(data) as T;
+    }
+    if (t == _i13.Types) {
+      return _i13.Types.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.Nullability?>()) {
       return (data != null ? _i2.Nullability.fromJson(data, this) : null) as T;
@@ -118,18 +123,22 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i8.ObjectWithObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i9.SimpleData?>()) {
-      return (data != null ? _i9.SimpleData.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i10.SimpleDataList?>()) {
-      return (data != null ? _i10.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i9.ObjectWithUuid?>()) {
+      return (data != null ? _i9.ObjectWithUuid.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i11.TestEnum?>()) {
-      return (data != null ? _i11.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i10.SimpleData?>()) {
+      return (data != null ? _i10.SimpleData.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i12.Types?>()) {
-      return (data != null ? _i12.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i11.SimpleDataList?>()) {
+      return (data != null ? _i11.SimpleDataList.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i12.TestEnum?>()) {
+      return (data != null ? _i12.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i13.Types?>()) {
+      return (data != null ? _i13.Types.fromJson(data, this) : null) as T;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
@@ -148,23 +157,23 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+    if (t == List<_i14.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData?>) {
+    if (t == List<_i14.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i13.SimpleData?>(e))
+          .map((e) => deserialize<_i14.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -185,22 +194,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -243,22 +252,22 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i13.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum>(e)).toList()
+    if (t == List<_i14.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i13.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum?>(e)).toList()
+    if (t == List<_i14.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i13.TestEnum>>) {
+    if (t == List<List<_i14.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i13.TestEnum>>(e))
+          .map((e) => deserialize<List<_i14.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData>) {
+    if (t == Map<String, _i14.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i13.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i14.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -270,9 +279,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -280,9 +289,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData?>) {
+    if (t == Map<String, _i14.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i13.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i14.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -293,9 +302,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -308,14 +317,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<int>) {
@@ -405,41 +414,41 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+    if (t == List<_i16.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData?>) {
+    if (t == List<_i16.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i15.SimpleData?>(e))
+          .map((e) => deserialize<_i16.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -493,14 +502,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i16.TestEnum, int>) {
+    if (t == Map<_i17.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i16.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i17.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i16.TestEnum>) {
+    if (t == Map<String, _i17.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i16.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i17.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -539,47 +548,47 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData>) {
+    if (t == Map<String, _i16.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData?>) {
+    if (t == Map<String, _i16.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i15.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i16.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -592,33 +601,33 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == _i17.CustomClass) {
-      return _i17.CustomClass.fromJson(data, this) as T;
+    if (t == _i18.CustomClass) {
+      return _i18.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.ExternalCustomClass) {
-      return _i18.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i19.ExternalCustomClass) {
+      return _i19.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.FreezedCustomClass) {
-      return _i18.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i19.FreezedCustomClass) {
+      return _i19.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i17.CustomClass?>()) {
-      return (data != null ? _i17.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i18.CustomClass?>()) {
+      return (data != null ? _i18.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i18.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i19.ExternalCustomClass?>()) {
       return (data != null
-          ? _i18.ExternalCustomClass.fromJson(data, this)
+          ? _i19.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i18.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i19.FreezedCustomClass?>()) {
       return (data != null
-          ? _i18.FreezedCustomClass.fromJson(data, this)
+          ? _i19.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
-    try {
-      return _i19.Protocol().deserialize<T>(data, t);
-    } catch (_) {}
     try {
       return _i20.Protocol().deserialize<T>(data, t);
+    } catch (_) {}
+    try {
+      return _i21.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -626,21 +635,21 @@ class Protocol extends _i1.SerializationManager {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i19.Protocol().getClassNameForObject(data);
+    className = _i20.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    className = _i20.Protocol().getClassNameForObject(data);
+    className = _i21.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i17.CustomClass) {
+    if (data is _i18.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i18.ExternalCustomClass) {
+    if (data is _i19.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i18.FreezedCustomClass) {
+    if (data is _i19.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.Nullability) {
@@ -664,16 +673,19 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i8.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i9.SimpleData) {
+    if (data is _i9.ObjectWithUuid) {
+      return 'ObjectWithUuid';
+    }
+    if (data is _i10.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i10.SimpleDataList) {
+    if (data is _i11.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i11.TestEnum) {
+    if (data is _i12.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i12.Types) {
+    if (data is _i13.Types) {
       return 'Types';
     }
     return super.getClassNameForObject(data);
@@ -683,20 +695,20 @@ class Protocol extends _i1.SerializationManager {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i19.Protocol().deserializeByClassName(data);
+      return _i20.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i20.Protocol().deserializeByClassName(data);
+      return _i21.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i17.CustomClass>(data['data']);
+      return deserialize<_i18.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i18.ExternalCustomClass>(data['data']);
+      return deserialize<_i19.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i18.FreezedCustomClass>(data['data']);
+      return deserialize<_i19.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'Nullability') {
       return deserialize<_i2.Nullability>(data['data']);
@@ -719,17 +731,20 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'ObjectWithObject') {
       return deserialize<_i8.ObjectWithObject>(data['data']);
     }
+    if (data['className'] == 'ObjectWithUuid') {
+      return deserialize<_i9.ObjectWithUuid>(data['data']);
+    }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i9.SimpleData>(data['data']);
+      return deserialize<_i10.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i10.SimpleDataList>(data['data']);
+      return deserialize<_i11.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i11.TestEnum>(data['data']);
+      return deserialize<_i12.TestEnum>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i12.Types>(data['data']);
+      return deserialize<_i13.Types>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -19,6 +19,7 @@ class Types extends _i1.SerializableEntity {
     this.aString,
     this.aByteData,
     this.aDuration,
+    this.aUuid,
   });
 
   factory Types.fromJson(
@@ -40,6 +41,8 @@ class Types extends _i1.SerializableEntity {
           .deserialize<_i2.ByteData?>(jsonSerialization['aByteData']),
       aDuration: serializationManager
           .deserialize<Duration?>(jsonSerialization['aDuration']),
+      aUuid:
+          serializationManager.deserialize<String?>(jsonSerialization['aUuid']),
     );
   }
 
@@ -62,6 +65,8 @@ class Types extends _i1.SerializableEntity {
 
   Duration? aDuration;
 
+  String? aUuid;
+
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -73,6 +78,7 @@ class Types extends _i1.SerializableEntity {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 }

--- a/tests/serverpod_test_server/generated/tables.pgsql
+++ b/tests/serverpod_test_server/generated/tables.pgsql
@@ -74,6 +74,20 @@ ALTER TABLE ONLY "object_with_object"
 
 
 --
+-- Class ObjectWithUuid as table object_with_uuid
+--
+
+CREATE TABLE "object_with_uuid" (
+  "id" serial,
+  "uuid" uuid NOT NULL,
+  "uuidNullable" uuid
+);
+
+ALTER TABLE ONLY "object_with_uuid"
+  ADD CONSTRAINT object_with_uuid_pkey PRIMARY KEY (id);
+
+
+--
 -- Class SimpleData as table simple_data
 --
 
@@ -98,7 +112,8 @@ CREATE TABLE "types" (
   "aDateTime" timestamp without time zone,
   "aString" text,
   "aByteData" bytea,
-  "aDuration" bigint
+  "aDuration" bigint,
+  "aUuid" uuid
 );
 
 ALTER TABLE ONLY "types"

--- a/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
@@ -50,4 +50,14 @@ class ExceptionWithData extends _i1.SerializableEntity
       'someNullableField': someNullableField,
     };
   }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'message': message,
+      'creationDate': creationDate,
+      'errorFields': errorFields,
+      'someNullableField': someNullableField,
+    };
+  }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -1,0 +1,218 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+class ObjectWithUuid extends _i1.TableRow {
+  ObjectWithUuid({
+    int? id,
+    required this.uuid,
+    this.uuidNullable,
+  }) : super(id);
+
+  factory ObjectWithUuid.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ObjectWithUuid(
+      id: serializationManager.deserialize<int?>(jsonSerialization['id']),
+      uuid: serializationManager.deserialize<String>(jsonSerialization['uuid']),
+      uuidNullable: serializationManager
+          .deserialize<String?>(jsonSerialization['uuidNullable']),
+    );
+  }
+
+  static final t = ObjectWithUuidTable();
+
+  String uuid;
+
+  String? uuidNullable;
+
+  @override
+  String get tableName => 'object_with_uuid';
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForDatabase() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+
+  @override
+  void setColumn(
+    String columnName,
+    value,
+  ) {
+    switch (columnName) {
+      case 'id':
+        id = value;
+        return;
+      case 'uuid':
+        uuid = value;
+        return;
+      case 'uuidNullable':
+        uuidNullable = value;
+        return;
+      default:
+        throw UnimplementedError();
+    }
+  }
+
+  static Future<List<ObjectWithUuid>> find(
+    _i1.Session session, {
+    ObjectWithUuidExpressionBuilder? where,
+    int? limit,
+    int? offset,
+    _i1.Column? orderBy,
+    List<_i1.Order>? orderByList,
+    bool orderDescending = false,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.find<ObjectWithUuid>(
+      where: where != null ? where(ObjectWithUuid.t) : null,
+      limit: limit,
+      offset: offset,
+      orderBy: orderBy,
+      orderByList: orderByList,
+      orderDescending: orderDescending,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+
+  static Future<ObjectWithUuid?> findSingleRow(
+    _i1.Session session, {
+    ObjectWithUuidExpressionBuilder? where,
+    int? offset,
+    _i1.Column? orderBy,
+    bool orderDescending = false,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.findSingleRow<ObjectWithUuid>(
+      where: where != null ? where(ObjectWithUuid.t) : null,
+      offset: offset,
+      orderBy: orderBy,
+      orderDescending: orderDescending,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+
+  static Future<ObjectWithUuid?> findById(
+    _i1.Session session,
+    int id,
+  ) async {
+    return session.db.findById<ObjectWithUuid>(id);
+  }
+
+  static Future<int> delete(
+    _i1.Session session, {
+    required ObjectWithUuidExpressionBuilder where,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.delete<ObjectWithUuid>(
+      where: where(ObjectWithUuid.t),
+      transaction: transaction,
+    );
+  }
+
+  static Future<bool> deleteRow(
+    _i1.Session session,
+    ObjectWithUuid row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.deleteRow(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<bool> update(
+    _i1.Session session,
+    ObjectWithUuid row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.update(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<void> insert(
+    _i1.Session session,
+    ObjectWithUuid row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.insert(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<int> count(
+    _i1.Session session, {
+    ObjectWithUuidExpressionBuilder? where,
+    int? limit,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.count<ObjectWithUuid>(
+      where: where != null ? where(ObjectWithUuid.t) : null,
+      limit: limit,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+}
+
+typedef ObjectWithUuidExpressionBuilder = _i1.Expression Function(
+    ObjectWithUuidTable);
+
+class ObjectWithUuidTable extends _i1.Table {
+  ObjectWithUuidTable() : super(tableName: 'object_with_uuid');
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  final id = _i1.ColumnInt('id');
+
+  final uuid = _i1.ColumnUUID('uuid');
+
+  final uuidNullable = _i1.ColumnUUID('uuidNullable');
+
+  @override
+  List<_i1.Column> get columns => [
+        id,
+        uuid,
+        uuidNullable,
+      ];
+}
+
+@Deprecated('Use ObjectWithUuidTable.t instead.')
+ObjectWithUuidTable tObjectWithUuid = ObjectWithUuidTable();

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -15,19 +15,20 @@ import 'object_with_duration.dart' as _i5;
 import 'object_with_enum.dart' as _i6;
 import 'object_with_maps.dart' as _i7;
 import 'object_with_object.dart' as _i8;
-import 'simple_data.dart' as _i9;
-import 'simple_data_list.dart' as _i10;
-import 'test_enum.dart' as _i11;
-import 'types.dart' as _i12;
-import 'protocol.dart' as _i13;
-import 'dart:typed_data' as _i14;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i15;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i16;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i17;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i18;
-import 'package:serverpod_test_module_server/module.dart' as _i19;
-import 'package:serverpod_auth_server/module.dart' as _i20;
-import 'package:serverpod/protocol.dart' as _i21;
+import 'object_with_uuid.dart' as _i9;
+import 'simple_data.dart' as _i10;
+import 'simple_data_list.dart' as _i11;
+import 'test_enum.dart' as _i12;
+import 'types.dart' as _i13;
+import 'protocol.dart' as _i14;
+import 'dart:typed_data' as _i15;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i16;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i17;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i18;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i19;
+import 'package:serverpod_test_module_server/module.dart' as _i20;
+import 'package:serverpod_auth_server/module.dart' as _i21;
+import 'package:serverpod/protocol.dart' as _i22;
 export 'nullability.dart';
 export 'object_field_scopes.dart';
 export 'object_with_bytedata.dart';
@@ -35,6 +36,7 @@ export 'object_with_duration.dart';
 export 'object_with_enum.dart';
 export 'object_with_maps.dart';
 export 'object_with_object.dart';
+export 'object_with_uuid.dart';
 export 'simple_data.dart';
 export 'simple_data_list.dart';
 export 'test_enum.dart';
@@ -79,17 +81,20 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i8.ObjectWithObject) {
       return _i8.ObjectWithObject.fromJson(data, this) as T;
     }
-    if (t == _i9.SimpleData) {
-      return _i9.SimpleData.fromJson(data, this) as T;
+    if (t == _i9.ObjectWithUuid) {
+      return _i9.ObjectWithUuid.fromJson(data, this) as T;
     }
-    if (t == _i10.SimpleDataList) {
-      return _i10.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i10.SimpleData) {
+      return _i10.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i11.TestEnum) {
-      return _i11.TestEnum.fromJson(data) as T;
+    if (t == _i11.SimpleDataList) {
+      return _i11.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i12.Types) {
-      return _i12.Types.fromJson(data, this) as T;
+    if (t == _i12.TestEnum) {
+      return _i12.TestEnum.fromJson(data) as T;
+    }
+    if (t == _i13.Types) {
+      return _i13.Types.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.Nullability?>()) {
       return (data != null ? _i2.Nullability.fromJson(data, this) : null) as T;
@@ -118,18 +123,22 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i8.ObjectWithObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i9.SimpleData?>()) {
-      return (data != null ? _i9.SimpleData.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i10.SimpleDataList?>()) {
-      return (data != null ? _i10.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i9.ObjectWithUuid?>()) {
+      return (data != null ? _i9.ObjectWithUuid.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i11.TestEnum?>()) {
-      return (data != null ? _i11.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i10.SimpleData?>()) {
+      return (data != null ? _i10.SimpleData.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i12.Types?>()) {
-      return (data != null ? _i12.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i11.SimpleDataList?>()) {
+      return (data != null ? _i11.SimpleDataList.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i12.TestEnum?>()) {
+      return (data != null ? _i12.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i13.Types?>()) {
+      return (data != null ? _i13.Types.fromJson(data, this) : null) as T;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
@@ -148,23 +157,23 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+    if (t == List<_i14.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData?>) {
+    if (t == List<_i14.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i13.SimpleData?>(e))
+          .map((e) => deserialize<_i14.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -185,22 +194,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -243,22 +252,22 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i13.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum>(e)).toList()
+    if (t == List<_i14.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i13.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum?>(e)).toList()
+    if (t == List<_i14.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i13.TestEnum>>) {
+    if (t == List<List<_i14.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i13.TestEnum>>(e))
+          .map((e) => deserialize<List<_i14.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData>) {
+    if (t == Map<String, _i14.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i13.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i14.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -270,9 +279,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -280,9 +289,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData?>) {
+    if (t == Map<String, _i14.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i13.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i14.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -293,9 +302,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -308,14 +317,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<int>) {
@@ -405,41 +414,41 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+    if (t == List<_i16.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData?>) {
+    if (t == List<_i16.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i15.SimpleData?>(e))
+          .map((e) => deserialize<_i16.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -493,14 +502,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i16.TestEnum, int>) {
+    if (t == Map<_i17.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i16.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i17.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i16.TestEnum>) {
+    if (t == Map<String, _i17.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i16.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i17.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -539,47 +548,47 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData>) {
+    if (t == Map<String, _i16.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData?>) {
+    if (t == Map<String, _i16.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i15.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i16.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -592,36 +601,36 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == _i17.CustomClass) {
-      return _i17.CustomClass.fromJson(data, this) as T;
+    if (t == _i18.CustomClass) {
+      return _i18.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.ExternalCustomClass) {
-      return _i18.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i19.ExternalCustomClass) {
+      return _i19.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.FreezedCustomClass) {
-      return _i18.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i19.FreezedCustomClass) {
+      return _i19.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i17.CustomClass?>()) {
-      return (data != null ? _i17.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i18.CustomClass?>()) {
+      return (data != null ? _i18.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i18.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i19.ExternalCustomClass?>()) {
       return (data != null
-          ? _i18.ExternalCustomClass.fromJson(data, this)
+          ? _i19.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i18.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i19.FreezedCustomClass?>()) {
       return (data != null
-          ? _i18.FreezedCustomClass.fromJson(data, this)
+          ? _i19.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
-    try {
-      return _i19.Protocol().deserialize<T>(data, t);
-    } catch (_) {}
     try {
       return _i20.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     try {
       return _i21.Protocol().deserialize<T>(data, t);
+    } catch (_) {}
+    try {
+      return _i22.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -629,21 +638,21 @@ class Protocol extends _i1.SerializationManagerServer {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i19.Protocol().getClassNameForObject(data);
+    className = _i20.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    className = _i20.Protocol().getClassNameForObject(data);
+    className = _i21.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i17.CustomClass) {
+    if (data is _i18.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i18.ExternalCustomClass) {
+    if (data is _i19.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i18.FreezedCustomClass) {
+    if (data is _i19.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.Nullability) {
@@ -667,16 +676,19 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i8.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i9.SimpleData) {
+    if (data is _i9.ObjectWithUuid) {
+      return 'ObjectWithUuid';
+    }
+    if (data is _i10.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i10.SimpleDataList) {
+    if (data is _i11.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i11.TestEnum) {
+    if (data is _i12.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i12.Types) {
+    if (data is _i13.Types) {
       return 'Types';
     }
     return super.getClassNameForObject(data);
@@ -686,20 +698,20 @@ class Protocol extends _i1.SerializationManagerServer {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i19.Protocol().deserializeByClassName(data);
+      return _i20.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i20.Protocol().deserializeByClassName(data);
+      return _i21.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i17.CustomClass>(data['data']);
+      return deserialize<_i18.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i18.ExternalCustomClass>(data['data']);
+      return deserialize<_i19.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i18.FreezedCustomClass>(data['data']);
+      return deserialize<_i19.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'Nullability') {
       return deserialize<_i2.Nullability>(data['data']);
@@ -722,29 +734,26 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'ObjectWithObject') {
       return deserialize<_i8.ObjectWithObject>(data['data']);
     }
+    if (data['className'] == 'ObjectWithUuid') {
+      return deserialize<_i9.ObjectWithUuid>(data['data']);
+    }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i9.SimpleData>(data['data']);
+      return deserialize<_i10.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i10.SimpleDataList>(data['data']);
+      return deserialize<_i11.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i11.TestEnum>(data['data']);
+      return deserialize<_i12.TestEnum>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i12.Types>(data['data']);
+      return deserialize<_i13.Types>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
 
   @override
   _i1.Table? getTableForType(Type t) {
-    {
-      var table = _i19.Protocol().getTableForType(t);
-      if (table != null) {
-        return table;
-      }
-    }
     {
       var table = _i20.Protocol().getTableForType(t);
       if (table != null) {
@@ -753,6 +762,12 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     {
       var table = _i21.Protocol().getTableForType(t);
+      if (table != null) {
+        return table;
+      }
+    }
+    {
+      var table = _i22.Protocol().getTableForType(t);
       if (table != null) {
         return table;
       }
@@ -768,10 +783,12 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i6.ObjectWithEnum.t;
       case _i8.ObjectWithObject:
         return _i8.ObjectWithObject.t;
-      case _i9.SimpleData:
-        return _i9.SimpleData.t;
-      case _i12.Types:
-        return _i12.Types.t;
+      case _i9.ObjectWithUuid:
+        return _i9.ObjectWithUuid.t;
+      case _i10.SimpleData:
+        return _i10.SimpleData.t;
+      case _i13.Types:
+        return _i13.Types.t;
     }
     return null;
   }

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -19,6 +19,7 @@ class Types extends _i1.TableRow {
     this.aString,
     this.aByteData,
     this.aDuration,
+    this.aUuid,
   }) : super(id);
 
   factory Types.fromJson(
@@ -40,6 +41,8 @@ class Types extends _i1.TableRow {
           .deserialize<_i2.ByteData?>(jsonSerialization['aByteData']),
       aDuration: serializationManager
           .deserialize<Duration?>(jsonSerialization['aDuration']),
+      aUuid:
+          serializationManager.deserialize<String?>(jsonSerialization['aUuid']),
     );
   }
 
@@ -59,6 +62,8 @@ class Types extends _i1.TableRow {
 
   Duration? aDuration;
 
+  String? aUuid;
+
   @override
   String get tableName => 'types';
   @override
@@ -72,6 +77,7 @@ class Types extends _i1.TableRow {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 
@@ -86,6 +92,7 @@ class Types extends _i1.TableRow {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 
@@ -100,6 +107,7 @@ class Types extends _i1.TableRow {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 
@@ -132,6 +140,9 @@ class Types extends _i1.TableRow {
         return;
       case 'aDuration':
         aDuration = value;
+        return;
+      case 'aUuid':
+        aUuid = value;
         return;
       default:
         throw UnimplementedError();
@@ -271,6 +282,8 @@ class TypesTable extends _i1.Table {
 
   final aDuration = _i1.ColumnDuration('aDuration');
 
+  final aUuid = _i1.ColumnUUID('aUuid');
+
   @override
   List<_i1.Column> get columns => [
         id,
@@ -281,6 +294,7 @@ class TypesTable extends _i1.Table {
         aString,
         aByteData,
         aDuration,
+        aUuid,
       ];
 }
 

--- a/tests/serverpod_test_server/lib/src/protocol/object_with_uuid.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/object_with_uuid.yaml
@@ -1,0 +1,5 @@
+class: ObjectWithUuid
+table: object_with_uuid
+fields:
+  uuid: _uuid
+  uuidNullable: _uuid?

--- a/tests/serverpod_test_server/lib/src/protocol/types.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/types.yaml
@@ -8,3 +8,4 @@ fields:
   aString: String?
   aByteData: ByteData?
   aDuration: Duration?
+  aUuid: _uuid?

--- a/tests/serverpod_test_server/test/connection_test.dart
+++ b/tests/serverpod_test_server/test/connection_test.dart
@@ -819,6 +819,7 @@ void main() {
     test('Write and read', () async {
       var dateTime = DateTime.utc(1976, 9, 10, 2, 10);
       var duration = const Duration(seconds: 1);
+      var uuid = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
 
       // TODO: Support ByteData in database store
       var types = Types(
@@ -829,6 +830,7 @@ void main() {
         aDuration: duration,
         aString: 'Foo',
         // aByteData: createByteData(),
+        aUuid: uuid,
       );
 
       var count = await client.basicDatabase.countTypesRows();
@@ -853,6 +855,7 @@ void main() {
         expect(storedTypes.aString, equals('Foo'));
         expect(storedTypes.aDateTime, equals(dateTime));
         expect(storedTypes.aDuration, equals(duration));
+        expect(storedTypes.aUuid, equals(uuid));
         // expect(storedTypes.aByteData!.lengthInBytes, equals(256));
       }
     });
@@ -882,6 +885,7 @@ void main() {
         expect(storedTypes.aString, isNull);
         expect(storedTypes.aDateTime, isNull);
         expect(storedTypes.aDuration, isNull);
+        expect(storedTypes.aUuid, isNull);
       }
     });
 

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -34,6 +34,7 @@ void main() {
       expect(unpacked.aDateTime, isNull);
       expect(unpacked.aByteData, isNull);
       expect(unpacked.aDuration, isNull);
+      expect(unpacked.aUuid, isNull);
     });
 
     test('Basic types with values', () {
@@ -45,6 +46,7 @@ void main() {
         aDateTime: DateTime.utc(1976),
         aByteData: createByteData(),
         aDuration: const Duration(seconds: 1),
+        aUuid: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
       );
       var s = SerializationManager.encode(types);
       var unpacked = protocol.deserialize<Types>(jsonDecode(s));
@@ -54,6 +56,7 @@ void main() {
       expect(unpacked.aDouble, equals(42.42));
       expect(unpacked.aDateTime, equals(DateTime.utc(1976)));
       expect(unpacked.aDuration, equals(const Duration(seconds: 1)));
+      expect(unpacked.aUuid, equals('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'));
       expect(unpacked.aByteData!.lengthInBytes, equals(256));
       for (var i = 0; i < 256; i++) {
         expect(unpacked.aByteData!.buffer.asUint8List()[i], equals(i));

--- a/tests/serverpod_test_server/test/types_test.dart
+++ b/tests/serverpod_test_server/test/types_test.dart
@@ -1,0 +1,12 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Test UUID', () {
+    test('Ensure ObjectWithUuid is generated correctly.', () {
+      expect(ObjectWithUuid.t.uuid, isA<ColumnUUID>());
+      expect(ObjectWithUuid.t.uuidNullable, isA<ColumnUUID>());
+    });
+  });
+}

--- a/tools/serverpod_cli/bin/generator/types.dart
+++ b/tools/serverpod_cli/bin/generator/types.dart
@@ -8,10 +8,21 @@ import 'class_generator_dart.dart';
 import 'config.dart';
 import 'protocol_definition.dart';
 
+const _uuidIdentifier = '_uuid';
+
 /// Contains information about the type of fields, arguments and return values.
 class TypeDefinition {
+  /// The class name of the type, or `_uuid`.
+  final String _className;
+
   /// The class name of the type.
-  final String className;
+  String get className {
+    if (_className == _uuidIdentifier) {
+      return 'String';
+    } else {
+      return _className;
+    }
+  }
 
   /// The generics the type has.
   final List<TypeDefinition> generics;
@@ -29,14 +40,14 @@ class TypeDefinition {
   bool isEnum;
 
   TypeDefinition({
-    required this.className,
+    required String className,
     this.generics = const [],
     required this.nullable,
     this.url,
     this.dartType,
     this.customClass = false,
     this.isEnum = false,
-  });
+  }) : _className = className;
 
   /// Creates an [TypeDefinition] from [mixed] where the [url]
   /// and [className] is separated by ':'.
@@ -82,7 +93,7 @@ class TypeDefinition {
   static TypeDefinition int = TypeDefinition(className: 'int', nullable: false);
 
   TypeDefinition get asNullable => TypeDefinition(
-        className: className,
+        className: _className,
         url: url,
         nullable: true,
         customClass: customClass,
@@ -157,6 +168,7 @@ class TypeDefinition {
 
   String get databaseType {
     //TODO: add all suported types here
+    if (_className == _uuidIdentifier) return 'uuid';
     if (className == 'String') return 'text';
     if (className == 'bool') return 'boolean';
     if (className == 'int' || isEnum) return 'integer';
@@ -170,6 +182,7 @@ class TypeDefinition {
 
   String get columnType {
     //TODO: add all suported types here
+    if (_className == _uuidIdentifier) return 'ColumnUUID';
     if (className == 'int') return 'ColumnInt';
     if (isEnum) return 'ColumnEnum';
     if (className == 'double') return 'ColumnDouble';
@@ -302,7 +315,7 @@ class TypeDefinition {
   TypeDefinition applyProtocolReferences(
       List<ProtocolFileDefinition> classDefinitions) {
     return TypeDefinition(
-        className: className,
+        className: _className,
         nullable: nullable,
         customClass: customClass,
         dartType: dartType,
@@ -310,10 +323,10 @@ class TypeDefinition {
             .map((e) => e.applyProtocolReferences(classDefinitions))
             .toList(),
         isEnum: isEnum,
-        url:
-            url == null && classDefinitions.any((c) => c.className == className)
-                ? 'protocol'
-                : url);
+        url: url == null &&
+                classDefinitions.any((c) => c.className == _className)
+            ? 'protocol'
+            : url);
   }
 
   @override


### PR DESCRIPTION
Adds support for UUIDs. They are represented as a `String` on the dart side, and as an [`uuid`](https://www.postgresql.org/docs/current/datatype-uuid.html) in the database.

Fix #635

I decided to introduce `_uuid` as a 'virtual' type.

This is an alternative implementation to #641.
Close #641

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

*none*

*(In theory, someone could have used `_uuid` as a type before, but since the name starts with an underscore, this is more then unlikely)*