### PR TITLE
fix: allow multiple uppercase chars in a class name in the protocol.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -192,7 +192,7 @@ class SerializableEntityAnalyzer {
 
     if (!StringValidators.isValidClassName(className)) {
       collector.addError(SourceSpanException(
-        'The "$type" property must be a valid class name (e.g. CamelCaseString).',
+        'The "$type" property must be a valid class name (e.g. PascalCaseString).',
         workingNode.span,
       ));
       return null;
@@ -581,7 +581,7 @@ class SerializableEntityAnalyzer {
 
     if (!StringValidators.isValidClassName(className)) {
       collector.addError(SourceSpanException(
-        'The "enum" property must be a valid class name (e.g. CamelCaseString).',
+        'The "enum" property must be a valid class name (e.g. PascalCaseString).',
         classNameNode.span,
       ));
       return null;

--- a/tools/serverpod_cli/lib/src/util/string_validators.dart
+++ b/tools/serverpod_cli/lib/src/util/string_validators.dart
@@ -1,6 +1,6 @@
 class StringValidators {
-  static final _pascalCaseTester =
-      RegExp(r'^([A-Z][a-z0-9]+)((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?$');
+  static final _pascalCaseWithUppercaseTester =
+      RegExp(r'^[A-Z]([A-Z0-9]*[a-z0-9]*)*([A-Z])?$');
   static final _camelCaseTester =
       RegExp(r'^[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?$');
   static final _snakeCaseTester = RegExp(r'^[a-z]+[a-z0-9_]*$');
@@ -12,7 +12,8 @@ class StringValidators {
   static bool isValidFieldName(String name) =>
       _camelCaseTester.hasMatch(name) || _snakeCaseTester.hasMatch(name);
 
-  static bool isValidClassName(String name) => _pascalCaseTester.hasMatch(name);
+  static bool isValidClassName(String name) =>
+      _pascalCaseWithUppercaseTester.hasMatch(name);
 
   static bool isValidTableName(String name) => _snakeCaseTester.hasMatch(name);
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_properties_test.dart
@@ -1,0 +1,104 @@
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given a PascalCASEString class name with several uppercase letters, then no errors are collected.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+exception: PascalCASEString
+fields:
+  name: String
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yaml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, 0);
+  });
+  test(
+      'Given a camelCase class name, then give an error indicating that PascalCase is required.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: exampleClass
+fields:
+  name: String
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yaml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The "class" property must be a valid class name (e.g. PascalCaseString).');
+  });
+
+  test(
+      'Given a snake_case exception name, then give an error indicating that PascalCase is required.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+exception: example_class
+fields:
+  name: String
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yaml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The "exception" property must be a valid class name (e.g. PascalCaseString).');
+  });
+
+  test(
+      'Given an enum name with a leading number, then give an error indicating that PascalCase is required.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+enum: 1ExampleType
+values:
+  - yes
+  - no
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yaml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The "enum" property must be a valid class name (e.g. PascalCaseString).');
+  });
+}


### PR DESCRIPTION
# Fixes

- Allow class names such as `ServerpodSQLException` to be used in the protocol files.
- Change the error message from "CamelCaseString" to "PascalCaseString" to more accurately reflect the string type.

Closes: https://github.com/serverpod/serverpod/issues/965

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.