### PR TITLE
Add bulk file URL lookup method

### DIFF
--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -464,6 +464,18 @@ class StorageAccess {
     return await storage.getPublicUrl(session: _session, path: path);
   }
 
+  /// Bulk lookup of a list of public links to files given a list of paths in
+  /// the storage. If any given file isn't public or if no such file exists,
+  /// null is stored at the corresponding position in the output list. Saves
+  /// on server roundtrips if a large number of public URLs must be fetched,
+  /// relative to calling [getPublicUrl] via an endpoint for each one.
+  Future<List<Uri?>> getPublicUrls({
+    required String storageId,
+    required List<String> paths,
+  }) =>
+      Future.wait(
+          paths.map((path) => getPublicUrl(storageId: storageId, path: path)));
+
   /// Creates a new file upload description, that can be passed to the client's
   /// [FileUploader]. After the file has been uploaded, the
   /// [verifyDirectFileUpload] method should be called, or the file may be


### PR DESCRIPTION
This PR adds a URL bulk lookup method method to avoid server roundtrips when a long list of file URLs must be looked up. It uses `Future.wait()` to wait on a list of `Future`s for maximum concurrency.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.