### PR TITLE
fix: Add error message if email is already in use

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -333,6 +333,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   }
 
   Future<void> _createAccount() async {
+    _resetIssues();
     var userName = _usernameController.text.trim();
     if (userName.isEmpty) {
       setState(() {
@@ -375,16 +376,18 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
     setState(() {
       _enabled = true;
-    });
 
-    if (success) {
-      setState(() {
+      if (success) {
         _page = _Page.confirmEmail;
-      });
-    }
+      } else {
+        _emailIssue = 'Email already in use';
+      }
+
+    });
   }
 
   Future<void> _validateAccount() async {
+    _resetIssues();
     if (_validationCodeController.text.isEmpty) {
       setState(() {
         _validationCodeIssue = 'Enter your code';
@@ -429,6 +432,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   }
 
   Future<void> _signIn() async {
+    _resetIssues();
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
@@ -467,6 +471,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   }
 
   Future<void> _initiatePasswordReset() async {
+    _resetIssues();
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
@@ -488,6 +493,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   }
 
   Future<void> _resetPassword() async {
+    _resetIssues();
     if (_passwordController.text.length < 8) {
       setState(() {
         _passwordIssue = 'Min 8 characters';
@@ -531,6 +537,15 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
       Navigator.of(context).pop();
     }
     widget.onSignedIn();
+  }
+
+  void _resetIssues() {
+    setState(() {
+      _emailIssue = '';
+      _passwordIssue = '';
+      _validationCodeIssue = '';
+      _userNameIssue = '';
+    });
   }
 
   void _resetTextFields() {

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -29,8 +29,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
-  final TextEditingController _validationCodeController =
-      TextEditingController();
+  final TextEditingController _validationCodeController = TextEditingController();
 
   String? _userNameIssue;
   String? _emailIssue;
@@ -382,7 +381,6 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
       } else {
         _emailIssue = 'Email already in use';
       }
-
     });
   }
 

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -29,7 +29,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
-  final TextEditingController _validationCodeController = TextEditingController();
+  final TextEditingController _validationCodeController =
+      TextEditingController();
 
   String? _userNameIssue;
   String? _emailIssue;


### PR DESCRIPTION
# Adds

## Auth module, flutter lib

- Displays "Email is already in use" error if you are trying to create an account with an email that already exists.
- Rests all errors when the user clicks any buttons, such as "create account", "reset password", "login" etc.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
