### PR TITLE
feat: Adds migrate --repair command to CLI.

### DIFF
--- a/packages/serverpod/lib/src/database/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migration_manager.dart
@@ -57,6 +57,7 @@ class MigrationManager {
         ),
       );
     }
+    installedVersions.clear();
     installedVersions.addAll(versions);
 
     // Get available migrations

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -216,8 +216,6 @@ class InsightsEndpoint extends Endpoint {
     }
     databaseDefinition.installedModules = installedModules;
 
-    print('Installed modules: $installedModules');
-
     return databaseDefinition;
   }
 

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -201,8 +201,24 @@ class InsightsEndpoint extends Endpoint {
   ///
   /// See also:
   /// - [getTargetDatabaseDefinition]
-  Future<DatabaseDefinition> getLiveDatabaseDefinition(Session session) {
-    return DatabaseAnalyzer.analyze(session.db);
+  Future<DatabaseDefinition> getLiveDatabaseDefinition(Session session) async {
+    // Get database definition of the live database.
+    var databaseDefinition = await DatabaseAnalyzer.analyze(session.db);
+
+    // Make sure that the migration manager is up-to-date.
+    await session.serverpod.migrationManager.initialize(session);
+
+    // Create map of installed modules.
+    var modules = session.serverpod.migrationManager.installedVersions;
+    var installedModules = <String, String>{};
+    for (var module in modules) {
+      installedModules[module.module] = module.version;
+    }
+    databaseDefinition.installedModules = installedModules;
+
+    print('Installed modules: $installedModules');
+
+    return databaseDefinition;
   }
 
   /// Exports raw data serialized in JSON from the database.

--- a/packages/serverpod/lib/src/generated/database/database_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definition.dart
@@ -15,6 +15,7 @@ class DatabaseDefinition extends _i1.SerializableEntity {
     this.name,
     required this.tables,
     this.priority,
+    this.installedModules,
   });
 
   factory DatabaseDefinition.fromJson(
@@ -28,6 +29,8 @@ class DatabaseDefinition extends _i1.SerializableEntity {
           .deserialize<List<_i2.TableDefinition>>(jsonSerialization['tables']),
       priority:
           serializationManager.deserialize<int?>(jsonSerialization['priority']),
+      installedModules: serializationManager.deserialize<Map<String, String>?>(
+          jsonSerialization['installedModules']),
     );
   }
 
@@ -38,7 +41,14 @@ class DatabaseDefinition extends _i1.SerializableEntity {
   /// The tables of the database.
   List<_i2.TableDefinition> tables;
 
+  /// The priority of this database definition. Determines the order in which
+  /// the database definitions are applied. Only valid if the definition
+  /// defines a single module.
   int? priority;
+
+  /// Modules installed in the database, together with their version. Only
+  /// set if known.
+  Map<String, String>? installedModules;
 
   @override
   Map<String, dynamic> toJson() {
@@ -46,6 +56,7 @@ class DatabaseDefinition extends _i1.SerializableEntity {
       'name': name,
       'tables': tables,
       'priority': priority,
+      'installedModules': installedModules,
     };
   }
 
@@ -55,6 +66,7 @@ class DatabaseDefinition extends _i1.SerializableEntity {
       'name': name,
       'tables': tables,
       'priority': priority,
+      'installedModules': installedModules,
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -1620,6 +1620,12 @@ class Protocol extends _i1.SerializationManagerServer {
           .map((e) => deserialize<_i47.TableDefinition>(e))
           .toList() as dynamic;
     }
+    if (t == _i1.getType<Map<String, String>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<String>(v)))
+          : null) as dynamic;
+    }
     if (t == List<_i47.DatabaseMigrationAction>) {
       return (data as List)
           .map((e) => deserialize<_i47.DatabaseMigrationAction>(e))

--- a/packages/serverpod/lib/src/protocol/database/database_definition.yaml
+++ b/packages/serverpod/lib/src/protocol/database/database_definition.yaml
@@ -3,10 +3,16 @@ class: DatabaseDefinition
 fields:
   ### The name of the database.
   ### Null if the name is not available.
-
   name: String?
 
   ### The tables of the database.
   tables: List<TableDefinition>
 
+  ### The priority of this database definition. Determines the order in which
+  ### the database definitions are applied. Only valid if the definition
+  ### defines a single module.
   priority: int?
+
+  ### Modules installed in the database, together with their version. Only
+  ### set if known.
+  installedModules: Map<String, String>?

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -100,6 +100,9 @@ class Serverpod {
   /// The web server managed by this [Serverpod].
   late WebServer webServer;
 
+  /// The migration manager used by this [Serverpod].
+  late MigrationManager migrationManager;
+
   /// Serverpod runtime settings as read from the database.
   internal.RuntimeSettings get runtimeSettings => _runtimeSettings!;
 
@@ -311,7 +314,7 @@ class Serverpod {
         try {
           // Initialize migration manager.
           logVerbose('Initializing migration manager.');
-          var migrationManager = MigrationManager();
+          migrationManager = MigrationManager();
           await migrationManager.initialize(session);
 
           if (commandLineArgs.applyMigrations) {

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
@@ -15,6 +15,7 @@ class DatabaseDefinition extends _i1.SerializableEntity {
     this.name,
     required this.tables,
     this.priority,
+    this.installedModules,
   });
 
   factory DatabaseDefinition.fromJson(
@@ -28,6 +29,8 @@ class DatabaseDefinition extends _i1.SerializableEntity {
           .deserialize<List<_i2.TableDefinition>>(jsonSerialization['tables']),
       priority:
           serializationManager.deserialize<int?>(jsonSerialization['priority']),
+      installedModules: serializationManager.deserialize<Map<String, String>?>(
+          jsonSerialization['installedModules']),
     );
   }
 
@@ -38,7 +41,14 @@ class DatabaseDefinition extends _i1.SerializableEntity {
   /// The tables of the database.
   List<_i2.TableDefinition> tables;
 
+  /// The priority of this database definition. Determines the order in which
+  /// the database definitions are applied. Only valid if the definition
+  /// defines a single module.
   int? priority;
+
+  /// Modules installed in the database, together with their version. Only
+  /// set if known.
+  Map<String, String>? installedModules;
 
   @override
   Map<String, dynamic> toJson() {
@@ -46,6 +56,7 @@ class DatabaseDefinition extends _i1.SerializableEntity {
       'name': name,
       'tables': tables,
       'priority': priority,
+      'installedModules': installedModules,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -449,6 +449,12 @@ class Protocol extends _i1.SerializationManager {
           .map((e) => deserialize<_i46.TableDefinition>(e))
           .toList() as dynamic;
     }
+    if (t == _i1.getType<Map<String, String>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<String>(v)))
+          : null) as dynamic;
+    }
     if (t == List<_i46.DatabaseMigrationAction>) {
       return (data as List)
           .map((e) => deserialize<_i46.DatabaseMigrationAction>(e))

--- a/tests/serverpod_test_server/test/migrations_test.dart
+++ b/tests/serverpod_test_server/test/migrations_test.dart
@@ -79,8 +79,7 @@ Future<void> testMigration({
     expect(migration, isNotNull);
 
     var sql = migration!.migration.toPgSql(
-      version: migration.versionName,
-      module: 'serverdpod_test',
+      versions: {'serverpod_test': migration.versionName},
     );
 
     await serviceClient.insights.executeSql(sql);

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -154,7 +154,23 @@ Future<void> _main(List<String> args) async {
     abbr: 'f',
     negatable: false,
     help:
-        'Creates the migration even if there are warnings or information that may be destroyed.',
+        'Creates the migration even if there are warnings or information that '
+        'may be destroyed.',
+  );
+  migrateParser.addFlag(
+    'repair',
+    abbr: 'r',
+    negatable: false,
+    help:
+        'Repairs the database by comparing the target state to what is in the '
+        'live database instead of comparing to the latest migration.',
+  );
+  migrateParser.addOption(
+    'mode',
+    abbr: 'm',
+    defaultsTo: 'development',
+    allowed: runModes,
+    help: 'Use together with --repair to specify which database to repair.',
   );
   migrateParser.addOption(
     'tag',
@@ -271,6 +287,8 @@ Future<void> _main(List<String> args) async {
     if (results.command!.name == cmdMigrate) {
       bool verbose = results.command!['verbose'];
       bool force = results.command!['force'];
+      bool repair = results.command!['repair'];
+      String mode = results.command!['mode'];
       String? tag = results.command!['tag'];
 
       if (tag != null) {
@@ -309,13 +327,23 @@ Future<void> _main(List<String> args) async {
         directory: Directory.current,
         projectName: projectName,
       );
-      await generator.createMigration(
-        tag: tag,
-        verbose: verbose,
-        force: force,
-        priority: priority,
-      );
-      print('Done.');
+
+      if (repair) {
+        await generator.repairMigration(
+          tag: tag,
+          force: force,
+          runMode: mode,
+          verbose: verbose,
+        );
+      } else {
+        await generator.createMigration(
+          tag: tag,
+          verbose: verbose,
+          force: force,
+          priority: priority,
+        );
+        print('Done.');
+      }
 
       _analytics.cleanUp();
       return;

--- a/tools/serverpod_cli/lib/src/config_info/config_info.dart
+++ b/tools/serverpod_cli/lib/src/config_info/config_info.dart
@@ -10,7 +10,6 @@ class ConfigInfo {
   }
 
   Client createServiceClient() {
-    print('serviceSecret: ${config.serviceSecret}');
     var keyManager = ServiceKeyManager('CLI', config);
     return Client(
       '${config.insightsServer.publicScheme}://'

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -367,8 +367,7 @@ extension ForeignKeyDefinitionPgSqlGeneration on ForeignKeyDefinition {
 
 extension DatabaseMigrationPgSqlGenerator on DatabaseMigration {
   String toPgSql({
-    required String version,
-    required String module,
+    required Map<String, String> versions,
   }) {
     var out = '';
 
@@ -380,11 +379,14 @@ extension DatabaseMigrationPgSqlGenerator on DatabaseMigration {
       out += action.toPgSql();
     }
 
-    out += _sqlStoreMigrationVersion(
-      module: module,
-      version: version,
-      priority: priority,
-    );
+    for (var module in versions.keys) {
+      var version = versions[module]!;
+      out += _sqlStoreMigrationVersion(
+        module: module,
+        version: version,
+        priority: priority,
+      );
+    }
 
     out += '\n';
     out += 'COMMIT;\n';

--- a/tools/serverpod_cli/lib/src/database/migration.dart
+++ b/tools/serverpod_cli/lib/src/database/migration.dart
@@ -12,6 +12,10 @@ DatabaseMigration generateDatabaseMigration({
   // Find deleted tables
   var deleteTables = <String>[];
   for (var srcTable in srcDatabase.tables) {
+    if (srcTable.name == 'serverpod_migrations') {
+      continue;
+    }
+
     if (!dstDatabase.containsTableNamed(srcTable.name)) {
       deleteTables.add(srcTable.name);
     }

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -183,6 +183,7 @@ class MigrationGenerator {
     // Get the live database definition from the server.
     var liveDatabase = await client.insights.getLiveDatabaseDefinition();
 
+    // Print warnings, if any exists.
     var warnings = <DatabaseMigrationWarning>[];
     var migration = generateDatabaseMigration(
       srcDatabase: liveDatabase,
@@ -197,6 +198,7 @@ class MigrationGenerator {
       return null;
     }
 
+    // Check if there are any changes.
     var versionsChanged = false;
     if (liveDatabase.installedModules == null) {
       versionsChanged = true;


### PR DESCRIPTION
This PR adds a repair option to the `serverpod migrate` command.

Example usage:
`serverpod migrate --repair --mode production`

The command will connect to the insights server and retrieve the structure of the database. The structure is compared with what is expected from the most up-to-date migrations (including modules). If the database is out of sync, the command will output the SQL queries required to synchronize the database with the latest migration. If any destructive changes are detected, warnings will be written and the `--force` option will need to be added to output the SQL code.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
