### PR TITLE
Exception bug with modules

### DIFF
--- a/packages/serverpod_serialization/lib/src/exceptions.dart
+++ b/packages/serverpod_serialization/lib/src/exceptions.dart
@@ -1,11 +1,13 @@
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-/// This is `SerializableException` that can be used to pass Domain exceptions from the Server to the Client
+/// This is `SerializableException` that can be used to pass Domain exceptions 
+/// from the Server to the Client
 ///
 /// You can `throw SerializableException()`
 ///
 /// Based on issue [#486](https://github.com/serverpod/serverpod/issues/486)
-abstract class SerializableException extends SerializableEntity implements Exception {
+abstract class SerializableException extends SerializableEntity
+    implements Exception {
   /// Const constructor to pass empty exception with `statusCode 500`
   SerializableException();
 

--- a/packages/serverpod_serialization/lib/src/exceptions.dart
+++ b/packages/serverpod_serialization/lib/src/exceptions.dart
@@ -1,6 +1,6 @@
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-/// This is `SerializableException` that can be used to pass Domain exceptions 
+/// This is `SerializableException` that can be used to pass Domain exceptions
 /// from the Server to the Client
 ///
 /// You can `throw SerializableException()`

--- a/packages/serverpod_serialization/lib/src/exceptions.dart
+++ b/packages/serverpod_serialization/lib/src/exceptions.dart
@@ -5,7 +5,7 @@ import 'package:serverpod_serialization/serverpod_serialization.dart';
 /// You can `throw SerializableException()`
 ///
 /// Based on issue [#486](https://github.com/serverpod/serverpod/issues/486)
-class SerializableException extends SerializableEntity implements Exception {
+abstract class SerializableException extends SerializableEntity implements Exception {
   /// Const constructor to pass empty exception with `statusCode 500`
   SerializableException();
 

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -95,8 +95,6 @@ abstract class SerializationManager {
       return 'ByteData';
     } else if (data is Duration) {
       return 'Duration';
-    } else if (data is SerializableException) {
-      return 'SerializableException';
     } else if (data is UuidValue) {
       return 'UuidValue';
     }
@@ -121,8 +119,6 @@ abstract class SerializationManager {
         return deserialize<ByteData>(data['data']);
       case 'Duration':
         return deserialize<Duration>(data['data']);
-      case 'SerializableException':
-        return SerializableException();
       case 'UuidValue':
         return deserialize<UuidValue>(data['data']);
     }

--- a/tests/docker/tests_single_server/run-tests.sh
+++ b/tests/docker/tests_single_server/run-tests.sh
@@ -24,6 +24,7 @@ dart test test/serialization_test.dart
 dart test test/service_protocol_test.dart
 dart test test/websocket_test.dart
 dart test test/types_test.dart
+dart test test/exception_test.dart
 
 #echo "### Running unit tests"
 #cd ../../packages/serverpod

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -552,13 +552,6 @@ class EndpointExceptionTest extends _i1.EndpointRef {
   @override
   String get name => 'exceptionTest';
 
-  _i2.Future<String> throwSerializableException() =>
-      caller.callServerEndpoint<String>(
-        'exceptionTest',
-        'throwSerializableException',
-        {},
-      );
-
   _i2.Future<String> throwNormalException() =>
       caller.callServerEndpoint<String>(
         'exceptionTest',

--- a/tests/serverpod_test_server/lib/src/endpoints/exception_test_endpoint.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/exception_test_endpoint.dart
@@ -2,9 +2,6 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/exception_with_data.dart';
 
 class ExceptionTestEndpoint extends Endpoint {
-  Future<String> throwSerializableException(Session session) async {
-    throw SerializableException();
-  }
 
   Future<String> throwNormalException(Session session) async {
     throw Exception('Something went wrong');

--- a/tests/serverpod_test_server/lib/src/endpoints/exception_test_endpoint.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/exception_test_endpoint.dart
@@ -2,7 +2,6 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/exception_with_data.dart';
 
 class ExceptionTestEndpoint extends Endpoint {
-
   Future<String> throwNormalException(Session session) async {
     throw Exception('Something went wrong');
   }

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -1333,16 +1333,6 @@ class Endpoints extends _i1.EndpointDispatch {
       name: 'exceptionTest',
       endpoint: endpoints['exceptionTest']!,
       methodConnectors: {
-        'throwSerializableException': _i1.MethodConnector(
-          name: 'throwSerializableException',
-          params: {},
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['exceptionTest'] as _i10.ExceptionTestEndpoint)
-                  .throwSerializableException(session),
-        ),
         'throwNormalException': _i1.MethodConnector(
           name: 'throwNormalException',
           params: {},

--- a/tests/serverpod_test_server/test/exception_test.dart
+++ b/tests/serverpod_test_server/test/exception_test.dart
@@ -16,17 +16,6 @@ void main() {
     test('Working without exception', () async {
       expect(await client.exceptionTest.workingWithoutException(), 'Success');
     });
-    test('Working with SerializableException', () async {
-      dynamic exception;
-      try {
-        await client.exceptionTest.throwSerializableException();
-      } catch (e) {
-        exception = e;
-      }
-
-      expect(exception is test_client.SerializableException, true);
-    });
-
     test('Working with ExceptionWithData exception', () async {
       dynamic exception;
       try {
@@ -35,7 +24,7 @@ void main() {
         exception = e;
       }
 
-      expect(exception is test_client.ExceptionWithData, true);
+      expect(exception.runtimeType, test_client.ExceptionWithData);
     });
 
     test('Catch specific type', () async {

--- a/tests/serverpod_test_server/test/exception_test.dart
+++ b/tests/serverpod_test_server/test/exception_test.dart
@@ -27,7 +27,8 @@ void main() {
       expect(exception.runtimeType, test_client.ExceptionWithData);
     });
 
-    test('Serialize and deserialize custom server exception with data', () async {
+    test('Serialize and deserialize custom server exception with data',
+        () async {
       ExceptionWithData? exceptionWithData;
       try {
         await client.exceptionTest.throwExceptionWithData();

--- a/tests/serverpod_test_server/test/exception_test.dart
+++ b/tests/serverpod_test_server/test/exception_test.dart
@@ -13,10 +13,10 @@ void main() {
   setUp(() {});
 
   group('Exception tests', () {
-    test('Working without exception', () async {
+    test('Sending normal primitive data', () async {
       expect(await client.exceptionTest.workingWithoutException(), 'Success');
     });
-    test('Working with ExceptionWithData exception', () async {
+    test('Serialize and deserialize custom server exception type', () async {
       dynamic exception;
       try {
         await client.exceptionTest.throwExceptionWithData();
@@ -27,7 +27,7 @@ void main() {
       expect(exception.runtimeType, test_client.ExceptionWithData);
     });
 
-    test('Catch specific type', () async {
+    test('Serialize and deserialize custom server exception with data', () async {
       ExceptionWithData? exceptionWithData;
       try {
         await client.exceptionTest.throwExceptionWithData();

--- a/tests/serverpod_test_server/test/exception_test.dart
+++ b/tests/serverpod_test_server/test/exception_test.dart
@@ -1,5 +1,4 @@
-import 'package:serverpod_test_client/serverpod_test_client.dart'
-    as test_client;
+import 'package:serverpod_test_client/serverpod_test_client.dart' as test_client;
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:test/test.dart';
 

--- a/tests/serverpod_test_server/test/exception_test.dart
+++ b/tests/serverpod_test_server/test/exception_test.dart
@@ -1,4 +1,5 @@
-import 'package:serverpod_test_client/serverpod_test_client.dart' as test_client;
+import 'package:serverpod_test_client/serverpod_test_client.dart'
+    as test_client;
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
# Fixes

Throwing generated exceptions ended up as SerializeableExceptions rather than the type they were supposed to be. This PR removes the SerializeableExceptions from parsing of primitive datatypes which caused this issue. 

This means you are no longer allowed to throw a SerializableException on its own, instead, you have to extend the class, which is exactly what the code generator does already. To reflect this limitation the SerializableException class was changed to be an abstract class.

The exception tests were not running in CI either, this PR adds these tests to the CI pipeline.

Fixes: #913

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

