### PR TITLE
Refactor analyzer parts

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -6,12 +6,7 @@ import 'package:yaml/yaml.dart';
 import 'package:yaml/src/equality.dart';
 
 List<String> convertIndexList(String stringifiedFields) {
-  return stringifiedFields
-      .split(',')
-      .map(
-        (String str) => str.trim(),
-      )
-      .toList();
+  return stringifiedFields.split(',').map((field) => field.trim()).toList();
 }
 
 YamlMap convertStringifiedNestedNodesToYamlMap(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -5,6 +5,15 @@ import 'package:yaml/yaml.dart';
 // ignore: implementation_imports
 import 'package:yaml/src/equality.dart';
 
+List<String> convertIndexList(String stringifiedFields) {
+  return stringifiedFields
+      .split(',')
+      .map(
+        (String str) => str.trim(),
+      )
+      .toList();
+}
+
 YamlMap convertStringifiedNestedNodesToYamlMap(
   String? content,
   YamlNode contentNode,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -23,7 +23,6 @@ String _transformFileNameWithoutPathOrExtension(String path) {
 
 /// Used to analyze a singe yaml protocol file.
 class SerializableEntityAnalyzer {
-
   static const Set<String> _protocolClassTypes = {
     Keyword.classType,
     Keyword.exceptionType,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -186,8 +186,8 @@ class SerializableEntityAnalyzer {
     String yaml,
     String sourceFileName,
     CodeAnalysisCollector collector,
-    SerializableEntityDefinition? yamlDefinition,
-    List<SerializableEntityDefinition>? protocolEntities,
+    SerializableEntityDefinition? entity,
+    List<SerializableEntityDefinition>? entities,
   ) {
     var yamlErrors = ErrorCollector();
     YamlMap? document = _loadYamlMap(yaml, sourceFileName, yamlErrors);
@@ -216,8 +216,8 @@ class SerializableEntityAnalyzer {
     var restrictions = Restrictions(
       documentType: definitionType,
       documentContents: documentContents,
-      documentDefinition: yamlDefinition,
-      protocolEntities: protocolEntities,
+      documentDefinition: entity,
+      protocolEntities: entities,
     );
 
     Set<ValidateNode> documentStructure;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -23,26 +23,12 @@ String _transformFileNameWithoutPathOrExtension(String path) {
 
 /// Used to analyze a singe yaml protocol file.
 class SerializableEntityAnalyzer {
-  String yaml;
-  final String sourceFileName;
-  late final String outFileName;
-  final List<String> subDirectoryParts;
-  final CodeAnalysisCollector collector;
+
   static const Set<String> _protocolClassTypes = {
     Keyword.classType,
     Keyword.exceptionType,
     Keyword.enumType,
   };
-
-  /// Create a new [SerializableEntityAnalyzer].
-  SerializableEntityAnalyzer({
-    required this.yaml,
-    required this.sourceFileName,
-    this.subDirectoryParts = const [],
-    required this.collector,
-  }) {
-    outFileName = _transformFileNameWithoutPathOrExtension(sourceFileName);
-  }
 
   /// Analyze all yaml files int the protocol directory.
   static Future<List<SerializableEntityDefinition>> analyzeAllFiles({
@@ -55,7 +41,7 @@ class SerializableEntityAnalyzer {
 
     var classDefinitions = protocols
         .map((protocol) {
-          return SerializableEntityAnalyzer.extractYamlDefinition(protocol);
+          return SerializableEntityAnalyzer.extractEntityDefinition(protocol);
         })
         .where((definition) => definition != null)
         .cast<SerializableEntityDefinition>()
@@ -98,31 +84,7 @@ class SerializableEntityAnalyzer {
     return classDefinitions;
   }
 
-  SerializableEntityDefinition? analyze({
-    String? yaml,
-    List<SerializableEntityDefinition>? protocolEntities,
-  }) {
-    this.yaml = yaml ?? this.yaml;
-
-    var protocolSource = ProtocolSource(
-      this.yaml,
-      Uri(path: sourceFileName),
-      subDirectoryParts,
-    );
-
-    var serializedEntity = extractYamlDefinition(protocolSource);
-    validateYamlDefinition(
-      this.yaml,
-      sourceFileName,
-      collector,
-      serializedEntity,
-      protocolEntities,
-    );
-
-    return serializedEntity;
-  }
-
-  static SerializableEntityDefinition? extractYamlDefinition(
+  static SerializableEntityDefinition? extractEntityDefinition(
     ProtocolSource protocolSource,
   ) {
     var outFileName = _transformFileNameWithoutPathOrExtension(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -38,13 +38,9 @@ class SerializableEntityAnalyzer {
     var protocols =
         await ProtocolHelper.loadProjectYamlProtocolsFromDisk(config);
 
-    var classDefinitions = protocols
-        .map((protocol) {
-          return SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        })
-        .where((definition) => definition != null)
-        .cast<SerializableEntityDefinition>()
-        .toList();
+    var classDefinitions = _convertProtocolToEntityDefinitions(
+      protocols,
+    );
 
     for (var classDefinition in classDefinitions) {
       SerializableEntityAnalyzer.validateYamlDefinition(
@@ -81,6 +77,16 @@ class SerializableEntityAnalyzer {
     }
 
     return classDefinitions;
+  }
+
+  static List<SerializableEntityDefinition> _convertProtocolToEntityDefinitions(
+      List<ProtocolSource> protocols) {
+    return protocols
+        .map((protocol) {
+          return SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        })
+        .whereType<SerializableEntityDefinition>()
+        .toList();
   }
 
   static SerializableEntityDefinition? extractEntityDefinition(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -10,12 +10,12 @@ import 'package:source_span/source_span.dart';
 import 'package:yaml/src/error_listener.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
-import '../../util/yaml_docs.dart';
-import '../code_analysis_collector.dart';
-import '../../config/config.dart';
-import 'definitions.dart';
-import 'entity_parser/entity_parser.dart';
-import 'validation/restrictions.dart';
+import 'package:serverpod_cli/src/util/yaml_docs.dart';
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_parser/entity_parser.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
 
 String _transformFileNameWithoutPathOrExtension(String path) {
   return p.basenameWithoutExtension(path);

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -126,12 +126,12 @@ class SerializableEntityAnalyzer {
     );
 
     var serializedEntity = extractYamlDefinition(protocolSource);
-    validateYamlDefinition(this.yaml, serializedEntity, protocolEntities);
+    validateYamlDefinition(this.yaml, sourceFileName, collector, serializedEntity, protocolEntities,);
 
     return serializedEntity;
   }
 
-  SerializableEntityDefinition? extractYamlDefinition(
+  static SerializableEntityDefinition? extractYamlDefinition(
     ProtocolSource protocolSource,
   ) {
     var outFileName = _transformFileNameWithoutPathOrExtension(
@@ -139,8 +139,8 @@ class SerializableEntityAnalyzer {
     );
     var yamlErrorCollector = ErrorCollector();
     YamlMap? documentContents = _loadYamlMap(
-      yaml,
-      sourceFileName,
+      protocolSource.yaml,
+      protocolSource.yamlSourceUri.path,
       yamlErrorCollector,
     );
 
@@ -148,7 +148,7 @@ class SerializableEntityAnalyzer {
     if (documentContents == null) return null;
 
     var definitionType = _findDefinitionType(documentContents);
-    var docsExtractor = YamlDocumentationExtractor(yaml);
+    var docsExtractor = YamlDocumentationExtractor(protocolSource.yaml);
 
     if (definitionType == null) return null;
 
@@ -191,8 +191,10 @@ class SerializableEntityAnalyzer {
     }
   }
 
-  void validateYamlDefinition(
+  static void validateYamlDefinition(
     String yaml,
+    String sourceFileName,
+    CodeAnalysisCollector collector,
     SerializableEntityDefinition? yamlDefinition,
     List<SerializableEntityDefinition>? protocolEntities,
   ) {
@@ -255,7 +257,7 @@ class SerializableEntityAnalyzer {
     return;
   }
 
-  YamlMap? _loadYamlMap(
+  static YamlMap? _loadYamlMap(
     String yaml,
     String sourceFileName, [
     ErrorCollector? collector,
@@ -272,7 +274,7 @@ class SerializableEntityAnalyzer {
     return documentContents;
   }
 
-  String? _findDefinitionType(YamlMap documentContents) {
+  static String? _findDefinitionType(YamlMap documentContents) {
     if (documentContents.nodes[Keyword.classType] != null) {
       return Keyword.classType;
     }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -29,7 +29,7 @@ class SerializableEntityAnalyzer {
     Keyword.enumType,
   };
 
-  /// Analyze all yaml files int the protocol directory.
+  /// Analyze all yaml files in the protocol directory.
   static Future<List<SerializableEntityDefinition>> analyzeAllFiles({
     bool verbose = true,
     required CodeAnalysisCollector collector,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -1,20 +1,21 @@
-import 'package:serverpod_cli/src/analyzer/entities/converter/converter.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
-import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/protocol_validator.dart';
+import 'package:serverpod_cli/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart';
+import 'package:serverpod_cli/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart';
+import 'package:serverpod_cli/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart';
 import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:source_span/source_span.dart';
 // ignore: implementation_imports
 import 'package:yaml/src/error_listener.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
-import '../../util/extensions.dart';
 import '../../util/yaml_docs.dart';
 import '../code_analysis_collector.dart';
 import '../../config/config.dart';
-import '../../generator/types.dart';
 import 'definitions.dart';
+import 'entity_parser/enetity_parser.dart';
+import 'validation/restrictions.dart';
 
 String _transformFileNameWithoutPathOrExtension(String path) {
   return p.basenameWithoutExtension(path);
@@ -57,7 +58,7 @@ class SerializableEntityAnalyzer {
     var validators = protocols.map((protocol) {
       return SerializableEntityAnalyzer(
         yaml: protocol.yaml,
-        sourceFileName: protocol.uri.path,
+        sourceFileName: protocol.yamlSourceUri.path,
         subDirectoryParts: protocol.protocolRootPathParts,
         collector: collector,
       );
@@ -116,578 +117,174 @@ class SerializableEntityAnalyzer {
     String? yaml,
     List<SerializableEntityDefinition>? protocolEntities,
   }) {
-    var yamlErrorCollector = ErrorCollector();
     this.yaml = yaml ?? this.yaml;
 
-    YamlDocument document;
-    try {
-      document = loadYamlDocument(
-        this.yaml,
-        sourceUrl: Uri.file(sourceFileName),
-        errorListener: yamlErrorCollector,
-        recover: true,
-      );
-    } catch (e) {
-      if (e is SourceSpanException) {
-        collector.addError(e);
+    var protocolSource = ProtocolSource(
+      this.yaml,
+      Uri(path: sourceFileName),
+      subDirectoryParts,
+    );
+
+    var serializedEntity = extractYamlDefinition(protocolSource);
+    validateYamlDefinition(this.yaml, serializedEntity, protocolEntities);
+
+    return serializedEntity;
+  }
+
+  SerializableEntityDefinition? extractYamlDefinition(
+    ProtocolSource protocolSource,
+  ) {
+    var outFileName = _transformFileNameWithoutPathOrExtension(
+      protocolSource.yamlSourceUri.path,
+    );
+    var yamlErrorCollector = ErrorCollector();
+    YamlMap? documentContents = _loadYamlMap(
+      yaml,
+      sourceFileName,
+      yamlErrorCollector,
+    );
+
+    if (yamlErrorCollector.errors.isNotEmpty) return null;
+    if (documentContents == null) return null;
+
+    var definitionType = _findDefinitionType(documentContents);
+    var docsExtractor = YamlDocumentationExtractor(yaml);
+
+    if (definitionType == null) return null;
+
+    var restrictions = Restrictions(
+      documentType: definitionType,
+      documentContents: documentContents,
+    );
+
+    switch (definitionType) {
+      case Keyword.classType:
+        var yamlStructure = ClassYamlDefinition(restrictions);
+        return EntityParser.serializeClassFile(
+          Keyword.classType,
+          protocolSource,
+          outFileName,
+          documentContents,
+          docsExtractor,
+          yamlStructure.fieldStructure,
+        );
+      case Keyword.exceptionType:
+        var yamlStructure = ExceptionYamlDefinition(restrictions);
+        return EntityParser.serializeClassFile(
+          Keyword.exceptionType,
+          protocolSource,
+          outFileName,
+          documentContents,
+          docsExtractor,
+          yamlStructure.fieldStructure,
+        );
+      case Keyword.enumType:
+        return EntityParser.serializeEnumFile(
+          Keyword.enumType,
+          protocolSource,
+          outFileName,
+          documentContents,
+          docsExtractor,
+        );
+      default:
         return null;
-      }
-      rethrow;
     }
+  }
 
-    collector.addErrors(yamlErrorCollector.errors);
+  void validateYamlDefinition(
+    String yaml,
+    SerializableEntityDefinition? yamlDefinition,
+    List<SerializableEntityDefinition>? protocolEntities,
+  ) {
+    var yamlErrors = ErrorCollector();
+    YamlMap? document = _loadYamlMap(yaml, sourceFileName, yamlErrors);
+    collector.addErrors(yamlErrors.errors);
 
-    if (yamlErrorCollector.errors.isNotEmpty) {
-      return null;
-    }
+    if (yamlErrors.errors.isNotEmpty) return;
 
-    var documentContents = document.contents;
-
-    // Validate document is a map.
+    var documentContents = document;
     if (documentContents is! YamlMap) {
       collector.addError(SourceSpanException(
         'The top level object in the class yaml file must be a Map.',
-        documentContents.span,
+        documentContents?.span,
       ));
-      return null;
+      return;
     }
 
-    validateTopLevelEntityType(
+    var topErrors = validateTopLevelEntityType(
       documentContents,
       _protocolClassTypes,
+    );
+    collector.addErrors(topErrors);
+
+    var definitionType = _findDefinitionType(documentContents);
+    if (definitionType == null) return;
+
+    var restrictions = Restrictions(
+      documentType: definitionType,
+      documentContents: documentContents,
+      documentDefinition: yamlDefinition,
+      protocolEntities: protocolEntities,
+    );
+
+    Set<ValidateNode> documentStructure;
+    switch (definitionType) {
+      case Keyword.classType:
+        documentStructure = ClassYamlDefinition(restrictions).documentStructure;
+        break;
+      case Keyword.exceptionType:
+        documentStructure = ExceptionYamlDefinition(
+          restrictions,
+        ).documentStructure;
+        break;
+      case Keyword.enumType:
+        documentStructure = EnumYamlDefinition(restrictions).documentStructure;
+        break;
+      default:
+        throw UnimplementedError(
+            'Validation for $definitionType is not implemented.');
+    }
+
+    validateYamlProtocol(
+      definitionType,
+      documentStructure,
+      documentContents,
       collector,
     );
 
-    var docsExtractor = YamlDocumentationExtractor(this.yaml);
+    return;
+  }
 
+  YamlMap? _loadYamlMap(
+    String yaml,
+    String sourceFileName, [
+    ErrorCollector? collector,
+  ]) {
+    YamlDocument document = loadYamlDocument(
+      yaml,
+      sourceUrl: Uri.file(sourceFileName),
+      errorListener: collector,
+      recover: true,
+    );
+
+    var documentContents = document.contents;
+    if (documentContents is! YamlMap) return null;
+    return documentContents;
+  }
+
+  String? _findDefinitionType(YamlMap documentContents) {
     if (documentContents.nodes[Keyword.classType] != null) {
-      return _analyzeClassFile(
-        documentContents,
-        docsExtractor,
-        protocolEntities,
-      );
+      return Keyword.classType;
     }
 
     if (documentContents.nodes[Keyword.exceptionType] != null) {
-      return _analyzeExceptionFile(
-        documentContents,
-        docsExtractor,
-        protocolEntities,
-      );
+      return Keyword.exceptionType;
     }
 
     if (documentContents.nodes[Keyword.enumType] != null) {
-      return _analyzeEnumFile(
-        documentContents,
-        docsExtractor,
-        protocolEntities,
-      );
+      return Keyword.enumType;
     }
 
     return null;
-  }
-
-  SerializableEntityDefinition? _analyzeClassFile(
-    YamlMap documentContents,
-    YamlDocumentationExtractor docsExtractor,
-    List<SerializableEntityDefinition>? protocolEntities,
-  ) {
-    var restrictions = Restrictions(
-      documentType: Keyword.classType,
-      documentContents: documentContents,
-      protocolEntities: protocolEntities,
-    );
-
-    var fieldStructure = ValidateNode(
-      Keyword.any,
-      keyRestriction: restrictions.validateFieldName,
-      allowStringifiedNestedValue: true,
-      nested: {
-        ValidateNode(
-          Keyword.type,
-          isRequired: true,
-          valueRestriction: restrictions.validateFieldType,
-        ),
-        ValidateNode(
-          Keyword.parent,
-          valueRestriction: restrictions.validateParentName,
-        ),
-        ValidateNode(
-          Keyword.database,
-          mutuallyExclusiveKeys: {Keyword.api},
-        ),
-        ValidateNode(
-          Keyword.api,
-          mutuallyExclusiveKeys: {Keyword.database},
-        ),
-      },
-    );
-
-    Set<ValidateNode> documentStructure = {
-      ValidateNode(
-        Keyword.classType,
-        isRequired: true,
-        valueRestriction: restrictions.validateClassName,
-      ),
-      ValidateNode(
-        Keyword.table,
-        valueRestriction: restrictions.validateTableName,
-      ),
-      ValidateNode(
-        Keyword.serverOnly,
-        valueRestriction: restrictions.validateBoolType,
-      ),
-      ValidateNode(
-        Keyword.fields,
-        isRequired: true,
-        nested: {
-          fieldStructure,
-        },
-      ),
-      ValidateNode(
-        Keyword.indexes,
-        nested: {
-          ValidateNode(
-            Keyword.any,
-            keyRestriction: restrictions.validateTableIndexName,
-            nested: {
-              ValidateNode(
-                Keyword.fields,
-                isRequired: true,
-                valueRestriction: restrictions.validateIndexFieldsValue,
-              ),
-              ValidateNode(
-                Keyword.type,
-                valueRestriction: restrictions.validateIndexType,
-              ),
-              ValidateNode(
-                Keyword.unique,
-                valueRestriction: restrictions.validateBoolType,
-              ),
-            },
-          )
-        },
-      ),
-    };
-
-    validateYamlProtocol(
-      Keyword.classType,
-      documentStructure,
-      documentContents,
-      collector,
-    );
-
-    return _serializeClassFile(
-      Keyword.classType,
-      documentContents,
-      docsExtractor,
-      fieldStructure,
-    );
-  }
-
-  SerializableEntityDefinition? _analyzeExceptionFile(
-    YamlMap documentContents,
-    YamlDocumentationExtractor docsExtractor,
-    List<SerializableEntityDefinition>? protocolEntities,
-  ) {
-    var restrictions = Restrictions(
-      documentType: Keyword.exceptionType,
-      documentContents: documentContents,
-      protocolEntities: protocolEntities,
-    );
-
-    var fieldStructure = ValidateNode(
-      Keyword.any,
-      keyRestriction: restrictions.validateFieldName,
-      allowStringifiedNestedValue: true,
-      nested: {
-        ValidateNode(
-          Keyword.type,
-          isRequired: true,
-          valueRestriction: restrictions.validateFieldDataType,
-        ),
-      },
-    );
-
-    Set<ValidateNode> documentStructure = {
-      ValidateNode(
-        Keyword.exceptionType,
-        isRequired: true,
-        valueRestriction: restrictions.validateClassName,
-      ),
-      ValidateNode(
-        Keyword.serverOnly,
-        valueRestriction: restrictions.validateBoolType,
-      ),
-      ValidateNode(
-        Keyword.fields,
-        isRequired: true,
-        nested: {
-          fieldStructure,
-        },
-      ),
-    };
-
-    validateYamlProtocol(
-      Keyword.exceptionType,
-      documentStructure,
-      documentContents,
-      collector,
-    );
-
-    return _serializeClassFile(
-      Keyword.exceptionType,
-      documentContents,
-      docsExtractor,
-      fieldStructure,
-    );
-  }
-
-  SerializableEntityDefinition? _analyzeEnumFile(
-    YamlMap documentContents,
-    YamlDocumentationExtractor docsExtractor,
-    List<SerializableEntityDefinition>? protocolEntities,
-  ) {
-    var restrictions = Restrictions(
-      documentType: Keyword.enumType,
-      documentContents: documentContents,
-      protocolEntities: protocolEntities,
-    );
-
-    Set<ValidateNode> documentStructure = {
-      ValidateNode(
-        Keyword.enumType,
-        isRequired: true,
-        valueRestriction: restrictions.validateClassName,
-      ),
-      ValidateNode(
-        Keyword.serverOnly,
-        valueRestriction: restrictions.validateBoolType,
-      ),
-      ValidateNode(
-        Keyword.values,
-        isRequired: true,
-        valueRestriction: restrictions.validateEnumValues,
-      ),
-    };
-
-    validateYamlProtocol(
-      Keyword.enumType,
-      documentStructure,
-      documentContents,
-      collector,
-    );
-
-    var className = documentContents[Keyword.enumType];
-    if (className is! String) return null;
-
-    var enumDocumentation = docsExtractor.getDocumentation(
-      documentContents.key(Keyword.enumType)!.span.start,
-    );
-
-    var serverOnly = _parseServerOnly(documentContents);
-    var values = _parseEnumValues(documentContents, docsExtractor);
-
-    return EnumDefinition(
-      yamlProtocol: yaml,
-      fileName: outFileName,
-      sourceFileName: sourceFileName,
-      className: className,
-      values: values,
-      documentation: enumDocumentation,
-      subDirParts: subDirectoryParts,
-      serverOnly: serverOnly,
-    );
-  }
-
-  SerializableEntityDefinition? _serializeClassFile(
-    String documentType,
-    YamlMap documentContents,
-    YamlDocumentationExtractor docsExtractor,
-    ValidateNode fieldStructure,
-  ) {
-    YamlNode? classNode = documentContents.nodes[documentType];
-
-    if (classNode == null) {
-      throw ArgumentError(
-        'No $documentType node found, only valid to call this function if '
-        ' the documentType exists as a top level key in the document.',
-      );
-    }
-
-    var classDocumentation = docsExtractor.getDocumentation(
-      documentContents.key(documentType)!.span.start,
-    );
-
-    var className = classNode.value;
-    if (className is! String) return null;
-
-    var tableName = _parseTableName(documentContents);
-    var serverOnly = _parseServerOnly(documentContents);
-    var fields = _parseClassFields(
-      documentContents,
-      docsExtractor,
-      tableName != null,
-      fieldStructure,
-    );
-    var indexes = _parseIndexes(documentContents, fields);
-
-    return ClassDefinition(
-      yamlProtocol: yaml,
-      className: className,
-      sourceFileName: sourceFileName,
-      tableName: tableName,
-      fileName: outFileName,
-      fields: fields,
-      indexes: indexes,
-      subDirParts: subDirectoryParts,
-      documentation: classDocumentation,
-      isException: documentType == Keyword.exceptionType,
-      serverOnly: serverOnly,
-    );
-  }
-
-  bool _parseServerOnly(YamlMap documentContents) {
-    var serverOnly = documentContents.nodes[Keyword.serverOnly]?.value;
-    if (serverOnly is! bool) return false;
-
-    return serverOnly;
-  }
-
-  String? _parseTableName(YamlMap documentContents) {
-    var tableName = documentContents.nodes[Keyword.table]?.value;
-    if (tableName is! String) return null;
-
-    return tableName;
-  }
-
-  List<SerializableEntityFieldDefinition> _parseClassFields(
-    YamlMap documentContents,
-    YamlDocumentationExtractor docsExtractor,
-    bool hasTable,
-    ValidateNode fieldStructure,
-  ) {
-    var fieldsNode = documentContents.nodes[Keyword.fields];
-    if (fieldsNode is! YamlMap) return [];
-
-    var parsedFields = fieldsNode.nodes.entries.map((fieldNode) {
-      return _parseEntityFieldDefinition(
-        fieldNode,
-        fieldStructure,
-        docsExtractor,
-      );
-    });
-
-    var fields = parsedFields
-        .where((field) => field != null)
-        .cast<SerializableEntityFieldDefinition>()
-        .toList();
-
-    if (hasTable) {
-      fields = [
-        SerializableEntityFieldDefinition(
-          name: 'id',
-          type: TypeDefinition.int.asNullable,
-          scope: SerializableEntityFieldScope.all,
-          documentation: [
-            '/// The database id, set if the object has been inserted into the',
-            '/// database or if it has been fetched from the database. Otherwise,',
-            '/// the id will be null.',
-          ],
-        ),
-        ...fields,
-      ];
-    }
-
-    return fields;
-  }
-
-  SerializableEntityFieldDefinition? _parseEntityFieldDefinition(
-    MapEntry<dynamic, YamlNode> fieldNode,
-    ValidateNode fieldStructure,
-    YamlDocumentationExtractor docsExtractor,
-  ) {
-    var key = fieldNode.key;
-    if (key is! YamlScalar) return null;
-
-    var nodeValue = fieldNode.value;
-    var value = nodeValue.value;
-    if (value is String) {
-      value = convertStringifiedNestedNodesToYamlMap(
-        value,
-        nodeValue,
-        fieldStructure,
-      );
-    }
-    if (value is! YamlMap) return null;
-
-    var fieldName = key.value;
-    if (fieldName is! String) return null;
-
-    var typeNode = value.nodes[Keyword.type];
-    var typeValue = typeNode?.value;
-    if (typeNode is! YamlScalar) return null;
-    if (typeValue is! String) return null;
-
-    var fieldDocumentation = docsExtractor.getDocumentation(key.span.start);
-    var typeResult = parseAndAnalyzeType(
-      typeValue.replaceAll(' ', ''),
-      sourceSpan: typeNode.span,
-    );
-    var scope = _parseClassFieldscope(value);
-    var parentTable = _parseParentTable(value);
-    var isEnum = _parseIsEnumField(value);
-
-    return SerializableEntityFieldDefinition(
-      name: fieldName,
-      scope: scope,
-      type: typeResult.type..isEnum = isEnum,
-      parentTable: parentTable,
-      documentation: fieldDocumentation,
-    );
-  }
-
-  SerializableEntityFieldScope _parseClassFieldscope(YamlMap documentContents) {
-    var database = documentContents.containsKey(Keyword.database);
-    var api = documentContents.containsKey(Keyword.api);
-
-    if (database) return SerializableEntityFieldScope.database;
-    if (api) return SerializableEntityFieldScope.api;
-
-    return SerializableEntityFieldScope.all;
-  }
-
-  String? _parseParentTable(YamlMap documentContents) {
-    var parent = documentContents.nodes[Keyword.parent]?.value;
-    if (parent is! String) return null;
-
-    return parent;
-  }
-
-  bool _parseIsEnumField(YamlMap documentContents) {
-    return documentContents.containsKey(Keyword.enumType);
-  }
-
-  List<SerializableEntityIndexDefinition>? _parseIndexes(
-    YamlMap documentContents,
-    List<SerializableEntityFieldDefinition> fields,
-  ) {
-    var indexesNode = documentContents.nodes[Keyword.indexes];
-    if (indexesNode is! YamlMap) return null;
-
-    var indexes = indexesNode.nodes.entries.map((node) {
-      var keyScalar = node.key;
-      var nodeDocument = node.value;
-      if (keyScalar is! YamlScalar) return null;
-      if (nodeDocument is! YamlMap) return null;
-
-      var indexName = keyScalar.value;
-      if (indexName is! String) return null;
-
-      var indexFields = _parseIndexFields(nodeDocument, fields);
-      var type = _parseIndexType(nodeDocument);
-      var unique = _parseUniqueKey(nodeDocument);
-
-      return SerializableEntityIndexDefinition(
-        name: indexName,
-        type: type,
-        unique: unique,
-        fields: indexFields,
-      );
-    });
-
-    return indexes
-        .where((index) => index != null)
-        .cast<SerializableEntityIndexDefinition>()
-        .toList();
-  }
-
-  List<String> _parseIndexFields(
-    YamlMap documentContents,
-    List<SerializableEntityFieldDefinition> fields,
-  ) {
-    var fieldsNode = documentContents.nodes[Keyword.fields];
-    if (fieldsNode is! YamlNode) return [];
-
-    var stringifiedFields = fieldsNode.value;
-    if (stringifiedFields is! String) return [];
-
-    var indexFields = stringifiedFields
-        .split(',')
-        .map(
-          (String str) => str.trim(),
-        )
-        .toList();
-
-    // Validate that index fields exists in class,
-    // Todo: move this to validation file when we support multipass parsing.
-    _validateIndexFileds(fields, indexFields, fieldsNode.span);
-
-    return indexFields;
-  }
-
-  String _parseIndexType(YamlMap documentContents) {
-    var typeNode = documentContents.nodes[Keyword.type];
-    var type = typeNode?.value;
-
-    if (type == null || type is! String) {
-      return 'btree';
-    }
-
-    return type;
-  }
-
-  bool _parseUniqueKey(YamlMap documentContents) {
-    var node = documentContents.nodes[Keyword.unique];
-    var nodeValue = node?.value;
-    return nodeValue is bool ? nodeValue : false;
-  }
-
-  List<ProtocolEnumValueDefinition> _parseEnumValues(
-    YamlMap documentContents,
-    YamlDocumentationExtractor docsExtractor,
-  ) {
-    var valuesNode = documentContents.nodes[Keyword.values];
-    if (valuesNode is! YamlList) return [];
-
-    var values = valuesNode.nodes.map((node) {
-      var value = node.value;
-      if (value is! String) return null;
-
-      var start = node.span.start;
-      // 2 is the length of '- ' in '- enumValue'
-      var valueDocumentation = docsExtractor.getDocumentation(
-        SourceLocation(start.offset - 2,
-            column: start.column - 2,
-            line: start.line,
-            sourceUrl: start.sourceUrl),
-      );
-
-      return ProtocolEnumValueDefinition(value, valueDocumentation);
-    });
-
-    return values
-        .where((value) => value != null)
-        .cast<ProtocolEnumValueDefinition>()
-        .toList();
-  }
-
-  void _validateIndexFileds(
-    List<SerializableEntityFieldDefinition> fields,
-    List<String> indexFields,
-    SourceSpan span,
-  ) {
-    var validDatabaseFieldNames = fields
-        .where((field) => field.scope != SerializableEntityFieldScope.api)
-        .fold(<String>{}, (output, field) => output..add(field.name));
-
-    for (var indexField in indexFields) {
-      if (!validDatabaseFieldNames.contains(indexField)) {
-        collector.addError(SourceSpanException(
-          'The field name "$indexField" is not added to the class or has an api scope.',
-          span,
-        ));
-      }
-    }
   }
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -14,7 +14,7 @@ import '../../util/yaml_docs.dart';
 import '../code_analysis_collector.dart';
 import '../../config/config.dart';
 import 'definitions.dart';
-import 'entity_parser/enetity_parser.dart';
+import 'entity_parser/entity_parser.dart';
 import 'validation/restrictions.dart';
 
 String _transformFileNameWithoutPathOrExtension(String path) {

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -138,7 +138,6 @@ class SerializableEntityAnalyzer {
         );
       case Keyword.enumType:
         return EntityParser.serializeEnumFile(
-          Keyword.enumType,
           protocolSource,
           outFileName,
           documentContents,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/enetity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/enetity_parser.dart
@@ -4,7 +4,6 @@ import 'package:serverpod_cli/src/util/yaml_docs.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
-
 import '../../../generator/types.dart';
 import '../converter/converter.dart';
 import '../definitions.dart';
@@ -190,7 +189,8 @@ class EntityParser {
     );
   }
 
-  static SerializableEntityFieldScope _parseClassFieldscope(YamlMap documentContents) {
+  static SerializableEntityFieldScope _parseClassFieldscope(
+      YamlMap documentContents) {
     var database = documentContents.containsKey(Keyword.database);
     var api = documentContents.containsKey(Keyword.api);
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/enetity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/enetity_parser.dart
@@ -1,0 +1,313 @@
+import 'package:serverpod_cli/src/util/extensions.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:serverpod_cli/src/util/yaml_docs.dart';
+import 'package:source_span/source_span.dart';
+import 'package:yaml/yaml.dart';
+
+
+import '../../../generator/types.dart';
+import '../converter/converter.dart';
+import '../definitions.dart';
+import '../validation/keywords.dart';
+import '../validation/validate_node.dart';
+
+class EntityParser {
+  static SerializableEntityDefinition? serializeClassFile(
+    String documentType,
+    ProtocolSource protocolSource,
+    String outFileName,
+    YamlMap documentContents,
+    YamlDocumentationExtractor docsExtractor,
+    ValidateNode fieldStructure,
+  ) {
+    YamlNode? classNode = documentContents.nodes[documentType];
+
+    if (classNode == null) {
+      throw ArgumentError(
+        'No $documentType node found, only valid to call this function if '
+        ' the documentType exists as a top level key in the document.',
+      );
+    }
+
+    var classDocumentation = docsExtractor.getDocumentation(
+      documentContents.key(documentType)!.span.start,
+    );
+
+    var className = classNode.value;
+    if (className is! String) return null;
+
+    var tableName = _parseTableName(documentContents);
+    var serverOnly = _parseServerOnly(documentContents);
+    var fields = _parseClassFields(
+      documentContents,
+      docsExtractor,
+      tableName != null,
+      fieldStructure,
+    );
+    var indexes = _parseIndexes(documentContents, fields);
+
+    return ClassDefinition(
+      yamlProtocol: protocolSource.yaml,
+      className: className,
+      sourceFileName: protocolSource.yamlSourceUri.path,
+      tableName: tableName,
+      fileName: outFileName,
+      fields: fields,
+      indexes: indexes,
+      subDirParts: protocolSource.protocolRootPathParts,
+      documentation: classDocumentation,
+      isException: documentType == Keyword.exceptionType,
+      serverOnly: serverOnly,
+    );
+  }
+
+  static SerializableEntityDefinition? serializeEnumFile(
+    String documentType,
+    ProtocolSource protocolSource,
+    String outFileName,
+    YamlMap documentContents,
+    YamlDocumentationExtractor docsExtractor,
+  ) {
+    var className = documentContents[Keyword.enumType];
+    if (className is! String) return null;
+
+    var enumDocumentation = docsExtractor.getDocumentation(
+      documentContents.key(Keyword.enumType)!.span.start,
+    );
+
+    var serverOnly = _parseServerOnly(documentContents);
+    var values = _parseEnumValues(documentContents, docsExtractor);
+
+    return EnumDefinition(
+      yamlProtocol: protocolSource.yaml,
+      fileName: outFileName,
+      sourceFileName: protocolSource.yamlSourceUri.path,
+      className: className,
+      values: values,
+      documentation: enumDocumentation,
+      subDirParts: protocolSource.protocolRootPathParts,
+      serverOnly: serverOnly,
+    );
+  }
+
+  static bool _parseServerOnly(YamlMap documentContents) {
+    var serverOnly = documentContents.nodes[Keyword.serverOnly]?.value;
+    if (serverOnly is! bool) return false;
+
+    return serverOnly;
+  }
+
+  static String? _parseTableName(YamlMap documentContents) {
+    var tableName = documentContents.nodes[Keyword.table]?.value;
+    if (tableName is! String) return null;
+
+    return tableName;
+  }
+
+  static List<SerializableEntityFieldDefinition> _parseClassFields(
+    YamlMap documentContents,
+    YamlDocumentationExtractor docsExtractor,
+    bool hasTable,
+    ValidateNode fieldStructure,
+  ) {
+    var fieldsNode = documentContents.nodes[Keyword.fields];
+    if (fieldsNode is! YamlMap) return [];
+
+    var parsedFields = fieldsNode.nodes.entries.map((fieldNode) {
+      return _parseEntityFieldDefinition(
+        fieldNode,
+        fieldStructure,
+        docsExtractor,
+      );
+    });
+
+    var fields = parsedFields
+        .where((field) => field != null)
+        .cast<SerializableEntityFieldDefinition>()
+        .toList();
+
+    if (hasTable) {
+      fields = [
+        SerializableEntityFieldDefinition(
+          name: 'id',
+          type: TypeDefinition.int.asNullable,
+          scope: SerializableEntityFieldScope.all,
+          documentation: [
+            '/// The database id, set if the object has been inserted into the',
+            '/// database or if it has been fetched from the database. Otherwise,',
+            '/// the id will be null.',
+          ],
+        ),
+        ...fields,
+      ];
+    }
+
+    return fields;
+  }
+
+  static SerializableEntityFieldDefinition? _parseEntityFieldDefinition(
+    MapEntry<dynamic, YamlNode> fieldNode,
+    ValidateNode fieldStructure,
+    YamlDocumentationExtractor docsExtractor,
+  ) {
+    var key = fieldNode.key;
+    if (key is! YamlScalar) return null;
+
+    var nodeValue = fieldNode.value;
+    var value = nodeValue.value;
+    if (value is String) {
+      value = convertStringifiedNestedNodesToYamlMap(
+        value,
+        nodeValue,
+        fieldStructure,
+      );
+    }
+    if (value is! YamlMap) return null;
+
+    var fieldName = key.value;
+    if (fieldName is! String) return null;
+
+    var typeNode = value.nodes[Keyword.type];
+    var typeValue = typeNode?.value;
+    if (typeNode is! YamlScalar) return null;
+    if (typeValue is! String) return null;
+
+    var fieldDocumentation = docsExtractor.getDocumentation(key.span.start);
+    var typeResult = parseAndAnalyzeType(
+      typeValue.replaceAll(' ', ''),
+      sourceSpan: typeNode.span,
+    );
+    var scope = _parseClassFieldscope(value);
+    var parentTable = _parseParentTable(value);
+    var isEnum = _parseIsEnumField(value);
+
+    return SerializableEntityFieldDefinition(
+      name: fieldName,
+      scope: scope,
+      type: typeResult.type..isEnum = isEnum,
+      parentTable: parentTable,
+      documentation: fieldDocumentation,
+    );
+  }
+
+  static SerializableEntityFieldScope _parseClassFieldscope(YamlMap documentContents) {
+    var database = documentContents.containsKey(Keyword.database);
+    var api = documentContents.containsKey(Keyword.api);
+
+    if (database) return SerializableEntityFieldScope.database;
+    if (api) return SerializableEntityFieldScope.api;
+
+    return SerializableEntityFieldScope.all;
+  }
+
+  static String? _parseParentTable(YamlMap documentContents) {
+    var parent = documentContents.nodes[Keyword.parent]?.value;
+    if (parent is! String) return null;
+
+    return parent;
+  }
+
+  static bool _parseIsEnumField(YamlMap documentContents) {
+    return documentContents.containsKey(Keyword.enumType);
+  }
+
+  static List<SerializableEntityIndexDefinition>? _parseIndexes(
+    YamlMap documentContents,
+    List<SerializableEntityFieldDefinition> fields,
+  ) {
+    var indexesNode = documentContents.nodes[Keyword.indexes];
+    if (indexesNode is! YamlMap) return null;
+
+    var indexes = indexesNode.nodes.entries.map((node) {
+      var keyScalar = node.key;
+      var nodeDocument = node.value;
+      if (keyScalar is! YamlScalar) return null;
+      if (nodeDocument is! YamlMap) return null;
+
+      var indexName = keyScalar.value;
+      if (indexName is! String) return null;
+
+      var indexFields = _parseIndexFields(nodeDocument, fields);
+      var type = _parseIndexType(nodeDocument);
+      var unique = _parseUniqueKey(nodeDocument);
+
+      return SerializableEntityIndexDefinition(
+        name: indexName,
+        type: type,
+        unique: unique,
+        fields: indexFields,
+      );
+    });
+
+    return indexes
+        .where((index) => index != null)
+        .cast<SerializableEntityIndexDefinition>()
+        .toList();
+  }
+
+  static List<String> _parseIndexFields(
+    YamlMap documentContents,
+    List<SerializableEntityFieldDefinition> fields,
+  ) {
+    var fieldsNode = documentContents.nodes[Keyword.fields];
+    if (fieldsNode is! YamlNode) return [];
+
+    var stringifiedFields = fieldsNode.value;
+    if (stringifiedFields is! String) return [];
+
+    var indexFields = stringifiedFields
+        .split(',')
+        .map(
+          (String str) => str.trim(),
+        )
+        .toList();
+
+    return indexFields;
+  }
+
+  static String _parseIndexType(YamlMap documentContents) {
+    var typeNode = documentContents.nodes[Keyword.type];
+    var type = typeNode?.value;
+
+    if (type == null || type is! String) {
+      return 'btree';
+    }
+
+    return type;
+  }
+
+  static bool _parseUniqueKey(YamlMap documentContents) {
+    var node = documentContents.nodes[Keyword.unique];
+    var nodeValue = node?.value;
+    return nodeValue is bool ? nodeValue : false;
+  }
+
+  static List<ProtocolEnumValueDefinition> _parseEnumValues(
+    YamlMap documentContents,
+    YamlDocumentationExtractor docsExtractor,
+  ) {
+    var valuesNode = documentContents.nodes[Keyword.values];
+    if (valuesNode is! YamlList) return [];
+
+    var values = valuesNode.nodes.map((node) {
+      var value = node.value;
+      if (value is! String) return null;
+
+      var start = node.span.start;
+      // 2 is the length of '- ' in '- enumValue'
+      var valueDocumentation = docsExtractor.getDocumentation(
+        SourceLocation(start.offset - 2,
+            column: start.column - 2,
+            line: start.line,
+            sourceUrl: start.sourceUrl),
+      );
+
+      return ProtocolEnumValueDefinition(value, valueDocumentation);
+    });
+
+    return values
+        .where((value) => value != null)
+        .cast<ProtocolEnumValueDefinition>()
+        .toList();
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -176,7 +176,7 @@ class EntityParser {
       typeValue.replaceAll(' ', ''),
       sourceSpan: typeNode.span,
     );
-    var scope = _parseClassFieldscope(value);
+    var scope = _parseClassFieldScope(value);
     var parentTable = _parseParentTable(value);
     var isEnum = _parseIsEnumField(value);
 
@@ -189,7 +189,7 @@ class EntityParser {
     );
   }
 
-  static SerializableEntityFieldScope _parseClassFieldscope(
+  static SerializableEntityFieldScope _parseClassFieldScope(
       YamlMap documentContents) {
     var database = documentContents.containsKey(Keyword.database);
     var api = documentContents.containsKey(Keyword.api);

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -12,24 +12,24 @@ import '../validation/validate_node.dart';
 
 class EntityParser {
   static SerializableEntityDefinition? serializeClassFile(
-    String documentType,
+    String documentTypeName,
     ProtocolSource protocolSource,
     String outFileName,
     YamlMap documentContents,
     YamlDocumentationExtractor docsExtractor,
     ValidateNode fieldStructure,
   ) {
-    YamlNode? classNode = documentContents.nodes[documentType];
+    YamlNode? classNode = documentContents.nodes[documentTypeName];
 
     if (classNode == null) {
       throw ArgumentError(
-        'No $documentType node found, only valid to call this function if '
+        'No $documentTypeName node found, only valid to call this function if '
         ' the documentType exists as a top level key in the document.',
       );
     }
 
     var classDocumentation = docsExtractor.getDocumentation(
-      documentContents.key(documentType)!.span.start,
+      documentContents.key(documentTypeName)!.span.start,
     );
 
     var className = classNode.value;
@@ -55,13 +55,12 @@ class EntityParser {
       indexes: indexes,
       subDirParts: protocolSource.protocolRootPathParts,
       documentation: classDocumentation,
-      isException: documentType == Keyword.exceptionType,
+      isException: documentTypeName == Keyword.exceptionType,
       serverOnly: serverOnly,
     );
   }
 
   static SerializableEntityDefinition? serializeEnumFile(
-    String documentType,
     ProtocolSource protocolSource,
     String outFileName,
     YamlMap documentContents,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -1,10 +1,10 @@
 import 'package:serverpod_cli/src/util/extensions.dart';
 import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:serverpod_cli/src/util/yaml_docs.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
-import '../../../generator/types.dart';
 import '../converter/converter.dart';
 import '../definitions.dart';
 import '../validation/keywords.dart';

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -255,12 +255,7 @@ class EntityParser {
     var stringifiedFields = fieldsNode.value;
     if (stringifiedFields is! String) return [];
 
-    var indexFields = stringifiedFields
-        .split(',')
-        .map(
-          (String str) => str.trim(),
-        )
-        .toList();
+    var indexFields = convertIndexList(stringifiedFields);
 
     return indexFields;
   }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -53,7 +53,7 @@ class StatefulAnalyzer {
 
     state.source.yaml = yaml;
 
-    var doc = SerializableEntityAnalyzer.extractYamlDefinition(state.source);
+    var doc = SerializableEntityAnalyzer.extractEntityDefinition(state.source);
     state.entity = doc;
     if (doc != null) {
       _upsertEntity(doc, uri);
@@ -121,7 +121,7 @@ class StatefulAnalyzer {
 
   List<SerializableEntityDefinition> _validateAllAnalyzers() {
     for (var state in _protocolStates.values) {
-      var doc = SerializableEntityAnalyzer.extractYamlDefinition(state.source);
+      var doc = SerializableEntityAnalyzer.extractEntityDefinition(state.source);
       state.entity = doc;
       if (doc != null) {
         _upsertEntity(doc, state.source.yamlSourceUri);

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -2,39 +2,43 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/util/protocol_helper.dart';
 
+class _ProtocolState {
+  ProtocolSource source;
+  SerializableEntityDefinition? entity;
+
+  _ProtocolState({
+    required this.source,
+  });
+}
+
 class StatefulAnalyzer {
-  final Map<String, SerializableEntityAnalyzer> _analyzers = {};
+  final Map<String, _ProtocolState> _protocolStates = {};
   List<SerializableEntityDefinition> _entities = [];
 
   Function(Uri, CodeGenerationCollector)? _onErrorsChangedNotifier;
 
-  /// Validates all protocols by running the validator twice to make sure all
-  /// references are resolved. The state is preserved to make future validations
-  /// less expensive. This method is required to use for the initialization of
-  /// the state. Subsequent validations should use [validateAll] or [validateProtocol].
+  /// Loads all yaml protocols and initializes the state. The state is preserved
+  /// to make future validations less expensive.
+  /// Subsequent validations should use [validateAll] or [validateProtocol].
   List<SerializableEntityDefinition> initialValidation(
       List<ProtocolSource> sources) {
     for (var yamlSource in sources) {
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: yamlSource.yaml,
-        sourceFileName: yamlSource.yamlSourceUri.path,
-        subDirectoryParts: yamlSource.protocolRootPathParts,
-        collector: CodeGenerationCollector(),
+      _protocolStates[yamlSource.yamlSourceUri.path] = _ProtocolState(
+        source: yamlSource,
       );
-
-      _analyzers[yamlSource.yamlSourceUri.path] = analyzer;
     }
 
     _entities = _validateAllAnalyzers();
-    _entities = _validateAllAnalyzers(_entities);
     return _entities;
   }
 
-  /// Runs the validation on all protocols, assumes [initialValidation] has been
-  /// run before, if not this returns an empty list.
+  /// Runs the validation on all protocols, assumes protocols have been added
+  /// by running [initialValidation] or adding them manually
+  /// with [addYamlProtocol]. If not protocol has been initialized this method
+  /// returns an empty list.
   /// Errors are reported through the [onErrorsChangedNotifier].
   List<SerializableEntityDefinition> validateAll() {
-    _entities = _validateAllAnalyzers(_entities);
+    _entities = _validateAllAnalyzers();
     return _entities;
   }
 
@@ -44,43 +48,50 @@ class StatefulAnalyzer {
   /// and then run [validateAll] or [validateProtocol].
   /// Errors are reported through the [registerOnErrorsChangedNotifier].
   List<SerializableEntityDefinition> validateProtocol(String yaml, Uri uri) {
-    var analyzer = _analyzers[uri.path];
-    if (analyzer == null) return _entities;
+    var state = _protocolStates[uri.path];
+    if (state == null) return _entities;
 
-    analyzer.collector.clearErrors();
-    var document = analyzer.analyze(yaml: yaml, protocolEntities: _entities);
-    if (document != null) {
-      _upsertEntity(document, uri);
-      // TODO if inserted, validate all again or we may miss errors.
-      // for now we let the caller take care of this.
+    state.source.yaml = yaml;
+
+    var doc = SerializableEntityAnalyzer.extractYamlDefinition(state.source);
+    state.entity = doc;
+    if (doc != null) {
+      _upsertEntity(doc, uri);
     }
+
+    var collector = CodeGenerationCollector();
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      state.source.yaml,
+      state.source.yamlSourceUri.path,
+      collector,
+      state.entity,
+      _entities,
+    );
 
     _onErrorsChangedNotifier?.call(
       uri,
-      (analyzer.collector as CodeGenerationCollector),
+      collector,
     );
 
     return _entities;
   }
 
   /// Adds a new protocol to the state but leaves the responsibility of validating
-  /// it to the caller. Please note that the validation needs to be done twice
-  /// for the first validation pass to detect all errors.
+  /// it to the caller. Please note that [validateAll] should be called to
+  /// guarantee that all errors are found.
   void addYamlProtocol(ProtocolSource yamlSource) {
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: yamlSource.yaml,
-      sourceFileName: yamlSource.yamlSourceUri.path,
-      subDirectoryParts: yamlSource.protocolRootPathParts,
-      collector: CodeGenerationCollector(),
+    var protocolState = _ProtocolState(
+      source: yamlSource,
     );
 
-    _analyzers[yamlSource.yamlSourceUri.path] = analyzer;
+    _protocolStates[yamlSource.yamlSourceUri.path] = protocolState;
   }
 
   /// Removes a protocol from the state but leaves the responsibility of validating
-  /// the new state to the caller.
+  /// the new state to the caller. Please note that [validateAll] should be called to
+  /// guarantee that all related errors are cleared.
   void removeYamlProtocol(Uri protocolUri) {
-    _analyzers.remove(protocolUri.path);
+    _protocolStates.remove(protocolUri.path);
     _entities
         .removeWhere((entity) => entity.sourceFileName == protocolUri.path);
   }
@@ -99,32 +110,41 @@ class StatefulAnalyzer {
 
   /// Checks if a protocol is registered in the state.
   bool isProtocolRegistered(Uri uri) {
-    return _analyzers.containsKey(uri.path);
+    return _protocolStates.containsKey(uri.path);
   }
 
   /// Reset the internal state of the analyzer.
   void clearState() {
-    _analyzers.clear();
+    _protocolStates.clear();
     _entities.clear();
   }
 
-  List<SerializableEntityDefinition> _validateAllAnalyzers(
-      [List<SerializableEntityDefinition>? entities]) {
-    List<SerializableEntityDefinition> parsedEntities = [];
-    for (var analyzer in _analyzers.values) {
-      analyzer.collector.clearErrors();
-      var document = analyzer.analyze(protocolEntities: entities);
-      if (document != null) {
-        parsedEntities.add(document);
+  List<SerializableEntityDefinition> _validateAllAnalyzers() {
+    for (var state in _protocolStates.values) {
+      var doc = SerializableEntityAnalyzer.extractYamlDefinition(state.source);
+      state.entity = doc;
+      if (doc != null) {
+        _upsertEntity(doc, state.source.yamlSourceUri);
       }
+    }
+
+    for (var state in _protocolStates.values) {
+      var collector = CodeGenerationCollector();
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        state.source.yaml,
+        state.source.yamlSourceUri.path,
+        collector,
+        state.entity,
+        _entities,
+      );
 
       _onErrorsChangedNotifier?.call(
-        Uri.file(analyzer.sourceFileName),
-        analyzer.collector as CodeGenerationCollector,
+        Uri.file(state.source.yamlSourceUri.path),
+        collector,
       );
     }
 
-    return parsedEntities;
+    return _entities;
   }
 
   void _upsertEntity(
@@ -134,7 +154,6 @@ class StatefulAnalyzer {
     var index = _entities.indexWhere(
       (element) => element.sourceFileName == uri.path,
     );
-
     if (index == -1) {
       _entities.add(entity);
     } else {

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -17,12 +17,12 @@ class StatefulAnalyzer {
     for (var yamlSource in sources) {
       var analyzer = SerializableEntityAnalyzer(
         yaml: yamlSource.yaml,
-        sourceFileName: yamlSource.uri.path,
+        sourceFileName: yamlSource.yamlSourceUri.path,
         subDirectoryParts: yamlSource.protocolRootPathParts,
         collector: CodeGenerationCollector(),
       );
 
-      _analyzers[yamlSource.uri.path] = analyzer;
+      _analyzers[yamlSource.yamlSourceUri.path] = analyzer;
     }
 
     _entities = _validateAllAnalyzers();
@@ -69,12 +69,12 @@ class StatefulAnalyzer {
   void addYamlProtocol(ProtocolSource yamlSource) {
     var analyzer = SerializableEntityAnalyzer(
       yaml: yamlSource.yaml,
-      sourceFileName: yamlSource.uri.path,
+      sourceFileName: yamlSource.yamlSourceUri.path,
       subDirectoryParts: yamlSource.protocolRootPathParts,
       collector: CodeGenerationCollector(),
     );
 
-    _analyzers[yamlSource.uri.path] = analyzer;
+    _analyzers[yamlSource.yamlSourceUri.path] = analyzer;
   }
 
   /// Removes a protocol from the state but leaves the responsibility of validating

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -121,7 +121,8 @@ class StatefulAnalyzer {
 
   List<SerializableEntityDefinition> _validateAllAnalyzers() {
     for (var state in _protocolStates.values) {
-      var doc = SerializableEntityAnalyzer.extractEntityDefinition(state.source);
+      var doc =
+          SerializableEntityAnalyzer.extractEntityDefinition(state.source);
       state.entity = doc;
       if (doc != null) {
         _upsertEntity(doc, state.source.yamlSourceUri);

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -7,26 +7,26 @@ import '../converter/converter.dart';
 import 'validate_node.dart';
 
 /// Validates that only one top level entity type is defined.
-void validateTopLevelEntityType(
+List<SourceSpanException> validateTopLevelEntityType(
   YamlNode documentContents,
   Set<String> classTypes,
-  CodeAnalysisCollector collector,
 ) {
-  if (documentContents is! YamlMap) return;
+  if (documentContents is! YamlMap) return [];
 
   var typeNodes = _findNodesByKeys(
     documentContents,
     classTypes,
   );
 
-  if (typeNodes.length == 1) return;
+  if (typeNodes.length == 1) return [];
 
   if (typeNodes.isEmpty) {
-    collector.addError(SourceSpanException(
-      'No $classTypes type is defined.',
-      documentContents.span,
-    ));
-    return;
+    return [
+      SourceSpanException(
+        'No $classTypes type is defined.',
+        documentContents.span,
+      )
+    ];
   }
 
   var formattedKeys = _formatNodeKeys(typeNodes);
@@ -39,7 +39,7 @@ void validateTopLevelEntityType(
       )
       .toList();
 
-  collector.addErrors(errors);
+  return errors;
 }
 
 /// Recursivly validates a yaml document against a set of [ValidateNode]s.

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -3,8 +3,8 @@ import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
 import 'package:serverpod_cli/src/util/extensions.dart';
 import 'package:yaml/yaml.dart';
 
-import '../converter/converter.dart';
-import 'validate_node.dart';
+import 'package:serverpod_cli/src/analyzer/entities/converter/converter.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
 
 /// Validates that only one top level entity type is defined.
 List<SourceSpanException> validateTopLevelEntityType(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -3,7 +3,7 @@ import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
-import '../converter/converter.dart';
+import 'package:serverpod_cli/src/analyzer/entities/converter/converter.dart';
 
 class Restrictions {
   String documentType;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -1,6 +1,6 @@
-import '../validation/keywords.dart';
-import '../validation/restrictions.dart';
-import '../validation/validate_node.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
 
 class ClassYamlDefinition {
   late Set<ValidateNode> documentStructure;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -1,0 +1,86 @@
+import '../validation/keywords.dart';
+import '../validation/restrictions.dart';
+import '../validation/validate_node.dart';
+
+class ClassYamlDefinition {
+  late Set<ValidateNode> documentStructure;
+
+  ValidateNode get fieldStructure {
+    return documentStructure
+        .firstWhere((element) => element.key == Keyword.fields)
+        .nested
+        .first;
+  }
+
+  ClassYamlDefinition(Restrictions restrictions) {
+    documentStructure = {
+      ValidateNode(
+        Keyword.classType,
+        isRequired: true,
+        valueRestriction: restrictions.validateClassName,
+      ),
+      ValidateNode(
+        Keyword.table,
+        valueRestriction: restrictions.validateTableName,
+      ),
+      ValidateNode(
+        Keyword.serverOnly,
+        valueRestriction: restrictions.validateBoolType,
+      ),
+      ValidateNode(
+        Keyword.fields,
+        isRequired: true,
+        nested: {
+          ValidateNode(
+            Keyword.any,
+            keyRestriction: restrictions.validateFieldName,
+            allowStringifiedNestedValue: true,
+            nested: {
+              ValidateNode(
+                Keyword.type,
+                isRequired: true,
+                valueRestriction: restrictions.validateFieldType,
+              ),
+              ValidateNode(
+                Keyword.parent,
+                valueRestriction: restrictions.validateParentName,
+              ),
+              ValidateNode(
+                Keyword.database,
+                mutuallyExclusiveKeys: {Keyword.api},
+              ),
+              ValidateNode(
+                Keyword.api,
+                mutuallyExclusiveKeys: {Keyword.database},
+              ),
+            },
+          ),
+        },
+      ),
+      ValidateNode(
+        Keyword.indexes,
+        nested: {
+          ValidateNode(
+            Keyword.any,
+            keyRestriction: restrictions.validateTableIndexName,
+            nested: {
+              ValidateNode(
+                Keyword.fields,
+                isRequired: true,
+                valueRestriction: restrictions.validateIndexFieldsValue,
+              ),
+              ValidateNode(
+                Keyword.type,
+                valueRestriction: restrictions.validateIndexType,
+              ),
+              ValidateNode(
+                Keyword.unique,
+                valueRestriction: restrictions.validateBoolType,
+              ),
+            },
+          )
+        },
+      ),
+    };
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
@@ -1,6 +1,6 @@
-import '../validation/keywords.dart';
-import '../validation/restrictions.dart';
-import '../validation/validate_node.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
 
 class EnumYamlDefinition {
   late Set<ValidateNode> documentStructure;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
@@ -1,0 +1,26 @@
+import '../validation/keywords.dart';
+import '../validation/restrictions.dart';
+import '../validation/validate_node.dart';
+
+class EnumYamlDefinition {
+  late Set<ValidateNode> documentStructure;
+
+  EnumYamlDefinition(Restrictions restrictions) {
+    documentStructure = {
+      ValidateNode(
+        Keyword.enumType,
+        isRequired: true,
+        valueRestriction: restrictions.validateClassName,
+      ),
+      ValidateNode(
+        Keyword.serverOnly,
+        valueRestriction: restrictions.validateBoolType,
+      ),
+      ValidateNode(
+        Keyword.values,
+        isRequired: true,
+        valueRestriction: restrictions.validateEnumValues,
+      ),
+    };
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
@@ -1,0 +1,46 @@
+import '../validation/keywords.dart';
+import '../validation/restrictions.dart';
+import '../validation/validate_node.dart';
+
+class ExceptionYamlDefinition {
+  late Set<ValidateNode> documentStructure;
+
+  ValidateNode get fieldStructure {
+    return documentStructure
+        .firstWhere((element) => element.key == Keyword.fields)
+        .nested
+        .first;
+  }
+
+  ExceptionYamlDefinition(Restrictions restrictions) {
+    documentStructure = {
+      ValidateNode(
+        Keyword.exceptionType,
+        isRequired: true,
+        valueRestriction: restrictions.validateClassName,
+      ),
+      ValidateNode(
+        Keyword.serverOnly,
+        valueRestriction: restrictions.validateBoolType,
+      ),
+      ValidateNode(
+        Keyword.fields,
+        isRequired: true,
+        nested: {
+          ValidateNode(
+            Keyword.any,
+            keyRestriction: restrictions.validateFieldName,
+            allowStringifiedNestedValue: true,
+            nested: {
+              ValidateNode(
+                Keyword.type,
+                isRequired: true,
+                valueRestriction: restrictions.validateFieldDataType,
+              ),
+            },
+          ),
+        },
+      ),
+    };
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
@@ -1,6 +1,6 @@
-import '../validation/keywords.dart';
-import '../validation/restrictions.dart';
-import '../validation/validate_node.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
 
 class ExceptionYamlDefinition {
   late Set<ValidateNode> documentStructure;

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -62,7 +62,7 @@ Future<void> runLanguageServer() async {
 
     statefulAnalyzer.removeYamlProtocol(params.textDocument.uri);
 
-    // This can be optimised to only validate the files we know have related errors.
+    // This can be optimized to only validate the files we know have related errors.
     statefulAnalyzer.validateAll();
   });
 

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -84,11 +84,6 @@ Future<void> runLanguageServer() async {
       ),
     );
 
-    statefulAnalyzer.validateProtocol(
-      params.textDocument.text,
-      params.textDocument.uri,
-    );
-
     // We need to validate all protocols as the new protocol might reference or
     // be referenced by other protocols.
     statefulAnalyzer.validateAll();

--- a/tools/serverpod_cli/lib/src/util/protocol_helper.dart
+++ b/tools/serverpod_cli/lib/src/util/protocol_helper.dart
@@ -5,10 +5,10 @@ import 'package:path/path.dart';
 
 class ProtocolSource {
   String yaml;
-  Uri uri;
+  Uri yamlSourceUri;
   List<String> protocolRootPathParts;
 
-  ProtocolSource(this.yaml, this.uri, this.protocolRootPathParts);
+  ProtocolSource(this.yaml, this.yamlSourceUri, this.protocolRootPathParts);
 }
 
 class ProtocolHelper {

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/class_conflicts_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/class_conflicts_test.dart
@@ -1,6 +1,6 @@
-import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -8,34 +8,49 @@ void main() {
       'Given two protocols with the same class name, then an error is collected that there is a collision in the class names.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+
+    var protocol1 = ProtocolSource(
+      '''
 class: Example
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    var entity1 = analyzer.analyze();
+    var definition1 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol1,
+    );
 
-    var analyzer2 = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol2 = ProtocolSource(
+      '''
 class: Example
 fields:
   differentName: String
 ''',
-      sourceFileName: 'lib/src/protocol/example2.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example2.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    var entity2 = analyzer2.analyze();
+    var definition2 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol2,
+    );
 
-    analyzer.analyze(
-      protocolEntities: [entity1, entity2].cast<SerializableEntityDefinition>(),
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol1.yaml,
+      protocol1.yamlSourceUri.path,
+      collector,
+      definition1,
+      [definition1!, definition2!],
+    );
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol2.yaml,
+      protocol2.yamlSourceUri.path,
+      collector,
+      definition2,
+      [definition1, definition2],
     );
 
     expect(collector.errors.length, greaterThan(0));
@@ -48,21 +63,27 @@ fields:
       'Given a single valid protocol, then there is no error collected for the class name.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+
+    var protocol = ProtocolSource(
+      '''
 class: Example
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    var entity = analyzer.analyze();
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    );
 
-    analyzer.analyze(
-      protocolEntities: [entity].cast<SerializableEntityDefinition>(),
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
     );
 
     expect(collector.errors, isEmpty);

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/documentation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/documentation_test.dart
@@ -1,124 +1,119 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
-import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
   test(
       'Given a class with a class documentation comment then an entity with the class documentation set is generated.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 ### This is a comment.
 class: Example
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition?;
 
-    expect(entities.documentation, ['/// This is a comment.']);
+    expect(entities?.documentation, ['/// This is a comment.']);
   });
 
   test(
       'Given a class with a multiline class documentation comment then an entity with the class documentation set is generated.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 ### This is a...
 ### multiline comment.
 class: Example
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition?;
 
-    expect(
-        entities.documentation, ['/// This is a...', '/// multiline comment.']);
+    expect(entities?.documentation,
+        ['/// This is a...', '/// multiline comment.']);
   });
 
   test(
       'Given a class with a normal class comment, then the entity that is generated has no documentation set.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 # This is a normal comment.
 class: Example
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-    expect(entities.documentation, null);
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition?;
+
+    expect(entities?.documentation, null);
   });
 
   test(
       'Given a class with a field documentation comment then the entity that is generated has the documentation set for that specific field.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 fields:
   ### This is a field comment.
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition?;
 
     expect(
-        entities.fields.first.documentation, ['/// This is a field comment.']);
+        entities?.fields.first.documentation, ['/// This is a field comment.']);
   });
 
   test(
       'Given a class with a multiline field documentation comment then the entity that is generated has the documentation set for that specific field.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 fields:
   ### This is a multiline
   ### field comment.
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition?;
 
-    expect(entities.fields.first.documentation,
+    expect(entities?.fields.first.documentation,
         ['/// This is a multiline', '/// field comment.']);
   });
 
   test(
       'Given a class with multiple fields but only one has a documentation comment then the entity that is generated has the documentation set for that specific field.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 fields:
   name: String
@@ -126,80 +121,79 @@ fields:
   ### field comment.
   age: int
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-    expect(entities.fields.first.documentation, null);
-    expect(entities.fields.last.documentation,
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition?;
+
+    expect(entities?.fields.first.documentation, null);
+    expect(entities?.fields.last.documentation,
         ['/// This is a multiline', '/// field comment.']);
   });
 
   test(
       'Given a class with a field with a normal comment, then the entity that is generated has no documentation set.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 fields:
   # This is a normal comment.
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-    expect(entities.fields.first.documentation, null);
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition?;
+
+    expect(entities?.fields.first.documentation, null);
   });
 
   test(
       'Given an enum with a multiline class documentation comment then an entity with the class documentation set is generated.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 ### This is a...
 ### multiline comment.
 enum: Example
 values:
   - first
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    EnumDefinition entities = analyzer.analyze() as EnumDefinition;
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as EnumDefinition?;
 
-    expect(
-        entities.documentation, ['/// This is a...', '/// multiline comment.']);
+    expect(entities?.documentation,
+        ['/// This is a...', '/// multiline comment.']);
   });
 
   test(
       'Given an enum with a multiline value documentation comment then the entity that is generated has the documentation set for that specific field.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 enum: Example
 values:
   ### This is a multiline
   ### field comment.
   - first
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    EnumDefinition entities = analyzer.analyze() as EnumDefinition;
+    var entities = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as EnumDefinition?;
 
-    expect(entities.values.first.documentation,
+    expect(entities?.values.first.documentation,
         ['/// This is a multiline', '/// field comment.']);
   });
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_types_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_types_test.dart
@@ -52,12 +52,7 @@ fields:
     var definition =
         SerializableEntityAnalyzer.extractEntityDefinition(protocol);
     SerializableEntityAnalyzer.validateYamlDefinition(
-      protocol.yaml,
-      protocol.yamlSourceUri.path,
-      collector,
-      definition,
-      []
-    );
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
 
     expect(collector.errors.length, 0);
   });
@@ -79,12 +74,7 @@ fields:
     var definition =
         SerializableEntityAnalyzer.extractEntityDefinition(protocol);
     SerializableEntityAnalyzer.validateYamlDefinition(
-      protocol.yaml,
-      protocol.yamlSourceUri.path,
-      collector,
-      definition,
-      []
-    );
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
 
     expect((definition as ClassDefinition).className, 'PascalCASEString');
   });
@@ -106,12 +96,7 @@ fields:
     var definition =
         SerializableEntityAnalyzer.extractEntityDefinition(protocol);
     SerializableEntityAnalyzer.validateYamlDefinition(
-      protocol.yaml,
-      protocol.yamlSourceUri.path,
-      collector,
-      definition,
-      []
-    );
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -138,12 +123,7 @@ fields:
     var definition =
         SerializableEntityAnalyzer.extractEntityDefinition(protocol);
     SerializableEntityAnalyzer.validateYamlDefinition(
-      protocol.yaml,
-      protocol.yamlSourceUri.path,
-      collector,
-      definition,
-      []
-    );
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -171,12 +151,7 @@ values:
     var definition =
         SerializableEntityAnalyzer.extractEntityDefinition(protocol);
     SerializableEntityAnalyzer.validateYamlDefinition(
-      protocol.yaml,
-      protocol.yamlSourceUri.path,
-      collector,
-      definition,
-      []
-    );
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -236,13 +211,8 @@ fields:
       var definition = SerializableEntityAnalyzer.extractEntityDefinition(
         protocol,
       );
-      SerializableEntityAnalyzer.validateYamlDefinition(
-        protocol.yaml,
-        protocol.yamlSourceUri.path,
-        collector,
-        definition,
-        []
-      );
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, []);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -268,13 +238,8 @@ fields:
       var definition = SerializableEntityAnalyzer.extractEntityDefinition(
         protocol,
       );
-      SerializableEntityAnalyzer.validateYamlDefinition(
-        protocol.yaml,
-        protocol.yamlSourceUri.path,
-        collector,
-        definition,
-        []
-      );
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, []);
 
       expect(collector.errors.length, greaterThan(0));
       var span = collector.errors.first.span;
@@ -305,13 +270,8 @@ fields:
       var definition = SerializableEntityAnalyzer.extractEntityDefinition(
         protocol,
       );
-      SerializableEntityAnalyzer.validateYamlDefinition(
-        protocol.yaml,
-        protocol.yamlSourceUri.path,
-        collector,
-        definition,
-        []
-      );
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, []);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -340,13 +300,8 @@ fields:
       var definition = SerializableEntityAnalyzer.extractEntityDefinition(
         protocol,
       );
-      SerializableEntityAnalyzer.validateYamlDefinition(
-        protocol.yaml,
-        protocol.yamlSourceUri.path,
-        collector,
-        definition,
-        []
-      );
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, []);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -373,13 +328,8 @@ fields:
       var definition = SerializableEntityAnalyzer.extractEntityDefinition(
         protocol,
       );
-      SerializableEntityAnalyzer.validateYamlDefinition(
-        protocol.yaml,
-        protocol.yamlSourceUri.path,
-        collector,
-        definition,
-        []
-      );
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, []);
 
       expect(collector.errors.length, greaterThan(1));
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_types_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_types_test.dart
@@ -1,24 +1,32 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('Given a class with a null value as name, then collect an error ....',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class:
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [],
+    );
 
     expect(collector.errors.length, greaterThan(0), reason: 'No errors found');
 
@@ -26,22 +34,30 @@ fields:
 
     expect(error.message, 'The "class" type must be a String.');
   });
+
   test(
       'Given a PascalCASEString class name with several uppercase letters, then no errors are collected.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 exception: PascalCASEString
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      []
+    );
 
     expect(collector.errors.length, 0);
   });
@@ -50,37 +66,52 @@ fields:
       'Given a PascalCASEString class name with several uppercase letters, then an exception with that name is generated.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 exception: PascalCASEString
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      []
+    );
 
-    expect(entities.className, 'PascalCASEString');
+    expect((definition as ClassDefinition).className, 'PascalCASEString');
   });
+
   test(
       'Given a camelCase class name, then give an error indicating that PascalCase is required.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: exampleClass
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      []
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -94,18 +125,25 @@ fields:
       'Given a snake_case exception name, then give an error indicating that PascalCase is required.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 exception: example_class
 fields:
   name: String
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      []
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -119,19 +157,26 @@ fields:
       'Given an enum name with a leading number, then give an error indicating that PascalCase is required.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 enum: 1ExampleType
 values:
   - yes
   - no
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      []
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -146,18 +191,25 @@ values:
         'Then return a human readable error message informing the user that the entity type is missing.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 invalid: Type 
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [],
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -169,19 +221,28 @@ fields:
   group('Given a protocol with class and exception type defined.', () {
     test('Then return a human readable error message when analyzing.', () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 exception: ExampleException
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        []
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -192,19 +253,28 @@ fields:
 
     test('Then the second type is highlighted.', () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 exception: ExampleException
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        []
+      );
 
       expect(collector.errors.length, greaterThan(0));
       var span = collector.errors.first.span;
@@ -220,19 +290,28 @@ fields:
   group('Given a protocol with exception and enum type defined.', () {
     test('Then return a human readable error message when analyzing.', () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 exception: ExampleException
 enum: ExampleType
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        []
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -245,20 +324,29 @@ fields:
   group('Given a protocol with three different types defined.', () {
     test('Then return a human readable error message when analyzing.', () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 exception: ExampleException
 enum: ExampleType
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        []
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -269,20 +357,29 @@ fields:
 
     test('Then the second and third type is highlighted.', () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 exception: ExampleException
 enum: ExampleType
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        []
+      );
 
       expect(collector.errors.length, greaterThan(1));
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
@@ -1,6 +1,7 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -8,17 +9,25 @@ void main() {
       'Given an enum without a values property, then collect an error that the values property is required.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    
+    var protocol = ProtocolSource(
+      '''
 enum: ExampleEnum
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
-
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
+    
     expect(collector.errors.length, greaterThan(0));
 
     var error = collector.errors.first;
@@ -30,17 +39,25 @@ enum: ExampleEnum
       'Given an enum with an empty values property, then collect an error that values must be defined.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    
+    var protocol = ProtocolSource(
+      '''
 enum: ExampleEnum
 values:
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -53,19 +70,27 @@ values:
       'Given an enum with the values property defined as a map, then collect an error that values must be a list.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    
+    var protocol = ProtocolSource(
+      '''
 enum: ExampleEnum
 values:
   value1: 1
   value2: 2
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -78,19 +103,27 @@ values:
       'Given an enum with the values with none string values, then collect an error that values must be a list of strings.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    
+    var protocol = ProtocolSource(
+      '''
 enum: ExampleEnum
 values:
   - 1
   - 2
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -103,18 +136,26 @@ values:
       'Given an enum with an invalid enum string structure, then collect an error that the string must follow the required syntax.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    
+    var protocol = ProtocolSource(
+      '''
 enum: ExampleEnum
 values:
   - InvalidValue
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -126,22 +167,20 @@ values:
   test(
       'Given a valid enum with two values, then the enum definition should contain two values.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 enum: ExampleEnum
 values:
   - first
   - second
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    EnumDefinition enumDefinition = analyzer.analyze() as EnumDefinition;
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol) as EnumDefinition;
 
-    expect(enumDefinition.values.first.name, 'first');
-    expect(enumDefinition.values.last.name, 'second');
+    expect(definition.values.first.name, 'first');
+    expect(definition.values.last.name, 'second');
   });
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
@@ -9,7 +9,7 @@ void main() {
       'Given an enum without a values property, then collect an error that the values property is required.',
       () {
     var collector = CodeGenerationCollector();
-    
+
     var protocol = ProtocolSource(
       '''
 enum: ExampleEnum
@@ -18,8 +18,9 @@ enum: ExampleEnum
       ['lib', 'src', 'protocol'],
     );
 
-    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-    
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
     SerializableEntityAnalyzer.validateYamlDefinition(
       protocol.yaml,
       protocol.yamlSourceUri.path,
@@ -27,7 +28,7 @@ enum: ExampleEnum
       definition,
       [definition!],
     );
-    
+
     expect(collector.errors.length, greaterThan(0));
 
     var error = collector.errors.first;
@@ -39,7 +40,7 @@ enum: ExampleEnum
       'Given an enum with an empty values property, then collect an error that values must be defined.',
       () {
     var collector = CodeGenerationCollector();
-    
+
     var protocol = ProtocolSource(
       '''
 enum: ExampleEnum
@@ -49,8 +50,9 @@ values:
       ['lib', 'src', 'protocol'],
     );
 
-    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-    
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
     SerializableEntityAnalyzer.validateYamlDefinition(
       protocol.yaml,
       protocol.yamlSourceUri.path,
@@ -70,7 +72,7 @@ values:
       'Given an enum with the values property defined as a map, then collect an error that values must be a list.',
       () {
     var collector = CodeGenerationCollector();
-    
+
     var protocol = ProtocolSource(
       '''
 enum: ExampleEnum
@@ -82,8 +84,9 @@ values:
       ['lib', 'src', 'protocol'],
     );
 
-    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-    
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
     SerializableEntityAnalyzer.validateYamlDefinition(
       protocol.yaml,
       protocol.yamlSourceUri.path,
@@ -103,7 +106,7 @@ values:
       'Given an enum with the values with none string values, then collect an error that values must be a list of strings.',
       () {
     var collector = CodeGenerationCollector();
-    
+
     var protocol = ProtocolSource(
       '''
 enum: ExampleEnum
@@ -115,8 +118,9 @@ values:
       ['lib', 'src', 'protocol'],
     );
 
-    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-    
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
     SerializableEntityAnalyzer.validateYamlDefinition(
       protocol.yaml,
       protocol.yamlSourceUri.path,
@@ -136,7 +140,7 @@ values:
       'Given an enum with an invalid enum string structure, then collect an error that the string must follow the required syntax.',
       () {
     var collector = CodeGenerationCollector();
-    
+
     var protocol = ProtocolSource(
       '''
 enum: ExampleEnum
@@ -147,8 +151,9 @@ values:
       ['lib', 'src', 'protocol'],
     );
 
-    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-    
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
     SerializableEntityAnalyzer.validateYamlDefinition(
       protocol.yaml,
       protocol.yamlSourceUri.path,
@@ -178,7 +183,9 @@ values:
       ['lib', 'src', 'protocol'],
     );
 
-    var definition = SerializableEntityAnalyzer.extractEntityDefinition(protocol) as EnumDefinition;
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as EnumDefinition;
 
     expect(definition.values.first.name, 'first');
     expect(definition.values.last.name, 'second');

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/extra_properties_test.dart
@@ -1,6 +1,7 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -9,19 +10,29 @@ void main() {
         'Given a class defined to serverOnly, then the serverOnly property is set to true.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 serverOnly: true
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      ClassDefinition entities = definition as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
 
       expect(entities.serverOnly, true);
     });
@@ -30,19 +41,29 @@ fields:
         'Given a class explicitly setting serverOnly to false, then the serverOnly property is set to false.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 serverOnly: false
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      ClassDefinition entities = definition as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
 
       expect(entities.serverOnly, false);
     });
@@ -51,18 +72,28 @@ fields:
         'Given a class without the serverOnly property, then the default "false" value is used.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      ClassDefinition entities = definition as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
 
       expect(entities.serverOnly, false);
     });
@@ -71,19 +102,28 @@ fields:
         'Given a class with the serverOnly property set to another datatype than bool, then an error is collected notifying that the serverOnly must be a bool.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 serverOnly: Yes
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -96,19 +136,28 @@ fields:
         'Given an exception with the serverOnly property set to another datatype than bool, then an error is collected notifying that the serverOnly must be a bool.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 exception: Example
 serverOnly: Yes
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -123,19 +172,29 @@ fields:
         'Given a class with a table defined, then the tableName is set in the definition.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      ClassDefinition entities = definition as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
 
       expect(entities.tableName, 'example');
     });
@@ -144,19 +203,28 @@ fields:
         'Given a class with a table name in a none snake_case_format, then collect an error that snake_case must be used.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: camelCaseTable
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -170,19 +238,28 @@ fields:
         'Given a class with a table name is not a string, then collect an error that snake_case must be used.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: true
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -196,19 +273,28 @@ fields:
         'Given an exception with a table defined, then collect an error that table cannot be used together with exceptions.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 exception: Example
 table: example
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -217,67 +303,50 @@ fields:
       expect(error.message,
           'The "table" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.');
     });
-  });
 
-  group('Invalid properties', () {
-    test(
-        'Given a class with an invalid property, then collect an error that such a property is not allowed.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+    group('Invalid properties', () {
+      test(
+          'Given a class with an invalid property, then collect an error that such a property is not allowed.',
+          () {
+        var collector = CodeGenerationCollector();
+
+        var protocol = ProtocolSource(
+          '''
 class: Example
 invalidProperty: true
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
 
-      analyzer.analyze();
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
 
-      expect(collector.errors.length, greaterThan(0));
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
 
-      var error = collector.errors.first;
+        expect(collector.errors.length, greaterThan(0));
 
-      expect(error.message,
-          'The "invalidProperty" property is not allowed for class type. Valid keys are {class, table, serverOnly, fields, indexes}.');
-    });
+        var error = collector.errors.first;
 
-    test(
-        'Given a class with an invalid property, then collect an error that such a property is not allowed.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-invalidProperty: true
-fields:
-  name: String
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
+        expect(error.message,
+            'The "invalidProperty" property is not allowed for class type. Valid keys are {class, table, serverOnly, fields, indexes}.');
+      });
 
-      analyzer.analyze();
+      test(
+          'Given an exception with an indexes defined, then collect an error that indexes cannot be used together with exceptions.',
+          () {
+        var collector = CodeGenerationCollector();
 
-      expect(collector.errors.length, greaterThan(0));
-
-      var error = collector.errors.first;
-
-      expect(error.message,
-          'The "invalidProperty" property is not allowed for class type. Valid keys are {class, table, serverOnly, fields, indexes}.');
-    });
-
-    test(
-        'Given an exception with an indexes defined, then collect an error that indexes cannot be used together with exceptions.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+        var protocol = ProtocolSource(
+          '''
 exception: ExampleException
 fields:
   name: String
@@ -286,46 +355,64 @@ indexes:
     fields: name
     unique: true
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
 
-      analyzer.analyze();
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
 
-      expect(collector.errors.length, greaterThan(0));
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
 
-      var error = collector.errors.first;
+        expect(collector.errors.length, greaterThan(0));
 
-      expect(error.message,
-          'The "indexes" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.');
-    });
+        var error = collector.errors.first;
 
-    test(
-        'Given an enum with a table defined, then collect an error that table cannot be used together with enums.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+        expect(error.message,
+            'The "indexes" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.');
+      });
+
+      test(
+          'Given an enum with a table defined, then collect an error that table cannot be used together with enums.',
+          () {
+        var collector = CodeGenerationCollector();
+
+        var protocol = ProtocolSource(
+          '''
 enum: Example
 table: example
 values:
   - yes
   - no
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
 
-      analyzer.analyze();
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
 
-      expect(collector.errors.length, greaterThan(0));
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
 
-      var error = collector.errors.first;
+        expect(collector.errors.length, greaterThan(0));
 
-      expect(error.message,
-          'The "table" property is not allowed for enum type. Valid keys are {enum, serverOnly, values}.');
+        var error = collector.errors.first;
+
+        expect(error.message,
+            'The "table" property is not allowed for enum type. Valid keys are {enum, serverOnly, values}.');
+      });
     });
   });
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -1,6 +1,7 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -9,16 +10,18 @@ void main() {
         'Given a class without the fields key, then collect an error that the fields key is required',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -31,16 +34,18 @@ class: Example
         'Given an exception without the fields key, then collect an error that the fields key is required',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 exception: Example
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -53,17 +58,19 @@ exception: Example
         'Given a class with the fields key defined but without any field, then collect an error that at least one field has to be added.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 fields:
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -77,17 +84,19 @@ fields:
         'Given an exception with the fields key defined but without any field, then collect an error that at least one field has to be added.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 exception: Example
 fields:
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -101,17 +110,19 @@ fields:
         'Given an class with the fields key defined as a primitive datatype instead of a Map, then collect an error that at least one field has to be added.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 fields: int
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -125,17 +136,19 @@ fields: int
         'Given an enum with the fields key defined, then collect an error that fields are not allowed.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 enum: Example
 fields:
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -151,18 +164,20 @@ fields:
         'Given a class with a field key that is not a string, then collect an error that field keys have to be of the type string.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 fields:
   1: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -175,18 +190,20 @@ fields:
         'Given a class with a field key that is not a valid dart variable name style, collect an error that the keys needs to follow the dart convention.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 fields:
   InvalidFieldName: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
 
       expect(collector.errors.length, greaterThan(0));
 
@@ -200,18 +217,22 @@ fields:
         'Given a class with a valid field key, then an entity with that field is generated.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
+
+      var entities = definition as ClassDefinition;
 
       expect(entities.fields.first.name, 'name');
     });
@@ -222,567 +243,775 @@ fields:
         'Given a class with a field without a datatype defined, then collect an error that defining a datatype is required.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 fields:
   name:
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
-
-      expect(collector.errors.length, greaterThan(0));
-
-      var error = collector.errors.first;
-
-      expect(error.message,
-          'The field must have a datatype defined (e.g. field: String).');
-    });
-
-    test(
-        'Given a exception with a field without a datatype defined, then collect an error that defining a datatype is required.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-exception: Example
-fields:
-  name:
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
       );
-
-      analyzer.analyze();
-
-      expect(collector.errors.length, greaterThan(0));
-
-      var error = collector.errors.first;
-
-      expect(error.message,
-          'The field must have a datatype defined (e.g. field: String).');
-    });
-
-    test(
-        'Given a exception with a field with the type String, then a class with that field type set to String is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-exception: Example
-fields:
-  name: String
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'String');
-    });
-
-    test(
-        'Given a class with a field with the parent keyword but without a value, then collect an error that the parent has to have a valid table name.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-table: example
-fields:
-  nameId: int, parent=
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      analyzer.analyze();
-
-      expect(collector.errors.length, greaterThan(0));
-
-      var error = collector.errors.first;
-
-      expect(error.message,
-          'The parent must reference a valid table name (e.g. parent=table_name). "" is not a valid parent name.');
-    });
-
-    test(
-        'Given a class with a field with the type String, then a class with that field type set to String is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: String
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'String');
-    });
-
-    test(
-        'Given a class with a field with the type int, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: int
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'int');
-    });
-
-    test(
-        'Given a class with a field with the type int, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: bool
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'bool');
-    });
-
-    test(
-        'Given a class with a field with the type double, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: double
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'double');
-    });
-
-    test(
-        'Given a class with a field with the type DateTime, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: DateTime
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'DateTime');
-    });
-
-    test(
-        'Given a class with a field with the type Uuid, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: Uuid
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'Uuid');
-    });
-
-    test(
-        'Given a class with a field with the type ByteData, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: ByteData
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'dart:typed_data:ByteData');
-    });
-
-    test(
-        'Given a class with a field with the type List, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: List<String>
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'List<String>');
-    });
-
-    test(
-        'Given a class with a field with the type Map, then a class with that field type is generated.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: Map<String,String>
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.first.type.toString(), 'Map<String,String>');
-    });
-  });
-
-  group('Parent table tests', () {
-    test(
-        'Given a class with a field with a parent, then the generated entity has a parentTable property set to the parent table name.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-table: example
-fields:
-  parentId: int, parent=parent_table
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      analyzer.analyze();
-
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
-
-      expect(entities.fields.last.parentTable, 'parent_table');
-    });
-    test(
-        'Given a class with a field with two parent keywords, then collect an error that only one parent is allowed.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-table: example
-fields:
-  name: String, parent=my_table, parent=second
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      analyzer.analyze();
-
-      expect(collector.errors.length, greaterThan(0));
-
-      var error = collector.errors.first;
-
-      expect(error.message,
-          'The field option "parent" is defined more than once.');
-    });
-  });
-
-  group('Field scope tests', () {
-    test(
-        'Given a class with a field with two database keywords, then collect an error that only one database is allowed.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: String, database, database
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      analyzer.analyze();
-
-      expect(collector.errors.length, greaterThan(0));
-
-      var error = collector.errors.first;
-
-      expect(error.message,
-          'The field option "database" is defined more than once.');
-    });
-
-    test(
-        'Given a class with a field with two api keywords, then collect an error that only one api is allowed.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: String, api, api
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
-
-      analyzer.analyze();
 
       expect(collector.errors.length, greaterThan(0));
 
       var error = collector.errors.first;
 
       expect(
-          error.message, 'The field option "api" is defined more than once.');
+        error.message,
+        'The field must have a datatype defined (e.g. field: String).',
+      );
     });
 
     test(
-        'Given a class with a field with both the api and database keywords, then collect an error that only one of them is allowed.',
+        'Given an exception with a field without a datatype defined, then collect an error that defining a datatype is required.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
+      var protocol = ProtocolSource(
+        '''
+exception: Example
 fields:
-  name: String, api, database
+  name:
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
-
-      expect(collector.errors.length, greaterThan(1));
-
-      var error1 = collector.errors[0];
-      var error2 = collector.errors[1];
-
-      expect(error1.message,
-          'The "database" property is mutually exclusive with the "api" property.');
-      expect(error2.message,
-          'The "api" property is mutually exclusive with the "database" property.');
-    });
-
-    test(
-        'Given a class with a field with a complex datatype, then generate an entity with that datatype.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: Map<String, String>
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      expect(collector.errors.length, greaterThan(0));
 
-      expect(entities.fields.first.type.className, 'Map');
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The field must have a datatype defined (e.g. field: String).',
+      );
     });
 
     test(
-        'Given a class with a field with no scope set, then the generated entity has the all scope.',
+        'Given an exception with a field with the type String, then a class with that field type set to String is generated.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-table: example
+      var protocol = ProtocolSource(
+        '''
+exception: Example
 fields:
   name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-      expect(entities.fields.last.scope, SerializableEntityFieldScope.all);
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'String');
     });
 
     test(
-        'Given a class with a field with the scope set to database, then the generated entity has the database scope.',
+        'Given a class with a field with the parent keyword but without a value, then collect an error that the parent has to have a valid table name.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
-  name: String, database
+  nameId: int, parent=
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-      expect(entities.fields.last.scope, SerializableEntityFieldScope.database);
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The parent must reference a valid table name (e.g. parent=table_name). "" is not a valid parent name.',
+      );
     });
 
     test(
-        'Given a class with a field with the scope set to api, then the generated entity has the api scope.',
+        'Given a class with a field with the type String, then a class with that field type set to String is generated.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+      var protocol = ProtocolSource(
+        '''
 class: Example
-table: example
 fields:
-  name: String, api
+  name: String
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-      expect(entities.fields.last.scope, SerializableEntityFieldScope.api);
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'String');
+    });
+
+    test(
+        'Given a class with a field with the type int, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: int
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+          (definition as ClassDefinition).fields.first.type.toString(), 'int');
+    });
+
+    test(
+        'Given a class with a field with the type bool, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: bool
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+          (definition as ClassDefinition).fields.first.type.toString(), 'bool');
+    });
+
+    test(
+        'Given a class with a field with the type double, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: double
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'double');
+    });
+
+    test(
+        'Given a class with a field with the type DateTime, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: DateTime
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'DateTime');
+    });
+
+    test(
+        'Given a class with a field with the type Uuid, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: Uuid
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+          (definition as ClassDefinition).fields.first.type.toString(), 'Uuid');
+    });
+
+    test(
+        'Given a class with a field with the type ByteData, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: ByteData
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'dart:typed_data:ByteData');
+    });
+
+    test(
+        'Given a class with a field with the type List, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: List<String>
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'List<String>');
+    });
+
+    test(
+        'Given a class with a field with the type Map, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: Map<String,String>
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'Map<String,String>');
     });
   });
 
-  group('Test id field.', () {
+  group('Parent table tests', () {
     test(
-        'Given a class with a table defined, then add an id field to the generated entity.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-table: example
-fields:
-  name: String
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
+      'Given a class with a field with a parent, then the generated entity has a parentTable property set to the parent table name.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          parentId: int, parent=parent_table
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
 
-      expect(entities.fields.first.name, 'id');
-      expect(entities.fields.first.type.className, 'int');
-      expect(entities.fields.first.type.nullable, true);
-    });
+        expect((definition as ClassDefinition).fields.last.parentTable,
+            'parent_table');
+      },
+    );
 
-    test('Given a class without a table defined, then no id field is added.',
-        () {
-      var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
-class: Example
-fields:
-  name: String
-''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
-      );
+    test(
+      'Given a class with a field with two parent keywords, then collect an error that only one parent is allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          name: String, parent=my_table, parent=second
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
 
-      ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
 
-      expect(entities.fields.first.name, isNot('id'));
-      expect(entities.fields, hasLength(1));
-    });
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(error.message,
+            'The field option "parent" is defined more than once.');
+      },
+    );
+  });
+
+  group('Field scope tests', () {
+    test(
+      'Given a class with a field with two database keywords, then collect an error that only one database is allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, database, database
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(error.message,
+            'The field option "database" is defined more than once.');
+      },
+    );
+
+    test(
+      'Given a class with a field with two api keywords, then collect an error that only one api is allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, api, api
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(
+            error.message, 'The field option "api" is defined more than once.');
+      },
+    );
+
+    test(
+      'Given a class with a field with both the api and database keywords, then collect an error that only one of them is allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, api, database
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(1));
+
+        var error1 = collector.errors[0];
+        var error2 = collector.errors[1];
+
+        expect(error1.message,
+            'The "database" property is mutually exclusive with the "api" property.');
+        expect(error2.message,
+            'The "api" property is mutually exclusive with the "database" property.');
+      },
+    );
+
+    test(
+      'Given a class with a field with a complex datatype, then generate an entity with that datatype.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: Map<String, String>
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(
+            (definition as ClassDefinition).fields.first.type.className, 'Map');
+      },
+    );
+
+    test(
+      'Given a class with a field with no scope set, then the generated entity has the all scope.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          name: String
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect((definition as ClassDefinition).fields.last.scope,
+            SerializableEntityFieldScope.all);
+      },
+    );
+
+    test(
+      'Given a class with a field with the scope set to database, then the generated entity has the database scope.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          name: String, database
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect((definition as ClassDefinition).fields.last.scope,
+            SerializableEntityFieldScope.database);
+      },
+    );
   });
 
   test(
-      'Given a class with a field of a Map type, then all the data types components are extracted.',
+    'Given a class with a field with the scope set to api, then the generated entity has the api scope.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+      class: Example
+      table: example
+      fields:
+        name: String, api
+      ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.last.scope,
+          SerializableEntityFieldScope.api);
+    },
+  );
+
+  group('Test id field.', () {
+    test(
+      'Given a class with a table defined, then add an id field to the generated entity.',
       () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
-class: Example
-fields:
-  customField: Map<String, CustomClass>
-''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          name: String
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect((definition as ClassDefinition).fields.first.name, 'id');
+        expect(definition.fields.first.type.className, 'int');
+        expect(definition.fields.first.type.nullable, true);
+      },
     );
 
-    ClassDefinition entities = analyzer.analyze() as ClassDefinition;
+    test(
+      'Given a class without a table defined, then no id field is added.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
 
-    expect(
-      entities.fields.first.type.className,
-      'Map',
-    );
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
 
-    expect(
-      entities.fields.first.type.generics.first.className,
-      'String',
-    );
-
-    expect(
-      entities.fields.first.type.generics.last.className,
-      'CustomClass',
+        expect((definition as ClassDefinition).fields.first.name, isNot('id'));
+        expect(definition.fields, hasLength(1));
+      },
     );
   });
+
+  test(
+    'Given a class with a field of a Map type, then all the data types components are extracted.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+      class: Example
+      fields:
+        customField: Map<String, CustomClass>
+      ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        (definition as ClassDefinition).fields.first.type.className,
+        'Map',
+      );
+
+      expect(
+        definition.fields.first.type.generics.first.className,
+        'String',
+      );
+
+      expect(
+        definition.fields.first.type.generics.last.className,
+        'CustomClass',
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
@@ -1,42 +1,54 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
   test(
-      'Given a class with the index property defined but without any index, then collect an error that at least one index has to be added.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with the index property defined but without any index, then collect an error that at least one index has to be added.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
   name: String
 indexes:
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(
-        error.message, 'The "indexes" property must have at least one value.');
-  });
+      expect(
+        error.message,
+        'The "indexes" property must have at least one value.',
+      );
+    },
+  );
 
   test(
-      'Given a class with an index that does not define the fields keyword, then collect an error that fields are required.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index that does not define the fields keyword, then collect an error that fields are required.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -44,27 +56,38 @@ fields:
 indexes:
   example_index:
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(error.message,
-        'The "example_index" property is missing required keys (fields).');
-  });
+      expect(
+        error.message,
+        'The "example_index" property is missing required keys (fields).',
+      );
+    },
+  );
 
   test(
-      'Given a class with an index key that is not a string, then collect an error that the index name has to be defined as a string.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index key that is not a string, then collect an error that the index name has to be defined as a string.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -73,26 +96,35 @@ indexes:
   1:
     fields: name
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(error.message, 'Key must be of type String.');
-  });
+      expect(error.message, 'Key must be of type String.');
+    },
+  );
 
   test(
-      'Given a class with an index key that is not a string in snake_case_format, then collect an error that the index name is using an invalid format.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index key that is not a string in snake_case_format, then collect an error that the index name is using an invalid format.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -101,26 +133,38 @@ indexes:
   PascalCaseIndex:
     fields: name
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(error.message,
-        'Invalid format for index "PascalCaseIndex", must follow the format lower_snake_case.');
-  });
+      expect(
+        error.message,
+        'Invalid format for index "PascalCaseIndex", must follow the format lower_snake_case.',
+      );
+    },
+  );
+
   test(
-      'Given a class with an index without any fields, then collect an error that at least one field has to be added.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index without any fields, then collect an error that at least one field has to be added.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -129,27 +173,38 @@ indexes:
   example_index:
     fields:
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(error.message,
-        'The "fields" property must have at least one field, (e.g. fields: fieldName).');
-  });
+      expect(
+        error.message,
+        'The "fields" property must have at least one field, (e.g. fields: fieldName).',
+      );
+    },
+  );
 
   test(
-      'Given a class with an index with a field that does not exist, then collect an error that the field is missing in the class.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index with a field that does not exist, then collect an error that the field is missing in the class.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -158,27 +213,38 @@ indexes:
   example_index:
     fields: missingField
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(error.message,
-        'The field name "missingField" is not added to the class or has an api scope.');
-  });
+      expect(
+        error.message,
+        'The field name "missingField" is not added to the class or has an api scope.',
+      );
+    },
+  );
 
   test(
-      'Given a class with an index with a field that has an api scope, then collect an error that the field is missing in the class.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index with a field that has an api scope, then collect an error that the field is missing in the class.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -188,27 +254,38 @@ indexes:
   example_index:
     fields: apiField
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(error.message,
-        'The field name "apiField" is not added to the class or has an api scope.');
-  });
+      expect(
+        error.message,
+        'The field name "apiField" is not added to the class or has an api scope.',
+      );
+    },
+  );
 
   test(
-      'Given a class with an index with two fields where the second is null, then collect an error that the field must be defined.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index with two fields where the second is null, then collect an error that the field must be defined.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -217,29 +294,37 @@ indexes:
   example_index:
     fields: name,
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    analyzer.analyze();
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-    expect(collector.errors.length, greaterThan(0));
+      expect(collector.errors.length, greaterThan(0));
 
-    var error = collector.errors.first;
+      var error = collector.errors.first;
 
-    expect(error.message,
-        'The field name "" is not added to the class or has an api scope.');
-  });
-
-  //Given a class with an index with a defined field, then the definition contains the index field.
+      expect(
+        error.message,
+        'The field name "" is not added to the class or has an api scope.',
+      );
+    },
+  );
 
   test(
-      'Given a class with an index with a defined field, then the definition contains the index.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index with a defined field, then the definition contains the index.',
+    () {
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -248,24 +333,23 @@ indexes:
   example_index:
     fields: name
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+      var entityDefinition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
 
-    var index = entityDefinition.indexes?.first;
+      var index = (entityDefinition as ClassDefinition).indexes?.first;
 
-    expect(index!.name, 'example_index');
-  });
-
+      expect(index!.name, 'example_index');
+    },
+  );
   test(
-      'Given a class with an index with a defined field, then the definition contains the fields of the index.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index with a defined field, then the definition contains the fields of the index.',
+    () {
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -274,26 +358,26 @@ indexes:
   example_index:
     fields: name
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+      var entityDefinition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
 
-    var index = entityDefinition.indexes?.first;
+      var index = (entityDefinition as ClassDefinition).indexes?.first;
 
-    var field = index?.fields.first;
+      var field = index?.fields.first;
 
-    expect(field, 'name');
-  });
+      expect(field, 'name');
+    },
+  );
 
   test(
-      'Given a class with an index with two defined fields, then the definition contains the fields of the index.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with an index with two defined fields, then the definition contains the fields of the index.',
+    () {
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -303,28 +387,28 @@ indexes:
   example_index:
     fields: name, foo
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+      var entityDefinition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
 
-    var index = entityDefinition.indexes?.first;
+      var index = (entityDefinition as ClassDefinition).indexes?.first;
 
-    var field1 = index?.fields.first;
-    var field2 = index?.fields.last;
+      var field1 = index?.fields.first;
+      var field2 = index?.fields.last;
 
-    expect(field1, 'name');
-    expect(field2, 'foo');
-  });
+      expect(field1, 'name');
+      expect(field2, 'foo');
+    },
+  );
 
   test(
-      'Given a class with two indexes, then the definition contains both the index names.',
-      () {
-    var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    'Given a class with two indexes, then the definition contains both the index names.',
+    () {
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -336,26 +420,28 @@ indexes:
   example_index2:
     fields: foo
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
-    );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
 
-    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+      var entityDefinition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
 
-    var index1 = entityDefinition.indexes?.first;
-    var index2 = entityDefinition.indexes?.last;
+      var index1 = (entityDefinition as ClassDefinition).indexes?.first;
+      var index2 = entityDefinition.indexes?.last;
 
-    expect(index1!.name, 'example_index');
-    expect(index2!.name, 'example_index2');
-  });
+      expect(index1!.name, 'example_index');
+      expect(index2!.name, 'example_index2');
+    },
+  );
 
+  // todo convert!!
   test(
       'Given a class with an index with a unique key that is not a bool, then collect an error that the unique key has to be defined as a bool.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 table: example
 fields:
@@ -365,17 +451,22 @@ indexes:
     fields: name
     unique: InvalidValue
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
 
     expect(collector.errors.length, greaterThan(0));
-
     var error = collector.errors.first;
-
     expect(error.message, 'The property value must be a bool.');
   });
 
@@ -383,8 +474,8 @@ indexes:
       'Given a class with an index with an undefined unique key, then return a definition where unique is set to false.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 table: example
 fields:
@@ -393,15 +484,22 @@ indexes:
   example_index:
     fields: name
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as ClassDefinition;
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
 
-    var index = entityDefinition.indexes?.first;
-
+    var index = definition.indexes?.first;
     expect(index!.unique, false);
   });
 
@@ -409,8 +507,8 @@ indexes:
       'Given a class with an index with a unique key set to false, then return a definition where unique is set to false.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 table: example
 fields:
@@ -420,15 +518,22 @@ indexes:
     fields: name
     unique: false
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as ClassDefinition;
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
 
-    var index = entityDefinition.indexes?.first;
-
+    var index = definition.indexes?.first;
     expect(index!.unique, false);
   });
 
@@ -436,8 +541,8 @@ indexes:
       'Given a class with an index with a unique key set to true, then return a definition where unique is set to true.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+    var protocol = ProtocolSource(
+      '''
 class: Example
 table: example
 fields:
@@ -447,24 +552,32 @@ indexes:
     fields: name
     unique: true
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as ClassDefinition;
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
 
-    var index = entityDefinition.indexes?.first;
-
+    var index = definition.indexes?.first;
     expect(index!.unique, true);
   });
 
   test(
-      'Given a class with an index with a an invalid key, then collect an error indicating that the key is invalid.',
+      'Given a class with an index with an invalid key, then collect an error indicating that the key is invalid.',
       () {
     var collector = CodeGenerationCollector();
-    var analyzer = SerializableEntityAnalyzer(
-      yaml: '''
+
+    var protocol = ProtocolSource(
+      '''
 class: Example
 table: example
 fields:
@@ -474,12 +587,20 @@ indexes:
     fields: name
     invalidKey: true
 ''',
-      sourceFileName: 'lib/src/protocol/example.yaml',
-      subDirectoryParts: ['lib', 'src', 'protocol'],
-      collector: collector,
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
     );
 
-    analyzer.analyze();
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
 
     expect(collector.errors.length, greaterThan(0));
 
@@ -494,8 +615,9 @@ indexes:
         'Given a class with an index without a type set, then default to type btree',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -504,24 +626,34 @@ indexes:
   example_index:
     fields: name
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
 
-      var index = entityDefinition.indexes?.first;
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      var index = definition.indexes?.first;
 
       expect(index?.type, 'btree');
     });
 
     test(
-        'Given a class with an index type explisitly set to btree, then use that type',
+        'Given a class with an index type explicitly set to btree, then use that type',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -531,14 +663,23 @@ indexes:
     fields: name
     type: btree
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      ClassDefinition entityDefinition = analyzer.analyze() as ClassDefinition;
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
 
-      var index = entityDefinition.indexes?.first;
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      var index = definition.indexes?.first;
 
       expect(index?.type, 'btree');
     });
@@ -547,8 +688,9 @@ indexes:
         'Given a class with an index with an invalid type, then collect an error indicating that the type is invalid.',
         () {
       var collector = CodeGenerationCollector();
-      var analyzer = SerializableEntityAnalyzer(
-        yaml: '''
+
+      var protocol = ProtocolSource(
+        '''
 class: Example
 table: example
 fields:
@@ -558,12 +700,20 @@ indexes:
     fields: name
     type: 1
 ''',
-        sourceFileName: 'lib/src/protocol/example.yaml',
-        subDirectoryParts: ['lib', 'src', 'protocol'],
-        collector: collector,
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
       );
 
-      analyzer.analyze();
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
       expect(collector.errors.length, greaterThan(0));
 

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
@@ -212,7 +212,7 @@ fields:
     );
 
     CodeGenerationCollector? reportedErrors;
-    statefulAnalyzer.regsiterOnErrorsChangedNotifier((uri, errors) {
+    statefulAnalyzer.registerOnErrorsChangedNotifier((uri, errors) {
       reportedErrors = errors;
     });
 

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
@@ -104,7 +104,6 @@ fields:
       protocolUri,
       [],
     );
-    statefulAnalyzer.addYamlProtocol(yamlSource);
 
     var entities = statefulAnalyzer.initialValidation([yamlSource]);
 
@@ -184,6 +183,49 @@ fields:
     statefulAnalyzer.validateProtocol(yamlSource.yaml, protocolUri);
 
     expect(wasCalled, true, reason: 'The error callback was not triggered.');
+  });
+
+  test(
+      'Given a protocol that was invalid on first validation, when validating the same protocol with an updated valid syntax, then the previous errors are cleared.',
+      () {
+    var statefulAnalyzer = StatefulAnalyzer();
+
+    var protocolUri = Uri(path: 'lib/src/protocol/example.yaml');
+    var invalidSource = ProtocolSource(
+      '''
+class: 
+fields:
+  name: String
+''',
+      protocolUri,
+      [],
+    );
+
+    var validSource = ProtocolSource(
+      '''
+class: Example
+fields:
+  name: String
+''',
+      protocolUri,
+      [],
+    );
+
+    CodeGenerationCollector? reportedErrors;
+    statefulAnalyzer.regsiterOnErrorsChangedNotifier((uri, errors) {
+      reportedErrors = errors;
+    });
+
+    statefulAnalyzer.initialValidation([invalidSource]);
+
+    expect(reportedErrors?.errors, hasLength(1),
+        reason: 'Expected an error to be reported.');
+
+    statefulAnalyzer.validateProtocol(validSource.yaml, protocolUri);
+
+    expect(reportedErrors?.errors, hasLength(0),
+        reason: 'Expected the error to be cleared.');
+
   });
 
   test(
@@ -303,8 +345,10 @@ fields:
     statefulAnalyzer.addYamlProtocol(yamlSource2);
 
     // Need to validate twice to run the two pass logic.
-    statefulAnalyzer.validateProtocol(yamlSource2.yaml, yamlSource2.yamlSourceUri);
-    statefulAnalyzer.validateProtocol(yamlSource2.yaml, yamlSource2.yamlSourceUri);
+    statefulAnalyzer.validateProtocol(
+        yamlSource2.yaml, yamlSource2.yamlSourceUri);
+    statefulAnalyzer.validateProtocol(
+        yamlSource2.yaml, yamlSource2.yamlSourceUri);
 
     expect(reportedErrors?.errors, hasLength(1),
         reason: 'Expected an error to be reported.');

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
@@ -225,7 +225,6 @@ fields:
 
     expect(reportedErrors?.errors, hasLength(0),
         reason: 'Expected the error to be cleared.');
-
   });
 
   test(

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
@@ -257,7 +257,7 @@ fields:
     expect(reportedErrors?.errors, hasLength(1),
         reason: 'Expected an error to be reported.');
 
-    statefulAnalyzer.removeYamlProtocol(yamlSource2.uri);
+    statefulAnalyzer.removeYamlProtocol(yamlSource2.yamlSourceUri);
 
     statefulAnalyzer.validateAll();
 
@@ -303,8 +303,8 @@ fields:
     statefulAnalyzer.addYamlProtocol(yamlSource2);
 
     // Need to validate twice to run the two pass logic.
-    statefulAnalyzer.validateProtocol(yamlSource2.yaml, yamlSource2.uri);
-    statefulAnalyzer.validateProtocol(yamlSource2.yaml, yamlSource2.uri);
+    statefulAnalyzer.validateProtocol(yamlSource2.yaml, yamlSource2.yamlSourceUri);
+    statefulAnalyzer.validateProtocol(yamlSource2.yaml, yamlSource2.yamlSourceUri);
 
     expect(reportedErrors?.errors, hasLength(1),
         reason: 'Expected an error to be reported.');

--- a/tools/serverpod_cli/test/util/protocol_helper_test.dart
+++ b/tools/serverpod_cli/test/util/protocol_helper_test.dart
@@ -106,7 +106,7 @@ void main() {
         var protocols =
             await ProtocolHelper.loadProjectYamlProtocolsFromDisk(config);
 
-        expect(protocols.first.uri.path,
+        expect(protocols.first.yamlSourceUri.path,
             'test/util/test_assets/protocol_helper/has_serverpod_server_project/test_server/lib/src/protocol/test.yaml');
       });
 


### PR DESCRIPTION
# Changes

Modifies the analyzer to do the serializing and validation in two steps. The benefits is that we can completely omit the first validation and collection of errors which saves us a lot of compute. This refactor also clears up a re-validation issue in the language server where we in some cases wouldn't re-parse a protocol file when it was necessary. 

This PR is dependent on #1075 being merged first.

Closes: https://github.com/serverpod/serverpod/issues/1077

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
