### PR TITLE
fix(auth): allow min and max password lengths to be configured

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
@@ -13,11 +13,24 @@ class SignInWithEmailButton extends StatefulWidget {
   /// The style of the button.
   final ButtonStyle? style;
 
+  /// Minimum allowed password length.
+  /// Defaults to 128.
+  /// If this value is modified, the server must be updated to match.
+  final int? maxPasswordLength;
+
+  /// Minimum allowed password length.
+  /// Defaults to 8.
+  /// If this value is modified, the server must be updated to match.
+  final int? minPasswordLength;
+
+
   /// Creates a new Sign in with Email button.
   const SignInWithEmailButton({
     required this.caller,
     this.onSignedIn,
     this.style,
+    this.maxPasswordLength,
+    this.minPasswordLength,
     Key? key,
   }) : super(key: key);
 
@@ -41,6 +54,8 @@ class SignInWithEmailButtonState extends State<SignInWithEmailButton> {
         showSignInWithEmailDialog(
           context: context,
           caller: widget.caller,
+          maxPasswordLength: widget.maxPasswordLength,
+          minPasswordLength: widget.minPasswordLength,
           onSignedIn: () {
             if (widget.onSignedIn != null) {
               widget.onSignedIn!();

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:serverpod_auth_client/module.dart';
 import 'package:serverpod_auth_email_flutter/src/auth.dart';
 
+const _defaultMaxPasswordLength = 128;
+const _defaultMinPasswordLength = 8;
+
 enum _Page {
   createAccount,
   confirmEmail,
@@ -14,11 +17,15 @@ enum _Page {
 class SignInWithEmailDialog extends StatefulWidget {
   final Caller caller;
   final VoidCallback onSignedIn;
+  final int maxPasswordLength;
+  final int minPasswordLength;
 
   const SignInWithEmailDialog({
     Key? key,
     required this.caller,
     required this.onSignedIn,
+    this.maxPasswordLength = _defaultMaxPasswordLength,
+    this.minPasswordLength = _defaultMinPasswordLength,
   }) : super(key: key);
 
   @override
@@ -283,7 +290,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         TextField(
           enabled: _enabled,
-          maxLength: 32,
+          maxLength: widget.maxPasswordLength,
           controller: _passwordController,
           obscureText: true,
           decoration: InputDecoration(
@@ -351,15 +358,15 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     }
 
     var password = _passwordController.text;
-    if (password.length < 8) {
+    if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = 'Minimum 8 characters';
+        _passwordIssue = 'Minimum ${widget.minPasswordLength} characters';
       });
       return;
     }
-    if (password.length > 32) {
+    if (password.length > widget.maxPasswordLength) {
       setState(() {
-        _passwordIssue = 'Maximum 32 characters';
+        _passwordIssue = 'Maximum ${widget.maxPasswordLength} characters';
       });
       return;
     }
@@ -441,9 +448,9 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     }
 
     var password = _passwordController.text;
-    if (password.length < 8) {
+    if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = 'Minimum 8 characters';
+        _passwordIssue = 'Minimum ${widget.minPasswordLength} characters';
       });
       return;
     }
@@ -561,6 +568,8 @@ void showSignInWithEmailDialog({
   required BuildContext context,
   required Caller caller,
   required VoidCallback onSignedIn,
+  int? maxPasswordLength,
+  int? minPasswordLength,
 }) {
   showDialog(
     context: context,
@@ -568,6 +577,8 @@ void showSignInWithEmailDialog({
       return SignInWithEmailDialog(
         caller: caller,
         onSignedIn: onSignedIn,
+        maxPasswordLength: maxPasswordLength ?? _defaultMaxPasswordLength,
+        minPasswordLength: minPasswordLength ?? _defaultMinPasswordLength,
       );
     },
   );

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -120,6 +120,14 @@ class AuthConfig {
   /// Firebase console.
   final String firebaseServiceAccountKeyJson;
 
+  /// The maximum length of passwords when signing up with email. 
+  /// Default is 128 characters.
+  final int maxPasswordLength;
+
+  /// The minimum length of passwords when signing up with email.
+  /// Default is 8 characters.
+  final int minPasswordLength;
+
   /// Creates a new Auth configuration. Use the [set] method to replace the
   /// default settings. Defaults to `config/firebase_service_account_key.json`.
   AuthConfig({
@@ -146,5 +154,7 @@ class AuthConfig {
     this.extraSaltyHash = true,
     this.firebaseServiceAccountKeyJson =
         'config/firebase_service_account_key.json',
+    this.maxPasswordLength = 128,
+    this.minPasswordLength = 8,
   });
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -212,7 +212,7 @@ class Emails {
         return false;
       }
 
-      if (password.length < 8 || password.length > 32) {
+      if (password.length < AuthConfig.current.minPasswordLength || password.length > AuthConfig.current.maxPasswordLength) {
         return false;
       }
 


### PR DESCRIPTION
# Fix

- Allows users to configure the max and min password length for sign up with email / password.

Needs to be configured on both client and server.

Usage:

```dart
// server

auth.AuthConfig.set(auth.AuthConfig(
    minPasswordLength: 256, // defaults to 8
    maxPasswordLength: 1024, // defaults to 128
));
```

```dart
// flutter

SignInWithEmailButton(
  caller: client.modules.auth,
  minPasswordLength: 256, // defaults to 8
  maxPasswordLength: 1024,  // defaults to 128
),
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.