### PR TITLE
test: Add test that that makes sure `serverpod generate` wont change any files.

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -7,7 +7,7 @@ on:
       - dev
       - tests
       - stable-1.0
-      - fix-770 
+      - fix-770
   pull_request:
     branches:
       - main
@@ -32,6 +32,9 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       # - name: Setup Firebase dummy file
       #   run: mv packages/serverpod/example/example_flutter/lib/firebase_options_dummy.dart packages/serverpod/example/example_flutter/lib/firebase_options.dart
       - name: Install dependencies
@@ -47,6 +50,9 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Run serverpod generate
         run: util/run_tests_serverpod_generate
 
@@ -58,6 +64,9 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Run serverpod generate
         run: util/run_tests_update_pubspecs
 
@@ -69,7 +78,9 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
-
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Run single server tests
         run: util/run_tests_single_server
 
@@ -81,5 +92,8 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Run CLI tests
         run: util/run_tests_cli

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -7,6 +7,7 @@ on:
       - dev
       - tests
       - stable-1.0
+      - fix-770 
   pull_request:
     branches:
       - main

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -7,7 +7,6 @@ on:
       - dev
       - tests
       - stable-1.0
-      - fix-770 
   pull_request:
     branches:
       - main

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -12,7 +12,6 @@ on:
       - main
       - dev
 jobs:
-
   dart_format:
     name: dart format
     runs-on: ubuntu-latest
@@ -39,16 +38,16 @@ jobs:
       - name: Analyze
         run: util/run_tests_analyze
 
-  # serverpod_generate:
-  #   name: serverpod generate
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: subosito/flutter-action@v2
-  #       with:
-  #         flutter-version: "3.3.2"
-  #     - name: Run serverpod generate
-  #       run: util/run_tests_serverpod_generate
+  serverpod_generate:
+    name: serverpod generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.7.0"
+      - name: Run serverpod generate
+        run: util/run_tests_serverpod_generate
 
   update_pubspecs:
     name: update pubspecs

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -7,7 +7,7 @@ on:
       - dev
       - tests
       - stable-1.0
-      - fix-770
+      - fix-770 
   pull_request:
     branches:
       - main
@@ -32,9 +32,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       # - name: Setup Firebase dummy file
       #   run: mv packages/serverpod/example/example_flutter/lib/firebase_options_dummy.dart packages/serverpod/example/example_flutter/lib/firebase_options.dart
       - name: Install dependencies
@@ -50,9 +47,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Run serverpod generate
         run: util/run_tests_serverpod_generate
 
@@ -64,9 +58,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Run serverpod generate
         run: util/run_tests_update_pubspecs
 
@@ -78,9 +69,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
+
       - name: Run single server tests
         run: util/run_tests_single_server
 
@@ -92,8 +81,5 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.7.0"
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
       - name: Run CLI tests
         run: util/run_tests_cli

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -7,6 +7,8 @@
 
 library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+// should fail
+
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_test_module_server/module.dart' as _i3;

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -7,8 +7,6 @@
 
 library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
-// should fail
-
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_test_module_server/module.dart' as _i3;

--- a/util/run_tests_serverpod_generate
+++ b/util/run_tests_serverpod_generate
@@ -25,6 +25,8 @@ dart pub global activate -s path .
 
 cd $SERVERPOD_HOME
 
+util/pub_get_all
+
 util/generate_all
 
 util/ensure_no_changes

--- a/util/run_tests_serverpod_generate
+++ b/util/run_tests_serverpod_generate
@@ -25,6 +25,6 @@ dart pub global activate -s path .
 
 cd $SERVERPOD_HOME
 
-# util/generate_all
+util/generate_all
 
 util/ensure_no_changes

--- a/util/run_tests_serverpod_generate
+++ b/util/run_tests_serverpod_generate
@@ -25,6 +25,6 @@ dart pub global activate -s path .
 
 cd $SERVERPOD_HOME
 
-util/generate_all
+# util/generate_all
 
 util/ensure_no_changes

--- a/util/run_tests_serverpod_generate
+++ b/util/run_tests_serverpod_generate
@@ -22,7 +22,8 @@ test -d $TEMPLATE_DIR
 
 cd tools/serverpod_cli
 dart pub global activate -s path .
-cd ../..
+
+cd $SERVERPOD_HOME
 
 util/generate_all
 


### PR DESCRIPTION
Enables and fixes the almost working `serverpod_generate` test.
There was just the `pub get` missing.

Close #770

I don't thinks it's necessary to add a test for tests. 😉 
However, I've validated that the test works. ([Notice that it failed for `make sure generation test works`](https://github.com/fischerscode/serverpod/actions?query=branch%3Afix-770). That was caused by d80ce043.)

I've also experimented with caching flutter. But apparently it makes almost no difference... reverted.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
*none*