### PR TITLE
Return bool from `SessionManager.initialize()`

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
@@ -87,10 +87,11 @@ class SessionManager with ChangeNotifier {
   bool get isSignedIn => signedInUser != null;
 
   /// Initializes the session manager by reading the current state from
-  /// shared preferences.
-  Future<void> initialize() async {
+  /// shared preferences. The returned bool is true if the session was
+  /// initialized, or false if the server could not be reached.
+  Future<bool> initialize() async {
     await _loadSharedPrefs();
-    unawaited(refreshSession());
+    return refreshSession();
   }
 
   /// Signs the user out from all connected devices. Returns true if successful.


### PR DESCRIPTION
Return bool from `SessionManager.initialize()` (address part of #764, but does not fix the whole issue).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
