### PR TITLE
test: Increase delay in test 'Logging in stream'

### DIFF
--- a/tests/serverpod_test_server/test/service_protocol_test.dart
+++ b/tests/serverpod_test_server/test/service_protocol_test.dart
@@ -279,7 +279,10 @@ void main() {
         await client.streamingLogging.sendStreamMessage(SimpleData(num: 42));
       }
 
-      await Future.delayed(const Duration(seconds: 1));
+      // This test failed some times due to some kind of race condition.
+      // Idealy we would not use a hard coded delay here.
+      // Ticket: https://github.com/serverpod/serverpod/issues/773
+      await Future.delayed(const Duration(seconds: 5));
 
       var logResult = await serviceClient.insights.getSessionLog(1, null);
       expect(logResult.sessionLog.length, equals(1));


### PR DESCRIPTION
The test 'Logging in stream' sometimes fails.
This PR is a dirty attempt to fix this.

For further information see #773.

Ideally we find a better fix for this in the future.

The 5s delay might sound drastic, but I want to make sure it's long enough.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
*none*
