### PR TITLE
lowercase modulename_client in module generator template

### DIFF
--- a/templates/serverpod_templates/modulename_server/config/generator.yaml
+++ b/templates/serverpod_templates/modulename_server/config/generator.yaml
@@ -1,3 +1,3 @@
 type: module
 
-client_package_path: ../MODULENAME_client
+client_package_path: ../modulename_client


### PR DESCRIPTION
This PR is basically a chore that lowercases `MODULENAME_client` to `modulename_client` in the `templates/serverpod_templates/modulename_server/config/generator.yaml` template so that the modulename gets updated by `serverpod create`, and so that `serverpod generate` can subsequently find the client folder.

Fixes #821 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
