### PR TITLE
Fix: Typo docker compose command on prompt

### DIFF
--- a/tools/serverpod_cli/bin/create/create.dart
+++ b/tools/serverpod_cli/bin/create/create.dart
@@ -363,7 +363,7 @@ Future<void> performCreate(
       printwwln('Start your Serverpod by running:');
       stdout.writeln('  \$ cd .\\${p.join(name, '${name}_server')}\\');
       stdout.writeln('  \$ .\\setup-tables.cmd');
-      stdout.writeln('  \$ docker compose up --build --detach');
+      stdout.writeln('  \$ docker-compose up --build --detach');
       stdout.writeln('  \$ dart .\\bin\\main.dart');
       printww('');
     } else {
@@ -374,7 +374,7 @@ Future<void> performCreate(
       printwwln('All setup. You are ready to rock!');
       printwwln('Start your Serverpod by running:');
       stdout.writeln('  \$ cd ${p.join(name, '${name}_server')}');
-      stdout.writeln('  \$ docker compose up --build --detach');
+      stdout.writeln('  \$ docker-compose up --build --detach');
       stdout.writeln('  \$ dart bin/main.dart');
       printww('');
     }


### PR DESCRIPTION
Fixes a small Typo in create.dart Prompt.
The command is now in line with the command displayed on https://docs.serverpod.dev/

The dash (-) is missing in the `docker-compose up` command displayed to the user.

