### PR TITLE
Fix: Calling setup tables for both windows and non-windows

### DIFF
--- a/tools/serverpod_cli/bin/create/create.dart
+++ b/tools/serverpod_cli/bin/create/create.dart
@@ -353,6 +353,7 @@ Future<void> performCreate(
   }
 
   if (dockerConfigured && template != 'module') {
+    await CommandLineTools.createTables(projectDir, name);
     if (Platform.isWindows) {
       await CommandLineTools.cleanupForWindows(projectDir, name);
       printwwln('');
@@ -367,8 +368,6 @@ Future<void> performCreate(
       stdout.writeln('  \$ dart .\\bin\\main.dart');
       printww('');
     } else {
-      // Create tables
-      await CommandLineTools.createTables(projectDir, name);
       printwwln('');
       printwwln('SERVERPOD CREATED 🥳');
       printwwln('All setup. You are ready to rock!');

--- a/tools/serverpod_cli/bin/util/command_line_tools.dart
+++ b/tools/serverpod_cli/bin/util/command_line_tools.dart
@@ -94,7 +94,7 @@ class CommandLineTools {
   static Future<void> cleanupForWindows(Directory dir, String name) async {
     var serverPath = p.join(dir.path, '${name}_server');
     print('Cleaning up');
-    var file = File(p.join(serverPath, 'setup-tables'));
+    var file = File(p.join(serverPath, 'setup-tables.cmd'));
     try {
       await file.delete();
     } catch (e) {


### PR DESCRIPTION
## PR Description
Have seen [many tickets/issues](https://github.com/serverpod/serverpod/issues?q=is%3Aissue+failed+to+connect) raised by windows developers for failing to start the server because no tables exist. On a closer look, found that it wasn't being called for a windows machine.

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the document follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.
