### PR TITLE
Don't print stacktrace when Google signin disconnect fails

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
@@ -98,7 +98,14 @@ Future<UserInfo?> signInWithGoogle(
     if (kDebugMode) print('serverpod_auth_google: Signing out from google');
     await googleSignIn.signOut();
 
-    if (kDebugMode) await googleSignIn.disconnect();
+    if (kDebugMode) {
+      try {
+        await googleSignIn.disconnect();
+      } catch (e) {
+        // Print without stacktrace (this seems to fail every time, #735)
+        print('serverpod_auth_google: $e');
+      }
+    }
 
     if (kDebugMode) {
       print(


### PR DESCRIPTION
Don't show a stacktrace when Google sign-in disconnect fails (#735). Doesn't fix the issue of disconnect failing, just makes the console output look less critical.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
