### PR TITLE
Prevent self referencing table endless loop in serverpod generate

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
@@ -11,7 +11,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 class ObjectWithSelfParent extends _i1.SerializableEntity {
   ObjectWithSelfParent({
     this.id,
-    required this.other,
+    this.other,
   });
 
   factory ObjectWithSelfParent.fromJson(
@@ -20,7 +20,7 @@ class ObjectWithSelfParent extends _i1.SerializableEntity {
   ) {
     return ObjectWithSelfParent(
       id: serializationManager.deserialize<int?>(jsonSerialization['id']),
-      other: serializationManager.deserialize<int>(jsonSerialization['other']),
+      other: serializationManager.deserialize<int?>(jsonSerialization['other']),
     );
   }
 
@@ -29,7 +29,7 @@ class ObjectWithSelfParent extends _i1.SerializableEntity {
   /// the id will be null.
   int? id;
 
-  int other;
+  int? other;
 
   @override
   Map<String, dynamic> toJson() {

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
@@ -1,0 +1,41 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+class ObjectWithSelfParent extends _i1.SerializableEntity {
+  ObjectWithSelfParent({
+    this.id,
+    required this.other,
+  });
+
+  factory ObjectWithSelfParent.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ObjectWithSelfParent(
+      id: serializationManager.deserialize<int?>(jsonSerialization['id']),
+      other: serializationManager.deserialize<int>(jsonSerialization['other']),
+    );
+  }
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  int? id;
+
+  int other;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'other': other,
+    };
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -18,23 +18,22 @@ import 'object_with_index.dart' as _i8;
 import 'object_with_maps.dart' as _i9;
 import 'object_with_object.dart' as _i10;
 import 'object_with_parent.dart' as _i11;
-import 'object_with_uuid.dart' as _i12;
-import 'serverOnly/default_server_only_class.dart' as _i13;
-import 'serverOnly/default_server_only_enum.dart' as _i14;
-import 'serverOnly/not_server_only_class.dart' as _i15;
-import 'serverOnly/not_server_only_enum.dart' as _i16;
-import 'simple_data.dart' as _i17;
-import 'simple_data_list.dart' as _i18;
-import 'test_enum.dart' as _i19;
-import 'types.dart' as _i20;
-import 'protocol.dart' as _i21;
-import 'dart:typed_data' as _i22;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i23;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i24;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i25;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i26;
-import 'package:serverpod_test_module_client/module.dart' as _i27;
-import 'package:serverpod_auth_client/module.dart' as _i28;
+import 'object_with_self_parent.dart' as _i12;
+import 'object_with_uuid.dart' as _i13;
+import 'serverOnly/default_server_only_class.dart' as _i14;
+import 'serverOnly/default_server_only_enum.dart' as _i15;
+import 'serverOnly/not_server_only_class.dart' as _i16;
+import 'serverOnly/not_server_only_enum.dart' as _i17;
+import 'simple_data.dart' as _i18;
+import 'simple_data_list.dart' as _i19;
+import 'test_enum.dart' as _i20;
+import 'types.dart' as _i21;
+import 'protocol.dart' as _i22;
+import 'dart:typed_data' as _i23;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i24;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i25;
+import 'package:serverpod_test_module_client/module.dart' as _i26;
+import 'package:serverpod_auth_client/module.dart' as _i27;
 export 'exception_with_data.dart';
 export 'nullability.dart';
 export 'object_field_scopes.dart';
@@ -45,6 +44,7 @@ export 'object_with_index.dart';
 export 'object_with_maps.dart';
 export 'object_with_object.dart';
 export 'object_with_parent.dart';
+export 'object_with_self_parent.dart';
 export 'object_with_uuid.dart';
 export 'serverOnly/default_server_only_class.dart';
 export 'serverOnly/default_server_only_enum.dart';
@@ -104,32 +104,35 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i11.ObjectWithParent) {
       return _i11.ObjectWithParent.fromJson(data, this) as T;
     }
-    if (t == _i12.ObjectWithUuid) {
-      return _i12.ObjectWithUuid.fromJson(data, this) as T;
+    if (t == _i12.ObjectWithSelfParent) {
+      return _i12.ObjectWithSelfParent.fromJson(data, this) as T;
     }
-    if (t == _i13.DefaultServerOnlyClass) {
-      return _i13.DefaultServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i13.ObjectWithUuid) {
+      return _i13.ObjectWithUuid.fromJson(data, this) as T;
     }
-    if (t == _i14.DefaultServerOnlyEnum) {
-      return _i14.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i14.DefaultServerOnlyClass) {
+      return _i14.DefaultServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i15.NotServerOnlyClass) {
-      return _i15.NotServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i15.DefaultServerOnlyEnum) {
+      return _i15.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i16.NotServerOnlyEnum) {
-      return _i16.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i16.NotServerOnlyClass) {
+      return _i16.NotServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i17.SimpleData) {
-      return _i17.SimpleData.fromJson(data, this) as T;
+    if (t == _i17.NotServerOnlyEnum) {
+      return _i17.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i18.SimpleDataList) {
-      return _i18.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i18.SimpleData) {
+      return _i18.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i19.TestEnum) {
-      return _i19.TestEnum.fromJson(data) as T;
+    if (t == _i19.SimpleDataList) {
+      return _i19.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i20.Types) {
-      return _i20.Types.fromJson(data, this) as T;
+    if (t == _i20.TestEnum) {
+      return _i20.TestEnum.fromJson(data) as T;
+    }
+    if (t == _i21.Types) {
+      return _i21.Types.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.ExceptionWithData?>()) {
       return (data != null ? _i2.ExceptionWithData.fromJson(data, this) : null)
@@ -170,39 +173,44 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i11.ObjectWithParent.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i12.ObjectWithUuid?>()) {
-      return (data != null ? _i12.ObjectWithUuid.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i13.DefaultServerOnlyClass?>()) {
+    if (t == _i1.getType<_i12.ObjectWithSelfParent?>()) {
       return (data != null
-          ? _i13.DefaultServerOnlyClass.fromJson(data, this)
+          ? _i12.ObjectWithSelfParent.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i14.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i14.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i13.ObjectWithUuid?>()) {
+      return (data != null ? _i13.ObjectWithUuid.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i15.NotServerOnlyClass?>()) {
+    if (t == _i1.getType<_i14.DefaultServerOnlyClass?>()) {
       return (data != null
-          ? _i15.NotServerOnlyClass.fromJson(data, this)
+          ? _i14.DefaultServerOnlyClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i16.NotServerOnlyEnum?>()) {
-      return (data != null ? _i16.NotServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i17.SimpleData?>()) {
-      return (data != null ? _i17.SimpleData.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i18.SimpleDataList?>()) {
-      return (data != null ? _i18.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i15.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i15.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i19.TestEnum?>()) {
-      return (data != null ? _i19.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i16.NotServerOnlyClass?>()) {
+      return (data != null
+          ? _i16.NotServerOnlyClass.fromJson(data, this)
+          : null) as T;
     }
-    if (t == _i1.getType<_i20.Types?>()) {
-      return (data != null ? _i20.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i17.NotServerOnlyEnum?>()) {
+      return (data != null ? _i17.NotServerOnlyEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i18.SimpleData?>()) {
+      return (data != null ? _i18.SimpleData.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i19.SimpleDataList?>()) {
+      return (data != null ? _i19.SimpleDataList.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i20.TestEnum?>()) {
+      return (data != null ? _i20.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i21.Types?>()) {
+      return (data != null ? _i21.Types.fromJson(data, this) : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList()
@@ -225,23 +233,23 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i21.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i21.SimpleData>(e)).toList()
+    if (t == List<_i22.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i22.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i21.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i22.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i21.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i22.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i21.SimpleData?>) {
+    if (t == List<_i22.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i21.SimpleData?>(e))
+          .map((e) => deserialize<_i22.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i21.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i22.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i21.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i22.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -262,22 +270,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i22.ByteData>) {
-      return (data as List).map((e) => deserialize<_i22.ByteData>(e)).toList()
+    if (t == List<_i23.ByteData>) {
+      return (data as List).map((e) => deserialize<_i23.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i22.ByteData>?>()) {
+    if (t == _i1.getType<List<_i23.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i22.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i23.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i22.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i22.ByteData?>(e)).toList()
+    if (t == List<_i23.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i23.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i22.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i23.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i22.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i23.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -338,22 +346,22 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i21.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i21.TestEnum>(e)).toList()
+    if (t == List<_i22.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i22.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i21.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i21.TestEnum?>(e)).toList()
+    if (t == List<_i22.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i22.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i21.TestEnum>>) {
+    if (t == List<List<_i22.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i21.TestEnum>>(e))
+          .map((e) => deserialize<List<_i22.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i21.SimpleData>) {
+    if (t == Map<String, _i22.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i21.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i22.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -365,9 +373,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i22.ByteData>) {
+    if (t == Map<String, _i23.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i22.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i23.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -380,9 +388,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i21.SimpleData?>) {
+    if (t == Map<String, _i22.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i21.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i22.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -393,9 +401,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i22.ByteData?>) {
+    if (t == Map<String, _i23.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i22.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i23.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -413,317 +421,43 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i21.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i22.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i21.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i22.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i21.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i22.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i21.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i22.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
+    if (t == _i24.CustomClass) {
+      return _i24.CustomClass.fromJson(data, this) as T;
     }
-    if (t == List<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toList()
-          as dynamic;
+    if (t == _i25.ExternalCustomClass) {
+      return _i25.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<List<int>?>()) {
+    if (t == _i25.FreezedCustomClass) {
+      return _i25.FreezedCustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i1.getType<_i24.CustomClass?>()) {
+      return (data != null ? _i24.CustomClass.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i25.ExternalCustomClass?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<List<int>?>) {
-      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
-          as dynamic;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList()
-          as dynamic;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i22.ByteData>) {
-      return (data as List).map((e) => deserialize<_i22.ByteData>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i22.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i22.ByteData?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i23.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i23.SimpleData>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i23.SimpleData?>) {
-      return (data as List)
-          .map((e) => deserialize<_i23.SimpleData?>(e))
-          .toList() as dynamic;
-    }
-    if (t == _i1.getType<List<_i23.SimpleData>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i23.SimpleData>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<_i23.SimpleData>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i23.SimpleData>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<_i23.SimpleData?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i23.SimpleData?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<_i23.SimpleData?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i23.SimpleData?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList()
-          as dynamic;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
-          as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
-          : null) as dynamic;
-    }
-    if (t == Map<String, Map<String, int>>) {
-      return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<Map<String, int>>(v))) as dynamic;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
-          as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
-          : null) as dynamic;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries((data as List).map((e) =>
-              MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
-          as dynamic;
-    }
-    if (t == Map<_i24.TestEnum, int>) {
-      return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i24.TestEnum>(e['k']), deserialize<int>(e['v']))))
-          as dynamic;
-    }
-    if (t == Map<String, _i24.TestEnum>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i24.TestEnum>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<double>(v))) as dynamic;
-    }
-    if (t == Map<String, double?>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<double?>(v))) as dynamic;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, bool?>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<String>(v))) as dynamic;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<String?>(v))) as dynamic;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i22.ByteData>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i22.ByteData>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i22.ByteData?>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i22.ByteData?>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i23.SimpleData>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i23.SimpleData>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i23.SimpleData?>) {
-      return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i23.SimpleData?>(v))) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i23.SimpleData>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i23.SimpleData>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i23.SimpleData>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i23.SimpleData>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i23.SimpleData?>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i23.SimpleData?>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i23.SimpleData?>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i23.SimpleData?>(v)))
-          : null) as dynamic;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
-          as dynamic;
-    }
-    if (t == _i25.CustomClass) {
-      return _i25.CustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i26.ExternalCustomClass) {
-      return _i26.ExternalCustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i26.FreezedCustomClass) {
-      return _i26.FreezedCustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i1.getType<_i25.CustomClass?>()) {
-      return (data != null ? _i25.CustomClass.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i26.ExternalCustomClass?>()) {
-      return (data != null
-          ? _i26.ExternalCustomClass.fromJson(data, this)
+          ? _i25.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i26.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i25.FreezedCustomClass?>()) {
       return (data != null
-          ? _i26.FreezedCustomClass.fromJson(data, this)
+          ? _i25.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
-      return _i27.Protocol().deserialize<T>(data, t);
+      return _i26.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     try {
-      return _i28.Protocol().deserialize<T>(data, t);
+      return _i27.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -731,21 +465,21 @@ class Protocol extends _i1.SerializationManager {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i27.Protocol().getClassNameForObject(data);
+    className = _i26.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    className = _i28.Protocol().getClassNameForObject(data);
+    className = _i27.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i25.CustomClass) {
+    if (data is _i24.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i26.ExternalCustomClass) {
+    if (data is _i25.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i26.FreezedCustomClass) {
+    if (data is _i25.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.ExceptionWithData) {
@@ -778,31 +512,34 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i11.ObjectWithParent) {
       return 'ObjectWithParent';
     }
-    if (data is _i12.ObjectWithUuid) {
+    if (data is _i12.ObjectWithSelfParent) {
+      return 'ObjectWithSelfParent';
+    }
+    if (data is _i13.ObjectWithUuid) {
       return 'ObjectWithUuid';
     }
-    if (data is _i13.DefaultServerOnlyClass) {
+    if (data is _i14.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i14.DefaultServerOnlyEnum) {
+    if (data is _i15.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i15.NotServerOnlyClass) {
+    if (data is _i16.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i16.NotServerOnlyEnum) {
+    if (data is _i17.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i17.SimpleData) {
+    if (data is _i18.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i18.SimpleDataList) {
+    if (data is _i19.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i19.TestEnum) {
+    if (data is _i20.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i20.Types) {
+    if (data is _i21.Types) {
       return 'Types';
     }
     return super.getClassNameForObject(data);
@@ -812,20 +549,20 @@ class Protocol extends _i1.SerializationManager {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i27.Protocol().deserializeByClassName(data);
+      return _i26.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i28.Protocol().deserializeByClassName(data);
+      return _i27.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i25.CustomClass>(data['data']);
+      return deserialize<_i24.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i26.ExternalCustomClass>(data['data']);
+      return deserialize<_i25.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i26.FreezedCustomClass>(data['data']);
+      return deserialize<_i25.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i2.ExceptionWithData>(data['data']);
@@ -857,32 +594,35 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'ObjectWithParent') {
       return deserialize<_i11.ObjectWithParent>(data['data']);
     }
+    if (data['className'] == 'ObjectWithSelfParent') {
+      return deserialize<_i12.ObjectWithSelfParent>(data['data']);
+    }
     if (data['className'] == 'ObjectWithUuid') {
-      return deserialize<_i12.ObjectWithUuid>(data['data']);
+      return deserialize<_i13.ObjectWithUuid>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyClass') {
-      return deserialize<_i13.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i14.DefaultServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyEnum') {
-      return deserialize<_i14.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i15.DefaultServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyClass') {
-      return deserialize<_i15.NotServerOnlyClass>(data['data']);
+      return deserialize<_i16.NotServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyEnum') {
-      return deserialize<_i16.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i17.NotServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i17.SimpleData>(data['data']);
+      return deserialize<_i18.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i18.SimpleDataList>(data['data']);
+      return deserialize<_i19.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i19.TestEnum>(data['data']);
+      return deserialize<_i20.TestEnum>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i20.Types>(data['data']);
+      return deserialize<_i21.Types>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -30,10 +30,12 @@ import 'test_enum.dart' as _i20;
 import 'types.dart' as _i21;
 import 'protocol.dart' as _i22;
 import 'dart:typed_data' as _i23;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i24;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i25;
-import 'package:serverpod_test_module_client/module.dart' as _i26;
-import 'package:serverpod_auth_client/module.dart' as _i27;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i24;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i25;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i26;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i27;
+import 'package:serverpod_test_module_client/module.dart' as _i28;
+import 'package:serverpod_auth_client/module.dart' as _i29;
 export 'exception_with_data.dart';
 export 'nullability.dart';
 export 'object_field_scopes.dart';
@@ -431,33 +433,307 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<_i22.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i24.CustomClass) {
-      return _i24.CustomClass.fromJson(data, this) as T;
+    if (t == List<int>) {
+      return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
     }
-    if (t == _i25.ExternalCustomClass) {
-      return _i25.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == List<List<int>>) {
+      return (data as List).map((e) => deserialize<List<int>>(e)).toList()
+          as dynamic;
     }
-    if (t == _i25.FreezedCustomClass) {
-      return _i25.FreezedCustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i1.getType<_i24.CustomClass?>()) {
-      return (data != null ? _i24.CustomClass.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i25.ExternalCustomClass?>()) {
+    if (t == _i1.getType<List<int>?>()) {
       return (data != null
-          ? _i25.ExternalCustomClass.fromJson(data, this)
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<List<int>?>) {
+      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<List<int>>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<List<int>>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<int?>) {
+      return (data as List).map((e) => deserialize<int?>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<int?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<int?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<double>) {
+      return (data as List).map((e) => deserialize<double>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<double?>) {
+      return (data as List).map((e) => deserialize<double?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<bool>) {
+      return (data as List).map((e) => deserialize<bool>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<bool?>) {
+      return (data as List).map((e) => deserialize<bool?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<String>) {
+      return (data as List).map((e) => deserialize<String>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<String?>) {
+      return (data as List).map((e) => deserialize<String?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<DateTime>) {
+      return (data as List).map((e) => deserialize<DateTime>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<DateTime?>) {
+      return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i23.ByteData>) {
+      return (data as List).map((e) => deserialize<_i23.ByteData>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i23.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i23.ByteData?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i24.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i24.SimpleData>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i24.SimpleData?>) {
+      return (data as List)
+          .map((e) => deserialize<_i24.SimpleData?>(e))
+          .toList() as dynamic;
+    }
+    if (t == _i1.getType<List<_i24.SimpleData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i24.SimpleData>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i24.SimpleData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i24.SimpleData>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i24.SimpleData?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i24.SimpleData?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i24.SimpleData?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i24.SimpleData?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<Duration>) {
+      return (data as List).map((e) => deserialize<Duration>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<Duration?>) {
+      return (data as List).map((e) => deserialize<Duration?>(e)).toList()
+          as dynamic;
+    }
+    if (t == Map<String, int>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          : null) as dynamic;
+    }
+    if (t == Map<String, Map<String, int>>) {
+      return (data as Map).map((k, v) => MapEntry(
+          deserialize<String>(k), deserialize<Map<String, int>>(v))) as dynamic;
+    }
+    if (t == Map<String, int?>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int?>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int?>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
+          : null) as dynamic;
+    }
+    if (t == Map<int, int>) {
+      return Map.fromEntries((data as List).map((e) =>
+              MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
+          as dynamic;
+    }
+    if (t == Map<_i25.TestEnum, int>) {
+      return Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i25.TestEnum>(e['k']), deserialize<int>(e['v']))))
+          as dynamic;
+    }
+    if (t == Map<String, _i25.TestEnum>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i25.TestEnum>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, double>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<double>(v))) as dynamic;
+    }
+    if (t == Map<String, double?>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<double?>(v))) as dynamic;
+    }
+    if (t == Map<String, bool>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, bool?>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, String>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<String>(v))) as dynamic;
+    }
+    if (t == Map<String, String?>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<String?>(v))) as dynamic;
+    }
+    if (t == Map<String, DateTime>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, DateTime?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i23.ByteData>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i23.ByteData>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i23.ByteData?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i23.ByteData?>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i24.SimpleData>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i24.SimpleData>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i24.SimpleData?>) {
+      return (data as Map).map((k, v) => MapEntry(
+          deserialize<String>(k), deserialize<_i24.SimpleData?>(v))) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i24.SimpleData>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i24.SimpleData>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i24.SimpleData>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i24.SimpleData>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i24.SimpleData?>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<_i24.SimpleData?>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i24.SimpleData?>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<_i24.SimpleData?>(v)))
+          : null) as dynamic;
+    }
+    if (t == Map<String, Duration>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, Duration?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
+          as dynamic;
+    }
+    if (t == _i26.CustomClass) {
+      return _i26.CustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i27.ExternalCustomClass) {
+      return _i27.ExternalCustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i27.FreezedCustomClass) {
+      return _i27.FreezedCustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i1.getType<_i26.CustomClass?>()) {
+      return (data != null ? _i26.CustomClass.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i27.ExternalCustomClass?>()) {
+      return (data != null
+          ? _i27.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i25.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i27.FreezedCustomClass?>()) {
       return (data != null
-          ? _i25.FreezedCustomClass.fromJson(data, this)
+          ? _i27.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
-      return _i26.Protocol().deserialize<T>(data, t);
+      return _i28.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     try {
-      return _i27.Protocol().deserialize<T>(data, t);
+      return _i29.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -465,21 +741,21 @@ class Protocol extends _i1.SerializationManager {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i26.Protocol().getClassNameForObject(data);
+    className = _i28.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    className = _i27.Protocol().getClassNameForObject(data);
+    className = _i29.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i24.CustomClass) {
+    if (data is _i26.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i25.ExternalCustomClass) {
+    if (data is _i27.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i25.FreezedCustomClass) {
+    if (data is _i27.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.ExceptionWithData) {
@@ -549,20 +825,20 @@ class Protocol extends _i1.SerializationManager {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i26.Protocol().deserializeByClassName(data);
+      return _i28.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i27.Protocol().deserializeByClassName(data);
+      return _i29.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i24.CustomClass>(data['data']);
+      return deserialize<_i26.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i25.ExternalCustomClass>(data['data']);
+      return deserialize<_i27.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i25.FreezedCustomClass>(data['data']);
+      return deserialize<_i27.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i2.ExceptionWithData>(data['data']);

--- a/tests/serverpod_test_server/generated/tables.pgsql
+++ b/tests/serverpod_test_server/generated/tables.pgsql
@@ -108,6 +108,24 @@ ALTER TABLE ONLY "object_with_parent"
         ON DELETE CASCADE;
 
 --
+-- Class ObjectWithSelfParent as table object_with_self_parent
+--
+
+CREATE TABLE "object_with_self_parent" (
+  "id" serial,
+  "other" integer NOT NULL
+);
+
+ALTER TABLE ONLY "object_with_self_parent"
+  ADD CONSTRAINT object_with_self_parent_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY "object_with_self_parent"
+  ADD CONSTRAINT object_with_self_parent_fk_0
+    FOREIGN KEY("other")
+      REFERENCES object_with_self_parent(id)
+        ON DELETE CASCADE;
+
+--
 -- Class ObjectWithUuid as table object_with_uuid
 --
 

--- a/tests/serverpod_test_server/generated/tables.pgsql
+++ b/tests/serverpod_test_server/generated/tables.pgsql
@@ -113,7 +113,7 @@ ALTER TABLE ONLY "object_with_parent"
 
 CREATE TABLE "object_with_self_parent" (
   "id" serial,
-  "other" integer NOT NULL
+  "other" integer
 );
 
 ALTER TABLE ONLY "object_with_self_parent"

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -11,7 +11,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 class ObjectWithSelfParent extends _i1.TableRow {
   ObjectWithSelfParent({
     int? id,
-    required this.other,
+    this.other,
   }) : super(id);
 
   factory ObjectWithSelfParent.fromJson(
@@ -20,13 +20,13 @@ class ObjectWithSelfParent extends _i1.TableRow {
   ) {
     return ObjectWithSelfParent(
       id: serializationManager.deserialize<int?>(jsonSerialization['id']),
-      other: serializationManager.deserialize<int>(jsonSerialization['other']),
+      other: serializationManager.deserialize<int?>(jsonSerialization['other']),
     );
   }
 
   static final t = ObjectWithSelfParentTable();
 
-  int other;
+  int? other;
 
   @override
   String get tableName => 'object_with_self_parent';

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -1,0 +1,204 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+class ObjectWithSelfParent extends _i1.TableRow {
+  ObjectWithSelfParent({
+    int? id,
+    required this.other,
+  }) : super(id);
+
+  factory ObjectWithSelfParent.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ObjectWithSelfParent(
+      id: serializationManager.deserialize<int?>(jsonSerialization['id']),
+      other: serializationManager.deserialize<int>(jsonSerialization['other']),
+    );
+  }
+
+  static final t = ObjectWithSelfParentTable();
+
+  int other;
+
+  @override
+  String get tableName => 'object_with_self_parent';
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'other': other,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForDatabase() {
+    return {
+      'id': id,
+      'other': other,
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'id': id,
+      'other': other,
+    };
+  }
+
+  @override
+  void setColumn(
+    String columnName,
+    value,
+  ) {
+    switch (columnName) {
+      case 'id':
+        id = value;
+        return;
+      case 'other':
+        other = value;
+        return;
+      default:
+        throw UnimplementedError();
+    }
+  }
+
+  static Future<List<ObjectWithSelfParent>> find(
+    _i1.Session session, {
+    ObjectWithSelfParentExpressionBuilder? where,
+    int? limit,
+    int? offset,
+    _i1.Column? orderBy,
+    List<_i1.Order>? orderByList,
+    bool orderDescending = false,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.find<ObjectWithSelfParent>(
+      where: where != null ? where(ObjectWithSelfParent.t) : null,
+      limit: limit,
+      offset: offset,
+      orderBy: orderBy,
+      orderByList: orderByList,
+      orderDescending: orderDescending,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+
+  static Future<ObjectWithSelfParent?> findSingleRow(
+    _i1.Session session, {
+    ObjectWithSelfParentExpressionBuilder? where,
+    int? offset,
+    _i1.Column? orderBy,
+    bool orderDescending = false,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.findSingleRow<ObjectWithSelfParent>(
+      where: where != null ? where(ObjectWithSelfParent.t) : null,
+      offset: offset,
+      orderBy: orderBy,
+      orderDescending: orderDescending,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+
+  static Future<ObjectWithSelfParent?> findById(
+    _i1.Session session,
+    int id,
+  ) async {
+    return session.db.findById<ObjectWithSelfParent>(id);
+  }
+
+  static Future<int> delete(
+    _i1.Session session, {
+    required ObjectWithSelfParentExpressionBuilder where,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.delete<ObjectWithSelfParent>(
+      where: where(ObjectWithSelfParent.t),
+      transaction: transaction,
+    );
+  }
+
+  static Future<bool> deleteRow(
+    _i1.Session session,
+    ObjectWithSelfParent row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.deleteRow(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<bool> update(
+    _i1.Session session,
+    ObjectWithSelfParent row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.update(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<void> insert(
+    _i1.Session session,
+    ObjectWithSelfParent row, {
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.insert(
+      row,
+      transaction: transaction,
+    );
+  }
+
+  static Future<int> count(
+    _i1.Session session, {
+    ObjectWithSelfParentExpressionBuilder? where,
+    int? limit,
+    bool useCache = true,
+    _i1.Transaction? transaction,
+  }) async {
+    return session.db.count<ObjectWithSelfParent>(
+      where: where != null ? where(ObjectWithSelfParent.t) : null,
+      limit: limit,
+      useCache: useCache,
+      transaction: transaction,
+    );
+  }
+}
+
+typedef ObjectWithSelfParentExpressionBuilder = _i1.Expression Function(
+    ObjectWithSelfParentTable);
+
+class ObjectWithSelfParentTable extends _i1.Table {
+  ObjectWithSelfParentTable() : super(tableName: 'object_with_self_parent');
+
+  /// The database id, set if the object has been inserted into the
+  /// database or if it has been fetched from the database. Otherwise,
+  /// the id will be null.
+  final id = _i1.ColumnInt('id');
+
+  final other = _i1.ColumnInt('other');
+
+  @override
+  List<_i1.Column> get columns => [
+        id,
+        other,
+      ];
+}
+
+@Deprecated('Use ObjectWithSelfParentTable.t instead.')
+ObjectWithSelfParentTable tObjectWithSelfParent = ObjectWithSelfParentTable();

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -433,8 +433,8 @@ class Protocol extends _i1.SerializationManagerServer {
         _i2.ColumnDefinition(
           name: 'other',
           columnType: _i2.ColumnType.integer,
-          isNullable: false,
-          dartType: 'int',
+          isNullable: true,
+          dartType: 'int?',
         ),
       ],
       foreignKeys: [

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -35,8 +35,10 @@ import 'test_enum.dart' as _i25;
 import 'types.dart' as _i26;
 import 'protocol.dart' as _i27;
 import 'dart:typed_data' as _i28;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i29;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i30;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i29;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i30;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i31;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i32;
 export 'exception_with_data.dart';
 export 'nullability.dart';
 export 'object_field_scopes.dart';
@@ -1004,26 +1006,300 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<_i27.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i29.CustomClass) {
-      return _i29.CustomClass.fromJson(data, this) as T;
+    if (t == List<int>) {
+      return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
     }
-    if (t == _i30.ExternalCustomClass) {
-      return _i30.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == List<List<int>>) {
+      return (data as List).map((e) => deserialize<List<int>>(e)).toList()
+          as dynamic;
     }
-    if (t == _i30.FreezedCustomClass) {
-      return _i30.FreezedCustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i1.getType<_i29.CustomClass?>()) {
-      return (data != null ? _i29.CustomClass.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i30.ExternalCustomClass?>()) {
+    if (t == _i1.getType<List<int>?>()) {
       return (data != null
-          ? _i30.ExternalCustomClass.fromJson(data, this)
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<List<int>?>) {
+      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<List<int>>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<List<int>>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<int?>) {
+      return (data as List).map((e) => deserialize<int?>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<List<int?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<int?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<double>) {
+      return (data as List).map((e) => deserialize<double>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<double?>) {
+      return (data as List).map((e) => deserialize<double?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<bool>) {
+      return (data as List).map((e) => deserialize<bool>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<bool?>) {
+      return (data as List).map((e) => deserialize<bool?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<String>) {
+      return (data as List).map((e) => deserialize<String>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<String?>) {
+      return (data as List).map((e) => deserialize<String?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<DateTime>) {
+      return (data as List).map((e) => deserialize<DateTime>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<DateTime?>) {
+      return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i28.ByteData>) {
+      return (data as List).map((e) => deserialize<_i28.ByteData>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i28.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i28.ByteData?>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i29.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i29.SimpleData>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i29.SimpleData?>) {
+      return (data as List)
+          .map((e) => deserialize<_i29.SimpleData?>(e))
+          .toList() as dynamic;
+    }
+    if (t == _i1.getType<List<_i29.SimpleData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i29.SimpleData>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i29.SimpleData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i29.SimpleData>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i29.SimpleData?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i29.SimpleData?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i29.SimpleData?>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i29.SimpleData?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<Duration>) {
+      return (data as List).map((e) => deserialize<Duration>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<Duration?>) {
+      return (data as List).map((e) => deserialize<Duration?>(e)).toList()
+          as dynamic;
+    }
+    if (t == Map<String, int>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          : null) as dynamic;
+    }
+    if (t == Map<String, Map<String, int>>) {
+      return (data as Map).map((k, v) => MapEntry(
+          deserialize<String>(k), deserialize<Map<String, int>>(v))) as dynamic;
+    }
+    if (t == Map<String, int?>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int?>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int?>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
+          : null) as dynamic;
+    }
+    if (t == Map<int, int>) {
+      return Map.fromEntries((data as List).map((e) =>
+              MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
+          as dynamic;
+    }
+    if (t == Map<_i30.TestEnum, int>) {
+      return Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i30.TestEnum>(e['k']), deserialize<int>(e['v']))))
+          as dynamic;
+    }
+    if (t == Map<String, _i30.TestEnum>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i30.TestEnum>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, double>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<double>(v))) as dynamic;
+    }
+    if (t == Map<String, double?>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<double?>(v))) as dynamic;
+    }
+    if (t == Map<String, bool>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, bool?>) {
+      return (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, String>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<String>(v))) as dynamic;
+    }
+    if (t == Map<String, String?>) {
+      return (data as Map).map((k, v) =>
+          MapEntry(deserialize<String>(k), deserialize<String?>(v))) as dynamic;
+    }
+    if (t == Map<String, DateTime>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, DateTime?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i28.ByteData>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i28.ByteData>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i28.ByteData?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i28.ByteData?>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i29.SimpleData>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i29.SimpleData>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, _i29.SimpleData?>) {
+      return (data as Map).map((k, v) => MapEntry(
+          deserialize<String>(k), deserialize<_i29.SimpleData?>(v))) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i29.SimpleData>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i29.SimpleData>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i29.SimpleData>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i29.SimpleData>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i29.SimpleData?>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<_i29.SimpleData?>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i29.SimpleData?>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<_i29.SimpleData?>(v)))
+          : null) as dynamic;
+    }
+    if (t == Map<String, Duration>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
+          as dynamic;
+    }
+    if (t == Map<String, Duration?>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
+          as dynamic;
+    }
+    if (t == _i31.CustomClass) {
+      return _i31.CustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i32.ExternalCustomClass) {
+      return _i32.ExternalCustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i32.FreezedCustomClass) {
+      return _i32.FreezedCustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i1.getType<_i31.CustomClass?>()) {
+      return (data != null ? _i31.CustomClass.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i32.ExternalCustomClass?>()) {
+      return (data != null
+          ? _i32.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i30.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i32.FreezedCustomClass?>()) {
       return (data != null
-          ? _i30.FreezedCustomClass.fromJson(data, this)
+          ? _i32.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
@@ -1049,13 +1325,13 @@ class Protocol extends _i1.SerializationManagerServer {
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i29.CustomClass) {
+    if (data is _i31.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i30.ExternalCustomClass) {
+    if (data is _i32.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i30.FreezedCustomClass) {
+    if (data is _i32.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i5.ExceptionWithData) {
@@ -1138,13 +1414,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return _i4.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i29.CustomClass>(data['data']);
+      return deserialize<_i31.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i30.ExternalCustomClass>(data['data']);
+      return deserialize<_i32.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i30.FreezedCustomClass>(data['data']);
+      return deserialize<_i32.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i5.ExceptionWithData>(data['data']);

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -21,23 +21,22 @@ import 'object_with_index.dart' as _i11;
 import 'object_with_maps.dart' as _i12;
 import 'object_with_object.dart' as _i13;
 import 'object_with_parent.dart' as _i14;
-import 'object_with_uuid.dart' as _i15;
-import 'serverOnly/default_server_only_class.dart' as _i16;
-import 'serverOnly/default_server_only_enum.dart' as _i17;
-import 'serverOnly/not_server_only_class.dart' as _i18;
-import 'serverOnly/not_server_only_enum.dart' as _i19;
-import 'serverOnly/server_only_class.dart' as _i20;
-import 'serverOnly/server_only_enum.dart' as _i21;
-import 'simple_data.dart' as _i22;
-import 'simple_data_list.dart' as _i23;
-import 'test_enum.dart' as _i24;
-import 'types.dart' as _i25;
-import 'protocol.dart' as _i26;
-import 'dart:typed_data' as _i27;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i28;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i29;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i30;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i31;
+import 'object_with_self_parent.dart' as _i15;
+import 'object_with_uuid.dart' as _i16;
+import 'serverOnly/default_server_only_class.dart' as _i17;
+import 'serverOnly/default_server_only_enum.dart' as _i18;
+import 'serverOnly/not_server_only_class.dart' as _i19;
+import 'serverOnly/not_server_only_enum.dart' as _i20;
+import 'serverOnly/server_only_class.dart' as _i21;
+import 'serverOnly/server_only_enum.dart' as _i22;
+import 'simple_data.dart' as _i23;
+import 'simple_data_list.dart' as _i24;
+import 'test_enum.dart' as _i25;
+import 'types.dart' as _i26;
+import 'protocol.dart' as _i27;
+import 'dart:typed_data' as _i28;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i29;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i30;
 export 'exception_with_data.dart';
 export 'nullability.dart';
 export 'object_field_scopes.dart';
@@ -48,6 +47,7 @@ export 'object_with_index.dart';
 export 'object_with_maps.dart';
 export 'object_with_object.dart';
 export 'object_with_parent.dart';
+export 'object_with_self_parent.dart';
 export 'object_with_uuid.dart';
 export 'serverOnly/default_server_only_class.dart';
 export 'serverOnly/default_server_only_enum.dart';
@@ -417,6 +417,54 @@ class Protocol extends _i1.SerializationManagerServer {
       managed: true,
     ),
     _i2.TableDefinition(
+      name: 'object_with_self_parent',
+      schema: 'public',
+      columns: [
+        _i2.ColumnDefinition(
+          name: 'id',
+          columnType: _i2.ColumnType.integer,
+          isNullable: false,
+          dartType: 'int?',
+          columnDefault:
+              'nextval(\'object_with_self_parent_id_seq\'::regclass)',
+        ),
+        _i2.ColumnDefinition(
+          name: 'other',
+          columnType: _i2.ColumnType.integer,
+          isNullable: false,
+          dartType: 'int',
+        ),
+      ],
+      foreignKeys: [
+        _i2.ForeignKeyDefinition(
+          constraintName: 'object_with_self_parent_fk_0',
+          columns: ['other'],
+          referenceTable: 'object_with_self_parent',
+          referenceTableSchema: 'public',
+          referenceColumns: ['id'],
+          onUpdate: null,
+          onDelete: _i2.ForeignKeyAction.cascade,
+          matchType: null,
+        )
+      ],
+      indexes: [
+        _i2.IndexDefinition(
+          indexName: 'object_with_self_parent_pkey',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'id',
+            )
+          ],
+          type: 'btree',
+          isUnique: true,
+          isPrimary: true,
+        )
+      ],
+      managed: true,
+    ),
+    _i2.TableDefinition(
       name: 'object_with_uuid',
       schema: 'public',
       columns: [
@@ -616,38 +664,41 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i14.ObjectWithParent) {
       return _i14.ObjectWithParent.fromJson(data, this) as T;
     }
-    if (t == _i15.ObjectWithUuid) {
-      return _i15.ObjectWithUuid.fromJson(data, this) as T;
+    if (t == _i15.ObjectWithSelfParent) {
+      return _i15.ObjectWithSelfParent.fromJson(data, this) as T;
     }
-    if (t == _i16.DefaultServerOnlyClass) {
-      return _i16.DefaultServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i16.ObjectWithUuid) {
+      return _i16.ObjectWithUuid.fromJson(data, this) as T;
     }
-    if (t == _i17.DefaultServerOnlyEnum) {
-      return _i17.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i17.DefaultServerOnlyClass) {
+      return _i17.DefaultServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i18.NotServerOnlyClass) {
-      return _i18.NotServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i18.DefaultServerOnlyEnum) {
+      return _i18.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i19.NotServerOnlyEnum) {
-      return _i19.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i19.NotServerOnlyClass) {
+      return _i19.NotServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i20.ServerOnlyClass) {
-      return _i20.ServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i20.NotServerOnlyEnum) {
+      return _i20.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i21.ServerOnlyEnum) {
-      return _i21.ServerOnlyEnum.fromJson(data) as T;
+    if (t == _i21.ServerOnlyClass) {
+      return _i21.ServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i22.SimpleData) {
-      return _i22.SimpleData.fromJson(data, this) as T;
+    if (t == _i22.ServerOnlyEnum) {
+      return _i22.ServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i23.SimpleDataList) {
-      return _i23.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i23.SimpleData) {
+      return _i23.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i24.TestEnum) {
-      return _i24.TestEnum.fromJson(data) as T;
+    if (t == _i24.SimpleDataList) {
+      return _i24.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i25.Types) {
-      return _i25.Types.fromJson(data, this) as T;
+    if (t == _i25.TestEnum) {
+      return _i25.TestEnum.fromJson(data) as T;
+    }
+    if (t == _i26.Types) {
+      return _i26.Types.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i5.ExceptionWithData?>()) {
       return (data != null ? _i5.ExceptionWithData.fromJson(data, this) : null)
@@ -688,46 +739,51 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i14.ObjectWithParent.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i15.ObjectWithUuid?>()) {
-      return (data != null ? _i15.ObjectWithUuid.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i16.DefaultServerOnlyClass?>()) {
+    if (t == _i1.getType<_i15.ObjectWithSelfParent?>()) {
       return (data != null
-          ? _i16.DefaultServerOnlyClass.fromJson(data, this)
+          ? _i15.ObjectWithSelfParent.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i17.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i17.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i16.ObjectWithUuid?>()) {
+      return (data != null ? _i16.ObjectWithUuid.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i18.NotServerOnlyClass?>()) {
+    if (t == _i1.getType<_i17.DefaultServerOnlyClass?>()) {
       return (data != null
-          ? _i18.NotServerOnlyClass.fromJson(data, this)
+          ? _i17.DefaultServerOnlyClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i19.NotServerOnlyEnum?>()) {
-      return (data != null ? _i19.NotServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.ServerOnlyClass?>()) {
-      return (data != null ? _i20.ServerOnlyClass.fromJson(data, this) : null)
+    if (t == _i1.getType<_i18.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i18.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i21.ServerOnlyEnum?>()) {
-      return (data != null ? _i21.ServerOnlyEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i19.NotServerOnlyClass?>()) {
+      return (data != null
+          ? _i19.NotServerOnlyClass.fromJson(data, this)
+          : null) as T;
     }
-    if (t == _i1.getType<_i22.SimpleData?>()) {
-      return (data != null ? _i22.SimpleData.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i20.NotServerOnlyEnum?>()) {
+      return (data != null ? _i20.NotServerOnlyEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i23.SimpleDataList?>()) {
-      return (data != null ? _i23.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i21.ServerOnlyClass?>()) {
+      return (data != null ? _i21.ServerOnlyClass.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i24.TestEnum?>()) {
-      return (data != null ? _i24.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i22.ServerOnlyEnum?>()) {
+      return (data != null ? _i22.ServerOnlyEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i25.Types?>()) {
-      return (data != null ? _i25.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i23.SimpleData?>()) {
+      return (data != null ? _i23.SimpleData.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i24.SimpleDataList?>()) {
+      return (data != null ? _i24.SimpleDataList.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i25.TestEnum?>()) {
+      return (data != null ? _i25.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i26.Types?>()) {
+      return (data != null ? _i26.Types.fromJson(data, this) : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList()
@@ -750,23 +806,23 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i26.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i26.SimpleData>(e)).toList()
+    if (t == List<_i27.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i27.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i26.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i27.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i26.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i27.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i26.SimpleData?>) {
+    if (t == List<_i27.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i26.SimpleData?>(e))
+          .map((e) => deserialize<_i27.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i26.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i27.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i26.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i27.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -787,22 +843,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i27.ByteData>) {
-      return (data as List).map((e) => deserialize<_i27.ByteData>(e)).toList()
+    if (t == List<_i28.ByteData>) {
+      return (data as List).map((e) => deserialize<_i28.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i27.ByteData>?>()) {
+    if (t == _i1.getType<List<_i28.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i27.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i28.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i27.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i27.ByteData?>(e)).toList()
+    if (t == List<_i28.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i28.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i27.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i28.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i27.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i28.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -863,22 +919,22 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i26.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i26.TestEnum>(e)).toList()
+    if (t == List<_i27.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i27.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i26.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i26.TestEnum?>(e)).toList()
+    if (t == List<_i27.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i27.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i26.TestEnum>>) {
+    if (t == List<List<_i27.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i26.TestEnum>>(e))
+          .map((e) => deserialize<List<_i27.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i26.SimpleData>) {
+    if (t == Map<String, _i27.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i26.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i27.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -890,9 +946,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i27.ByteData>) {
+    if (t == Map<String, _i28.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i27.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i28.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -905,9 +961,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i26.SimpleData?>) {
+    if (t == Map<String, _i27.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i26.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i27.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -918,9 +974,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i27.ByteData?>) {
+    if (t == Map<String, _i28.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i27.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i28.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -938,310 +994,36 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i26.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i27.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i26.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i27.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i26.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i27.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i26.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i27.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<int>) {
-      return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
+    if (t == _i29.CustomClass) {
+      return _i29.CustomClass.fromJson(data, this) as T;
     }
-    if (t == List<List<int>>) {
-      return (data as List).map((e) => deserialize<List<int>>(e)).toList()
-          as dynamic;
+    if (t == _i30.ExternalCustomClass) {
+      return _i30.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<List<int>?>()) {
+    if (t == _i30.FreezedCustomClass) {
+      return _i30.FreezedCustomClass.fromJson(data, this) as T;
+    }
+    if (t == _i1.getType<_i29.CustomClass?>()) {
+      return (data != null ? _i29.CustomClass.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i30.ExternalCustomClass?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<List<int>?>) {
-      return (data as List).map((e) => deserialize<List<int>?>(e)).toList()
-          as dynamic;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<int>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<List<int>>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<List<int>>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<int?>) {
-      return (data as List).map((e) => deserialize<int?>(e)).toList()
-          as dynamic;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<int?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<int?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<double>) {
-      return (data as List).map((e) => deserialize<double>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<double?>) {
-      return (data as List).map((e) => deserialize<double?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<bool>) {
-      return (data as List).map((e) => deserialize<bool>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<bool?>) {
-      return (data as List).map((e) => deserialize<bool?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<String?>) {
-      return (data as List).map((e) => deserialize<String?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<DateTime>) {
-      return (data as List).map((e) => deserialize<DateTime>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<DateTime?>) {
-      return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i27.ByteData>) {
-      return (data as List).map((e) => deserialize<_i27.ByteData>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i27.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i27.ByteData?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i28.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i28.SimpleData>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i28.SimpleData?>) {
-      return (data as List)
-          .map((e) => deserialize<_i28.SimpleData?>(e))
-          .toList() as dynamic;
-    }
-    if (t == _i1.getType<List<_i28.SimpleData>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i28.SimpleData>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<_i28.SimpleData>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i28.SimpleData>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<_i28.SimpleData?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i28.SimpleData?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<List<_i28.SimpleData?>?>()) {
-      return (data != null
-          ? (data as List).map((e) => deserialize<_i28.SimpleData?>(e)).toList()
-          : null) as dynamic;
-    }
-    if (t == List<Duration>) {
-      return (data as List).map((e) => deserialize<Duration>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<Duration?>) {
-      return (data as List).map((e) => deserialize<Duration?>(e)).toList()
-          as dynamic;
-    }
-    if (t == Map<String, int>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
-          as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
-          : null) as dynamic;
-    }
-    if (t == Map<String, Map<String, int>>) {
-      return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<Map<String, int>>(v))) as dynamic;
-    }
-    if (t == Map<String, int?>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
-          as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, int?>?>()) {
-      return (data != null
-          ? (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
-          : null) as dynamic;
-    }
-    if (t == Map<int, int>) {
-      return Map.fromEntries((data as List).map((e) =>
-              MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
-          as dynamic;
-    }
-    if (t == Map<_i29.TestEnum, int>) {
-      return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i29.TestEnum>(e['k']), deserialize<int>(e['v']))))
-          as dynamic;
-    }
-    if (t == Map<String, _i29.TestEnum>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i29.TestEnum>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, double>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<double>(v))) as dynamic;
-    }
-    if (t == Map<String, double?>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<double?>(v))) as dynamic;
-    }
-    if (t == Map<String, bool>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, bool?>) {
-      return (data as Map).map(
-              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool?>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, String>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<String>(v))) as dynamic;
-    }
-    if (t == Map<String, String?>) {
-      return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<String?>(v))) as dynamic;
-    }
-    if (t == Map<String, DateTime>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, DateTime?>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i27.ByteData>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i27.ByteData>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i27.ByteData?>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i27.ByteData?>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i28.SimpleData>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i28.SimpleData>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, _i28.SimpleData?>) {
-      return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i28.SimpleData?>(v))) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i28.SimpleData>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i28.SimpleData>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i28.SimpleData>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i28.SimpleData>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i28.SimpleData?>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i28.SimpleData?>(v)))
-          : null) as dynamic;
-    }
-    if (t == _i1.getType<Map<String, _i28.SimpleData?>?>()) {
-      return (data != null
-          ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i28.SimpleData?>(v)))
-          : null) as dynamic;
-    }
-    if (t == Map<String, Duration>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
-          as dynamic;
-    }
-    if (t == Map<String, Duration?>) {
-      return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
-          as dynamic;
-    }
-    if (t == _i30.CustomClass) {
-      return _i30.CustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i31.ExternalCustomClass) {
-      return _i31.ExternalCustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i31.FreezedCustomClass) {
-      return _i31.FreezedCustomClass.fromJson(data, this) as T;
-    }
-    if (t == _i1.getType<_i30.CustomClass?>()) {
-      return (data != null ? _i30.CustomClass.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i31.ExternalCustomClass?>()) {
-      return (data != null
-          ? _i31.ExternalCustomClass.fromJson(data, this)
+          ? _i30.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i31.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i30.FreezedCustomClass?>()) {
       return (data != null
-          ? _i31.FreezedCustomClass.fromJson(data, this)
+          ? _i30.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
@@ -1267,13 +1049,13 @@ class Protocol extends _i1.SerializationManagerServer {
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    if (data is _i30.CustomClass) {
+    if (data is _i29.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i31.ExternalCustomClass) {
+    if (data is _i30.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i31.FreezedCustomClass) {
+    if (data is _i30.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i5.ExceptionWithData) {
@@ -1306,37 +1088,40 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i14.ObjectWithParent) {
       return 'ObjectWithParent';
     }
-    if (data is _i15.ObjectWithUuid) {
+    if (data is _i15.ObjectWithSelfParent) {
+      return 'ObjectWithSelfParent';
+    }
+    if (data is _i16.ObjectWithUuid) {
       return 'ObjectWithUuid';
     }
-    if (data is _i16.DefaultServerOnlyClass) {
+    if (data is _i17.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i17.DefaultServerOnlyEnum) {
+    if (data is _i18.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i18.NotServerOnlyClass) {
+    if (data is _i19.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i19.NotServerOnlyEnum) {
+    if (data is _i20.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i20.ServerOnlyClass) {
+    if (data is _i21.ServerOnlyClass) {
       return 'ServerOnlyClass';
     }
-    if (data is _i21.ServerOnlyEnum) {
+    if (data is _i22.ServerOnlyEnum) {
       return 'ServerOnlyEnum';
     }
-    if (data is _i22.SimpleData) {
+    if (data is _i23.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i23.SimpleDataList) {
+    if (data is _i24.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i24.TestEnum) {
+    if (data is _i25.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i25.Types) {
+    if (data is _i26.Types) {
       return 'Types';
     }
     return super.getClassNameForObject(data);
@@ -1353,13 +1138,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return _i4.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i30.CustomClass>(data['data']);
+      return deserialize<_i29.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i31.ExternalCustomClass>(data['data']);
+      return deserialize<_i30.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i31.FreezedCustomClass>(data['data']);
+      return deserialize<_i30.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i5.ExceptionWithData>(data['data']);
@@ -1391,38 +1176,41 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'ObjectWithParent') {
       return deserialize<_i14.ObjectWithParent>(data['data']);
     }
+    if (data['className'] == 'ObjectWithSelfParent') {
+      return deserialize<_i15.ObjectWithSelfParent>(data['data']);
+    }
     if (data['className'] == 'ObjectWithUuid') {
-      return deserialize<_i15.ObjectWithUuid>(data['data']);
+      return deserialize<_i16.ObjectWithUuid>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyClass') {
-      return deserialize<_i16.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i17.DefaultServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyEnum') {
-      return deserialize<_i17.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i18.DefaultServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyClass') {
-      return deserialize<_i18.NotServerOnlyClass>(data['data']);
+      return deserialize<_i19.NotServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyEnum') {
-      return deserialize<_i19.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i20.NotServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'ServerOnlyClass') {
-      return deserialize<_i20.ServerOnlyClass>(data['data']);
+      return deserialize<_i21.ServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'ServerOnlyEnum') {
-      return deserialize<_i21.ServerOnlyEnum>(data['data']);
+      return deserialize<_i22.ServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i22.SimpleData>(data['data']);
+      return deserialize<_i23.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i23.SimpleDataList>(data['data']);
+      return deserialize<_i24.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i24.TestEnum>(data['data']);
+      return deserialize<_i25.TestEnum>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i25.Types>(data['data']);
+      return deserialize<_i26.Types>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -1462,12 +1250,14 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i13.ObjectWithObject.t;
       case _i14.ObjectWithParent:
         return _i14.ObjectWithParent.t;
-      case _i15.ObjectWithUuid:
-        return _i15.ObjectWithUuid.t;
-      case _i22.SimpleData:
-        return _i22.SimpleData.t;
-      case _i25.Types:
-        return _i25.Types.t;
+      case _i15.ObjectWithSelfParent:
+        return _i15.ObjectWithSelfParent.t;
+      case _i16.ObjectWithUuid:
+        return _i16.ObjectWithUuid.t;
+      case _i23.SimpleData:
+        return _i23.SimpleData.t;
+      case _i26.Types:
+        return _i26.Types.t;
     }
     return null;
   }

--- a/tests/serverpod_test_server/lib/src/protocol/object_with_self_parent.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/object_with_self_parent.yaml
@@ -1,0 +1,4 @@
+class: ObjectWithSelfParent
+table: object_with_self_parent
+fields:
+  other: int, parent=object_with_self_parent

--- a/tests/serverpod_test_server/lib/src/protocol/object_with_self_parent.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/object_with_self_parent.yaml
@@ -1,4 +1,4 @@
 class: ObjectWithSelfParent
 table: object_with_self_parent
 fields:
-  other: int, parent=object_with_self_parent
+  other: int?, parent=object_with_self_parent

--- a/tools/serverpod_cli/lib/src/generator/psql/pgsql_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/psql/pgsql_generator.dart
@@ -60,8 +60,9 @@ class PgsqlCodeGenerator extends CodeGenerator {
         var tableInfo = tableInfos[i];
 
         for (var field in tableInfo.fields) {
-          // Check if a parent is not above the current table
+          // Check if a parent is not above the current table and not self-referencing
           if (field.parentTable != null &&
+              field.parentTable != tableInfo.tableName &&
               !visitedTableNames.contains(field.parentTable!)) {
             var tableToMove = tableInfo;
             for (int j = i; j < tableInfos.length; j++) {


### PR DESCRIPTION
Say I define a self-referencing table, like this:

```yaml
class: MyTable
table: my_table
fields:
  parentId: int?, parent=my_table
  someData: String
```

Running `serverpod generate` hangs forever. I traced it to an endless loop in the `_sortClassInfos` function in `pgsql_generator.dart`. It seems that it gets stuck when it tries to move the self-referenced table below itself as a dependency, and this occurs repeatedly in an endless loop.

This PR fixes this issue by:

When looping through the table fields in `_sortClassInfos` and checking if a parent is not above the current table, also adds a check that the parent is not the same table as the current table.

_List which issues are fixed by this PR. You must list at least one issue._
#807 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A