### PR TITLE
fix: only report validation errors once

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -82,6 +82,8 @@ class SerializableEntityAnalyzer {
       }
     }
 
+    collector.clearErrors();
+
     var classes = classDefinitions.map((definition) {
       var analyzer = SerializableEntityAnalyzer(
         yaml: definition.yamlProtocol,

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -14,13 +14,13 @@ void main() {
       var emptyFolder = Directory(p.join(testAssetsPath, 'empty_folder'));
       setUp(() {
         if (!emptyFolder.existsSync()) {
-          emptyFolder.create();
+          emptyFolder.createSync();
         }
       });
 
       tearDown(() {
         if (emptyFolder.existsSync()) {
-          emptyFolder.delete();
+          emptyFolder.deleteSync();
         }
       });
 


### PR DESCRIPTION
# Fix

The generator reported issues twice per error, now only reports once.

[_List which issues are fixed by this PR. You must list at least one issue._](https://github.com/serverpod/serverpod/issues/1077)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

