### PR TITLE
fix: Silence pubspec open or parse errors when checking cli and serverpod packages compatibility

### DIFF
--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -266,18 +266,12 @@ Future<void> _main(List<String> args) async {
       }
 
       // Validate cli version is compatible with serverpod packages
-      try {
-        var warnings = performServerpodPackagesAndCliVersionCheck(
-            Version.parse(templateVersion), Directory.current.parent);
-        if (warnings.isNotEmpty) {
-          printww(
-              'WARNING: The version of the CLI may be incompatible with the '
-              'Serverpod packages used in your project.');
-          warnings.forEach(print);
-        }
-      } catch (e) {
-        print(e);
-        exit(1);
+      var warnings = performServerpodPackagesAndCliVersionCheck(
+          Version.parse(templateVersion), Directory.current.parent);
+      if (warnings.isNotEmpty) {
+        printww('WARNING: The version of the CLI may be incompatible with the '
+            'Serverpod packages used in your project.');
+        warnings.forEach(print);
       }
 
       // Copy migrations from modules.

--- a/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
+++ b/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
@@ -39,8 +39,8 @@ List<SourceSpanException> performServerpodPackagesAndCliVersionCheck(
 
       accumulatedWarnings.addAll(warnings);
     } catch (e) {
-      throw Exception(
-          'Error while parsing pubspec file: ${pubspecFile.path}: $e');
+      // TODO: Log to debug output
+      // Failed to open or parse pubspec file
     }
   }
 

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -162,5 +162,20 @@ void main() {
                 cliVersion));
       });
     });
+
+    group('With corrupted pubspec', () {
+      var corruptedPubspecPath =
+          Directory(p.join(testAssetsPath, 'corrupted_pubspec'));
+      test('performServerpodPackagesAndCliVersionCheck() with same version',
+          () {
+        var cliVersion = Version(1, 1, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          cliVersion,
+          corruptedPubspecPath,
+        );
+
+        expect(packageWarnings.isEmpty, isTrue);
+      });
+    });
   });
 }

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/corrupted_pubspec/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/corrupted_pubspec/pubspec.yaml
@@ -1,0 +1,13 @@
+# Test asset
+this_field_corrupts_the_file
+
+name: serverpod_cli
+version: 1.1.0
+description: Command line tools for Serverpod.
+repository: https://github.com/serverpod/serverpod
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  serverpod_shared: 1.1.0


### PR DESCRIPTION
Fix for: https://github.com/serverpod/serverpod/issues/1072

With a recent addition we now parse and warn if Serverpod packages are incompatible with the running Serverpod Cli.

This check wrongly aborted and exited the Serverpod Cli if a pub spec file could not be parsed.

This PR silences irrelevant errors and only validates valid pubspec files.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).