### PR TITLE
fix: remove onFailure from email auth module (dead code)

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
@@ -10,9 +10,6 @@ class SignInWithEmailButton extends StatefulWidget {
   /// Called if sign in is successful.
   final VoidCallback? onSignedIn;
 
-  /// Called if sign in is unsuccessful.
-  final VoidCallback? onFailure;
-
   /// The style of the button.
   final ButtonStyle? style;
 
@@ -20,7 +17,6 @@ class SignInWithEmailButton extends StatefulWidget {
   const SignInWithEmailButton({
     required this.caller,
     this.onSignedIn,
-    this.onFailure,
     this.style,
     Key? key,
   }) : super(key: key);


### PR DESCRIPTION
# Removes

## Auth module, flutter email
- onFailure callback removed from SignInWithEmailButton as it was not implemented

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

onFailure callback removed, it was not implemented and was none functional, if this was used by anyone, they had dead code that can safely be deleted without any additional effect.