### PR TITLE
Require consent in order to generate refresh token on every signin

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
@@ -57,6 +57,7 @@ Future<UserInfo?> signInWithGoogle(
       clientId: clientId,
       serverClientId: serverClientId,
       redirectUri: redirectUri,
+      forceCodeForRefreshToken: true,
     );
 
     // Authenticate with the Serverpod server.

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
@@ -57,7 +57,6 @@ Future<UserInfo?> signInWithGoogle(
       clientId: clientId,
       serverClientId: serverClientId,
       redirectUri: redirectUri,
-      forceCodeForRefreshToken: true,
     );
 
     // Authenticate with the Serverpod server.

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/google/sign_in_with_google_mobile.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/google/sign_in_with_google_mobile.dart
@@ -13,6 +13,9 @@ SignInWithGooglePlatform signInWithGooglePlatform = ({
     scopes: scopes,
     clientId: clientId,
     serverClientId: serverClientId,
+    // Required because of bug in googleapis.dart:
+    // https://github.com/google/googleapis.dart/issues/487
+    forceCodeForRefreshToken: true,
   );
 
   var result = await googleSignIn.signIn();


### PR DESCRIPTION
Generate a refresh token for every Google sign-in, by forcing a user to re-consent to access rules each time they sign in. This is required because without a valid refresh token, the Google dart libraries throw an assertion error (https://github.com/google/googleapis.dart/issues/487).

Fixes #754.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
