### PR TITLE
Fix: Use explicit version for all module and Serverpod pub specs

### DIFF
--- a/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod: #1.1.0
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 
 dependencies:
-  serverpod: #^1.1.0
+  serverpod: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod: #1.1.0
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 
 dependencies:
-  serverpod: #^1.1.0
+  serverpod: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
-  serverpod_auth_client: #^1.1.0
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^1.1.0
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_shared_flutter
   sign_in_with_apple: ^4.3.0
 

--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_client: #1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_shared_flutter: #1.1.0
     path: ../serverpod_auth_shared_flutter
   sign_in_with_apple: ^4.3.0
 

--- a/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -13,5 +13,5 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
   lints: ^2.0.1
-  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_client: #1.1.0
     path: ../../../packages/serverpod_client

--- a/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -13,5 +13,5 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
   lints: ^2.0.1
-  serverpod_client: #^1.1.0
+  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../../packages/serverpod_client

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   flutter:
     sdk: flutter
   email_validator: ^2.1.17
-  serverpod_auth_client: #^1.1.0
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^1.1.0
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
   flutter:
     sdk: flutter
   email_validator: ^2.1.17
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_client: #1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_shared_flutter: #1.1.0
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 <7.0.0"
-  serverpod_auth_client: #^1.1.0
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^1.1.0
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 <7.0.0"
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_client: #1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_shared_flutter: #1.1.0
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
@@ -14,9 +14,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_client: #1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_shared_flutter: #1.1.0
     path: ../serverpod_auth_shared_flutter
   google_sign_in: ^6.1.0
 

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
@@ -14,9 +14,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_auth_client: #^1.1.0
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^1.1.0
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_shared_flutter
   google_sign_in: ^6.1.0
 

--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod: #1.1.0
     path: ../../../packages/serverpod
-  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_serialization: #1.1.0
     path: ../../../packages/serverpod_serialization
   crypto: ^3.0.2
   email_validator: ^2.1.17

--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #^1.1.0
+  serverpod: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../../packages/serverpod
-  serverpod_serialization: #^1.1.0
+  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../../packages/serverpod_serialization
   crypto: ^3.0.2
   email_validator: ^2.1.17

--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -16,9 +16,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_client: #1.1.0
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_client: #1.1.0
     path: ../serverpod_auth_client
   shared_preferences: ^2.1.0
   cached_network_image: ^3.2.3

--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -16,9 +16,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_client: #^1.1.0
+  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #^1.1.0
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_auth_client
   shared_preferences: ^2.1.0
   cached_network_image: ^3.2.3

--- a/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
@@ -12,7 +12,7 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
-  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_client: #1.1.0
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_client: #1.1.0
     path: ../../serverpod_auth/serverpod_auth_client

--- a/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
@@ -12,7 +12,7 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
-  serverpod_client: #^1.1.0
+  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #^1.1.0
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../serverpod_auth/serverpod_auth_client

--- a/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -20,11 +20,11 @@ dependencies:
   intl: ^0.17.0
   url_launcher: ^6.1.10
   path: ^1.8.2
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_client: #1.1.0
     path: ../../serverpod_auth/serverpod_auth_client
-  serverpod_chat_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_chat_client: #1.1.0
     path: ../serverpod_chat_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_shared_flutter: #1.1.0
     path: ../../serverpod_auth/serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -20,11 +20,11 @@ dependencies:
   intl: ^0.17.0
   url_launcher: ^6.1.10
   path: ^1.8.2
-  serverpod_auth_client: #^1.1.0
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../serverpod_auth/serverpod_auth_client
-  serverpod_chat_client: #^1.1.0
+  serverpod_chat_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_chat_client
-  serverpod_auth_shared_flutter: #^1.1.0
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../serverpod_auth/serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -11,11 +11,11 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod: #1.1.0
     path: ../../../packages/serverpod
-  serverpod_auth_server: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_auth_server: #1.1.0
     path: ../../serverpod_auth/serverpod_auth_server
-  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_serialization: #1.1.0
     path: ../../../packages/serverpod_serialization/
   http: ^0.13.5
   image: ^4.0.15

--- a/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -11,11 +11,11 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #^1.1.0
+  serverpod: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../../packages/serverpod
-  serverpod_auth_server: #^1.1.0
+  serverpod_auth_server: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../serverpod_auth/serverpod_auth_server
-  serverpod_serialization: #^1.1.0
+  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../../packages/serverpod_serialization/
   http: ^0.13.5
   image: ^4.0.15

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -29,13 +29,13 @@ dependencies:
   system_resources: ^1.6.0
   vm_service: ^11.4.0
   yaml: ^3.1.1
-  serverpod_shared: #^1.1.0
+  serverpod_shared: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_shared
-  serverpod_serialization: #^1.1.0
+  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_serialization
-  serverpod_service_client: #^1.1.0
+  serverpod_service_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_service_client
-  serverpod_client: #^1.1.0
+  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_client
 
 dev_dependencies:

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -29,13 +29,13 @@ dependencies:
   system_resources: ^1.6.0
   vm_service: ^11.4.0
   yaml: ^3.1.1
-  serverpod_shared: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_shared: #1.1.0
     path: ../serverpod_shared
-  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_serialization: #1.1.0
     path: ../serverpod_serialization
-  serverpod_service_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_service_client: #1.1.0
     path: ../serverpod_service_client
-  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_client: #1.1.0
     path: ../serverpod_client
 
 dev_dependencies:

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_serialization: #^1.1.0
+  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_serialization
   http: ^0.13.5
   meta: ^1.8.0

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_serialization: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_serialization: #1.1.0
     path: ../serverpod_serialization
   http: ^0.13.5
   meta: ^1.8.0

--- a/packages/serverpod_flutter/pubspec.yaml
+++ b/packages/serverpod_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   connectivity_plus: ^3.0.4
-  serverpod_client: #^1.1.0
+  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_client
   flutter:
     sdk: flutter

--- a/packages/serverpod_flutter/pubspec.yaml
+++ b/packages/serverpod_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   connectivity_plus: ^3.0.4
-  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_client: #1.1.0
     path: ../serverpod_client
   flutter:
     sdk: flutter

--- a/packages/serverpod_service_client/pubspec.yaml
+++ b/packages/serverpod_service_client/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_client: #^1.1.0
+  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_client
   meta: ^1.8.0
 

--- a/packages/serverpod_service_client/pubspec.yaml
+++ b/packages/serverpod_service_client/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_client: #1.1.0
     path: ../serverpod_client
   meta: ^1.8.0
 

--- a/packages/serverpod_shared/pubspec.yaml
+++ b/packages/serverpod_shared/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   yaml: ^3.1.1
   super_string: ^1.0.3
-  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_client: #1.1.0
     path: ../serverpod_client
 
 dev_dependencies:

--- a/packages/serverpod_shared/pubspec.yaml
+++ b/packages/serverpod_shared/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   yaml: ^3.1.1
   super_string: ^1.0.3
-  serverpod_client: #^1.1.0
+  serverpod_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../serverpod_client
 
 dev_dependencies:

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#VERSION
+  serverpod: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 
 dependencies:
-  serverpod: #^VERSION
+  serverpod: #--CONDITIONAL COMMENT--#VERSION
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#VERSION
+  serverpod: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 
 dependencies:
-  serverpod: #^VERSION
+  serverpod: #--CONDITIONAL COMMENT--#VERSION
     path: ../../packages/serverpod
   amazon_cognito_identity_dart_2: ^1.0.3
   http: ^0.13.5

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
   sign_in_with_apple: ^4.3.0
 

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
-  serverpod_auth_client: #^VERSION
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
   sign_in_with_apple: ^4.3.0
 

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -12,5 +12,5 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
   lints: ^2.0.1
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_client

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -12,5 +12,5 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
   lints: ^2.0.1
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_client

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
@@ -14,9 +14,9 @@ dependencies:
   flutter:
     sdk: flutter
   email_validator: ^2.1.17
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_email_flutter/pubspec.yaml
@@ -14,9 +14,9 @@ dependencies:
   flutter:
     sdk: flutter
   email_validator: ^2.1.17
-  serverpod_auth_client: #^VERSION
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
@@ -19,9 +19,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 <7.0.0"
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_firebase_flutter/pubspec.yaml
@@ -19,9 +19,9 @@ dependencies:
   flutter:
     sdk: flutter
   material_design_icons_flutter: ">=6.0.0 <7.0.0"
-  serverpod_auth_client: #^VERSION
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
@@ -13,9 +13,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_auth_client: #^VERSION
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #^VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
   google_sign_in: ^6.1.0
 

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_google_flutter/pubspec.yaml
@@ -13,9 +13,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_shared_flutter
   google_sign_in: ^6.1.0
 

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#VERSION
+  serverpod: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod
-  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_serialization: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_serialization
   crypto: ^3.0.2
   email_validator: ^2.1.17

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #^VERSION
+  serverpod: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod
-  serverpod_serialization: #^VERSION
+  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_serialization
   crypto: ^3.0.2
   email_validator: ^2.1.17

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -15,9 +15,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #^VERSION
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_auth_client
   shared_preferences: ^2.1.0
   cached_network_image: ^3.2.3

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -15,9 +15,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_auth_client
   shared_preferences: ^2.1.0
   cached_network_image: ^3.2.3

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
@@ -11,7 +11,7 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #^VERSION
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_client

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_client/pubspec.yaml
@@ -11,7 +11,7 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_client
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_client

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -19,11 +19,11 @@ dependencies:
   intl: ^0.17.0
   url_launcher: ^6.1.10
   path: ^1.8.2
-  serverpod_auth_client: #^VERSION
+  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_client
-  serverpod_chat_client: #^VERSION
+  serverpod_chat_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_chat_client
-  serverpod_auth_shared_flutter: #^VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -19,11 +19,11 @@ dependencies:
   intl: ^0.17.0
   url_launcher: ^6.1.10
   path: ^1.8.2
-  serverpod_auth_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_client
-  serverpod_chat_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_chat_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_chat_client
-  serverpod_auth_shared_flutter: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_shared_flutter: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_shared_flutter
 
 dev_dependencies:

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#VERSION
+  serverpod: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod
-  serverpod_auth_server: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_auth_server: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_server
-  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_serialization: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_serialization/
   http: ^0.13.5
   image: ^4.0.15

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #^VERSION
+  serverpod: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod
-  serverpod_auth_server: #^VERSION
+  serverpod_auth_server: #--CONDITIONAL COMMENT--#VERSION
     path: ../../serverpod_auth/serverpod_auth_server
-  serverpod_serialization: #^VERSION
+  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_serialization/
   http: ^0.13.5
   image: ^4.0.15

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -28,13 +28,13 @@ dependencies:
   system_resources: ^1.6.0
   vm_service: ^11.4.0
   yaml: ^3.1.1
-  serverpod_shared: #^VERSION
+  serverpod_shared: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_shared
-  serverpod_serialization: #^VERSION
+  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_serialization
-  serverpod_service_client: #^VERSION
+  serverpod_service_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_service_client
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_client
 
 dev_dependencies:

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -28,13 +28,13 @@ dependencies:
   system_resources: ^1.6.0
   vm_service: ^11.4.0
   yaml: ^3.1.1
-  serverpod_shared: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_shared: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_shared
-  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_serialization: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_serialization
-  serverpod_service_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_service_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_service_client
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_client
 
 dev_dependencies:

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_serialization: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_serialization
   http: ^0.13.5
   meta: ^1.8.0

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_serialization: #^VERSION
+  serverpod_serialization: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_serialization
   http: ^0.13.5
   meta: ^1.8.0

--- a/templates/pubspecs/packages/serverpod_flutter/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   connectivity_plus: ^3.0.4
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_client
   flutter:
     sdk: flutter

--- a/templates/pubspecs/packages/serverpod_flutter/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   connectivity_plus: ^3.0.4
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_client
   flutter:
     sdk: flutter

--- a/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_client
   meta: ^1.8.0
 

--- a/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_service_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_client
   meta: ^1.8.0
 

--- a/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   yaml: ^3.1.1
   super_string: ^1.0.3
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../serverpod_client
 
 dev_dependencies:

--- a/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_shared/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   yaml: ^3.1.1
   super_string: ^1.0.3
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_client
 
 dev_dependencies:

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -30,9 +30,9 @@ dependencies:
   pub_api_client: ^2.4.0
   uuid: ^3.0.7
   yaml: ^3.1.1
-  serverpod_shared: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_shared: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../packages/serverpod_shared
-  serverpod_service_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_service_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../packages/serverpod_service_client
   async: ^2.11.0
   meta: ^1.8.0

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -30,9 +30,9 @@ dependencies:
   pub_api_client: ^2.4.0
   uuid: ^3.0.7
   yaml: ^3.1.1
-  serverpod_shared: #^VERSION
+  serverpod_shared: #--CONDITIONAL COMMENT--#VERSION
     path: ../../packages/serverpod_shared
-  serverpod_service_client: #^VERSION
+  serverpod_service_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../packages/serverpod_service_client
   async: ^2.11.0
   meta: ^1.8.0

--- a/templates/serverpod_templates/modulename_client/pubspec.yaml
+++ b/templates/serverpod_templates/modulename_client/pubspec.yaml
@@ -6,5 +6,5 @@ description: Starting point for a Serverpod module client.
 environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_client

--- a/templates/serverpod_templates/modulename_client/pubspec.yaml
+++ b/templates/serverpod_templates/modulename_client/pubspec.yaml
@@ -6,5 +6,5 @@ description: Starting point for a Serverpod module client.
 environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_client

--- a/templates/serverpod_templates/modulename_server/pubspec.yaml
+++ b/templates/serverpod_templates/modulename_server/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#VERSION
+  serverpod: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod
 
 dev_dependencies:

--- a/templates/serverpod_templates/modulename_server/pubspec.yaml
+++ b/templates/serverpod_templates/modulename_server/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #^VERSION
+  serverpod: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod
 
 dev_dependencies:

--- a/templates/serverpod_templates/projectname_client/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_client/pubspec.yaml
@@ -5,5 +5,5 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_client: #^VERSION
+  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_client

--- a/templates/serverpod_templates/projectname_client/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_client/pubspec.yaml
@@ -5,5 +5,5 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod_client: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_client: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_client

--- a/templates/serverpod_templates/projectname_flutter/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_flutter/pubspec.yaml
@@ -24,7 +24,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_flutter: #^VERSION
+  serverpod_flutter: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod_flutter
   projectname_client:
     path: ../projectname_client

--- a/templates/serverpod_templates/projectname_flutter/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_flutter/pubspec.yaml
@@ -24,7 +24,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  serverpod_flutter: #--CONDITIONAL COMMENT--#VERSION
+  serverpod_flutter: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod_flutter
   projectname_client:
     path: ../projectname_client

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #^VERSION
+  serverpod: #--CONDITIONAL COMMENT--#VERSION
     path: ../../../packages/serverpod
 
 dev_dependencies:

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
-  serverpod: #--CONDITIONAL COMMENT--#VERSION
+  serverpod: #--CONDITIONAL_COMMENT--#VERSION
     path: ../../../packages/serverpod
 
 dev_dependencies:

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -140,7 +140,7 @@ Future<void> performCreate(
         ),
         Replacement(
           slotName: '#^',
-          replacement: '^',
+          replacement: '',
         ),
         Replacement(
           slotName: 'VERSION',
@@ -207,7 +207,7 @@ Future<void> performCreate(
         ),
         Replacement(
           slotName: '#^',
-          replacement: '^',
+          replacement: '',
         ),
         Replacement(
           slotName: 'VERSION',
@@ -242,7 +242,7 @@ Future<void> performCreate(
         ),
         Replacement(
           slotName: '#^',
-          replacement: '^',
+          replacement: '',
         ),
         Replacement(
           slotName: 'VERSION',
@@ -315,7 +315,7 @@ Future<void> performCreate(
         ),
         Replacement(
           slotName: '#^',
-          replacement: '^',
+          replacement: '',
         ),
         Replacement(
           slotName: 'VERSION',
@@ -350,7 +350,7 @@ Future<void> performCreate(
         ),
         Replacement(
           slotName: '#^',
-          replacement: '^',
+          replacement: '',
         ),
         Replacement(
           slotName: 'VERSION',

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -139,7 +139,7 @@ Future<void> performCreate(
           replacement: randomAwsId,
         ),
         Replacement(
-          slotName: '#^',
+          slotName: '#--CONDITIONAL COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -206,7 +206,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#^',
+          slotName: '#--CONDITIONAL COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -241,7 +241,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#^',
+          slotName: '#--CONDITIONAL COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -314,7 +314,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#^',
+          slotName: '#--CONDITIONAL COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -349,7 +349,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#^',
+          slotName: '#--CONDITIONAL COMMENT--#',
           replacement: '',
         ),
         Replacement(

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -139,7 +139,7 @@ Future<void> performCreate(
           replacement: randomAwsId,
         ),
         Replacement(
-          slotName: '#--CONDITIONAL COMMENT--#',
+          slotName: '#--CONDITIONAL_COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -206,7 +206,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#--CONDITIONAL COMMENT--#',
+          slotName: '#--CONDITIONAL_COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -241,7 +241,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#--CONDITIONAL COMMENT--#',
+          slotName: '#--CONDITIONAL_COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -314,7 +314,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#--CONDITIONAL COMMENT--#',
+          slotName: '#--CONDITIONAL_COMMENT--#',
           replacement: '',
         ),
         Replacement(
@@ -349,7 +349,7 @@ Future<void> performCreate(
           replacement: name,
         ),
         Replacement(
-          slotName: '#--CONDITIONAL COMMENT--#',
+          slotName: '#--CONDITIONAL_COMMENT--#',
           replacement: '',
         ),
         Replacement(

--- a/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
@@ -68,7 +68,7 @@ void performGeneratePubspecs(String version, String mode) {
         ),
         Replacement(
           slotName: '#^',
-          replacement: '^',
+          replacement: '',
         ),
         Replacement(
           slotName: 'PRODUCTION_MODE',

--- a/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
@@ -67,7 +67,7 @@ void performGeneratePubspecs(String version, String mode) {
               '# This file is generated. Do not modify, instead edit the files in the templates/pubspecs directory.\n# Mode: $mode',
         ),
         Replacement(
-          slotName: '#^',
+          slotName: '#--CONDITIONAL COMMENT--#',
           replacement: '',
         ),
         Replacement(

--- a/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
@@ -30,7 +30,7 @@ void performGeneratePubspecs(String version, String mode) {
           replacement: 'publish_to: none',
         ),
         Replacement(
-          slotName: '#--CONDITIONAL COMMENT--#',
+          slotName: '#--CONDITIONAL_COMMENT--#',
           replacement: '#',
         ),
         Replacement(
@@ -71,7 +71,7 @@ void performGeneratePubspecs(String version, String mode) {
               '# This file is generated. Do not modify, instead edit the files in the templates/pubspecs directory.\n# Mode: $mode',
         ),
         Replacement(
-          slotName: '#--CONDITIONAL COMMENT--#',
+          slotName: '#--CONDITIONAL_COMMENT--#',
           replacement: '',
         ),
         Replacement(

--- a/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/generate_pubspecs.dart
@@ -30,6 +30,10 @@ void performGeneratePubspecs(String version, String mode) {
           replacement: 'publish_to: none',
         ),
         Replacement(
+          slotName: '#--CONDITIONAL COMMENT--#',
+          replacement: '#',
+        ),
+        Replacement(
           slotName: 'VERSION',
           replacement: version,
         ),

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -31,9 +31,9 @@ dependencies:
   pub_api_client: ^2.4.0
   uuid: ^3.0.7
   yaml: ^3.1.1
-  serverpod_shared: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_shared: #1.1.0
     path: ../../packages/serverpod_shared
-  serverpod_service_client: #--CONDITIONAL COMMENT--#1.1.0
+  serverpod_service_client: #1.1.0
     path: ../../packages/serverpod_service_client
   async: ^2.11.0
   meta: ^1.8.0

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -31,9 +31,9 @@ dependencies:
   pub_api_client: ^2.4.0
   uuid: ^3.0.7
   yaml: ^3.1.1
-  serverpod_shared: #^1.1.0
+  serverpod_shared: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../packages/serverpod_shared
-  serverpod_service_client: #^1.1.0
+  serverpod_service_client: #--CONDITIONAL COMMENT--#1.1.0
     path: ../../packages/serverpod_service_client
   async: ^2.11.0
   meta: ^1.8.0


### PR DESCRIPTION
# Adds

To prevent minor version mismatches we no longer use `^` when defining what version of Serverpod that is used in pub specs.
This fix is applied to both the Serverpod modules and to projects created with Serverpod.

## Review notes

Since files are modified multiple times it is easiest to review commit by commit.

Last three commits are open for discussion. I didn't like the implicit meaning of `#^` as a conditional comment so I would rather write it out so that anyone that stumbles upon it would understand its meaning directly.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

https://github.com/serverpod/serverpod/issues/940