### PR TITLE
refactor: centralize error collection logic

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -187,11 +187,12 @@ void _collectKeyRestrictionErrors(
   if (node.keyRestriction == null) return;
 
   for (var document in documentContents.nodes.entries) {
-    node.keyRestriction?.call(
-      document.key.toString(),
-      document.key.span,
-      collector,
-    );
+    var errors =
+        node.keyRestriction?.call(document.key.toString(), document.key.span);
+
+    if (errors != null) {
+      collector.addErrors(errors);
+    }
   }
 }
 
@@ -204,7 +205,11 @@ void _collectValueRestrictionErrors(
   var span = documentContents.nodes[node.key]?.span;
 
   if (documentContents.containsKey(node.key)) {
-    node.valueRestriction?.call(content, span, collector);
+    var errors = node.valueRestriction?.call(content, span);
+
+    if (errors != null) {
+      collector.addErrors(errors);
+    }
   }
 }
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -1,4 +1,3 @@
-import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:source_span/source_span.dart';
@@ -15,183 +14,219 @@ class Restrictions {
     this.entities = const {},
   });
 
-  void validateClassName(
+  List<SourceSpanException> validateClassName(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! String) {
-      collector.addError(SourceSpanException(
-        'The "$documentType" type must be a String.',
-        span,
-      ));
-      return;
+      return [
+        SourceSpanException(
+          'The "$documentType" type must be a String.',
+          span,
+        )
+      ];
     }
 
     if (!StringValidators.isValidClassName(content)) {
-      collector.addError(SourceSpanException(
-        'The "$documentType" type must be a valid class name (e.g. PascalCaseString).',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'The "$documentType" type must be a valid class name (e.g. PascalCaseString).',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateTableName(
+  List<SourceSpanException> validateTableName(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! String) {
-      collector.addError(SourceSpanException(
-        'The "table" property must be a snake_case_string.',
-        span,
-      ));
-      return;
+      return [
+        SourceSpanException(
+          'The "table" property must be a snake_case_string.',
+          span,
+        )
+      ];
     }
 
     if (!StringValidators.isValidTableName(content)) {
-      collector.addError(SourceSpanException(
-        'The "table" property must be a snake_case_string.',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'The "table" property must be a snake_case_string.',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateBoolType(
+  List<SourceSpanException> validateBoolType(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
-    if (content is! bool) {
-      collector.addError(SourceSpanException(
+    if (content is bool) return [];
+
+    return [
+      SourceSpanException(
         'The property value must be a bool.',
         span,
-      ));
-    }
+      )
+    ];
   }
 
-  void validateTableIndexName(
+  List<SourceSpanException> validateTableIndexName(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! String ||
         !StringValidators.isValidTableIndexName(content)) {
-      collector.addError(SourceSpanException(
-        'Invalid format for index "$content", must follow the format lower_snake_case.',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'Invalid format for index "$content", must follow the format lower_snake_case.',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateFieldName(
+  List<SourceSpanException> validateFieldName(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (!StringValidators.isValidFieldName(content)) {
-      collector.addError(SourceSpanException(
-        'Keys of "fields" Map must be valid Dart variable names (e.g. camelCaseString).',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'Keys of "fields" Map must be valid Dart variable names (e.g. camelCaseString).',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateParentName(
+  List<SourceSpanException> validateParentName(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content != null && !StringValidators.isValidTableIndexName(content)) {
-      collector.addError(SourceSpanException(
-        'The parent must reference a valid table name (e.g. parent=table_name). "$content" is not a valid parent name.',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'The parent must reference a valid table name (e.g. parent=table_name). "$content" is not a valid parent name.',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateFieldType(
+  List<SourceSpanException> validateFieldType(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! String) {
-      collector.addError(SourceSpanException(
-        'The field must have a datatype defined (e.g. field: String).',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'The field must have a datatype defined (e.g. field: String).',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateFieldDataType(
+  List<SourceSpanException> validateFieldDataType(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! String) {
-      collector.addError(SourceSpanException(
-        'The field must have a datatype defined (e.g. field: String).',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'The field must have a datatype defined (e.g. field: String).',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateIndexFieldsValue(
+  List<SourceSpanException> validateIndexFieldsValue(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! String) {
-      collector.addError(SourceSpanException(
-        'The "fields" property must have at least one field, (e.g. fields: fieldName).',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'The "fields" property must have at least one field, (e.g. fields: fieldName).',
+          span,
+        )
+      ];
     }
+
+    return [];
 
     // todo add 2 pass check that fields exists in the class
   }
 
-  void validateIndexType(
+  List<SourceSpanException> validateIndexType(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! String) {
-      collector.addError(SourceSpanException(
-        'The "type" property must be of type String.',
-        span,
-      ));
+      return [
+        SourceSpanException(
+          'The "type" property must be of type String.',
+          span,
+        )
+      ];
     }
+
+    return [];
   }
 
-  void validateEnumValues(
+  List<SourceSpanException> validateEnumValues(
     dynamic content,
     SourceSpan? span,
-    CodeAnalysisCollector collector,
   ) {
     if (content is! YamlList) {
-      collector.addError(SourceSpanException(
-        'The "values" property must be a list of strings.',
-        span,
-      ));
-      return;
+      return [
+        SourceSpanException(
+          'The "values" property must be a list of strings.',
+          span,
+        )
+      ];
     }
 
-    for (var node in content.nodes) {
+    var nodeExceptions = content.nodes.map((node) {
       if (node is! YamlScalar || node.value is! String) {
-        collector.addError(SourceSpanException(
+        return SourceSpanException(
           'The "values" property must be a list of strings.',
           node.span,
-        ));
-        continue;
+        );
       }
 
       if (!StringValidators.isValidFieldName(node.value)) {
-        collector.addError(SourceSpanException(
+        return SourceSpanException(
           'Enum values must be lowerCamelCase.',
           node.span,
-        ));
+        );
       }
-    }
+
+      return null;
+    });
+
+    return nodeExceptions
+        .where((node) => node != null)
+        .cast<SourceSpanException>()
+        .toList();
   }
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
@@ -1,4 +1,3 @@
-import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
 import 'package:source_span/source_span.dart';
 
@@ -11,10 +10,10 @@ class ValidateNode {
 
   /// If set, the key must match the restriction, add any errors to the collector.
   /// Should only be used together with a [Keyword.any].
-  void Function(String, SourceSpan?, CodeAnalysisCollector)? keyRestriction;
+  List<SourceSpanException>? Function(String, SourceSpan?)? keyRestriction;
 
   /// If set, the value must match the restriction, add any errors to the collector.
-  void Function(dynamic, SourceSpan?, CodeAnalysisCollector)? valueRestriction;
+  List<SourceSpanException>? Function(dynamic, SourceSpan?)? valueRestriction;
 
   // A set of keys that are mutually exclusive with this key.
   late Set<String> mutuallyExclusiveKeys;


### PR DESCRIPTION
Refactors the error collection logic to be centralized to a single file in the validator.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.