### PR TITLE
fix: Add missing recover option while parsing yaml documents

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -108,6 +108,7 @@ class SerializableEntityAnalyzer {
         yaml,
         sourceUrl: Uri.file(sourceFileName),
         errorListener: yamlErrorCollector,
+        recover: true,
       );
     } catch (e) {
       if (e is SourceSpanException) {


### PR DESCRIPTION
This PR is part of the long term goal of supporting database migrations (#154).

The `recover` was not set. This resulted in an assert failing when running it in debug mode.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
*none*