### PR TITLE
Protocol property rules for entities

### DIFF
--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -178,6 +178,11 @@ Future<void> _main(List<String> args) async {
 
   // "language-server" command
   var languageServerParser = ArgParser();
+  languageServerParser.addFlag(
+    'stdio',
+    defaultsTo: true,
+    help: 'Use stdin/stdout channels for communication.',
+  );
   parser.addCommand(cmdLanguageServer, languageServerParser);
 
   // "generate-pubspecs"

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -137,7 +137,7 @@ class SerializableEntityAnalyzer {
     }
     var docsExtractor = YamlDocumentationExtractor(yaml);
 
-    _validateEntityProperties(documentContents);
+    _validateEntityType(documentContents);
 
     if (documentContents.nodes['class'] != null ||
         documentContents.nodes['exception'] != null) {
@@ -150,8 +150,8 @@ class SerializableEntityAnalyzer {
     return null;
   }
 
-  void _validateEntityProperties(YamlMap documentContents) {
-    var typeNodes = _readNodesByKeys(
+  void _validateEntityType(YamlMap documentContents) {
+    var typeNodes = _findNodesByKeys(
       documentContents,
       {'class', 'exception', 'enum'},
     );
@@ -160,7 +160,7 @@ class SerializableEntityAnalyzer {
 
     if (typeNodes.isEmpty) {
       collector.addError(SourceSpanException(
-        'No "class", "exception" or "enum" property is defined.',
+        'No "class", "exception" or "enum" type is defined.',
         documentContents.span,
       ));
       return;
@@ -171,7 +171,7 @@ class SerializableEntityAnalyzer {
         .skip(1)
         .map(
           (e) => SourceSpanException(
-              'Multiple entity properties ($formattedKeys) found for a single entity. Only one property per entity allowed.',
+              'Multiple entity types ($formattedKeys) found for a single entity. Only one type per entity allowed.',
               documentContents.key(e.key.toString())?.span),
         )
         .toList();
@@ -186,7 +186,7 @@ class SerializableEntityAnalyzer {
     });
   }
 
-  Iterable<MapEntry<dynamic, YamlNode>> _readNodesByKeys(
+  Iterable<MapEntry<dynamic, YamlNode>> _findNodesByKeys(
     YamlMap documentContents,
     Set<String> keys,
   ) {
@@ -227,7 +227,7 @@ class SerializableEntityAnalyzer {
     var className = workingNode.value;
     if (className is! String) {
       collector.addError(SourceSpanException(
-        'The "$type" property must be a String.',
+        'The "$type" type must be a String.',
         workingNode.span,
       ));
       return null;
@@ -235,7 +235,7 @@ class SerializableEntityAnalyzer {
 
     if (!StringValidators.isValidClassName(className)) {
       collector.addError(SourceSpanException(
-        'The "$type" property must be a valid class name (e.g. CamelCaseString).',
+        'The "$type" type must be a valid class name (e.g. CamelCaseString).',
         workingNode.span,
       ));
       return null;
@@ -605,7 +605,7 @@ class SerializableEntityAnalyzer {
     var classNameNode = documentContents.nodes['enum'];
     if (classNameNode == null) {
       collector.addError(SourceSpanException(
-        'No "enum" property is defined.',
+        'No "enum" type is defined.',
         documentContents.span,
       ));
       return null;
@@ -616,7 +616,7 @@ class SerializableEntityAnalyzer {
     var className = classNameNode.value;
     if (className is! String) {
       collector.addError(SourceSpanException(
-        'The "enum" property must be a String.',
+        'The "enum" type must be a String.',
         classNameNode.span,
       ));
       return null;
@@ -624,7 +624,7 @@ class SerializableEntityAnalyzer {
 
     if (!StringValidators.isValidClassName(className)) {
       collector.addError(SourceSpanException(
-        'The "enum" property must be a valid class name (e.g. CamelCaseString).',
+        'The "enum" type must be a valid class name (e.g. CamelCaseString).',
         classNameNode.span,
       ));
       return null;

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
@@ -3,14 +3,14 @@ import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Given a protocol without any defined entity property', () {
+  group('Given a protocol without any defined entity type', () {
     test(
-        'Then return a human readable error message informing the user that the entity property is missing.',
+        'Then return a human readable error message informing the user that the entity type is missing.',
         () {
       var collector = CodeGenerationCollector();
       var analyzer = SerializableEntityAnalyzer(
         yaml: '''
-invalid: Property 
+invalid: Type 
 fields:
   name: String
 ''',
@@ -26,11 +26,11 @@ fields:
 
       var error = collector.errors.first;
       expect(error.message,
-          'No "class", "exception" or "enum" property is defined.');
+          'No "class", "exception" or "enum" type is defined.');
     });
   });
 
-  group('Given a protocol with class and exception property defined.', () {
+  group('Given a protocol with class and exception type defined.', () {
     test('Then return a human readable error message when analyzing.', () {
       var collector = CodeGenerationCollector();
       var analyzer = SerializableEntityAnalyzer(
@@ -52,10 +52,10 @@ fields:
 
       var error = collector.errors.first;
       expect(error.message,
-          'Multiple entity properties ("class", "exception") found for a single entity. Only one property per entity allowed.');
+          'Multiple entity types ("class", "exception") found for a single entity. Only one type per entity allowed.');
     });
 
-    test('Then the second property is highlighted.', () {
+    test('Then the second type is highlighted.', () {
       var collector = CodeGenerationCollector();
       var analyzer = SerializableEntityAnalyzer(
         yaml: '''
@@ -83,7 +83,7 @@ fields:
     });
   });
 
-  group('Given a protocol with exception and enum property defined.', () {
+  group('Given a protocol with exception and enum type defined.', () {
     test('Then return a human readable error message when analyzing.', () {
       var collector = CodeGenerationCollector();
       var analyzer = SerializableEntityAnalyzer(
@@ -105,11 +105,11 @@ fields:
 
       var error = collector.errors.first;
       expect(error.message,
-          'Multiple entity properties ("exception", "enum") found for a single entity. Only one property per entity allowed.');
+          'Multiple entity types ("exception", "enum") found for a single entity. Only one type per entity allowed.');
     });
   });
 
-  group('Given a protocol with three different properties defined.', () {
+  group('Given a protocol with three different types defined.', () {
     test('Then return a human readable error message when analyzing.', () {
       var collector = CodeGenerationCollector();
       var analyzer = SerializableEntityAnalyzer(
@@ -132,10 +132,10 @@ fields:
 
       var error = collector.errors.first;
       expect(error.message,
-          'Multiple entity properties ("class", "exception", "enum") found for a single entity. Only one property per entity allowed.');
+          'Multiple entity types ("class", "exception", "enum") found for a single entity. Only one type per entity allowed.');
     });
 
-    test('Then the second and third property is highlighted.', () {
+    test('Then the second and third type is highlighted.', () {
       var collector = CodeGenerationCollector();
       var analyzer = SerializableEntityAnalyzer(
         yaml: '''

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
@@ -25,8 +25,8 @@ fields:
       expect(collector.errors, hasLength(1));
 
       var error = collector.errors.first;
-      expect(error.message,
-          'No "class", "exception" or "enum" type is defined.');
+      expect(
+          error.message, 'No "class", "exception" or "enum" type is defined.');
     });
   });
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
@@ -3,9 +3,10 @@ import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:test/test.dart';
 
 void main() {
-
   group('Given a protocol without any defined entity property', () {
-    test('Then return a human readable error message informing the user that the entity property is missing.', () {
+    test(
+        'Then return a human readable error message informing the user that the entity property is missing.',
+        () {
       var collector = CodeGenerationCollector();
       var analyzer = SerializableEntityAnalyzer(
         yaml: '''
@@ -160,7 +161,6 @@ fields:
       expect(span?.start.column, 0);
       expect(span?.end.line, 1);
       expect(span?.end.column, 'exception'.length);
-
 
       var span2 = collector.errors[1].span;
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer_test.dart
@@ -1,0 +1,173 @@
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+void main() {
+
+  group('Given a protocol without any defined entity property', () {
+    test('Then return a human readable error message informing the user that the entity property is missing.', () {
+      var collector = CodeGenerationCollector();
+      var analyzer = SerializableEntityAnalyzer(
+        yaml: '''
+invalid: Property 
+fields:
+  name: String
+''',
+        sourceFileName: 'lib/src/protocol/example.yaml',
+        outFileName: 'example.yaml',
+        subDirectoryParts: ['lib', 'src', 'protocol'],
+        collector: collector,
+      );
+
+      analyzer.analyze();
+
+      expect(collector.errors, hasLength(1));
+
+      var error = collector.errors.first;
+      expect(error.message,
+          'No "class", "exception" or "enum" property is defined.');
+    });
+  });
+
+  group('Given a protocol with class and exception property defined.', () {
+    test('Then return a human readable error message when analyzing.', () {
+      var collector = CodeGenerationCollector();
+      var analyzer = SerializableEntityAnalyzer(
+        yaml: '''
+class: Example
+exception: ExampleException
+fields:
+  name: String
+''',
+        sourceFileName: 'lib/src/protocol/example.yaml',
+        outFileName: 'example.yaml',
+        subDirectoryParts: ['lib', 'src', 'protocol'],
+        collector: collector,
+      );
+
+      analyzer.analyze();
+
+      expect(collector.errors, hasLength(1));
+
+      var error = collector.errors.first;
+      expect(error.message,
+          'Multiple entity properties ("class", "exception") found for a single entity. Only one property per entity allowed.');
+    });
+
+    test('Then the second property is highlighted.', () {
+      var collector = CodeGenerationCollector();
+      var analyzer = SerializableEntityAnalyzer(
+        yaml: '''
+class: Example
+exception: ExampleException
+fields:
+  name: String
+''',
+        sourceFileName: 'lib/src/protocol/example.yaml',
+        outFileName: 'example.yaml',
+        subDirectoryParts: ['lib', 'src', 'protocol'],
+        collector: collector,
+      );
+
+      analyzer.analyze();
+
+      expect(collector.errors, hasLength(1));
+      var span = collector.errors.first.span;
+
+      expect(span?.start.line, 1);
+      expect(span?.start.column, 0);
+
+      expect(span?.end.line, 1);
+      expect(span?.end.column, 'exception'.length);
+    });
+  });
+
+  group('Given a protocol with exception and enum property defined.', () {
+    test('Then return a human readable error message when analyzing.', () {
+      var collector = CodeGenerationCollector();
+      var analyzer = SerializableEntityAnalyzer(
+        yaml: '''
+exception: ExampleException
+enum: ExampleType
+fields:
+  name: String
+''',
+        sourceFileName: 'lib/src/protocol/example.yaml',
+        outFileName: 'example.yaml',
+        subDirectoryParts: ['lib', 'src', 'protocol'],
+        collector: collector,
+      );
+
+      analyzer.analyze();
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+      expect(error.message,
+          'Multiple entity properties ("exception", "enum") found for a single entity. Only one property per entity allowed.');
+    });
+  });
+
+  group('Given a protocol with three different properties defined.', () {
+    test('Then return a human readable error message when analyzing.', () {
+      var collector = CodeGenerationCollector();
+      var analyzer = SerializableEntityAnalyzer(
+        yaml: '''
+class: Example
+exception: ExampleException
+enum: ExampleType
+fields:
+  name: String
+''',
+        sourceFileName: 'lib/src/protocol/example.yaml',
+        outFileName: 'example.yaml',
+        subDirectoryParts: ['lib', 'src', 'protocol'],
+        collector: collector,
+      );
+
+      analyzer.analyze();
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+      expect(error.message,
+          'Multiple entity properties ("class", "exception", "enum") found for a single entity. Only one property per entity allowed.');
+    });
+
+    test('Then the second and third property is highlighted.', () {
+      var collector = CodeGenerationCollector();
+      var analyzer = SerializableEntityAnalyzer(
+        yaml: '''
+class: Example
+exception: ExampleException
+enum: ExampleType
+fields:
+  name: String
+''',
+        sourceFileName: 'lib/src/protocol/example.yaml',
+        outFileName: 'example.yaml',
+        subDirectoryParts: ['lib', 'src', 'protocol'],
+        collector: collector,
+      );
+
+      analyzer.analyze();
+
+      expect(collector.errors.length, greaterThan(1));
+
+      var span = collector.errors[0].span;
+
+      expect(span?.start.line, 1);
+      expect(span?.start.column, 0);
+      expect(span?.end.line, 1);
+      expect(span?.end.column, 'exception'.length);
+
+
+      var span2 = collector.errors[1].span;
+
+      expect(span2?.start.line, 2);
+      expect(span2?.start.column, 0);
+      expect(span2?.end.line, 2);
+      expect(span2?.end.column, 'enum'.length);
+    });
+  });
+}


### PR DESCRIPTION
# Fixes

- Only allow 'class' OR 'exception' OR 'enum' in protocol files.
- Renable --stdio flag for language server as is required by the client.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.