### PR TITLE
feat: add dual pass parsing to validation of protocol files

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -5,13 +5,17 @@ import 'package:serverpod_cli/src/generator/types.dart';
 /// An abstract representation of a yaml file in the
 /// protocol directory.
 abstract class SerializableEntityDefinition {
+  final String yamlProtocol;
   final String fileName;
+  final String sourceFileName;
   final String className;
   final List<String> subDirParts;
   final bool serverOnly;
 
   SerializableEntityDefinition({
+    required this.yamlProtocol,
     required this.fileName,
+    required this.sourceFileName,
     required this.className,
     required this.serverOnly,
     this.subDirParts = const [],
@@ -52,7 +56,9 @@ class ClassDefinition extends SerializableEntityDefinition {
 
   /// Create a new [ClassDefinition].
   ClassDefinition({
+    required super.yamlProtocol,
     required super.fileName,
+    required super.sourceFileName,
     required super.className,
     required this.fields,
     required super.serverOnly,
@@ -193,7 +199,9 @@ class EnumDefinition extends SerializableEntityDefinition {
 
   /// Create a new [EnumDefinition].
   EnumDefinition({
+    required super.yamlProtocol,
     required super.fileName,
+    required super.sourceFileName,
     required super.className,
     required this.values,
     required super.serverOnly,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -82,6 +82,22 @@ class SerializableEntityAnalyzer {
       }
     }
 
+    var classes = classDefinitions.map((definition) {
+      var analyzer = SerializableEntityAnalyzer(
+        yaml: definition.yamlProtocol,
+        sourceFileName: definition.sourceFileName,
+        outFileName: definition.fileName,
+        collector: collector,
+        subDirectoryParts: definition.subDirParts,
+      );
+      return analyzer.analyze(protocolEntities: classDefinitions);
+    });
+
+    classDefinitions = classes
+        .where((definition) => definition != null)
+        .cast<SerializableEntityDefinition>()
+        .toList();
+
     // Detect protocol references
     for (var classDefinition in classDefinitions) {
       if (classDefinition is ClassDefinition) {
@@ -109,7 +125,9 @@ class SerializableEntityAnalyzer {
     return classDefinitions;
   }
 
-  SerializableEntityDefinition? analyze() {
+  SerializableEntityDefinition? analyze({
+    List<SerializableEntityDefinition>? protocolEntities,
+  }) {
     var yamlErrorCollector = ErrorCollector();
 
     YamlDocument document;
@@ -154,15 +172,27 @@ class SerializableEntityAnalyzer {
     var docsExtractor = YamlDocumentationExtractor(yaml);
 
     if (documentContents.nodes[Keyword.classType] != null) {
-      return _analyzeClassFile(documentContents, docsExtractor);
+      return _analyzeClassFile(
+        documentContents,
+        docsExtractor,
+        protocolEntities,
+      );
     }
 
     if (documentContents.nodes[Keyword.exceptionType] != null) {
-      return _analyzeExceptionFile(documentContents, docsExtractor);
+      return _analyzeExceptionFile(
+        documentContents,
+        docsExtractor,
+        protocolEntities,
+      );
     }
 
     if (documentContents.nodes[Keyword.enumType] != null) {
-      return _analyzeEnumFile(documentContents, docsExtractor);
+      return _analyzeEnumFile(
+        documentContents,
+        docsExtractor,
+        protocolEntities,
+      );
     }
 
     return null;
@@ -171,10 +201,13 @@ class SerializableEntityAnalyzer {
   SerializableEntityDefinition? _analyzeClassFile(
     YamlMap documentContents,
     YamlDocumentationExtractor docsExtractor,
+    List<SerializableEntityDefinition>? protocolEntities,
   ) {
     var restrictions = Restrictions(
       documentType: Keyword.classType,
       documentContents: documentContents,
+      collector: collector,
+      protocolEntities: protocolEntities,
     );
 
     var fieldStructure = ValidateNode(
@@ -265,10 +298,15 @@ class SerializableEntityAnalyzer {
   }
 
   SerializableEntityDefinition? _analyzeExceptionFile(
-      YamlMap documentContents, YamlDocumentationExtractor docsExtractor) {
+    YamlMap documentContents,
+    YamlDocumentationExtractor docsExtractor,
+    List<SerializableEntityDefinition>? protocolEntities,
+  ) {
     var restrictions = Restrictions(
       documentType: Keyword.exceptionType,
       documentContents: documentContents,
+      collector: collector,
+      protocolEntities: protocolEntities,
     );
 
     var fieldStructure = ValidateNode(
@@ -321,10 +359,13 @@ class SerializableEntityAnalyzer {
   SerializableEntityDefinition? _analyzeEnumFile(
     YamlMap documentContents,
     YamlDocumentationExtractor docsExtractor,
+    List<SerializableEntityDefinition>? protocolEntities,
   ) {
     var restrictions = Restrictions(
       documentType: Keyword.enumType,
       documentContents: documentContents,
+      collector: collector,
+      protocolEntities: protocolEntities,
     );
 
     Set<ValidateNode> documentStructure = {
@@ -362,7 +403,9 @@ class SerializableEntityAnalyzer {
     var values = _parseEnumValues(documentContents, docsExtractor);
 
     return EnumDefinition(
+      yamlProtocol: yaml,
       fileName: outFileName,
+      sourceFileName: sourceFileName,
       className: className,
       values: values,
       documentation: enumDocumentation,
@@ -404,7 +447,9 @@ class SerializableEntityAnalyzer {
     var indexes = _parseIndexes(documentContents, fields);
 
     return ClassDefinition(
+      yamlProtocol: yaml,
       className: className,
+      sourceFileName: sourceFileName,
       tableName: tableName,
       fileName: outFileName,
       fields: fields,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -36,6 +36,7 @@ class Restrictions {
       ));
     }
 
+    // TODO n-squared time complexity when validating all protocol files.
     if (_countClassNames(content, protocolEntities) > 1) {
       collector.addError(SourceSpanException(
         'The $documentType name "$content" is already used by another protocol class.',

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -7,12 +7,13 @@ import 'package:yaml/yaml.dart';
 class Restrictions {
   String documentType;
   YamlMap documentContents;
-  Set<SerializableEntityDefinition> entities;
+  List<SerializableEntityDefinition>? protocolEntities;
 
   Restrictions({
     required this.documentType,
     required this.documentContents,
-    this.entities = const {},
+    required CodeAnalysisCollector collector,
+    this.protocolEntities,
   });
 
   void validateClassName(
@@ -34,6 +35,23 @@ class Restrictions {
         span,
       ));
     }
+
+    if (_countClassNames(content, protocolEntities) > 1) {
+      collector.addError(SourceSpanException(
+        'The $documentType name "$content" is already used by another protocol class.',
+        span,
+      ));
+    }
+  }
+
+  int _countClassNames(
+      String className, List<SerializableEntityDefinition>? protocolEntities) {
+    if (protocolEntities == null) return 0;
+
+    return protocolEntities.fold(
+      0,
+      (sum, entity) => sum += entity.className == className ? 1 : 0,
+    );
   }
 
   void validateTableName(

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/class_conflicts_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/class_conflicts_test.dart
@@ -1,0 +1,73 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given two protocols with the same class name, then an error is collected that there is a collision in the class names.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+fields:
+  name: String
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yaml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    var entity1 = analyzer.analyze();
+
+    var analyzer2 = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+fields:
+  differentName: String
+''',
+      sourceFileName: 'lib/src/protocol/example2.yaml',
+      outFileName: 'example2.yaml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    var entity2 = analyzer2.analyze();
+
+    analyzer.analyze(
+      protocolEntities: [entity1, entity2].cast<SerializableEntityDefinition>(),
+    );
+
+    expect(collector.errors.length, greaterThan(0));
+
+    expect(collector.errors.first.message,
+        'The class name "Example" is already used by another protocol class.');
+  });
+
+  test(
+      'Given a single valid protocol, then there is no error collected for the class name.',
+      () {
+    var collector = CodeGenerationCollector();
+    var analyzer = SerializableEntityAnalyzer(
+      yaml: '''
+class: Example
+fields:
+  name: String
+''',
+      sourceFileName: 'lib/src/protocol/example.yaml',
+      outFileName: 'example.yaml',
+      subDirectoryParts: ['lib', 'src', 'protocol'],
+      collector: collector,
+    );
+
+    var entity = analyzer.analyze();
+
+    analyzer.analyze(
+      protocolEntities: [entity].cast<SerializableEntityDefinition>(),
+    );
+
+    expect(collector.errors, isEmpty);
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -550,7 +550,7 @@ fields:
 class: Example
 table: example
 fields:
-  name: String, parent=first, parent=second
+  name: String, parent=my_table, parent=second
 ''',
         sourceFileName: 'lib/src/protocol/example.yaml',
         outFileName: 'example.yaml',


### PR DESCRIPTION
# Add

- Two pass validation of protocol files.
- Validate that class names do not have collisions (exists in more than 1 file)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
