### PR TITLE
feat: Allow loading the `GeneratorConfig` for a dependency

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
     path: ../../packages/serverpod_service_client
   async: ^2.11.0
   meta: ^1.9.1
+  package_config: ^2.1.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -15,6 +15,7 @@ import 'package:serverpod_cli/src/internal_tools/generate_pubspecs.dart';
 import 'package:serverpod_cli/src/shared/environment.dart';
 import 'package:serverpod_cli/src/util/command_line_tools.dart';
 import 'package:serverpod_cli/src/util/internal_error.dart';
+import 'package:serverpod_cli/src/util/print.dart';
 import 'package:serverpod_cli/src/util/version.dart';
 
 const cmdCreate = 'create';
@@ -199,9 +200,12 @@ Future<void> _main(List<String> args) async {
       var verbose = results.command!['verbose'];
       var watch = results.command!['watch'];
 
-      // TODO: add a -d option to select the directory
-      var config = GeneratorConfig.load();
-      if (config == null) {
+      late GeneratorConfig config;
+      try {
+        // TODO: add a -d option to select the directory
+        config = GeneratorConfig.load();
+      } on Exception catch (e) {
+        printww(e.toString());
         return;
       }
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:package_config/package_config.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 import 'package:path/path.dart' as p;
@@ -227,6 +228,31 @@ generatedServerProtocol: ${p.joinAll(generatedServerProtocolPathParts)}
       }
     }
     return str;
+  }
+
+  /// Load the [GeneratorConfig] for a the dependency [packageName].
+  ///
+  /// Usually [packageName] should either be `serverpod` or a package name from
+  /// [modules].
+  Future<GeneratorConfig> loadDependency({
+    required String packageName,
+    required GeneratorConfig config,
+  }) async {
+    var path = p.joinAll(config.serverPackageDirectoryPathParts);
+    var packageConfig = await findPackageConfig(Directory(path));
+
+    if (packageConfig == null) {
+      throw Exception('Failed to find a package config in $path.');
+    }
+
+    var package = packageConfig[packageName];
+
+    if (package == null) {
+      throw Exception('${config.serverPackage} does not seem to depend on '
+          '$packageName.');
+    }
+
+    return GeneratorConfig.load(Directory.fromUri(package.root).path);
   }
 }
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -99,7 +99,7 @@ class GeneratorConfig {
   final List<TypeDefinition> extraClasses;
 
   /// Create a new [GeneratorConfig] by loading the configuration in the [dir].
-  static GeneratorConfig? load([String dir = '']) {
+  static GeneratorConfig load([String dir = '']) {
     var serverPackageDirectoryPathParts = p.split(dir);
 
     Map? pubspec;
@@ -108,9 +108,10 @@ class GeneratorConfig {
       var yamlStr = file.readAsStringSync();
       pubspec = loadYaml(yamlStr);
     } catch (_) {
-      print(
-          'Failed to load pubspec.yaml. Are you running serverpod from your projects root directory?');
-      return null;
+      //TODO: This message doesn't make sens for a package.
+      throw Exception(
+          'Failed to load pubspec.yaml. Are you running serverpod from your '
+          'projects root directory?');
     }
 
     if (pubspec!['name'] == null) {
@@ -125,9 +126,8 @@ class GeneratorConfig {
       var yamlStr = file.readAsStringSync();
       generatorConfig = loadYaml(yamlStr);
     } catch (_) {
-      print(
+      throw Exception(
           'Failed to load config/generator.yaml. Is this a Serverpod project?');
-      return null;
     }
 
     var typeStr = generatorConfig!['type'];
@@ -160,9 +160,9 @@ class GeneratorConfig {
       dartClientDependsOnServiceClient =
           yaml['dependencies'].containsKey('serverpod_service_client');
     } catch (_) {
-      print(
-          'Failed to load client pubspec.yaml. Is your client_package_path set correctly?');
-      return null;
+      throw Exception(
+          'Failed to load client pubspec.yaml. Is your client_package_path set '
+          'correctly?');
     }
 
     // Load module settings

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
     path: ../../packages/serverpod_service_client
   async: ^2.11.0
   meta: ^1.9.1
+  package_config: ^2.1.0
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
_This PR is part of the long term goal of supporting database migrations (#154)._

This PR adds support for loading the `GeneratorConfig` for a dependency (mostly `serverpod` or module). This is required for generating the **entire** database target on the fly. (See #779 for the implementation of that.)

The package directory of the dependency is determined by [`package:package_config`](https://pub.dev/packages/package_config), which is published directly by the dart team.

This PR also improves the error handling when loading a `GeneratorConfig`, since it's needed for this.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

_none_