### PR TITLE
test: add tests for the index fields of the protocol analyzer

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -443,7 +443,7 @@ class SerializableEntityAnalyzer {
     if (indexesNode != null) {
       if (indexesNode is! YamlMap) {
         collector.addError(SourceSpanException(
-          'The "indexes" property must be a Map.',
+          'The "indexes" property must have at least one index.',
           indexesNode.span,
         ));
         return null;
@@ -456,7 +456,7 @@ class SerializableEntityAnalyzer {
         // Validate index name.
         if (indexNameNode is! YamlScalar) {
           collector.addError(SourceSpanException(
-            'Keys of "indexes" Map must be of type String.',
+            'Keys of "indexes" must be of type String.',
             indexNameNode.span,
           ));
           continue;
@@ -465,7 +465,7 @@ class SerializableEntityAnalyzer {
         var indexName = indexNameNode.value;
         if (indexName is! String) {
           collector.addError(SourceSpanException(
-            'Keys of "indexes" Map must be of type String.',
+            'Keys of "indexes" must be of type String.',
             indexNameNode.span,
           ));
           continue;
@@ -473,7 +473,7 @@ class SerializableEntityAnalyzer {
 
         if (!StringValidators.isValidTableIndexName(indexName)) {
           collector.addError(SourceSpanException(
-            'The index name must be in lower_snake_case.',
+            'Invalid format for index "$indexName", must follow the format lower_snake_case.',
             indexNameNode.span,
           ));
           continue;
@@ -490,7 +490,7 @@ class SerializableEntityAnalyzer {
         }
         if (indexDescriptionNode is! YamlMap) {
           collector.addError(SourceSpanException(
-            'The index description mus be of type Map.',
+            'The "$indexNameNode" needs to define at least one field, (e.g. fields: fieldName).',
             indexDescriptionNode.span,
           ));
           continue;
@@ -508,7 +508,7 @@ class SerializableEntityAnalyzer {
         var fieldsStr = fieldsNode.value;
         if (fieldsStr is! String) {
           collector.addError(SourceSpanException(
-            'The "fields" property must be of type String.',
+            'The "fields" property must have at least one field, (e.g. fields: fieldName).',
             fieldsNode.span,
           ));
           continue;

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
@@ -1,0 +1,478 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given a class with the index property defined but without any index, then collect an error that at least one index has to be added.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(
+        error.message, 'The "indexes" property must have at least one index.');
+  });
+
+  test(
+      'Given a class with an index key that is not a string, then collect an error that the index name has do be defined as a string.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  1:
+    fields: name
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message, 'Keys of "indexes" must be of type String.');
+  });
+
+  test(
+      'Given a class with an index key that is not a string in snake_case_format, then collect an error that the index name is using an invalid format.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  PascalCaseIndex:
+    fields: name
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'Invalid format for index "PascalCaseIndex", must follow the format lower_snake_case.');
+  });
+
+  test(
+      'Given a class with an index defined but without any definitions, then collect an error that at least one field has to be defined.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  name_index:
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The "name_index" needs to define at least one field, (e.g. fields: fieldName).');
+  });
+
+  test(
+      'Given a class with an index without any fields, then collect an error that at least one field has to be added.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields:
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The "fields" property must have at least one field, (e.g. fields: fieldName).');
+  });
+
+  test(
+      'Given a class with an index with a field that does not exist, then collect an error that the field is missing in the class.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: missingField
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The field name "missingField" is not added to the class or has an api scope.');
+  });
+
+  test(
+      'Given a class with an index with a field that has an api scope, then collect an error that the field is missing in the class.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+  apiField: String, api
+indexes:
+  example_index:
+    fields: apiField
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The field name "apiField" is not added to the class or has an api scope.');
+  });
+
+  test(
+      'Given a class with an index with two fields where the second is null, then collect an error that the field must be defined.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name,
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message,
+        'The field name "" is not added to the class or has an api scope.');
+  });
+
+  //Given a class with an index with a defined field, then the definition contains the index field.
+
+  test(
+      'Given a class with an index with a defined field, then the definition contains the index.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+
+    var index = entityDefinition.indexes?.first;
+
+    expect(index!.name, 'example_index');
+  });
+
+  test(
+      'Given a class with an index with a defined field, then the definition contains the fields of the index.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+
+    var index = entityDefinition.indexes?.first;
+
+    var field = index?.fields.first;
+
+    expect(field, 'name');
+  });
+
+  test(
+      'Given a class with an index with two defined fields, then the definition contains the fields of the index.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+  foo: String
+indexes:
+  example_index:
+    fields: name, foo
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+
+    var index = entityDefinition.indexes?.first;
+
+    var field1 = index?.fields.first;
+    var field2 = index?.fields.last;
+
+    expect(field1, 'name');
+    expect(field2, 'foo');
+  });
+
+  test(
+      'Given a class with two indexes, then the definition contains both the index names.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+  foo: String
+indexes:
+  example_index:
+    fields: name
+  example_index2:
+    fields: foo
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+
+    var index1 = entityDefinition.indexes?.first;
+    var index2 = entityDefinition.indexes?.last;
+
+    expect(index1!.name, 'example_index');
+    expect(index2!.name, 'example_index2');
+  });
+
+  test(
+      'Given a class with an index with a unique key that is not a bool, then collect an error that the unique key has to be defined as a bool.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    unique: InvalidValue
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    analyzer.analyze();
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(error.message, 'The "unique" property must be of type bool.');
+  });
+
+  test(
+      'Given a class with an index with an undefined unique key, then return a definition where unique is set to false.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+
+    var index = entityDefinition.indexes?.first;
+
+    expect(index!.unique, false);
+  });
+
+  test(
+      'Given a class with an index with a unique key set to false, then return a definition where unique is set to false.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    unique: false
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+
+    var index = entityDefinition.indexes?.first;
+
+    expect(index!.unique, false);
+  });
+
+  test(
+      'Given a class with an index with a unique key set to true, then return a definition where unique is set to true.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    unique: true
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yateriml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+
+    var index = entityDefinition.indexes?.first;
+
+    expect(index!.unique, true);
+  });
+}


### PR DESCRIPTION
# Adds

Tests for the index definitions in the protocol analyzer.

Slight modification to the error messages for the indexs.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.