### PR TITLE
Fix:  Validate serverpod packages and cli version before generating project

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   json_rpc_2: ^3.0.2
   stream_channel: ^2.1.1
   lsp_server: ^0.1.0
+  pub_semver: ^2.1.4
 
 dev_dependencies:
   lints: ^2.0.1

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -271,8 +271,8 @@ Future<void> _main(List<String> args) async {
             Version.parse(templateVersion), Directory.current.parent);
         if (warnings.isNotEmpty) {
           printww(
-              'WARNING: Version compatibility warnings between the running cli and '
-              'serverpod packages found.');
+              'WARNING: The version of the CLI may be incompatible with the '
+              'Serverpod packages used in your project.');
           warnings.forEach(print);
         }
       } catch (e) {

--- a/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
+++ b/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
@@ -9,14 +9,13 @@ import 'package:yaml/yaml.dart';
 
 class ServerpodPackagesVersionCheckWarnings {
   static const incompatibleVersion =
-      'Version not compatible with the running serverpod cli version. This '
-      'may cause unexpected behavior. Please use the same version for both to '
-      'ensure full functionality.';
+      'The package version does not match the version of the Serverpod\'s '
+      'CLI. This may cause errors or unexpected behavior.';
   static String approximateVersion(Version cliVersion) =>
-      'Package is defined with a version range (for example "^$cliVersion"). '
-      'Ensure full compatibility between the serverpod cli and serverpod '
-      'packages by defining a concrete package version. Prefer "$cliVersion" '
-      'over "^$cliVersion".';
+      'The package is defined with a version range (for example '
+      '"^$cliVersion"). This can cause a mismatch with Serverpod\'s CLI '
+      'version. It\'s preferred to use "$cliVersion" over "^$cliVersion" for '
+      'the Serverpod packages.';
 }
 
 List<SourceSpanException> performServerpodPackagesAndCliVersionCheck(
@@ -101,7 +100,7 @@ List<SourceSpanException> _validatePackageCompatibilities(
 
     if (packageYamlNode == null) {
       throw SourceSpanException(
-          'Could not find package "$packageName" when inspecting as Yaml file',
+          'Could not find package "$packageName" in pubspec file.',
           packagesYaml.span);
     }
 

--- a/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
+++ b/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
+import 'package:source_span/source_span.dart';
+import 'package:yaml/yaml.dart';
+
+class ServerpodPackagesVersionCheckWarnings {
+  static const incompatibleVersion =
+      'Version not compatible with the running serverpod cli version. This '
+      'may cause unexpected behavior. Please use the same version for both to '
+      'ensure full functionality.';
+  static String approximateVersion(Version cliVersion) =>
+      'Package is defined with a version range (for example "^$cliVersion"). '
+      'Ensure full compatibility between the serverpod cli and serverpod '
+      'packages by defining a concrete package version. Prefer "$cliVersion" '
+      'over "^$cliVersion".';
+}
+
+List<SourceSpanException> performServerpodPackagesAndCliVersionCheck(
+  Version cliVersion,
+  Directory directory,
+) {
+  List<SourceSpanException> accumulatedWarnings = [];
+
+  var pubspecFiles = findPubspecsFiles(directory);
+  if (pubspecFiles.isEmpty) {
+    return accumulatedWarnings;
+  }
+
+  for (var pubspecFile in pubspecFiles) {
+    try {
+      var file = pubspecFile.readAsStringSync();
+      var pubspec = Pubspec.parse(file);
+      var yaml = loadYaml(file, sourceUrl: pubspecFile.uri) as YamlMap;
+      var warnings =
+          _validateServerpodPackagesVersion(cliVersion, pubspec, yaml);
+
+      accumulatedWarnings.addAll(warnings);
+    } catch (e) {
+      throw Exception(
+          'Error while parsing pubspec file: ${pubspecFile.path}: $e');
+    }
+  }
+
+  return accumulatedWarnings;
+}
+
+List<SourceSpanException> _validateServerpodPackagesVersion(
+  Version version,
+  Pubspec pubspec,
+  YamlMap yamlPubspec,
+) {
+  List<SourceSpanException> warnings = [];
+
+  var serverpodDependencies =
+      _getHostedServerpodDependencies(pubspec.dependencies);
+  if (serverpodDependencies.isNotEmpty) {
+    warnings.addAll(_validatePackageCompatibilities(
+        serverpodDependencies, version, yamlPubspec['dependencies']));
+  }
+
+  var serverpodDevDependencies =
+      _getHostedServerpodDependencies(pubspec.devDependencies);
+  if (serverpodDevDependencies.isNotEmpty) {
+    warnings.addAll(_validatePackageCompatibilities(
+        serverpodDependencies, version, yamlPubspec['devDependencies']));
+  }
+
+  return warnings;
+}
+
+List<MapEntry<String, HostedDependency>> _getHostedServerpodDependencies(
+  Map<String, Dependency> dependencies,
+) {
+  return dependencies.entries.fold([], (hostedDependencies, dependency) {
+    if (!dependency.key.startsWith('serverpod') ||
+        dependency.value is! HostedDependency) return hostedDependencies;
+
+    // Cast dependencies to HostedDependency type
+    return [
+      ...hostedDependencies,
+      MapEntry(dependency.key, dependency.value as HostedDependency)
+    ];
+  });
+}
+
+List<SourceSpanException> _validatePackageCompatibilities(
+  List<MapEntry<String, HostedDependency>> serverpodPackages,
+  Version cliVersion,
+  YamlMap packagesYaml,
+) {
+  List<SourceSpanException> packageWarnings = [];
+
+  for (var element in serverpodPackages) {
+    var packageName = element.key;
+    var package = element.value;
+    var packageYamlNode = packagesYaml.nodes[packageName];
+
+    if (packageYamlNode == null) {
+      throw SourceSpanException(
+          'Could not find package "$packageName" when inspecting as Yaml file',
+          packagesYaml.span);
+    }
+
+    var packageVersion = package.version;
+    if (!packageVersion.allowsAny(cliVersion)) {
+      packageWarnings.add(SourceSpanException(
+          ServerpodPackagesVersionCheckWarnings.incompatibleVersion,
+          packageYamlNode.span));
+    }
+
+    if (packageVersion is! Version) {
+      packageWarnings.add(SourceSpanException(
+          ServerpodPackagesVersionCheckWarnings.approximateVersion(cliVersion),
+          packageYamlNode.span));
+    }
+  }
+
+  return packageWarnings;
+}

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   json_rpc_2: ^3.0.2
   stream_channel: ^2.1.1
   lsp_server: ^0.1.0
+  pub_semver: ^2.1.4
 
 dev_dependencies:
   lints: ^2.0.1

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -1,0 +1,157 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:serverpod_cli/src/serverpod_packages_version_check/serverpod_packages_version_check.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var testAssetsPath =
+      p.join('test', 'serverpod_packages_version_check', 'test_assets');
+  group('performServerpodPackagesVersionCheck', () {
+    test(
+        '.performServerpodPackagesVersionCheck() when there are no pubspec files',
+        () {
+      var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+        Version(1, 1, 0),
+        Directory(p.join(testAssetsPath, 'empty_folder')),
+      );
+
+      expect(packageWarnings.isEmpty, equals(true));
+    });
+
+    group('With explicit serverpod package version', () {
+      var explicitVersionPath =
+          Directory(p.join(testAssetsPath, 'explicit_1.1.0'));
+      test('.performServerpodPackagesVersionCheck() with same version', () {
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          Version(1, 1, 0),
+          explicitVersionPath,
+        );
+
+        expect(packageWarnings.isEmpty, equals(true));
+      });
+
+      test('.performServerpodPackagesVersionCheck() with older version', () {
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          Version(1, 0, 0),
+          explicitVersionPath,
+        );
+
+        expect(packageWarnings.length, equals(1));
+        expect(packageWarnings.first.message,
+            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
+      });
+
+      test('.performServerpodPackagesVersionCheck() with newer version', () {
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          Version(1, 2, 0),
+          explicitVersionPath,
+        );
+
+        expect(packageWarnings.length, equals(1));
+        expect(packageWarnings.first.message,
+            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
+      });
+    });
+
+    group('With approximate serverpod package version', () {
+      var approximateVersionPath =
+          Directory(p.join(testAssetsPath, 'approximate_1.1.0'));
+      test('.performServerpodPackagesVersionCheck() with same version', () {
+        var cliVersion = Version(1, 1, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          cliVersion,
+          approximateVersionPath,
+        );
+
+        expect(packageWarnings.length, equals(1));
+        expect(
+            packageWarnings.first.message,
+            ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                cliVersion));
+      });
+
+      test('.performServerpodPackagesVersionCheck() with older version', () {
+        var cliVersion = Version(1, 0, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          cliVersion,
+          approximateVersionPath,
+        );
+
+        expect(packageWarnings.length, equals(2));
+        expect(packageWarnings[0].message,
+            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
+        expect(
+            packageWarnings[1].message,
+            ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                cliVersion));
+      });
+
+      test('.performServerpodPackagesVersionCheck() with newer version', () {
+        var cliVersion = Version(1, 2, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          cliVersion,
+          approximateVersionPath,
+        );
+
+        expect(packageWarnings.length, equals(1));
+        expect(
+            packageWarnings.first.message,
+            ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                cliVersion));
+      });
+    });
+
+    group('With multiple pubspec files', () {
+      var testAssets = Directory(testAssetsPath);
+      test('.performServerpodPackagesVersionCheck() with same version', () {
+        var cliVersion = Version(1, 1, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          Version(1, 1, 0),
+          testAssets,
+        );
+
+        expect(packageWarnings.length, equals(1));
+        expect(
+            packageWarnings.first.message,
+            ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                cliVersion));
+      });
+
+      test('.performServerpodPackagesVersionCheck() with older version', () {
+        var cliVersion = Version(1, 0, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          cliVersion,
+          testAssets,
+        );
+
+        expect(packageWarnings.length, equals(3));
+        expect(packageWarnings[0].message,
+            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
+        expect(packageWarnings[1].message,
+            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
+        expect(
+            packageWarnings[2].message,
+            ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                cliVersion));
+      });
+
+      test('.performServerpodPackagesVersionCheck() with newer version', () {
+        var cliVersion = Version(1, 2, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          cliVersion,
+          testAssets,
+        );
+
+        expect(packageWarnings.length, equals(2));
+        expect(packageWarnings[0].message,
+            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
+        expect(
+            packageWarnings[1].message,
+            ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                cliVersion));
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -8,9 +8,9 @@ import 'package:test/test.dart';
 void main() {
   var testAssetsPath =
       p.join('test', 'serverpod_packages_version_check', 'test_assets');
-  group('performServerpodPackagesVersionCheck', () {
+  group('performServerpodPackagesAndCliVersionCheck', () {
     test(
-        '.performServerpodPackagesVersionCheck() when there are no pubspec files',
+        'performServerpodPackagesAndCliVersionCheck() when there are no pubspec files',
         () {
       var packageWarnings = performServerpodPackagesAndCliVersionCheck(
         Version(1, 1, 0),
@@ -23,7 +23,8 @@ void main() {
     group('With explicit serverpod package version', () {
       var explicitVersionPath =
           Directory(p.join(testAssetsPath, 'explicit_1.1.0'));
-      test('.performServerpodPackagesVersionCheck() with same version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with same version',
+          () {
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           Version(1, 1, 0),
           explicitVersionPath,
@@ -32,7 +33,8 @@ void main() {
         expect(packageWarnings.isEmpty, equals(true));
       });
 
-      test('.performServerpodPackagesVersionCheck() with older version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with older version',
+          () {
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           Version(1, 0, 0),
           explicitVersionPath,
@@ -43,7 +45,8 @@ void main() {
             ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
       });
 
-      test('.performServerpodPackagesVersionCheck() with newer version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with newer version',
+          () {
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           Version(1, 2, 0),
           explicitVersionPath,
@@ -58,7 +61,8 @@ void main() {
     group('With approximate serverpod package version', () {
       var approximateVersionPath =
           Directory(p.join(testAssetsPath, 'approximate_1.1.0'));
-      test('.performServerpodPackagesVersionCheck() with same version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with same version',
+          () {
         var cliVersion = Version(1, 1, 0);
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           cliVersion,
@@ -72,7 +76,8 @@ void main() {
                 cliVersion));
       });
 
-      test('.performServerpodPackagesVersionCheck() with older version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with older version',
+          () {
         var cliVersion = Version(1, 0, 0);
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           cliVersion,
@@ -88,7 +93,8 @@ void main() {
                 cliVersion));
       });
 
-      test('.performServerpodPackagesVersionCheck() with newer version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with newer version',
+          () {
         var cliVersion = Version(1, 2, 0);
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           cliVersion,
@@ -105,7 +111,8 @@ void main() {
 
     group('With multiple pubspec files', () {
       var testAssets = Directory(testAssetsPath);
-      test('.performServerpodPackagesVersionCheck() with same version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with same version',
+          () {
         var cliVersion = Version(1, 1, 0);
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           Version(1, 1, 0),
@@ -119,7 +126,8 @@ void main() {
                 cliVersion));
       });
 
-      test('.performServerpodPackagesVersionCheck() with older version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with older version',
+          () {
         var cliVersion = Version(1, 0, 0);
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           cliVersion,
@@ -137,7 +145,8 @@ void main() {
                 cliVersion));
       });
 
-      test('.performServerpodPackagesVersionCheck() with newer version', () {
+      test('performServerpodPackagesAndCliVersionCheck() with newer version',
+          () {
         var cliVersion = Version(1, 2, 0);
         var packageWarnings = performServerpodPackagesAndCliVersionCheck(
           cliVersion,

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/approximate_1.1.0/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/approximate_1.1.0/pubspec.yaml
@@ -1,0 +1,13 @@
+# Test asset
+publish_to: none
+
+name: serverpod_cli
+version: 1.1.0
+description: Command line tools for Serverpod.
+repository: https://github.com/serverpod/serverpod
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  serverpod_shared: ^1.1.0

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/explicit_1.1.0/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/explicit_1.1.0/pubspec.yaml
@@ -1,0 +1,13 @@
+# Test asset
+publish_to: none
+
+name: serverpod_cli
+version: 1.1.0
+description: Command line tools for Serverpod.
+repository: https://github.com/serverpod/serverpod
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  serverpod_shared: 1.1.0


### PR DESCRIPTION
Adds a new step to the generate process that validates that the current version of the CLI is compatible with the Serverpod packages specified in the pubspec files.

- Prints a warnings if a the version for the package is defined using an approximate version (for example "^").
- Prints a warning if the version of the package is not compatible with the running version of the Cli. 


### Output in the Cli for both errors after review fixes
<img width="829" alt="Screenshot 2023-07-03 at 16 07 56" src="https://github.com/serverpod/serverpod/assets/137198655/8ab20482-6f9b-4fc2-85c1-9f0cacddfc22">


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).