### PR TITLE
feat: Allow creating the `DatabaseDefinition` on the fly

### DIFF
--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -6,7 +6,7 @@ DatabaseDefinition createDatabaseDefinitionFromEntities(
     List<SerializableEntityDefinition> serializableEntities) {
   return DatabaseDefinition(tables: [
     for (var classDefinition in serializableEntities)
-      if (classDefinition is ProtocolClassDefinition &&
+      if (classDefinition is ClassDefinition &&
           classDefinition.tableName != null)
         TableDefinition(
           name: classDefinition.tableName!,
@@ -58,8 +58,8 @@ DatabaseDefinition createDatabaseDefinitionFromEntities(
               isUnique: true,
               isPrimary: true,
             ),
-            for (var index
-                in classDefinition.indexes ?? <ProtocolIndexDefinition>[])
+            for (var index in classDefinition.indexes ??
+                <SerializableEntityIndexDefinition>[])
               IndexDefinition(
                 indexName: index.name,
                 elements: [

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -1,0 +1,80 @@
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+
+/// Create the target [DatabaseDefinition] based on the [serializableEntities].
+DatabaseDefinition createDatabaseDefinitionFromEntities(
+    List<SerializableEntityDefinition> serializableEntities) {
+  return DatabaseDefinition(tables: [
+    for (var classDefinition in serializableEntities)
+      if (classDefinition is ProtocolClassDefinition &&
+          classDefinition.tableName != null)
+        TableDefinition(
+          name: classDefinition.tableName!,
+          schema: 'public',
+          columns: [
+            for (var column in classDefinition.fields)
+              if (column.shouldSerializeFieldForDatabase(true))
+                ColumnDefinition(
+                  name: column.name,
+                  columnType:
+                      ColumnType.values.byName(column.type.databaseTypeEnum),
+                  // The id column is not null, since it is auto incrementing.
+                  isNullable: column.name != 'id' && column.type.nullable,
+                  dartType: column.type.toString(),
+                  columnDefault: column.name == 'id'
+                      ? "nextval('${classDefinition.tableName!}_id_seq'::regclass)"
+                      : null,
+                )
+          ],
+          foreignKeys: [
+            for (var i = 0;
+                i <
+                    classDefinition.fields
+                        .where((field) => field.parentTable != null)
+                        .length;
+                i++)
+              () {
+                var column = classDefinition.fields
+                    .where((field) => field.parentTable != null)
+                    .toList()[i];
+                return ForeignKeyDefinition(
+                  constraintName: '${classDefinition.tableName!}_fk_$i',
+                  columns: [column.name],
+                  referenceTable: column.parentTable!,
+                  referenceTableSchema: 'public',
+                  referenceColumns: ['id'],
+                  onDelete: ForeignKeyAction.cascade,
+                );
+              }()
+          ],
+          indexes: [
+            IndexDefinition(
+              indexName: '${classDefinition.tableName!}_pkey',
+              elements: [
+                IndexElementDefinition(
+                    definition: 'id', type: IndexElementDefinitionType.column)
+              ],
+              type: 'btree',
+              isUnique: true,
+              isPrimary: true,
+            ),
+            for (var index
+                in classDefinition.indexes ?? <ProtocolIndexDefinition>[])
+              IndexDefinition(
+                indexName: index.name,
+                elements: [
+                  for (var field in index.fields)
+                    IndexElementDefinition(
+                        type: IndexElementDefinitionType.column,
+                        definition: field)
+                ],
+                type: index.type,
+                isUnique: index.unique,
+                isPrimary: false,
+              ),
+          ],
+          //TODO: Add an option in the yaml-protocol specification for this.
+          managed: true,
+        ),
+  ]);
+}

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -73,7 +73,7 @@ DatabaseDefinition createDatabaseDefinitionFromEntities(
                 isPrimary: false,
               ),
           ],
-          //TODO: Add an option in the yaml-protocol specification for this.
+          //TODO: Add an option in the class specification for this.
           managed: true,
         ),
   ]);


### PR DESCRIPTION
*This PR is part of the long term goal of supporting database migrations (#154).*

This PR creates a new function called `createDatabaseDefinitionFromEntities` that can be used to generate the target `DatabaseDefinition` on the fly based on a supplied list of `SerializableEntityDefinition`.

**It does not add the tables from modules or the `package:serverpod` automatically.**

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
*none*
