### PR TITLE
feat: Add support for UUIDs (`UuidValue`)

### DIFF
--- a/examples/auth_example/auth_example_server/lib/src/endpoints/example_endpoint.dart
+++ b/examples/auth_example/auth_example_server/lib/src/endpoints/example_endpoint.dart
@@ -10,9 +10,9 @@ import 'package:serverpod/serverpod.dart';
 class ExampleEndpoint extends Endpoint {
   // You create methods in your endpoint which are accessible from the client by
   // creating a public method with `Session` as its first parameter. Supported
-  // parameter types are `bool`, `int`, `double`, `String`, `DateTime`, and any
-  // objects that are generated from your `protocol` directory. The methods
-  // should return a typed future; the same types as for the parameters are
+  // parameter types are `bool`, `int`, `double`, `String`, `DateTime`, `Duration`,
+  // `UuidValue` and and objects that are generated from your `protocol` directory.
+  // The methods should return a typed future; the same types as for the parameters are
   // supported. The `session` object provides access to the database, logging,
   // passwords, and information about the request being made to the server.
   Future<String> hello(Session session, String name) async {

--- a/examples/auth_example/auth_example_server/lib/src/protocol/example.yaml
+++ b/examples/auth_example/auth_example_server/lib/src/protocol/example.yaml
@@ -6,7 +6,6 @@
 # Please consult the documentation for more information on what you can add to
 # your yaml-files.
 
-
 # Name of the class to generate.
 class: Example
 
@@ -14,8 +13,8 @@ class: Example
 #table: example
 
 # The fields (and columns if connected to the database) of the class. Supported
-# types are `bool`, `int`, `double`, `String`, `DateTime`, and any other
-# generated classes. You can also add lists of objects and types have support
+# types are `bool`, `int`, `double`, `String`, `DateTime`, `Duration`, `UuidValue`
+# and any other generated classes. You can also add lists of objects and types have support
 # for null safety. Eg. `List<int>?` or `List<MyOtherClass?>`.
 fields:
   name: String

--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -300,6 +300,36 @@ class ColumnDuration extends Column {
   }
 }
 
+/// A [Column] holding [UuidValue].
+class ColumnUuid extends Column {
+  /// Creates a new [Column], this is typically done in generated code only.
+  ColumnUuid(String name) : super(name, UuidValue);
+
+  /// Creates an [Expression] checking if the value in the column equals the
+  /// specified value.
+  Expression equals(UuidValue? value) {
+    if (value == null) {
+      return Expression('"$columnName" IS NULL');
+    } else {
+      return Expression(
+        '"$columnName" = ${DatabasePoolManager.encoder.convert(value)}',
+      );
+    }
+  }
+
+  /// Creates an [Expression] checking if the value in the column does not equal
+  /// the specified value.
+  Expression notEquals(UuidValue? value) {
+    if (value == null) {
+      return Expression('"$columnName" IS NOT NULL');
+    } else {
+      return Expression(
+        '"$columnName" != ${DatabasePoolManager.encoder.convert(value)}',
+      );
+    }
+  }
+}
+
 /// A [Column] holding an [SerializableEntity]. The entity will be stored in the
 /// database as a json column.
 class ColumnSerializable extends Column {

--- a/packages/serverpod/lib/src/database/value_encoder.dart
+++ b/packages/serverpod/lib/src/database/value_encoder.dart
@@ -18,6 +18,9 @@ class ValueEncoder extends PostgresTextEncoder {
     } else if (input is Duration) {
       return super.convert(SerializationManager.encode(input),
           escapeStrings: escapeStrings);
+    } else if (input is UuidValue) {
+      return super.convert(SerializationManager.encode(input),
+          escapeStrings: escapeStrings);
     } else if (input is String &&
         input.startsWith('decode(\'') &&
         input.endsWith('\', \'base64\')')) {

--- a/packages/serverpod/lib/src/database/value_encoder.dart
+++ b/packages/serverpod/lib/src/database/value_encoder.dart
@@ -19,8 +19,7 @@ class ValueEncoder extends PostgresTextEncoder {
       return super.convert(SerializationManager.encode(input),
           escapeStrings: escapeStrings);
     } else if (input is UuidValue) {
-      return super.convert(SerializationManager.encode(input),
-          escapeStrings: escapeStrings);
+      return "'${input.uuid}'";
     } else if (input is String &&
         input.startsWith('decode(\'') &&
         input.endsWith('\', \'base64\')')) {

--- a/packages/serverpod_serialization/lib/serverpod_serialization.dart
+++ b/packages/serverpod_serialization/lib/serverpod_serialization.dart
@@ -2,3 +2,4 @@ library serverpod_serialization;
 
 export 'src/serialization.dart';
 export 'src/bytedata_base64_ext.dart';
+export 'package:uuid/uuid.dart' show UuidValue;

--- a/packages/serverpod_serialization/lib/serverpod_serialization.dart
+++ b/packages/serverpod_serialization/lib/serverpod_serialization.dart
@@ -1,6 +1,6 @@
 library serverpod_serialization;
 
-export 'package:uuid/uuid.dart' show UuidValue;
+export 'package:uuid/uuid.dart';
 
 export 'src/bytedata_base64_ext.dart';
 export 'src/exceptions.dart';

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -5,8 +5,6 @@ import 'dart:typed_data';
 
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-import 'bytedata_base64_ext.dart';
-
 /// The constructor takes JSON structure and turns it into a decoded
 /// [SerializableEntity].
 typedef constructor<T> = T Function(

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -74,7 +74,7 @@ abstract class SerializationManager {
     } else if (t == UuidValue) {
       return UuidValue(data as String) as T;
     } else if (t == getType<UuidValue?>()) {
-      return data == null ? data : UuidValue(data as String) as T;
+      return (data == null ? null : UuidValue(data as String)) as T;
     }
     throw FormatException('No deserialization found for type $t');
   }

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -73,6 +73,10 @@ abstract class SerializationManager {
       return Duration(milliseconds: (data as int)) as T;
     } else if (t == getType<Duration?>()) {
       return data == null ? data : Duration(milliseconds: (data as int)) as T;
+    } else if (t == UuidValue) {
+      return UuidValue(data as String) as T;
+    } else if (t == getType<Duration?>()) {
+      return data == null ? data : UuidValue(data as String) as T;
     }
     throw FormatException('No deserialization found for type $t');
   }
@@ -93,6 +97,8 @@ abstract class SerializationManager {
       return 'ByteData';
     } else if (data is Duration) {
       return 'Duration';
+    } else if (data is UuidValue) {
+      return 'UuidValue';
     }
     return null;
   }
@@ -115,6 +121,8 @@ abstract class SerializationManager {
         return deserialize<ByteData>(data['data']);
       case 'Duration':
         return deserialize<Duration>(data['data']);
+      case 'UuidValue':
+        return deserialize<UuidValue>(data['data']);
     }
     throw FormatException('No deserialization found for type named $className');
   }
@@ -147,6 +155,8 @@ abstract class SerializationManager {
           return nonEncodable.base64encodedString();
         } else if (nonEncodable is Duration) {
           return nonEncodable.inMilliseconds;
+        } else if (nonEncodable is UuidValue) {
+          return nonEncodable.uuid;
         } else if (nonEncodable is Map && nonEncodable.keyType != String) {
           return nonEncodable.entries
               .map((e) => {'k': e.key, 'v': e.value})

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -73,7 +73,7 @@ abstract class SerializationManager {
       return data == null ? data : Duration(milliseconds: (data as int)) as T;
     } else if (t == UuidValue) {
       return UuidValue(data as String) as T;
-    } else if (t == getType<Duration?>()) {
+    } else if (t == getType<UuidValue?>()) {
       return data == null ? data : UuidValue(data as String) as T;
     }
     throw FormatException('No deserialization found for type $t');

--- a/packages/serverpod_serialization/pubspec.yaml
+++ b/packages/serverpod_serialization/pubspec.yaml
@@ -14,6 +14,7 @@ environment:
 
 dependencies:
   yaml: ^3.1.0
+  uuid: ^3.0.7
 
 dev_dependencies:
   lints: ^2.0.0

--- a/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
 
 dependencies:
   yaml: ^3.1.0
+  uuid: ^3.0.7
 
 dev_dependencies:
   lints: ^2.0.0

--- a/tests/docker/tests_single_server/run-tests.sh
+++ b/tests/docker/tests_single_server/run-tests.sh
@@ -23,6 +23,7 @@ dart test test/redis_test.dart
 dart test test/serialization_test.dart
 dart test test/service_protocol_test.dart
 dart test test/websocket_test.dart
+dart test test/types_test.dart
 
 #echo "### Running unit tests"
 #cd ../../packages/serverpod

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -10,23 +10,24 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:async' as _i2;
 import 'package:serverpod_auth_client/module.dart' as _i3;
 import 'dart:typed_data' as _i4;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i5;
-import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i6;
-import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i7;
-import 'package:serverpod_test_client/src/protocol/types.dart' as _i8;
+import 'package:uuid/uuid.dart' as _i5;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i6;
+import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i7;
+import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i8;
+import 'package:serverpod_test_client/src/protocol/types.dart' as _i9;
 import 'package:serverpod_test_client/src/protocol/object_with_enum.dart'
-    as _i9;
-import 'package:serverpod_test_client/src/protocol/simple_data_list.dart'
     as _i10;
-import 'package:serverpod_test_client/src/protocol/object_with_object.dart'
+import 'package:serverpod_test_client/src/protocol/simple_data_list.dart'
     as _i11;
-import 'package:serverpod_test_client/src/protocol/object_field_scopes.dart'
+import 'package:serverpod_test_client/src/protocol/object_with_object.dart'
     as _i12;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i13;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i14;
-import 'package:serverpod_test_module_client/module.dart' as _i15;
-import 'dart:io' as _i16;
-import 'protocol.dart' as _i17;
+import 'package:serverpod_test_client/src/protocol/object_field_scopes.dart'
+    as _i13;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i14;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i15;
+import 'package:serverpod_test_module_client/module.dart' as _i16;
+import 'dart:io' as _i17;
+import 'protocol.dart' as _i18;
 
 class _EndpointAsyncTasks extends _i1.EndpointRef {
   _EndpointAsyncTasks(_i1.EndpointCaller caller) : super(caller);
@@ -156,6 +157,13 @@ class _EndpointBasicTypes extends _i1.EndpointRef {
       caller.callServerEndpoint<Duration?>(
         'basicTypes',
         'testDuration',
+        {'value': value},
+      );
+
+  _i2.Future<_i5.UuidValue?> testUuid(_i5.UuidValue? value) =>
+      caller.callServerEndpoint<_i5.UuidValue?>(
+        'basicTypes',
+        'testUuid',
         {'value': value},
       );
 }
@@ -296,63 +304,63 @@ class _EndpointCustomTypes extends _i1.EndpointRef {
   @override
   String get name => 'customTypes';
 
-  _i2.Future<_i5.CustomClass> returnCustomClass(_i5.CustomClass data) =>
-      caller.callServerEndpoint<_i5.CustomClass>(
+  _i2.Future<_i6.CustomClass> returnCustomClass(_i6.CustomClass data) =>
+      caller.callServerEndpoint<_i6.CustomClass>(
         'customTypes',
         'returnCustomClass',
         {'data': data},
       );
 
-  _i2.Future<_i5.CustomClass?> returnCustomClassNullable(
-          _i5.CustomClass? data) =>
-      caller.callServerEndpoint<_i5.CustomClass?>(
+  _i2.Future<_i6.CustomClass?> returnCustomClassNullable(
+          _i6.CustomClass? data) =>
+      caller.callServerEndpoint<_i6.CustomClass?>(
         'customTypes',
         'returnCustomClassNullable',
         {'data': data},
       );
 
-  _i2.Future<_i5.CustomClass2> returnCustomClass2(_i5.CustomClass2 data) =>
-      caller.callServerEndpoint<_i5.CustomClass2>(
+  _i2.Future<_i6.CustomClass2> returnCustomClass2(_i6.CustomClass2 data) =>
+      caller.callServerEndpoint<_i6.CustomClass2>(
         'customTypes',
         'returnCustomClass2',
         {'data': data},
       );
 
-  _i2.Future<_i5.CustomClass2?> returnCustomClass2Nullable(
-          _i5.CustomClass2? data) =>
-      caller.callServerEndpoint<_i5.CustomClass2?>(
+  _i2.Future<_i6.CustomClass2?> returnCustomClass2Nullable(
+          _i6.CustomClass2? data) =>
+      caller.callServerEndpoint<_i6.CustomClass2?>(
         'customTypes',
         'returnCustomClass2Nullable',
         {'data': data},
       );
 
-  _i2.Future<_i6.ExternalCustomClass> returnExternalCustomClass(
-          _i6.ExternalCustomClass data) =>
-      caller.callServerEndpoint<_i6.ExternalCustomClass>(
+  _i2.Future<_i7.ExternalCustomClass> returnExternalCustomClass(
+          _i7.ExternalCustomClass data) =>
+      caller.callServerEndpoint<_i7.ExternalCustomClass>(
         'customTypes',
         'returnExternalCustomClass',
         {'data': data},
       );
 
-  _i2.Future<_i6.ExternalCustomClass?> returnExternalCustomClassNullable(
-          _i6.ExternalCustomClass? data) =>
-      caller.callServerEndpoint<_i6.ExternalCustomClass?>(
+  _i2.Future<_i7.ExternalCustomClass?> returnExternalCustomClassNullable(
+          _i7.ExternalCustomClass? data) =>
+      caller.callServerEndpoint<_i7.ExternalCustomClass?>(
         'customTypes',
         'returnExternalCustomClassNullable',
         {'data': data},
       );
 
-  _i2.Future<_i7.FreezedCustomClass> returnFreezedCustomClass(
-          _i7.FreezedCustomClass data) =>
-      caller.callServerEndpoint<_i7.FreezedCustomClass>(
+  _i2.Future<_i8.FreezedCustomClass> returnFreezedCustomClass(
+          _i8.FreezedCustomClass data) =>
+      caller.callServerEndpoint<_i8.FreezedCustomClass>(
         'customTypes',
         'returnFreezedCustomClass',
         {'data': data},
       );
 
-  _i2.Future<_i7.FreezedCustomClass?> returnFreezedCustomClassNullable(
-          _i7.FreezedCustomClass? data) =>
-      caller.callServerEndpoint<_i7.FreezedCustomClass?>(
+  _i2.Future<_i8.FreezedCustomClass?> returnFreezedCustomClassNullable(
+          _i8.FreezedCustomClass? data) =>
+      caller.callServerEndpoint<_i8.FreezedCustomClass?>(
         'customTypes',
         'returnFreezedCustomClassNullable',
         {'data': data},
@@ -365,29 +373,29 @@ class _EndpointBasicDatabase extends _i1.EndpointRef {
   @override
   String get name => 'basicDatabase';
 
-  _i2.Future<int?> storeTypes(_i8.Types types) =>
+  _i2.Future<int?> storeTypes(_i9.Types types) =>
       caller.callServerEndpoint<int?>(
         'basicDatabase',
         'storeTypes',
         {'types': types},
       );
 
-  _i2.Future<_i8.Types?> getTypes(int id) =>
-      caller.callServerEndpoint<_i8.Types?>(
+  _i2.Future<_i9.Types?> getTypes(int id) =>
+      caller.callServerEndpoint<_i9.Types?>(
         'basicDatabase',
         'getTypes',
         {'id': id},
       );
 
-  _i2.Future<int?> storeObjectWithEnum(_i9.ObjectWithEnum object) =>
+  _i2.Future<int?> storeObjectWithEnum(_i10.ObjectWithEnum object) =>
       caller.callServerEndpoint<int?>(
         'basicDatabase',
         'storeObjectWithEnum',
         {'object': object},
       );
 
-  _i2.Future<_i9.ObjectWithEnum?> getObjectWithEnum(int id) =>
-      caller.callServerEndpoint<_i9.ObjectWithEnum?>(
+  _i2.Future<_i10.ObjectWithEnum?> getObjectWithEnum(int id) =>
+      caller.callServerEndpoint<_i10.ObjectWithEnum?>(
         'basicDatabase',
         'getObjectWithEnum',
         {'id': id},
@@ -444,13 +452,13 @@ class _EndpointBasicDatabase extends _i1.EndpointRef {
         {'num': num},
       );
 
-  _i2.Future<_i10.SimpleDataList?> findSimpleDataRowsLessThan(
+  _i2.Future<_i11.SimpleDataList?> findSimpleDataRowsLessThan(
     int num,
     int offset,
     int limit,
     bool descending,
   ) =>
-      caller.callServerEndpoint<_i10.SimpleDataList?>(
+      caller.callServerEndpoint<_i11.SimpleDataList?>(
         'basicDatabase',
         'findSimpleDataRowsLessThan',
         {
@@ -474,15 +482,15 @@ class _EndpointBasicDatabase extends _i1.EndpointRef {
         },
       );
 
-  _i2.Future<int?> storeObjectWithObject(_i11.ObjectWithObject object) =>
+  _i2.Future<int?> storeObjectWithObject(_i12.ObjectWithObject object) =>
       caller.callServerEndpoint<int?>(
         'basicDatabase',
         'storeObjectWithObject',
         {'object': object},
       );
 
-  _i2.Future<_i11.ObjectWithObject?> getObjectWithObject(int id) =>
-      caller.callServerEndpoint<_i11.ObjectWithObject?>(
+  _i2.Future<_i12.ObjectWithObject?> getObjectWithObject(int id) =>
+      caller.callServerEndpoint<_i12.ObjectWithObject?>(
         'basicDatabase',
         'getObjectWithObject',
         {'id': id},
@@ -573,15 +581,15 @@ class _EndpointFieldScopes extends _i1.EndpointRef {
   @override
   String get name => 'fieldScopes';
 
-  _i2.Future<void> storeObject(_i12.ObjectFieldScopes object) =>
+  _i2.Future<void> storeObject(_i13.ObjectFieldScopes object) =>
       caller.callServerEndpoint<void>(
         'fieldScopes',
         'storeObject',
         {'object': object},
       );
 
-  _i2.Future<_i12.ObjectFieldScopes?> retrieveObject() =>
-      caller.callServerEndpoint<_i12.ObjectFieldScopes?>(
+  _i2.Future<_i13.ObjectFieldScopes?> retrieveObject() =>
+      caller.callServerEndpoint<_i13.ObjectFieldScopes?>(
         'fieldScopes',
         'retrieveObject',
         {},
@@ -594,7 +602,7 @@ class _EndpointFutureCalls extends _i1.EndpointRef {
   @override
   String get name => 'futureCalls';
 
-  _i2.Future<void> makeFutureCall(_i13.SimpleData? data) =>
+  _i2.Future<void> makeFutureCall(_i14.SimpleData? data) =>
       caller.callServerEndpoint<void>(
         'futureCalls',
         'makeFutureCall',
@@ -733,34 +741,34 @@ class _EndpointListParameters extends _i1.EndpointRef {
         {'list': list},
       );
 
-  _i2.Future<List<_i13.SimpleData>> returnSimpleDataList(
-          List<_i13.SimpleData> list) =>
-      caller.callServerEndpoint<List<_i13.SimpleData>>(
+  _i2.Future<List<_i14.SimpleData>> returnSimpleDataList(
+          List<_i14.SimpleData> list) =>
+      caller.callServerEndpoint<List<_i14.SimpleData>>(
         'listParameters',
         'returnSimpleDataList',
         {'list': list},
       );
 
-  _i2.Future<List<_i13.SimpleData?>> returnSimpleDataListNullableSimpleData(
-          List<_i13.SimpleData?> list) =>
-      caller.callServerEndpoint<List<_i13.SimpleData?>>(
+  _i2.Future<List<_i14.SimpleData?>> returnSimpleDataListNullableSimpleData(
+          List<_i14.SimpleData?> list) =>
+      caller.callServerEndpoint<List<_i14.SimpleData?>>(
         'listParameters',
         'returnSimpleDataListNullableSimpleData',
         {'list': list},
       );
 
-  _i2.Future<List<_i13.SimpleData>?> returnSimpleDataListNullable(
-          List<_i13.SimpleData>? list) =>
-      caller.callServerEndpoint<List<_i13.SimpleData>?>(
+  _i2.Future<List<_i14.SimpleData>?> returnSimpleDataListNullable(
+          List<_i14.SimpleData>? list) =>
+      caller.callServerEndpoint<List<_i14.SimpleData>?>(
         'listParameters',
         'returnSimpleDataListNullable',
         {'list': list},
       );
 
-  _i2.Future<List<_i13.SimpleData?>?>
+  _i2.Future<List<_i14.SimpleData?>?>
       returnNullableSimpleDataListNullableSimpleData(
-              List<_i13.SimpleData?>? list) =>
-          caller.callServerEndpoint<List<_i13.SimpleData?>?>(
+              List<_i14.SimpleData?>? list) =>
+          caller.callServerEndpoint<List<_i14.SimpleData?>?>(
             'listParameters',
             'returnNullableSimpleDataListNullableSimpleData',
             {'list': list},
@@ -880,17 +888,17 @@ class _EndpointMapParameters extends _i1.EndpointRef {
         {'map': map},
       );
 
-  _i2.Future<Map<_i14.TestEnum, int>> returnEnumIntMap(
-          Map<_i14.TestEnum, int> map) =>
-      caller.callServerEndpoint<Map<_i14.TestEnum, int>>(
+  _i2.Future<Map<_i15.TestEnum, int>> returnEnumIntMap(
+          Map<_i15.TestEnum, int> map) =>
+      caller.callServerEndpoint<Map<_i15.TestEnum, int>>(
         'mapParameters',
         'returnEnumIntMap',
         {'map': map},
       );
 
-  _i2.Future<Map<String, _i14.TestEnum>> returnEnumMap(
-          Map<String, _i14.TestEnum> map) =>
-      caller.callServerEndpoint<Map<String, _i14.TestEnum>>(
+  _i2.Future<Map<String, _i15.TestEnum>> returnEnumMap(
+          Map<String, _i15.TestEnum> map) =>
+      caller.callServerEndpoint<Map<String, _i15.TestEnum>>(
         'mapParameters',
         'returnEnumMap',
         {'map': map},
@@ -973,35 +981,35 @@ class _EndpointMapParameters extends _i1.EndpointRef {
         {'map': map},
       );
 
-  _i2.Future<Map<String, _i13.SimpleData>> returnSimpleDataMap(
-          Map<String, _i13.SimpleData> map) =>
-      caller.callServerEndpoint<Map<String, _i13.SimpleData>>(
+  _i2.Future<Map<String, _i14.SimpleData>> returnSimpleDataMap(
+          Map<String, _i14.SimpleData> map) =>
+      caller.callServerEndpoint<Map<String, _i14.SimpleData>>(
         'mapParameters',
         'returnSimpleDataMap',
         {'map': map},
       );
 
-  _i2.Future<Map<String, _i13.SimpleData?>>
+  _i2.Future<Map<String, _i14.SimpleData?>>
       returnSimpleDataMapNullableSimpleData(
-              Map<String, _i13.SimpleData?> map) =>
-          caller.callServerEndpoint<Map<String, _i13.SimpleData?>>(
+              Map<String, _i14.SimpleData?> map) =>
+          caller.callServerEndpoint<Map<String, _i14.SimpleData?>>(
             'mapParameters',
             'returnSimpleDataMapNullableSimpleData',
             {'map': map},
           );
 
-  _i2.Future<Map<String, _i13.SimpleData>?> returnSimpleDataMapNullable(
-          Map<String, _i13.SimpleData>? map) =>
-      caller.callServerEndpoint<Map<String, _i13.SimpleData>?>(
+  _i2.Future<Map<String, _i14.SimpleData>?> returnSimpleDataMapNullable(
+          Map<String, _i14.SimpleData>? map) =>
+      caller.callServerEndpoint<Map<String, _i14.SimpleData>?>(
         'mapParameters',
         'returnSimpleDataMapNullable',
         {'map': map},
       );
 
-  _i2.Future<Map<String, _i13.SimpleData?>?>
+  _i2.Future<Map<String, _i14.SimpleData?>?>
       returnNullableSimpleDataMapNullableSimpleData(
-              Map<String, _i13.SimpleData?>? map) =>
-          caller.callServerEndpoint<Map<String, _i13.SimpleData?>?>(
+              Map<String, _i14.SimpleData?>? map) =>
+          caller.callServerEndpoint<Map<String, _i14.SimpleData?>?>(
             'mapParameters',
             'returnNullableSimpleDataMapNullableSimpleData',
             {'map': map},
@@ -1036,8 +1044,8 @@ class _EndpointModuleSerialization extends _i1.EndpointRef {
         {},
       );
 
-  _i2.Future<_i15.ModuleClass> modifyModuleObject(_i15.ModuleClass object) =>
-      caller.callServerEndpoint<_i15.ModuleClass>(
+  _i2.Future<_i16.ModuleClass> modifyModuleObject(_i16.ModuleClass object) =>
+      caller.callServerEndpoint<_i16.ModuleClass>(
         'moduleSerialization',
         'modifyModuleObject',
         {'object': object},
@@ -1103,7 +1111,7 @@ class _EndpointRedis extends _i1.EndpointRef {
 
   _i2.Future<void> setSimpleData(
     String key,
-    _i13.SimpleData data,
+    _i14.SimpleData data,
   ) =>
       caller.callServerEndpoint<void>(
         'redis',
@@ -1116,7 +1124,7 @@ class _EndpointRedis extends _i1.EndpointRef {
 
   _i2.Future<void> setSimpleDataWithLifetime(
     String key,
-    _i13.SimpleData data,
+    _i14.SimpleData data,
   ) =>
       caller.callServerEndpoint<void>(
         'redis',
@@ -1127,8 +1135,8 @@ class _EndpointRedis extends _i1.EndpointRef {
         },
       );
 
-  _i2.Future<_i13.SimpleData?> getSimpleData(String key) =>
-      caller.callServerEndpoint<_i13.SimpleData?>(
+  _i2.Future<_i14.SimpleData?> getSimpleData(String key) =>
+      caller.callServerEndpoint<_i14.SimpleData?>(
         'redis',
         'getSimpleData',
         {'key': key},
@@ -1147,8 +1155,8 @@ class _EndpointRedis extends _i1.EndpointRef {
         {},
       );
 
-  _i2.Future<_i13.SimpleData?> listenToChannel(String channel) =>
-      caller.callServerEndpoint<_i13.SimpleData?>(
+  _i2.Future<_i14.SimpleData?> listenToChannel(String channel) =>
+      caller.callServerEndpoint<_i14.SimpleData?>(
         'redis',
         'listenToChannel',
         {'channel': channel},
@@ -1156,7 +1164,7 @@ class _EndpointRedis extends _i1.EndpointRef {
 
   _i2.Future<void> postToChannel(
     String channel,
-    _i13.SimpleData data,
+    _i14.SimpleData data,
   ) =>
       caller.callServerEndpoint<void>(
         'redis',
@@ -1240,11 +1248,11 @@ class _EndpointStreamingLogging extends _i1.EndpointRef {
 
 class _Modules {
   _Modules(Client client) {
-    module = _i15.Caller(client);
+    module = _i16.Caller(client);
     auth = _i3.Caller(client);
   }
 
-  late final _i15.Caller module;
+  late final _i16.Caller module;
 
   late final _i3.Caller auth;
 }
@@ -1252,11 +1260,11 @@ class _Modules {
 class Client extends _i1.ServerpodClient {
   Client(
     String host, {
-    _i16.SecurityContext? context,
+    _i17.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
   }) : super(
           host,
-          _i17.Protocol(),
+          _i18.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
         ) {

--- a/tests/serverpod_test_client/lib/src/protocol/nullability.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/nullability.dart
@@ -26,6 +26,8 @@ class Nullability extends _i1.SerializableEntity {
     this.aNullableByteData,
     required this.aDuration,
     this.aNullableDuration,
+    required this.aUuid,
+    this.aNullableUuid,
     required this.anObject,
     this.aNullableObject,
     required this.anIntList,
@@ -48,6 +50,10 @@ class Nullability extends _i1.SerializableEntity {
     this.aNullableDurationList,
     required this.aListWithNullableDurations,
     this.aNullableListWithNullableDurations,
+    required this.aUuidList,
+    this.aNullableUuidList,
+    required this.aListWithNullableUuids,
+    this.aNullableListWithNullableUuids,
     required this.anIntMap,
     this.aNullableIntMap,
     required this.aMapWithNullableInts,
@@ -85,6 +91,10 @@ class Nullability extends _i1.SerializableEntity {
           .deserialize<Duration>(jsonSerialization['aDuration']),
       aNullableDuration: serializationManager
           .deserialize<Duration?>(jsonSerialization['aNullableDuration']),
+      aUuid: serializationManager
+          .deserialize<_i1.UuidValue>(jsonSerialization['aUuid']),
+      aNullableUuid: serializationManager
+          .deserialize<_i1.UuidValue?>(jsonSerialization['aNullableUuid']),
       anObject: serializationManager
           .deserialize<_i3.SimpleData>(jsonSerialization['anObject']),
       aNullableObject: serializationManager
@@ -140,6 +150,16 @@ class Nullability extends _i1.SerializableEntity {
       aNullableListWithNullableDurations:
           serializationManager.deserialize<List<Duration?>?>(
               jsonSerialization['aNullableListWithNullableDurations']),
+      aUuidList: serializationManager
+          .deserialize<List<_i1.UuidValue>>(jsonSerialization['aUuidList']),
+      aNullableUuidList: serializationManager.deserialize<List<_i1.UuidValue>?>(
+          jsonSerialization['aNullableUuidList']),
+      aListWithNullableUuids:
+          serializationManager.deserialize<List<_i1.UuidValue?>>(
+              jsonSerialization['aListWithNullableUuids']),
+      aNullableListWithNullableUuids:
+          serializationManager.deserialize<List<_i1.UuidValue?>?>(
+              jsonSerialization['aNullableListWithNullableUuids']),
       anIntMap: serializationManager
           .deserialize<Map<String, int>>(jsonSerialization['anIntMap']),
       aNullableIntMap: serializationManager
@@ -179,6 +199,10 @@ class Nullability extends _i1.SerializableEntity {
   Duration aDuration;
 
   Duration? aNullableDuration;
+
+  _i1.UuidValue aUuid;
+
+  _i1.UuidValue? aNullableUuid;
 
   _i3.SimpleData anObject;
 
@@ -224,6 +248,14 @@ class Nullability extends _i1.SerializableEntity {
 
   List<Duration?>? aNullableListWithNullableDurations;
 
+  List<_i1.UuidValue> aUuidList;
+
+  List<_i1.UuidValue>? aNullableUuidList;
+
+  List<_i1.UuidValue?> aListWithNullableUuids;
+
+  List<_i1.UuidValue?>? aNullableListWithNullableUuids;
+
   Map<String, int> anIntMap;
 
   Map<String, int>? aNullableIntMap;
@@ -249,6 +281,8 @@ class Nullability extends _i1.SerializableEntity {
       'aNullableByteData': aNullableByteData,
       'aDuration': aDuration,
       'aNullableDuration': aNullableDuration,
+      'aUuid': aUuid,
+      'aNullableUuid': aNullableUuid,
       'anObject': anObject,
       'aNullableObject': aNullableObject,
       'anIntList': anIntList,
@@ -271,6 +305,10 @@ class Nullability extends _i1.SerializableEntity {
       'aNullableDurationList': aNullableDurationList,
       'aListWithNullableDurations': aListWithNullableDurations,
       'aNullableListWithNullableDurations': aNullableListWithNullableDurations,
+      'aUuidList': aUuidList,
+      'aNullableUuidList': aNullableUuidList,
+      'aListWithNullableUuids': aListWithNullableUuids,
+      'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
       'anIntMap': anIntMap,
       'aNullableIntMap': aNullableIntMap,
       'aMapWithNullableInts': aMapWithNullableInts,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
@@ -18,12 +18,14 @@ class ObjectWithMaps extends _i1.SerializableEntity {
     required this.dateTimeMap,
     required this.byteDataMap,
     required this.durationMap,
+    required this.uuidMap,
     required this.nullableDataMap,
     required this.nullableIntMap,
     required this.nullableStringMap,
     required this.nullableDateTimeMap,
     required this.nullableByteDataMap,
     required this.nullableDurationMap,
+    required this.nullableUuidMap,
     required this.intIntMap,
   });
 
@@ -44,6 +46,8 @@ class ObjectWithMaps extends _i1.SerializableEntity {
           jsonSerialization['byteDataMap']),
       durationMap: serializationManager
           .deserialize<Map<String, Duration>>(jsonSerialization['durationMap']),
+      uuidMap: serializationManager.deserialize<Map<String, _i1.UuidValue>>(
+          jsonSerialization['uuidMap']),
       nullableDataMap:
           serializationManager.deserialize<Map<String, _i2.SimpleData?>>(
               jsonSerialization['nullableDataMap']),
@@ -60,6 +64,9 @@ class ObjectWithMaps extends _i1.SerializableEntity {
       nullableDurationMap:
           serializationManager.deserialize<Map<String, Duration?>>(
               jsonSerialization['nullableDurationMap']),
+      nullableUuidMap:
+          serializationManager.deserialize<Map<String, _i1.UuidValue?>>(
+              jsonSerialization['nullableUuidMap']),
       intIntMap: serializationManager
           .deserialize<Map<int, int>>(jsonSerialization['intIntMap']),
     );
@@ -77,6 +84,8 @@ class ObjectWithMaps extends _i1.SerializableEntity {
 
   Map<String, Duration> durationMap;
 
+  Map<String, _i1.UuidValue> uuidMap;
+
   Map<String, _i2.SimpleData?> nullableDataMap;
 
   Map<String, int?> nullableIntMap;
@@ -89,6 +98,8 @@ class ObjectWithMaps extends _i1.SerializableEntity {
 
   Map<String, Duration?> nullableDurationMap;
 
+  Map<String, _i1.UuidValue?> nullableUuidMap;
+
   Map<int, int> intIntMap;
 
   @override
@@ -100,12 +111,14 @@ class ObjectWithMaps extends _i1.SerializableEntity {
       'dateTimeMap': dateTimeMap,
       'byteDataMap': byteDataMap,
       'durationMap': durationMap,
+      'uuidMap': uuidMap,
       'nullableDataMap': nullableDataMap,
       'nullableIntMap': nullableIntMap,
       'nullableStringMap': nullableStringMap,
       'nullableDateTimeMap': nullableDateTimeMap,
       'nullableByteDataMap': nullableByteDataMap,
       'nullableDurationMap': nullableDurationMap,
+      'nullableUuidMap': nullableUuidMap,
       'intIntMap': intIntMap,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
@@ -1,0 +1,48 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+class ObjectWithUuid extends _i1.SerializableEntity {
+  ObjectWithUuid({
+    this.id,
+    required this.uuid,
+    this.uuidNullable,
+  });
+
+  factory ObjectWithUuid.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ObjectWithUuid(
+      id: serializationManager.deserialize<int?>(jsonSerialization['id']),
+      uuid: serializationManager
+          .deserialize<_i1.UuidValue>(jsonSerialization['uuid']),
+      uuidNullable: serializationManager
+          .deserialize<_i1.UuidValue?>(jsonSerialization['uuidNullable']),
+    );
+  }
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  int? id;
+
+  _i1.UuidValue uuid;
+
+  _i1.UuidValue? uuidNullable;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -15,18 +15,19 @@ import 'object_with_duration.dart' as _i5;
 import 'object_with_enum.dart' as _i6;
 import 'object_with_maps.dart' as _i7;
 import 'object_with_object.dart' as _i8;
-import 'simple_data.dart' as _i9;
-import 'simple_data_list.dart' as _i10;
-import 'test_enum.dart' as _i11;
-import 'types.dart' as _i12;
-import 'protocol.dart' as _i13;
-import 'dart:typed_data' as _i14;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i15;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i16;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i17;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i18;
-import 'package:serverpod_test_module_client/module.dart' as _i19;
-import 'package:serverpod_auth_client/module.dart' as _i20;
+import 'object_with_uuid.dart' as _i9;
+import 'simple_data.dart' as _i10;
+import 'simple_data_list.dart' as _i11;
+import 'test_enum.dart' as _i12;
+import 'types.dart' as _i13;
+import 'protocol.dart' as _i14;
+import 'dart:typed_data' as _i15;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i16;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i17;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i18;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i19;
+import 'package:serverpod_test_module_client/module.dart' as _i20;
+import 'package:serverpod_auth_client/module.dart' as _i21;
 export 'nullability.dart';
 export 'object_field_scopes.dart';
 export 'object_with_bytedata.dart';
@@ -34,6 +35,7 @@ export 'object_with_duration.dart';
 export 'object_with_enum.dart';
 export 'object_with_maps.dart';
 export 'object_with_object.dart';
+export 'object_with_uuid.dart';
 export 'simple_data.dart';
 export 'simple_data_list.dart';
 export 'test_enum.dart';
@@ -79,17 +81,20 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i8.ObjectWithObject) {
       return _i8.ObjectWithObject.fromJson(data, this) as T;
     }
-    if (t == _i9.SimpleData) {
-      return _i9.SimpleData.fromJson(data, this) as T;
+    if (t == _i9.ObjectWithUuid) {
+      return _i9.ObjectWithUuid.fromJson(data, this) as T;
     }
-    if (t == _i10.SimpleDataList) {
-      return _i10.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i10.SimpleData) {
+      return _i10.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i11.TestEnum) {
-      return _i11.TestEnum.fromJson(data) as T;
+    if (t == _i11.SimpleDataList) {
+      return _i11.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i12.Types) {
-      return _i12.Types.fromJson(data, this) as T;
+    if (t == _i12.TestEnum) {
+      return _i12.TestEnum.fromJson(data) as T;
+    }
+    if (t == _i13.Types) {
+      return _i13.Types.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.Nullability?>()) {
       return (data != null ? _i2.Nullability.fromJson(data, this) : null) as T;
@@ -118,18 +123,22 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i8.ObjectWithObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i9.SimpleData?>()) {
-      return (data != null ? _i9.SimpleData.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i10.SimpleDataList?>()) {
-      return (data != null ? _i10.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i9.ObjectWithUuid?>()) {
+      return (data != null ? _i9.ObjectWithUuid.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i11.TestEnum?>()) {
-      return (data != null ? _i11.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i10.SimpleData?>()) {
+      return (data != null ? _i10.SimpleData.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i12.Types?>()) {
-      return (data != null ? _i12.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i11.SimpleDataList?>()) {
+      return (data != null ? _i11.SimpleDataList.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i12.TestEnum?>()) {
+      return (data != null ? _i12.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i13.Types?>()) {
+      return (data != null ? _i13.Types.fromJson(data, this) : null) as T;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
@@ -148,23 +157,23 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+    if (t == List<_i14.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData?>) {
+    if (t == List<_i14.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i13.SimpleData?>(e))
+          .map((e) => deserialize<_i14.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -185,22 +194,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -219,6 +228,24 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<List<Duration?>?>()) {
       return (data != null
           ? (data as List).map((e) => deserialize<Duration?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<_i1.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<_i1.UuidValue?>) {
+      return (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<_i1.UuidValue?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
           : null) as dynamic;
     }
     if (t == Map<String, int>) {
@@ -243,22 +270,22 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i13.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum>(e)).toList()
+    if (t == List<_i14.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i13.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum?>(e)).toList()
+    if (t == List<_i14.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i13.TestEnum>>) {
+    if (t == List<List<_i14.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i13.TestEnum>>(e))
+          .map((e) => deserialize<List<_i14.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData>) {
+    if (t == Map<String, _i14.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i13.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i14.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -270,9 +297,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -280,9 +307,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData?>) {
+    if (t == Map<String, _i1.UuidValue>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i14.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i13.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i14.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -293,9 +325,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -303,19 +335,24 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
+    if (t == Map<String, _i1.UuidValue?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue?>(v)))
+          as dynamic;
+    }
     if (t == Map<int, int>) {
       return Map.fromEntries((data as List).map((e) =>
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<int>) {
@@ -405,41 +442,41 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+    if (t == List<_i16.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData?>) {
+    if (t == List<_i16.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i15.SimpleData?>(e))
+          .map((e) => deserialize<_i16.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -493,14 +530,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i16.TestEnum, int>) {
+    if (t == Map<_i17.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i16.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i17.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i16.TestEnum>) {
+    if (t == Map<String, _i17.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i16.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i17.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -539,47 +576,47 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData>) {
+    if (t == Map<String, _i16.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData?>) {
+    if (t == Map<String, _i16.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i15.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i16.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -592,33 +629,33 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == _i17.CustomClass) {
-      return _i17.CustomClass.fromJson(data, this) as T;
+    if (t == _i18.CustomClass) {
+      return _i18.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.ExternalCustomClass) {
-      return _i18.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i19.ExternalCustomClass) {
+      return _i19.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.FreezedCustomClass) {
-      return _i18.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i19.FreezedCustomClass) {
+      return _i19.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i17.CustomClass?>()) {
-      return (data != null ? _i17.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i18.CustomClass?>()) {
+      return (data != null ? _i18.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i18.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i19.ExternalCustomClass?>()) {
       return (data != null
-          ? _i18.ExternalCustomClass.fromJson(data, this)
+          ? _i19.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i18.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i19.FreezedCustomClass?>()) {
       return (data != null
-          ? _i18.FreezedCustomClass.fromJson(data, this)
+          ? _i19.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
-    try {
-      return _i19.Protocol().deserialize<T>(data, t);
-    } catch (_) {}
     try {
       return _i20.Protocol().deserialize<T>(data, t);
+    } catch (_) {}
+    try {
+      return _i21.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -626,21 +663,21 @@ class Protocol extends _i1.SerializationManager {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i19.Protocol().getClassNameForObject(data);
+    className = _i20.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    className = _i20.Protocol().getClassNameForObject(data);
+    className = _i21.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i17.CustomClass) {
+    if (data is _i18.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i18.ExternalCustomClass) {
+    if (data is _i19.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i18.FreezedCustomClass) {
+    if (data is _i19.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.Nullability) {
@@ -664,16 +701,19 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i8.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i9.SimpleData) {
+    if (data is _i9.ObjectWithUuid) {
+      return 'ObjectWithUuid';
+    }
+    if (data is _i10.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i10.SimpleDataList) {
+    if (data is _i11.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i11.TestEnum) {
+    if (data is _i12.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i12.Types) {
+    if (data is _i13.Types) {
       return 'Types';
     }
     return super.getClassNameForObject(data);
@@ -683,20 +723,20 @@ class Protocol extends _i1.SerializationManager {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i19.Protocol().deserializeByClassName(data);
+      return _i20.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i20.Protocol().deserializeByClassName(data);
+      return _i21.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i17.CustomClass>(data['data']);
+      return deserialize<_i18.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i18.ExternalCustomClass>(data['data']);
+      return deserialize<_i19.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i18.FreezedCustomClass>(data['data']);
+      return deserialize<_i19.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'Nullability') {
       return deserialize<_i2.Nullability>(data['data']);
@@ -719,17 +759,20 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'ObjectWithObject') {
       return deserialize<_i8.ObjectWithObject>(data['data']);
     }
+    if (data['className'] == 'ObjectWithUuid') {
+      return deserialize<_i9.ObjectWithUuid>(data['data']);
+    }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i9.SimpleData>(data['data']);
+      return deserialize<_i10.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i10.SimpleDataList>(data['data']);
+      return deserialize<_i11.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i11.TestEnum>(data['data']);
+      return deserialize<_i12.TestEnum>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i12.Types>(data['data']);
+      return deserialize<_i13.Types>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -19,6 +19,7 @@ class Types extends _i1.SerializableEntity {
     this.aString,
     this.aByteData,
     this.aDuration,
+    this.aUuid,
   });
 
   factory Types.fromJson(
@@ -40,6 +41,8 @@ class Types extends _i1.SerializableEntity {
           .deserialize<_i2.ByteData?>(jsonSerialization['aByteData']),
       aDuration: serializationManager
           .deserialize<Duration?>(jsonSerialization['aDuration']),
+      aUuid: serializationManager
+          .deserialize<_i1.UuidValue?>(jsonSerialization['aUuid']),
     );
   }
 
@@ -62,6 +65,8 @@ class Types extends _i1.SerializableEntity {
 
   Duration? aDuration;
 
+  _i1.UuidValue? aUuid;
+
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -73,6 +78,7 @@ class Types extends _i1.SerializableEntity {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 }

--- a/tests/serverpod_test_server/generated/protocol.yaml
+++ b/tests/serverpod_test_server/generated/protocol.yaml
@@ -15,6 +15,7 @@ basicTypes:
   - testString:
   - testByteData:
   - testDuration:
+  - testUuid:
 cloudStorage:
   - reset:
   - storePublicFile:

--- a/tests/serverpod_test_server/generated/tables.pgsql
+++ b/tests/serverpod_test_server/generated/tables.pgsql
@@ -74,6 +74,20 @@ ALTER TABLE ONLY "object_with_object"
 
 
 --
+-- Class ObjectWithUuid as table object_with_uuid
+--
+
+CREATE TABLE "object_with_uuid" (
+  "id" serial,
+  "uuid" uuid NOT NULL,
+  "uuidNullable" uuid
+);
+
+ALTER TABLE ONLY "object_with_uuid"
+  ADD CONSTRAINT object_with_uuid_pkey PRIMARY KEY (id);
+
+
+--
 -- Class SimpleData as table simple_data
 --
 
@@ -98,7 +112,8 @@ CREATE TABLE "types" (
   "aDateTime" timestamp without time zone,
   "aString" text,
   "aByteData" bytea,
-  "aDuration" bigint
+  "aDuration" bigint,
+  "aUuid" uuid
 );
 
 ALTER TABLE ONLY "types"

--- a/tests/serverpod_test_server/lib/src/endpoints/basic_types.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/basic_types.dart
@@ -29,4 +29,8 @@ class BasicTypesEndpoint extends Endpoint {
   Future<Duration?> testDuration(Session session, Duration? value) async {
     return value;
   }
+
+  Future<UuidValue?> testUuid(Session session, UuidValue? value) async {
+    return value;
+  }
 }

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -31,20 +31,21 @@ import '../endpoints/simple.dart' as _i22;
 import '../endpoints/streaming.dart' as _i23;
 import '../endpoints/streaming_logging.dart' as _i24;
 import 'dart:typed_data' as _i25;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i26;
-import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i27;
-import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i28;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i29;
+import 'package:uuid/uuid.dart' as _i26;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i27;
+import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i28;
+import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i29;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i30;
 import 'package:serverpod_test_server/src/generated/object_with_enum.dart'
-    as _i30;
-import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i31;
-import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i32;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i33;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i34;
-import 'package:serverpod_test_module_server/module.dart' as _i35;
-import 'package:serverpod_auth_server/module.dart' as _i36;
+import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+    as _i33;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i34;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i35;
+import 'package:serverpod_test_module_server/module.dart' as _i36;
+import 'package:serverpod_auth_server/module.dart' as _i37;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -455,6 +456,24 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
+        'testUuid': _i1.MethodConnector(
+          name: 'testUuid',
+          params: {
+            'value': _i1.ParameterDescription(
+              name: 'value',
+              type: _i1.getType<_i26.UuidValue?>(),
+              nullable: true,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['basicTypes'] as _i4.BasicTypesEndpoint).testUuid(
+            session,
+            params['value'],
+          ),
+        ),
       },
     );
     connectors['cloudStorage'] = _i1.EndpointConnector(
@@ -766,7 +785,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i26.CustomClass>(),
+              type: _i1.getType<_i27.CustomClass>(),
               nullable: false,
             )
           },
@@ -785,7 +804,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i26.CustomClass?>(),
+              type: _i1.getType<_i27.CustomClass?>(),
               nullable: true,
             )
           },
@@ -804,7 +823,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i26.CustomClass2>(),
+              type: _i1.getType<_i27.CustomClass2>(),
               nullable: false,
             )
           },
@@ -823,7 +842,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i26.CustomClass2?>(),
+              type: _i1.getType<_i27.CustomClass2?>(),
               nullable: true,
             )
           },
@@ -842,7 +861,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i27.ExternalCustomClass>(),
+              type: _i1.getType<_i28.ExternalCustomClass>(),
               nullable: false,
             )
           },
@@ -861,7 +880,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i27.ExternalCustomClass?>(),
+              type: _i1.getType<_i28.ExternalCustomClass?>(),
               nullable: true,
             )
           },
@@ -880,7 +899,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i28.FreezedCustomClass>(),
+              type: _i1.getType<_i29.FreezedCustomClass>(),
               nullable: false,
             )
           },
@@ -899,7 +918,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i28.FreezedCustomClass?>(),
+              type: _i1.getType<_i29.FreezedCustomClass?>(),
               nullable: true,
             )
           },
@@ -924,7 +943,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'types': _i1.ParameterDescription(
               name: 'types',
-              type: _i1.getType<_i29.Types>(),
+              type: _i1.getType<_i30.Types>(),
               nullable: false,
             )
           },
@@ -960,7 +979,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i30.ObjectWithEnum>(),
+              type: _i1.getType<_i31.ObjectWithEnum>(),
               nullable: false,
             )
           },
@@ -1176,7 +1195,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i31.ObjectWithObject>(),
+              type: _i1.getType<_i32.ObjectWithObject>(),
               nullable: false,
             )
           },
@@ -1354,7 +1373,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i32.ObjectFieldScopes>(),
+              type: _i1.getType<_i33.ObjectFieldScopes>(),
               nullable: false,
             )
           },
@@ -1389,7 +1408,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.SimpleData?>(),
+              type: _i1.getType<_i34.SimpleData?>(),
               nullable: true,
             )
           },
@@ -1737,7 +1756,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i33.SimpleData>>(),
+              type: _i1.getType<List<_i34.SimpleData>>(),
               nullable: false,
             )
           },
@@ -1756,7 +1775,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i33.SimpleData?>>(),
+              type: _i1.getType<List<_i34.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -1775,7 +1794,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i33.SimpleData>?>(),
+              type: _i1.getType<List<_i34.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -1794,7 +1813,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i33.SimpleData?>?>(),
+              type: _i1.getType<List<_i34.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -2061,7 +2080,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<_i34.TestEnum, int>>(),
+              type: _i1.getType<Map<_i35.TestEnum, int>>(),
               nullable: false,
             )
           },
@@ -2080,7 +2099,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i34.TestEnum>>(),
+              type: _i1.getType<Map<String, _i35.TestEnum>>(),
               nullable: false,
             )
           },
@@ -2289,7 +2308,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i33.SimpleData>>(),
+              type: _i1.getType<Map<String, _i34.SimpleData>>(),
               nullable: false,
             )
           },
@@ -2308,7 +2327,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i33.SimpleData?>>(),
+              type: _i1.getType<Map<String, _i34.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -2327,7 +2346,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i33.SimpleData>?>(),
+              type: _i1.getType<Map<String, _i34.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -2346,7 +2365,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i33.SimpleData?>?>(),
+              type: _i1.getType<Map<String, _i34.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -2420,7 +2439,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i35.ModuleClass>(),
+              type: _i1.getType<_i36.ModuleClass>(),
               nullable: false,
             )
           },
@@ -2545,7 +2564,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.SimpleData>(),
+              type: _i1.getType<_i34.SimpleData>(),
               nullable: false,
             ),
           },
@@ -2569,7 +2588,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.SimpleData>(),
+              type: _i1.getType<_i34.SimpleData>(),
               nullable: false,
             ),
           },
@@ -2658,7 +2677,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.SimpleData>(),
+              type: _i1.getType<_i34.SimpleData>(),
               nullable: false,
             ),
           },
@@ -2760,8 +2779,8 @@ class Endpoints extends _i1.EndpointDispatch {
       endpoint: endpoints['streamingLogging']!,
       methodConnectors: {},
     );
-    modules['serverpod_test_module'] = _i35.Endpoints()
+    modules['serverpod_test_module'] = _i36.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth'] = _i36.Endpoints()..initializeEndpoints(server);
+    modules['serverpod_auth'] = _i37.Endpoints()..initializeEndpoints(server);
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
@@ -50,4 +50,14 @@ class ExceptionWithData extends _i1.SerializableEntity
       'someNullableField': someNullableField,
     };
   }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'message': message,
+      'creationDate': creationDate,
+      'errorFields': errorFields,
+      'someNullableField': someNullableField,
+    };
+  }
 }

--- a/tests/serverpod_test_server/lib/src/generated/nullability.dart
+++ b/tests/serverpod_test_server/lib/src/generated/nullability.dart
@@ -26,6 +26,8 @@ class Nullability extends _i1.SerializableEntity {
     this.aNullableByteData,
     required this.aDuration,
     this.aNullableDuration,
+    required this.aUuid,
+    this.aNullableUuid,
     required this.anObject,
     this.aNullableObject,
     required this.anIntList,
@@ -48,6 +50,10 @@ class Nullability extends _i1.SerializableEntity {
     this.aNullableDurationList,
     required this.aListWithNullableDurations,
     this.aNullableListWithNullableDurations,
+    required this.aUuidList,
+    this.aNullableUuidList,
+    required this.aListWithNullableUuids,
+    this.aNullableListWithNullableUuids,
     required this.anIntMap,
     this.aNullableIntMap,
     required this.aMapWithNullableInts,
@@ -85,6 +91,10 @@ class Nullability extends _i1.SerializableEntity {
           .deserialize<Duration>(jsonSerialization['aDuration']),
       aNullableDuration: serializationManager
           .deserialize<Duration?>(jsonSerialization['aNullableDuration']),
+      aUuid: serializationManager
+          .deserialize<_i1.UuidValue>(jsonSerialization['aUuid']),
+      aNullableUuid: serializationManager
+          .deserialize<_i1.UuidValue?>(jsonSerialization['aNullableUuid']),
       anObject: serializationManager
           .deserialize<_i3.SimpleData>(jsonSerialization['anObject']),
       aNullableObject: serializationManager
@@ -140,6 +150,16 @@ class Nullability extends _i1.SerializableEntity {
       aNullableListWithNullableDurations:
           serializationManager.deserialize<List<Duration?>?>(
               jsonSerialization['aNullableListWithNullableDurations']),
+      aUuidList: serializationManager
+          .deserialize<List<_i1.UuidValue>>(jsonSerialization['aUuidList']),
+      aNullableUuidList: serializationManager.deserialize<List<_i1.UuidValue>?>(
+          jsonSerialization['aNullableUuidList']),
+      aListWithNullableUuids:
+          serializationManager.deserialize<List<_i1.UuidValue?>>(
+              jsonSerialization['aListWithNullableUuids']),
+      aNullableListWithNullableUuids:
+          serializationManager.deserialize<List<_i1.UuidValue?>?>(
+              jsonSerialization['aNullableListWithNullableUuids']),
       anIntMap: serializationManager
           .deserialize<Map<String, int>>(jsonSerialization['anIntMap']),
       aNullableIntMap: serializationManager
@@ -179,6 +199,10 @@ class Nullability extends _i1.SerializableEntity {
   Duration aDuration;
 
   Duration? aNullableDuration;
+
+  _i1.UuidValue aUuid;
+
+  _i1.UuidValue? aNullableUuid;
 
   _i3.SimpleData anObject;
 
@@ -224,6 +248,14 @@ class Nullability extends _i1.SerializableEntity {
 
   List<Duration?>? aNullableListWithNullableDurations;
 
+  List<_i1.UuidValue> aUuidList;
+
+  List<_i1.UuidValue>? aNullableUuidList;
+
+  List<_i1.UuidValue?> aListWithNullableUuids;
+
+  List<_i1.UuidValue?>? aNullableListWithNullableUuids;
+
   Map<String, int> anIntMap;
 
   Map<String, int>? aNullableIntMap;
@@ -249,6 +281,8 @@ class Nullability extends _i1.SerializableEntity {
       'aNullableByteData': aNullableByteData,
       'aDuration': aDuration,
       'aNullableDuration': aNullableDuration,
+      'aUuid': aUuid,
+      'aNullableUuid': aNullableUuid,
       'anObject': anObject,
       'aNullableObject': aNullableObject,
       'anIntList': anIntList,
@@ -271,6 +305,10 @@ class Nullability extends _i1.SerializableEntity {
       'aNullableDurationList': aNullableDurationList,
       'aListWithNullableDurations': aListWithNullableDurations,
       'aNullableListWithNullableDurations': aNullableListWithNullableDurations,
+      'aUuidList': aUuidList,
+      'aNullableUuidList': aNullableUuidList,
+      'aListWithNullableUuids': aListWithNullableUuids,
+      'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
       'anIntMap': anIntMap,
       'aNullableIntMap': aNullableIntMap,
       'aMapWithNullableInts': aMapWithNullableInts,
@@ -295,6 +333,8 @@ class Nullability extends _i1.SerializableEntity {
       'aNullableByteData': aNullableByteData,
       'aDuration': aDuration,
       'aNullableDuration': aNullableDuration,
+      'aUuid': aUuid,
+      'aNullableUuid': aNullableUuid,
       'anObject': anObject,
       'aNullableObject': aNullableObject,
       'anIntList': anIntList,
@@ -317,6 +357,10 @@ class Nullability extends _i1.SerializableEntity {
       'aNullableDurationList': aNullableDurationList,
       'aListWithNullableDurations': aListWithNullableDurations,
       'aNullableListWithNullableDurations': aNullableListWithNullableDurations,
+      'aUuidList': aUuidList,
+      'aNullableUuidList': aNullableUuidList,
+      'aListWithNullableUuids': aListWithNullableUuids,
+      'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
       'anIntMap': anIntMap,
       'aNullableIntMap': aNullableIntMap,
       'aMapWithNullableInts': aMapWithNullableInts,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
@@ -18,12 +18,14 @@ class ObjectWithMaps extends _i1.SerializableEntity {
     required this.dateTimeMap,
     required this.byteDataMap,
     required this.durationMap,
+    required this.uuidMap,
     required this.nullableDataMap,
     required this.nullableIntMap,
     required this.nullableStringMap,
     required this.nullableDateTimeMap,
     required this.nullableByteDataMap,
     required this.nullableDurationMap,
+    required this.nullableUuidMap,
     required this.intIntMap,
   });
 
@@ -44,6 +46,8 @@ class ObjectWithMaps extends _i1.SerializableEntity {
           jsonSerialization['byteDataMap']),
       durationMap: serializationManager
           .deserialize<Map<String, Duration>>(jsonSerialization['durationMap']),
+      uuidMap: serializationManager.deserialize<Map<String, _i1.UuidValue>>(
+          jsonSerialization['uuidMap']),
       nullableDataMap:
           serializationManager.deserialize<Map<String, _i2.SimpleData?>>(
               jsonSerialization['nullableDataMap']),
@@ -60,6 +64,9 @@ class ObjectWithMaps extends _i1.SerializableEntity {
       nullableDurationMap:
           serializationManager.deserialize<Map<String, Duration?>>(
               jsonSerialization['nullableDurationMap']),
+      nullableUuidMap:
+          serializationManager.deserialize<Map<String, _i1.UuidValue?>>(
+              jsonSerialization['nullableUuidMap']),
       intIntMap: serializationManager
           .deserialize<Map<int, int>>(jsonSerialization['intIntMap']),
     );
@@ -77,6 +84,8 @@ class ObjectWithMaps extends _i1.SerializableEntity {
 
   Map<String, Duration> durationMap;
 
+  Map<String, _i1.UuidValue> uuidMap;
+
   Map<String, _i2.SimpleData?> nullableDataMap;
 
   Map<String, int?> nullableIntMap;
@@ -89,6 +98,8 @@ class ObjectWithMaps extends _i1.SerializableEntity {
 
   Map<String, Duration?> nullableDurationMap;
 
+  Map<String, _i1.UuidValue?> nullableUuidMap;
+
   Map<int, int> intIntMap;
 
   @override
@@ -100,12 +111,14 @@ class ObjectWithMaps extends _i1.SerializableEntity {
       'dateTimeMap': dateTimeMap,
       'byteDataMap': byteDataMap,
       'durationMap': durationMap,
+      'uuidMap': uuidMap,
       'nullableDataMap': nullableDataMap,
       'nullableIntMap': nullableIntMap,
       'nullableStringMap': nullableStringMap,
       'nullableDateTimeMap': nullableDateTimeMap,
       'nullableByteDataMap': nullableByteDataMap,
       'nullableDurationMap': nullableDurationMap,
+      'nullableUuidMap': nullableUuidMap,
       'intIntMap': intIntMap,
     };
   }
@@ -119,12 +132,14 @@ class ObjectWithMaps extends _i1.SerializableEntity {
       'dateTimeMap': dateTimeMap,
       'byteDataMap': byteDataMap,
       'durationMap': durationMap,
+      'uuidMap': uuidMap,
       'nullableDataMap': nullableDataMap,
       'nullableIntMap': nullableIntMap,
       'nullableStringMap': nullableStringMap,
       'nullableDateTimeMap': nullableDateTimeMap,
       'nullableByteDataMap': nullableByteDataMap,
       'nullableDurationMap': nullableDurationMap,
+      'nullableUuidMap': nullableUuidMap,
       'intIntMap': intIntMap,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -1,0 +1,219 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+class ObjectWithUuid extends _i1.TableRow {
+  ObjectWithUuid({
+    int? id,
+    required this.uuid,
+    this.uuidNullable,
+  }) : super(id);
+
+  factory ObjectWithUuid.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ObjectWithUuid(
+      id: serializationManager.deserialize<int?>(jsonSerialization['id']),
+      uuid: serializationManager
+          .deserialize<_i1.UuidValue>(jsonSerialization['uuid']),
+      uuidNullable: serializationManager
+          .deserialize<_i1.UuidValue?>(jsonSerialization['uuidNullable']),
+    );
+  }
+
+  static final t = ObjectWithUuidTable();
+
+  _i1.UuidValue uuid;
+
+  _i1.UuidValue? uuidNullable;
+
+  @override
+  String get tableName => 'object_with_uuid';
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForDatabase() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
+    };
+  }
+
+  @override
+  void setColumn(
+    String columnName,
+    value,
+  ) {
+    switch (columnName) {
+      case 'id':
+        id = value;
+        return;
+      case 'uuid':
+        uuid = value;
+        return;
+      case 'uuidNullable':
+        uuidNullable = value;
+        return;
+      default:
+        throw UnimplementedError();
+    }
+  }
+
+  static Future<List<ObjectWithUuid>> find(
+    _i1.Session session, {
+    ObjectWithUuidExpressionBuilder? where,
+    int? limit,
+    int? offset,
+    _i1.Column? orderBy,
+    List<_i1.Order>? orderByList,
+    bool orderDescending = false,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.find<ObjectWithUuid>(
+      where: where != null ? where(ObjectWithUuid.t) : null,
+      limit: limit,
+      offset: offset,
+      orderBy: orderBy,
+      orderByList: orderByList,
+      orderDescending: orderDescending,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+
+  static Future<ObjectWithUuid?> findSingleRow(
+    _i1.Session session, {
+    ObjectWithUuidExpressionBuilder? where,
+    int? offset,
+    _i1.Column? orderBy,
+    bool orderDescending = false,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.findSingleRow<ObjectWithUuid>(
+      where: where != null ? where(ObjectWithUuid.t) : null,
+      offset: offset,
+      orderBy: orderBy,
+      orderDescending: orderDescending,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+
+  static Future<ObjectWithUuid?> findById(
+    _i1.Session session,
+    int id,
+  ) async {
+    return session.db.findById<ObjectWithUuid>(id);
+  }
+
+  static Future<int> delete(
+    _i1.Session session, {
+    required ObjectWithUuidExpressionBuilder where,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.delete<ObjectWithUuid>(
+      where: where(ObjectWithUuid.t),
+      transaction: transaction,
+    );
+  }
+
+  static Future<bool> deleteRow(
+    _i1.Session session,
+    ObjectWithUuid row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.deleteRow(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<bool> update(
+    _i1.Session session,
+    ObjectWithUuid row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.update(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<void> insert(
+    _i1.Session session,
+    ObjectWithUuid row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.insert(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<int> count(
+    _i1.Session session, {
+    ObjectWithUuidExpressionBuilder? where,
+    int? limit,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.count<ObjectWithUuid>(
+      where: where != null ? where(ObjectWithUuid.t) : null,
+      limit: limit,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+}
+
+typedef ObjectWithUuidExpressionBuilder = _i1.Expression Function(
+    ObjectWithUuidTable);
+
+class ObjectWithUuidTable extends _i1.Table {
+  ObjectWithUuidTable() : super(tableName: 'object_with_uuid');
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  final id = _i1.ColumnInt('id');
+
+  final uuid = _i1.ColumnUuid('uuid');
+
+  final uuidNullable = _i1.ColumnUuid('uuidNullable');
+
+  @override
+  List<_i1.Column> get columns => [
+        id,
+        uuid,
+        uuidNullable,
+      ];
+}
+
+@Deprecated('Use ObjectWithUuidTable.t instead.')
+ObjectWithUuidTable tObjectWithUuid = ObjectWithUuidTable();

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -15,19 +15,20 @@ import 'object_with_duration.dart' as _i5;
 import 'object_with_enum.dart' as _i6;
 import 'object_with_maps.dart' as _i7;
 import 'object_with_object.dart' as _i8;
-import 'simple_data.dart' as _i9;
-import 'simple_data_list.dart' as _i10;
-import 'test_enum.dart' as _i11;
-import 'types.dart' as _i12;
-import 'protocol.dart' as _i13;
-import 'dart:typed_data' as _i14;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i15;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i16;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i17;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i18;
-import 'package:serverpod_test_module_server/module.dart' as _i19;
-import 'package:serverpod_auth_server/module.dart' as _i20;
-import 'package:serverpod/protocol.dart' as _i21;
+import 'object_with_uuid.dart' as _i9;
+import 'simple_data.dart' as _i10;
+import 'simple_data_list.dart' as _i11;
+import 'test_enum.dart' as _i12;
+import 'types.dart' as _i13;
+import 'protocol.dart' as _i14;
+import 'dart:typed_data' as _i15;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i16;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i17;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i18;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i19;
+import 'package:serverpod_test_module_server/module.dart' as _i20;
+import 'package:serverpod_auth_server/module.dart' as _i21;
+import 'package:serverpod/protocol.dart' as _i22;
 export 'nullability.dart';
 export 'object_field_scopes.dart';
 export 'object_with_bytedata.dart';
@@ -35,6 +36,7 @@ export 'object_with_duration.dart';
 export 'object_with_enum.dart';
 export 'object_with_maps.dart';
 export 'object_with_object.dart';
+export 'object_with_uuid.dart';
 export 'simple_data.dart';
 export 'simple_data_list.dart';
 export 'test_enum.dart';
@@ -79,17 +81,20 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i8.ObjectWithObject) {
       return _i8.ObjectWithObject.fromJson(data, this) as T;
     }
-    if (t == _i9.SimpleData) {
-      return _i9.SimpleData.fromJson(data, this) as T;
+    if (t == _i9.ObjectWithUuid) {
+      return _i9.ObjectWithUuid.fromJson(data, this) as T;
     }
-    if (t == _i10.SimpleDataList) {
-      return _i10.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i10.SimpleData) {
+      return _i10.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i11.TestEnum) {
-      return _i11.TestEnum.fromJson(data) as T;
+    if (t == _i11.SimpleDataList) {
+      return _i11.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i12.Types) {
-      return _i12.Types.fromJson(data, this) as T;
+    if (t == _i12.TestEnum) {
+      return _i12.TestEnum.fromJson(data) as T;
+    }
+    if (t == _i13.Types) {
+      return _i13.Types.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.Nullability?>()) {
       return (data != null ? _i2.Nullability.fromJson(data, this) : null) as T;
@@ -118,18 +123,22 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i8.ObjectWithObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i9.SimpleData?>()) {
-      return (data != null ? _i9.SimpleData.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i10.SimpleDataList?>()) {
-      return (data != null ? _i10.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i9.ObjectWithUuid?>()) {
+      return (data != null ? _i9.ObjectWithUuid.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i11.TestEnum?>()) {
-      return (data != null ? _i11.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i10.SimpleData?>()) {
+      return (data != null ? _i10.SimpleData.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i12.Types?>()) {
-      return (data != null ? _i12.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i11.SimpleDataList?>()) {
+      return (data != null ? _i11.SimpleDataList.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i12.TestEnum?>()) {
+      return (data != null ? _i12.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i13.Types?>()) {
+      return (data != null ? _i13.Types.fromJson(data, this) : null) as T;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
@@ -148,23 +157,23 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+    if (t == List<_i14.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i13.SimpleData?>) {
+    if (t == List<_i14.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i13.SimpleData?>(e))
+          .map((e) => deserialize<_i14.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -185,22 +194,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i14.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i15.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -219,6 +228,24 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<List<Duration?>?>()) {
       return (data != null
           ? (data as List).map((e) => deserialize<Duration?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<_i1.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<_i1.UuidValue?>) {
+      return (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<_i1.UuidValue?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i1.UuidValue?>(e)).toList()
           : null) as dynamic;
     }
     if (t == Map<String, int>) {
@@ -243,22 +270,22 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i13.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum>(e)).toList()
+    if (t == List<_i14.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i13.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i13.TestEnum?>(e)).toList()
+    if (t == List<_i14.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i14.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i13.TestEnum>>) {
+    if (t == List<List<_i14.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i13.TestEnum>>(e))
+          .map((e) => deserialize<List<_i14.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData>) {
+    if (t == Map<String, _i14.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i13.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i14.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -270,9 +297,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -280,9 +307,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i13.SimpleData?>) {
+    if (t == Map<String, _i1.UuidValue>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i14.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i13.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i14.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -293,9 +325,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -303,19 +335,24 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
+    if (t == Map<String, _i1.UuidValue?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue?>(v)))
+          as dynamic;
+    }
     if (t == Map<int, int>) {
       return Map.fromEntries((data as List).map((e) =>
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i13.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i14.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i13.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i14.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<int>) {
@@ -405,41 +442,41 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData>(e)).toList()
+    if (t == List<_i15.ByteData>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i14.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i14.ByteData?>(e)).toList()
+    if (t == List<_i15.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i15.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+    if (t == List<_i16.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i15.SimpleData?>) {
+    if (t == List<_i16.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i15.SimpleData?>(e))
+          .map((e) => deserialize<_i16.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i15.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i16.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i15.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i16.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -493,14 +530,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i16.TestEnum, int>) {
+    if (t == Map<_i17.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i16.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i17.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i16.TestEnum>) {
+    if (t == Map<String, _i17.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i16.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i17.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -539,47 +576,47 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData>) {
+    if (t == Map<String, _i15.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i14.ByteData?>) {
+    if (t == Map<String, _i15.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i14.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i15.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData>) {
+    if (t == Map<String, _i16.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i15.SimpleData?>) {
+    if (t == Map<String, _i16.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i15.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i16.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i15.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i16.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i15.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i16.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i15.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i16.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -592,36 +629,36 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == _i17.CustomClass) {
-      return _i17.CustomClass.fromJson(data, this) as T;
+    if (t == _i18.CustomClass) {
+      return _i18.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.ExternalCustomClass) {
-      return _i18.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i19.ExternalCustomClass) {
+      return _i19.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i18.FreezedCustomClass) {
-      return _i18.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i19.FreezedCustomClass) {
+      return _i19.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i17.CustomClass?>()) {
-      return (data != null ? _i17.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i18.CustomClass?>()) {
+      return (data != null ? _i18.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i18.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i19.ExternalCustomClass?>()) {
       return (data != null
-          ? _i18.ExternalCustomClass.fromJson(data, this)
+          ? _i19.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i18.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i19.FreezedCustomClass?>()) {
       return (data != null
-          ? _i18.FreezedCustomClass.fromJson(data, this)
+          ? _i19.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
-    try {
-      return _i19.Protocol().deserialize<T>(data, t);
-    } catch (_) {}
     try {
       return _i20.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     try {
       return _i21.Protocol().deserialize<T>(data, t);
+    } catch (_) {}
+    try {
+      return _i22.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -629,21 +666,21 @@ class Protocol extends _i1.SerializationManagerServer {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i19.Protocol().getClassNameForObject(data);
+    className = _i20.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    className = _i20.Protocol().getClassNameForObject(data);
+    className = _i21.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i17.CustomClass) {
+    if (data is _i18.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i18.ExternalCustomClass) {
+    if (data is _i19.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i18.FreezedCustomClass) {
+    if (data is _i19.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.Nullability) {
@@ -667,16 +704,19 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i8.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i9.SimpleData) {
+    if (data is _i9.ObjectWithUuid) {
+      return 'ObjectWithUuid';
+    }
+    if (data is _i10.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i10.SimpleDataList) {
+    if (data is _i11.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i11.TestEnum) {
+    if (data is _i12.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i12.Types) {
+    if (data is _i13.Types) {
       return 'Types';
     }
     return super.getClassNameForObject(data);
@@ -686,20 +726,20 @@ class Protocol extends _i1.SerializationManagerServer {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i19.Protocol().deserializeByClassName(data);
+      return _i20.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i20.Protocol().deserializeByClassName(data);
+      return _i21.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i17.CustomClass>(data['data']);
+      return deserialize<_i18.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i18.ExternalCustomClass>(data['data']);
+      return deserialize<_i19.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i18.FreezedCustomClass>(data['data']);
+      return deserialize<_i19.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'Nullability') {
       return deserialize<_i2.Nullability>(data['data']);
@@ -722,29 +762,26 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'ObjectWithObject') {
       return deserialize<_i8.ObjectWithObject>(data['data']);
     }
+    if (data['className'] == 'ObjectWithUuid') {
+      return deserialize<_i9.ObjectWithUuid>(data['data']);
+    }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i9.SimpleData>(data['data']);
+      return deserialize<_i10.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i10.SimpleDataList>(data['data']);
+      return deserialize<_i11.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i11.TestEnum>(data['data']);
+      return deserialize<_i12.TestEnum>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i12.Types>(data['data']);
+      return deserialize<_i13.Types>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
 
   @override
   _i1.Table? getTableForType(Type t) {
-    {
-      var table = _i19.Protocol().getTableForType(t);
-      if (table != null) {
-        return table;
-      }
-    }
     {
       var table = _i20.Protocol().getTableForType(t);
       if (table != null) {
@@ -753,6 +790,12 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     {
       var table = _i21.Protocol().getTableForType(t);
+      if (table != null) {
+        return table;
+      }
+    }
+    {
+      var table = _i22.Protocol().getTableForType(t);
       if (table != null) {
         return table;
       }
@@ -768,10 +811,12 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i6.ObjectWithEnum.t;
       case _i8.ObjectWithObject:
         return _i8.ObjectWithObject.t;
-      case _i9.SimpleData:
-        return _i9.SimpleData.t;
-      case _i12.Types:
-        return _i12.Types.t;
+      case _i9.ObjectWithUuid:
+        return _i9.ObjectWithUuid.t;
+      case _i10.SimpleData:
+        return _i10.SimpleData.t;
+      case _i13.Types:
+        return _i13.Types.t;
     }
     return null;
   }

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -19,6 +19,7 @@ class Types extends _i1.TableRow {
     this.aString,
     this.aByteData,
     this.aDuration,
+    this.aUuid,
   }) : super(id);
 
   factory Types.fromJson(
@@ -40,6 +41,8 @@ class Types extends _i1.TableRow {
           .deserialize<_i2.ByteData?>(jsonSerialization['aByteData']),
       aDuration: serializationManager
           .deserialize<Duration?>(jsonSerialization['aDuration']),
+      aUuid: serializationManager
+          .deserialize<_i1.UuidValue?>(jsonSerialization['aUuid']),
     );
   }
 
@@ -59,6 +62,8 @@ class Types extends _i1.TableRow {
 
   Duration? aDuration;
 
+  _i1.UuidValue? aUuid;
+
   @override
   String get tableName => 'types';
   @override
@@ -72,6 +77,7 @@ class Types extends _i1.TableRow {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 
@@ -86,6 +92,7 @@ class Types extends _i1.TableRow {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 
@@ -100,6 +107,7 @@ class Types extends _i1.TableRow {
       'aString': aString,
       'aByteData': aByteData,
       'aDuration': aDuration,
+      'aUuid': aUuid,
     };
   }
 
@@ -132,6 +140,9 @@ class Types extends _i1.TableRow {
         return;
       case 'aDuration':
         aDuration = value;
+        return;
+      case 'aUuid':
+        aUuid = value;
         return;
       default:
         throw UnimplementedError();
@@ -271,6 +282,8 @@ class TypesTable extends _i1.Table {
 
   final aDuration = _i1.ColumnDuration('aDuration');
 
+  final aUuid = _i1.ColumnUuid('aUuid');
+
   @override
   List<_i1.Column> get columns => [
         id,
@@ -281,6 +294,7 @@ class TypesTable extends _i1.Table {
         aString,
         aByteData,
         aDuration,
+        aUuid,
       ];
 }
 

--- a/tests/serverpod_test_server/lib/src/protocol/nullability.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/nullability.yaml
@@ -21,6 +21,9 @@ fields:
   aDuration: Duration
   aNullableDuration: Duration?
 
+  aUuid: UuidValue
+  aNullableUuid: UuidValue?
+
   anObject: SimpleData
   aNullableObject: SimpleData?
 
@@ -48,6 +51,11 @@ fields:
   aNullableDurationList: List<Duration>?
   aListWithNullableDurations: List<Duration?>
   aNullableListWithNullableDurations: List<Duration?>?
+
+  aUuidList: List<UuidValue>
+  aNullableUuidList: List<UuidValue>?
+  aListWithNullableUuids: List<UuidValue?>
+  aNullableListWithNullableUuids: List<UuidValue?>?
 
   anIntMap: Map<String,int>
   aNullableIntMap: Map<String,int>?

--- a/tests/serverpod_test_server/lib/src/protocol/object_with_maps.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/object_with_maps.yaml
@@ -6,10 +6,12 @@ fields:
   dateTimeMap: Map<String, DateTime>
   byteDataMap: Map<String, ByteData>
   durationMap: Map<String, Duration>
+  uuidMap: Map<String, UuidValue>
   nullableDataMap: Map<String, SimpleData?>
   nullableIntMap: Map<String, int?>
   nullableStringMap: Map<String, String?>
   nullableDateTimeMap: Map<String, DateTime?>
   nullableByteDataMap: Map<String, ByteData?>
   nullableDurationMap: Map<String, Duration?>
+  nullableUuidMap: Map<String, UuidValue?>
   intIntMap: Map<int, int>

--- a/tests/serverpod_test_server/lib/src/protocol/object_with_uuid.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/object_with_uuid.yaml
@@ -1,0 +1,5 @@
+class: ObjectWithUuid
+table: object_with_uuid
+fields:
+  uuid: UuidValue
+  uuidNullable: UuidValue?

--- a/tests/serverpod_test_server/lib/src/protocol/types.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/types.yaml
@@ -8,3 +8,4 @@ fields:
   aString: String?
   aByteData: ByteData?
   aDuration: Duration?
+  aUuid: UuidValue?

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     path: ../../integrations/serverpod_cloud_storage_s3
   serverpod_test_shared:
     path: ../serverpod_test_shared
+  uuid: ^3.0.7
 
 
 dev_dependencies:

--- a/tests/serverpod_test_server/test/connection_test.dart
+++ b/tests/serverpod_test_server/test/connection_test.dart
@@ -732,6 +732,7 @@ void main() {
   group('Basic types', () {
     var dateTime = DateTime.utc(1976, 9, 10, 2, 10);
     var duration = const Duration(seconds: 1);
+    var uuid = UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
 
     test('Simple calls', () async {
       await client.simple.setGlobalInt(10);
@@ -813,12 +814,23 @@ void main() {
       var result = await client.basicTypes.testDuration(null);
       expect(result, isNull);
     });
+
+    test('Type UuidValue', () async {
+      var result = await client.basicTypes.testUuid(uuid);
+      expect(result, equals(uuid));
+    });
+
+    test('Type null UuidValue', () async {
+      var result = await client.basicTypes.testUuid(null);
+      expect(result, isNull);
+    });
   });
 
   group('Database', () {
     test('Write and read', () async {
       var dateTime = DateTime.utc(1976, 9, 10, 2, 10);
       var duration = const Duration(seconds: 1);
+      var uuid = UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
 
       // TODO: Support ByteData in database store
       var types = Types(
@@ -828,6 +840,7 @@ void main() {
         aDateTime: dateTime,
         aDuration: duration,
         aString: 'Foo',
+        aUuid: uuid,
         // aByteData: createByteData(),
       );
 
@@ -853,6 +866,7 @@ void main() {
         expect(storedTypes.aString, equals('Foo'));
         expect(storedTypes.aDateTime, equals(dateTime));
         expect(storedTypes.aDuration, equals(duration));
+        expect(storedTypes.aUuid, equals(uuid));
         // expect(storedTypes.aByteData!.lengthInBytes, equals(256));
       }
     });
@@ -882,6 +896,7 @@ void main() {
         expect(storedTypes.aString, isNull);
         expect(storedTypes.aDateTime, isNull);
         expect(storedTypes.aDuration, isNull);
+        expect(storedTypes.aUuid, isNull);
       }
     });
 

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -188,7 +188,7 @@ void main() {
 
       expect(unpacked.aListWithNullableUuids.length, equals(2));
       expect(unpacked.aListWithNullableUuids[0],
-          equals('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'));
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
       expect(unpacked.aListWithNullableUuids[1], isNull);
 
       expect(unpacked.aNullableInt, isNull);

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -433,13 +433,13 @@ void main() {
       expect(unpacked.byteDataMap['0']!.lengthInBytes, equals(256));
       expect(unpacked.byteDataMap['1']!.lengthInBytes, equals(256));
 
-      expect(unpacked.durationMap['0']!.inSeconds,
-          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
-      expect(unpacked.durationMap['1']!.inMinutes,
-          equals(UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a')));
+      expect(unpacked.durationMap['0']!.inSeconds, equals(equals(1)));
+      expect(unpacked.durationMap['1']!.inMinutes, equals(equals(1)));
 
-      expect(unpacked.uuidMap['0'], equals(1));
-      expect(unpacked.uuidMap['1'], equals(1));
+      expect(unpacked.uuidMap['0'],
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
+      expect(unpacked.uuidMap['1'],
+          equals(UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a')));
 
       expect(unpacked.nullableDataMap['0']!.num, equals(0));
       expect(unpacked.nullableDataMap['1'], isNull);

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -34,6 +34,7 @@ void main() {
       expect(unpacked.aDateTime, isNull);
       expect(unpacked.aByteData, isNull);
       expect(unpacked.aDuration, isNull);
+      expect(unpacked.aUuid, isNull);
     });
 
     test('Basic types with values', () {
@@ -45,6 +46,7 @@ void main() {
         aDateTime: DateTime.utc(1976),
         aByteData: createByteData(),
         aDuration: const Duration(seconds: 1),
+        aUuid: UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
       );
       var s = SerializationManager.encode(types);
       var unpacked = protocol.deserialize<Types>(jsonDecode(s));
@@ -58,6 +60,8 @@ void main() {
       for (var i = 0; i < 256; i++) {
         expect(unpacked.aByteData!.buffer.asUint8List()[i], equals(i));
       }
+      expect(unpacked.aUuid,
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
     });
 
     test('Object with enum', () {
@@ -127,6 +131,15 @@ void main() {
           Duration(seconds: 1),
           null,
         ],
+        aUuid: UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+        aUuidList: [
+          UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a')
+        ],
+        aListWithNullableUuids: [
+          UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          null,
+        ],
       );
 
       var s = SerializationManager.encode(nullability);
@@ -173,6 +186,11 @@ void main() {
       expect(unpacked.aListWithNullableDurations[0]!.inSeconds, equals(1));
       expect(unpacked.aListWithNullableDurations[1], isNull);
 
+      expect(unpacked.aListWithNullableUuids.length, equals(2));
+      expect(unpacked.aListWithNullableUuids[0],
+          equals('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'));
+      expect(unpacked.aListWithNullableUuids[1], isNull);
+
       expect(unpacked.aNullableInt, isNull);
       expect(unpacked.aNullableDouble, isNull);
       expect(unpacked.aNullableBool, isNull);
@@ -181,6 +199,7 @@ void main() {
       expect(unpacked.aNullableByteData, isNull);
       expect(unpacked.aNullableObject, isNull);
       expect(unpacked.aNullableDuration, isNull);
+      expect(unpacked.aNullableUuid, isNull);
 
       expect(unpacked.aNullableListWithNullableInts, isNull);
       expect(unpacked.aNullableIntList, isNull);
@@ -189,6 +208,7 @@ void main() {
       expect(unpacked.aNullableDateTimeList, isNull);
       expect(unpacked.aNullableListWithNullableDateTimes, isNull);
       expect(unpacked.aNullableListWithNullableDurations, isNull);
+      expect(unpacked.aNullableListWithNullableUuids, isNull);
 
       expect(unpacked.anIntMap['0'], equals(0));
       expect(unpacked.anIntMap['1'], equals(1));
@@ -251,6 +271,24 @@ void main() {
           const Duration(seconds: 1),
           null,
         ],
+        aUuidList: [
+          UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a')
+        ],
+        aListWithNullableUuids: [
+          UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          null,
+        ],
+        aNullableUuidList: [
+          UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a')
+        ],
+        aUuid: UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+        aNullableUuid: UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+        aNullableListWithNullableUuids: [
+          UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          null,
+        ],
       );
 
       var s = SerializationManager.encode(nullability);
@@ -263,6 +301,8 @@ void main() {
       expect(unpacked.aNullableByteData!.lengthInBytes, equals(256));
       expect(unpacked.aNullableObject!.num, equals(42));
       expect(unpacked.aNullableDuration, equals(const Duration(seconds: 1)));
+      expect(unpacked.aNullableUuid,
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
 
       expect(unpacked.aNullableIntList!.length, equals(2));
       expect(unpacked.aNullableIntList![0], equals(10));
@@ -302,62 +342,75 @@ void main() {
       expect(unpacked.aNullableDurationList![0].inSeconds, equals(1));
       expect(unpacked.aNullableDurationList![1].inMinutes, equals(1));
 
+      expect(unpacked.aNullableUuidList!.length, equals(2));
+      expect(unpacked.aNullableUuidList![0],
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
+      expect(unpacked.aNullableUuidList![1],
+          equals(UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a')));
+
       expect(unpacked.aNullableListWithNullableDurations!.length, equals(2));
       expect(unpacked.aNullableListWithNullableDurations![0]!.inSeconds,
           equals(1));
       expect(unpacked.aNullableListWithNullableDurations![1], isNull);
+
+      expect(unpacked.aNullableListWithNullableUuids!.length, equals(2));
+      expect(unpacked.aNullableListWithNullableUuids![0],
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
+      expect(unpacked.aNullableListWithNullableUuids![1], isNull);
     });
 
     test('Map types', () {
-      var maps = ObjectWithMaps(dataMap: {
-        '0': SimpleData(num: 0),
-        '1': SimpleData(num: 1),
-        '2': SimpleData(num: 2),
-      }, intMap: {
-        '0': 0,
-        '1': 1,
-        '2': 2
-      }, stringMap: {
-        '0': 'String 0',
-        '1': 'String 1',
-        '2': 'String 2'
-      }, dateTimeMap: {
-        '2020': DateTime.utc(2020),
-        '2021': DateTime.utc(2021),
-        '2022': DateTime.utc(2022),
-      }, byteDataMap: {
-        '0': createByteData(),
-        '1': createByteData(),
-      }, nullableDataMap: {
-        '0': SimpleData(num: 0),
-        '1': null,
-        '2': SimpleData(num: 2),
-      }, nullableIntMap: {
-        '0': 0,
-        '1': null,
-        '2': 2
-      }, nullableStringMap: {
-        '0': 'null',
-        '1': null,
-        '2': 'String 2'
-      }, nullableDateTimeMap: {
-        '2020': DateTime.utc(2020),
-        '2021': null,
-        '2022': DateTime.utc(2022),
-      }, nullableByteDataMap: {
-        '0': createByteData(),
-        '1': null,
-      }, intIntMap: {
-        1: 1,
-        2: 4,
-        3: 9
-      }, durationMap: {
-        '0': const Duration(seconds: 1),
-        '1': const Duration(minutes: 1),
-      }, nullableDurationMap: {
-        '0': const Duration(seconds: 1),
-        '1': null,
-      });
+      var maps = ObjectWithMaps(
+        dataMap: {
+          '0': SimpleData(num: 0),
+          '1': SimpleData(num: 1),
+          '2': SimpleData(num: 2),
+        },
+        intMap: {'0': 0, '1': 1, '2': 2},
+        stringMap: {'0': 'String 0', '1': 'String 1', '2': 'String 2'},
+        dateTimeMap: {
+          '2020': DateTime.utc(2020),
+          '2021': DateTime.utc(2021),
+          '2022': DateTime.utc(2022),
+        },
+        byteDataMap: {
+          '0': createByteData(),
+          '1': createByteData(),
+        },
+        nullableDataMap: {
+          '0': SimpleData(num: 0),
+          '1': null,
+          '2': SimpleData(num: 2),
+        },
+        nullableIntMap: {'0': 0, '1': null, '2': 2},
+        nullableStringMap: {'0': 'null', '1': null, '2': 'String 2'},
+        nullableDateTimeMap: {
+          '2020': DateTime.utc(2020),
+          '2021': null,
+          '2022': DateTime.utc(2022),
+        },
+        nullableByteDataMap: {
+          '0': createByteData(),
+          '1': null,
+        },
+        intIntMap: {1: 1, 2: 4, 3: 9},
+        durationMap: {
+          '0': const Duration(seconds: 1),
+          '1': const Duration(minutes: 1),
+        },
+        nullableDurationMap: {
+          '0': const Duration(seconds: 1),
+          '1': null,
+        },
+        uuidMap: {
+          '0': UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          '1': UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a'),
+        },
+        nullableUuidMap: {
+          '0': UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'),
+          '1': null,
+        },
+      );
 
       var s = SerializationManager.encode(maps);
       var unpacked = protocol.deserialize<ObjectWithMaps>(jsonDecode(s));
@@ -380,8 +433,13 @@ void main() {
       expect(unpacked.byteDataMap['0']!.lengthInBytes, equals(256));
       expect(unpacked.byteDataMap['1']!.lengthInBytes, equals(256));
 
-      expect(unpacked.durationMap['0']!.inSeconds, equals(1));
-      expect(unpacked.durationMap['1']!.inMinutes, equals(1));
+      expect(unpacked.durationMap['0']!.inSeconds,
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
+      expect(unpacked.durationMap['1']!.inMinutes,
+          equals(UuidValue('6c84fb90-12c4-11e1-840d-7b25c5ee775a')));
+
+      expect(unpacked.uuidMap['0'], equals(1));
+      expect(unpacked.uuidMap['1'], equals(1));
 
       expect(unpacked.nullableDataMap['0']!.num, equals(0));
       expect(unpacked.nullableDataMap['1'], isNull);
@@ -404,6 +462,10 @@ void main() {
 
       expect(unpacked.nullableDurationMap['0']!.inSeconds, equals(1));
       expect(unpacked.nullableDurationMap['1'], isNull);
+
+      expect(unpacked.nullableUuidMap['0']!,
+          equals(UuidValue('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')));
+      expect(unpacked.nullableUuidMap['1'], isNull);
 
       expect(unpacked.intIntMap.length, equals(3));
       expect(unpacked.intIntMap[1], equals(1));

--- a/tests/serverpod_test_server/test/types_test.dart
+++ b/tests/serverpod_test_server/test/types_test.dart
@@ -1,0 +1,12 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Test UUID', () {
+    test('Ensure ObjectWithUuid is generated correctly.', () {
+      expect(ObjectWithUuid.t.uuid, isA<ColumnUuid>());
+      expect(ObjectWithUuid.t.uuidNullable, isA<ColumnUuid>());
+    });
+  });
+}

--- a/tools/serverpod_cli/bin/generator/types.dart
+++ b/tools/serverpod_cli/bin/generator/types.dart
@@ -112,7 +112,8 @@ class TypeDefinition {
           }
           t.url =
               'package:${serverCode ? module.serverPackage : module.clientPackage}/module.dart';
-        } else if (url == 'serverpod') {
+        } else if (url == 'serverpod' ||
+            (url == null && ['UuidValue'].contains(className))) {
           // serverpod: reference
           t.url = serverpodUrl(serverCode);
         } else if (url?.startsWith('project:') ?? false) {
@@ -164,6 +165,7 @@ class TypeDefinition {
     if (className == 'DateTime') return 'timestamp without time zone';
     if (className == 'ByteData') return 'bytea';
     if (className == 'Duration') return 'bigint';
+    if (className == 'UuidValue') return 'uuid';
 
     return 'json';
   }
@@ -178,6 +180,7 @@ class TypeDefinition {
     if (className == 'DateTime') return 'ColumnDateTime';
     if (className == 'ByteData') return 'ColumnByteData';
     if (className == 'Duration') return 'ColumnDuration';
+    if (className == 'UuidValue') return 'ColumnUuid';
 
     return 'ColumnSerializable';
   }


### PR DESCRIPTION
Adds support for UUIDs. They are represented as a [`UuidValue`](https://pub.dev/documentation/uuid/latest/uuid/UuidValue-class.html) on the dart side, and as an [`uuid`](https://www.postgresql.org/docs/current/datatype-uuid.html) in the database.

Fix #635

This is an alternative implementation to #640.
Close #640

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

*none*