### PR TITLE
add requireSsl parameter to db config yaml for better security and to…

### DIFF
--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -44,6 +44,7 @@ class DatabasePoolManager {
         database: config.name,
         username: config.user,
         password: config.password,
+        requireSsl: config.requireSsl,
         isUnixSocket: config.isUnixSocket,
       ),
       settings: poolSettings,

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -133,6 +133,9 @@ class DatabaseConfig {
   /// Database name.
   late final String name;
 
+  /// True if the database requires an SSL connection.
+  late final bool requireSsl;
+
   /// True if the database is running on a unix socket.
   late final bool isUnixSocket;
 
@@ -141,6 +144,7 @@ class DatabaseConfig {
     port = dbSetup['port']!;
     name = dbSetup['name']!;
     user = dbSetup['user']!;
+    requireSsl = dbSetup['requireSsl'] ?? true;
     isUnixSocket = dbSetup['isUnixSocket'] ?? false;
     assert(passwords['database'] != null, 'Database password is missing');
     password = passwords['database']!;
@@ -153,6 +157,7 @@ class DatabaseConfig {
     str += 'database port: $port\n';
     str += 'database name: $name\n';
     str += 'database user: $user\n';
+    str += 'database require SSL: $requireSsl\n';
     str += 'database unix socket: $isUnixSocket\n';
     str += 'database pass: ********\n';
     return str;

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -144,7 +144,7 @@ class DatabaseConfig {
     port = dbSetup['port']!;
     name = dbSetup['name']!;
     user = dbSetup['user']!;
-    requireSsl = dbSetup['requireSsl'] ?? true;
+    requireSsl = dbSetup['requireSsl'] ?? false;
     isUnixSocket = dbSetup['isUnixSocket'] ?? false;
     assert(passwords['database'] != null, 'Database password is missing');
     password = passwords['database']!;


### PR DESCRIPTION
… support hosting services that require it

This PR is adding the ability to pass the `requireSsl` parameter from the `database` map in the `_environment_.yaml` config file, to Serverpod, through `DatabasePoolManager`, and down to `PgEndpoint`, which is part of the `postgres_pool` package and already supports it, so that it will allow SSL connections to Postgres.

Fixes #819.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

Please let me know if this flag requires tests as it may take some jerry-rigging with Docker scripts, as the `pg_hba.conf` file doesn't get created until Postgres is already launched. I think I can write tests if you think it's needed/a good idea.

I have tested on my project and it works on DigitalOcean for me.

## Breaking changes

Unknown / I don't believe so as it's just passing a parameter down.