### PR TITLE
Fix: Fix unit test runner

### DIFF
--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -132,24 +132,28 @@ void main() {
         required int expectedIncompatibleWarnings,
         required int expectedApproximateVersionWarnings,
       }) {
-        var actualIncompatibleWarnings = packageWarnings
-            .where(
-              (warning) =>
-                  warning.message ==
-                  ServerpodPackagesVersionCheckWarnings.incompatibleVersion,
-            )
-            .length;
-        var actualApproximateVersionWarnings = packageWarnings
-            .where((warning) =>
-                warning.message ==
-                ServerpodPackagesVersionCheckWarnings.approximateVersion(
-                  cliVersion,
-                ))
-            .length;
+        var actualIncompatibleWarnings = packageWarnings.where(
+          (warning) {
+            return warning.message ==
+                ServerpodPackagesVersionCheckWarnings.incompatibleVersion;
+          },
+        ).length;
+
+        var actualApproximateVersionWarnings = packageWarnings.where((warning) {
+          return warning.message ==
+              ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                cliVersion,
+              );
+        }).length;
+
         expect(
-            actualIncompatibleWarnings, equals(expectedIncompatibleWarnings));
-        expect(actualApproximateVersionWarnings,
-            equals(expectedApproximateVersionWarnings));
+          actualIncompatibleWarnings,
+          equals(expectedIncompatibleWarnings),
+        );
+        expect(
+          actualApproximateVersionWarnings,
+          equals(expectedApproximateVersionWarnings),
+        );
       }
 
       test('performServerpodPackagesAndCliVersionCheck() with same version',

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -9,15 +9,28 @@ void main() {
   var testAssetsPath =
       p.join('test', 'serverpod_packages_version_check', 'test_assets');
   group('performServerpodPackagesAndCliVersionCheck', () {
-    test(
-        'performServerpodPackagesAndCliVersionCheck() when there are no pubspec files',
-        () {
-      var packageWarnings = performServerpodPackagesAndCliVersionCheck(
-        Version(1, 1, 0),
-        Directory(p.join(testAssetsPath, 'empty_folder')),
-      );
+    group('With empty folder', () {
+      var emptyFolder = Directory(p.join(testAssetsPath, 'empty_folder'));
+      setUp(() {
+        if (!emptyFolder.existsSync()) {
+          emptyFolder.create();
+        }
+      });
 
-      expect(packageWarnings.isEmpty, equals(true));
+      tearDown(() {
+        if (emptyFolder.existsSync()) {
+          emptyFolder.delete();
+        }
+      });
+
+      test('performServerpodPackagesAndCliVersionCheck()', () {
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          Version(1, 1, 0),
+          emptyFolder,
+        );
+
+        expect(packageWarnings.isEmpty, equals(true));
+      });
     });
 
     group('With explicit serverpod package version', () {

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/serverpod_packages_version_check/serverpod_packages_version_check.dart';
+import 'package:source_span/source_span.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -124,6 +125,33 @@ void main() {
 
     group('With multiple pubspec files', () {
       var testAssets = Directory(testAssetsPath);
+
+      void expectWarningTypes({
+        required Version cliVersion,
+        required List<SourceSpanException> packageWarnings,
+        required int expectedIncompatibleWarnings,
+        required int expectedApproximateVersionWarnings,
+      }) {
+        var actualIncompatibleWarnings = packageWarnings
+            .where(
+              (warning) =>
+                  warning.message ==
+                  ServerpodPackagesVersionCheckWarnings.incompatibleVersion,
+            )
+            .length;
+        var actualApproximateVersionWarnings = packageWarnings
+            .where((warning) =>
+                warning.message ==
+                ServerpodPackagesVersionCheckWarnings.approximateVersion(
+                  cliVersion,
+                ))
+            .length;
+        expect(
+            actualIncompatibleWarnings, equals(expectedIncompatibleWarnings));
+        expect(actualApproximateVersionWarnings,
+            equals(expectedApproximateVersionWarnings));
+      }
+
       test('performServerpodPackagesAndCliVersionCheck() with same version',
           () {
         var cliVersion = Version(1, 1, 0);
@@ -148,14 +176,12 @@ void main() {
         );
 
         expect(packageWarnings.length, equals(3));
-        expect(packageWarnings[0].message,
-            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
-        expect(packageWarnings[1].message,
-            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
-        expect(
-            packageWarnings[2].message,
-            ServerpodPackagesVersionCheckWarnings.approximateVersion(
-                cliVersion));
+        expectWarningTypes(
+          cliVersion: cliVersion,
+          packageWarnings: packageWarnings,
+          expectedIncompatibleWarnings: 2,
+          expectedApproximateVersionWarnings: 1,
+        );
       });
 
       test('performServerpodPackagesAndCliVersionCheck() with newer version',
@@ -167,12 +193,12 @@ void main() {
         );
 
         expect(packageWarnings.length, equals(2));
-        expect(packageWarnings[0].message,
-            ServerpodPackagesVersionCheckWarnings.incompatibleVersion);
-        expect(
-            packageWarnings[1].message,
-            ServerpodPackagesVersionCheckWarnings.approximateVersion(
-                cliVersion));
+        expectWarningTypes(
+          cliVersion: cliVersion,
+          packageWarnings: packageWarnings,
+          expectedIncompatibleWarnings: 1,
+          expectedApproximateVersionWarnings: 1,
+        );
       });
     });
 

--- a/util/run_tests_unit
+++ b/util/run_tests_unit
@@ -12,12 +12,20 @@ declare -a projectPaths=(
     "tools/serverpod_cli" 
 )
 
+exit_code=0
+
 for i in "${projectPaths[@]}"
 do
    echo "Running unit tests in $i"
    cd $i
 
-   dart test -r expanded
+   dart test 
+
+   if [ $? != 0 ]; then
+     exit_code=1
+   fi
 
    cd -
 done
+
+exit $exit_code


### PR DESCRIPTION
Because the script for triggering the unit tests utilised a loop, the return value from the tests were not propagated back to the process that started it. This caused Github to report all tests passed even if tests failed.

This PR:
- Returns exit code 1 if any of the tests in the loop fail.
- Fixes a failing test - The test was missing test assets.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).