### PR TITLE
feat: allow nested endpoint classes

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -111,10 +111,9 @@ class EndpointsAnalyzer {
         for (var element in topElements) {
           if (element is ClassElement) {
             var className = element.name;
-            var superclassName = element.supertype!.element.name;
             var endpointName = _formatEndpointName(className);
 
-            if (superclassName == 'Endpoint') {
+            if (_extendsEndpointClass(element)) {
               var classDocumentationComment = element.documentationComment;
 
               var methodDefs = <MethodDefinition>[];
@@ -187,6 +186,11 @@ class EndpointsAnalyzer {
     }
 
     return endpointDefs;
+  }
+
+  bool _extendsEndpointClass(ClassElement element) {
+    return element.allSupertypes.any((InterfaceType element) =>
+        element.getDisplayString(withNullability: false) == 'Endpoint');
   }
 
   String _formatEndpointName(String className) {


### PR DESCRIPTION
# Incomplete

This PR needs additional work to be valid. Right now the use case below does indeed work, however, if you would add methods to the classes these are not propagated on the client.

```dart
class LoggedInEndpoint extends Endpoint {
  @override
  bool get requireLogin => true;

  Future<String> helloLoggedIn(Session session) async { ... }
}

class AdminEndpoint extends LoggedInEndpoint {
  @override
  Set<Scope> get requiredScopes => {Scope.admin};

  Future<String> helloAdmin(Session session) async { ... }
}

class MyEndpoint extends AdminEndpoint {
   Future<String> hello(Session session) async { ... }
}
```

Then on the client `MyEndpoint` would only have access to the `hello` function but not the `helloAdmin` or `helloLoggedIn`. 

## Changes

Allows nested Endpoint classes, I.E. as long the Endpoint class is extended at the n:th level the class will be treated as an Endpoint class.

Example
```dart
class LoggedInEndpoint extends Endpoint {
  @override
  bool get requireLogin => true;
}

class AdminEndpoint extends LoggedInEndpoint {
  @override
  Set<Scope> get requiredScopes => {Scope.admin};
}

class MyEndpoint extends AdminEndpoint {
    // some methods...
}
```


_List which issues are fixed by this PR. You must list at least one issue._
https://github.com/serverpod/serverpod/issues/912

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
