### PR TITLE
fix: handle invalid return types when parsing endpoint methods

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   source_span: ^1.10.0
   super_string: ^1.0.3
   watcher: ^1.0.2
-  analyzer: ^5.10.0
+  analyzer: ^5.13.0
   path: ^1.8.2
   pub_api_client: ^2.4.0
   uuid: ^3.0.7

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -234,7 +234,7 @@ class EndpointsAnalyzer {
     var innerType = typeArguments[0];
 
     if (innerType is VoidType) {
-      return false;
+      return true;
     }
 
     if (innerType is InvalidType) {

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -225,7 +225,6 @@ class EndpointsAnalyzer {
 
     var typeArguments = dartType.typeArguments;
     if (typeArguments.length != 1) {
-      print('length is not 1');
       collector.addError(SourceSpanException(
         'Future must have a type defined. E.g. Future<String>.',
         dartElement.span,
@@ -247,7 +246,6 @@ class EndpointsAnalyzer {
     }
 
     if (innerType is DynamicType) {
-      print('is dynamic type');
       collector.addError(SourceSpanException(
         'Future must have a type defined. E.g. Future<String>.',
         dartElement.span,

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -150,15 +150,12 @@ class EndpointsAnalyzer {
                   }
                 }
 
-                if (paramDefs.isNotEmpty &&
-                    paramDefs[0].type.className == 'Session' &&
-                    method.returnType.isDartAsyncFuture) {
-                  _validateReturnType(
-                    dartType: method.returnType,
-                    dartElement: method,
-                    collector: collector,
-                  );
-
+                if (_isEndpointMethod(paramDefs) &&
+                    _isValidReturnType(
+                      dartType: method.returnType,
+                      dartElement: method,
+                      collector: collector,
+                    )) {
                   var methodDef = MethodDefinition(
                     name: method.name,
                     documentationComment: method.documentationComment,
@@ -201,48 +198,64 @@ class EndpointsAnalyzer {
     return endpointName;
   }
 
-  void _validateReturnType({
+  bool _isEndpointMethod(List<ParameterDefinition> paramDefs) {
+    return paramDefs.isNotEmpty && paramDefs[0].type.className == 'Session';
+  }
+
+  bool _isValidReturnType({
     required DartType dartType,
     required Element dartElement,
     required CodeAnalysisCollector collector,
   }) {
-    if (dartType is! InterfaceType) {
-      collector.addError(SourceSpanException(
-        'This type is not supported as return type.',
-        dartElement.span,
-      ));
-      return;
-    }
-
     if (!dartType.isDartAsyncFuture) {
       collector.addError(SourceSpanException(
         'Return type must be a Future.',
         dartElement.span,
       ));
-      return;
+      return false;
     }
+
+    if (dartType is! InterfaceType) {
+      collector.addError(SourceSpanException(
+        'This type is not supported as return type.',
+        dartElement.span,
+      ));
+      return false;
+    }  
 
     var typeArguments = dartType.typeArguments;
     if (typeArguments.length != 1) {
+      print('length is not 1');
       collector.addError(SourceSpanException(
         'Future must have a type defined. E.g. Future<String>.',
         dartElement.span,
       ));
-      return;
+      return false;
     }
     var innerType = typeArguments[0];
 
     if (innerType is VoidType) {
-      return;
+      return false;
+    }
+
+    if (innerType is InvalidType) {
+      collector.addError(SourceSpanException(
+        'Future has an invalid return type.',
+        dartElement.span,
+      ));
+      return false;
     }
 
     if (innerType is DynamicType) {
+      print('is dynamic type');
       collector.addError(SourceSpanException(
         'Future must have a type defined. E.g. Future<String>.',
         dartElement.span,
       ));
-      return;
+      return false;
     }
+
+    return true;
   }
 }
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -221,7 +221,7 @@ class EndpointsAnalyzer {
         dartElement.span,
       ));
       return false;
-    }  
+    }
 
     var typeArguments = dartType.typeArguments;
     if (typeArguments.length != 1) {

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   source_span: ^1.10.0
   super_string: ^1.0.3
   watcher: ^1.0.2
-  analyzer: ^5.10.0
+  analyzer: ^5.13.0
   path: ^1.8.2
   pub_api_client: ^2.4.0
   uuid: ^3.0.7


### PR DESCRIPTION
# Fixes

The analyzer package was updated with a new type: `InvalidType` this PR implements support for this when checking the return type of endpoint methods. 

This PR also changes the behaviour of the parsing somewhat as it will **NOT** include any methods that does not meet the requirements for endpoint methods. Requirements here meaning the return types are following the required synax, e.g. Must be a Future, Must be a superset of InterfaceType, Must be a Valid type. 

A type can be for example be invalid if it was not defined or imported to the endpoint file.

_List which issues are fixed by this PR. You must list at least one issue._
https://github.com/serverpod/serverpod/issues/963

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

