### PR TITLE
Refactors structure of language server and simplifies the code.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -104,12 +104,6 @@ class StatefulAnalyzer {
     return _protocolStates.containsKey(uri.path);
   }
 
-  /// Reset the internal state of the analyzer.
-  void clearState() {
-    _protocolStates.clear();
-    _entities.clear();
-  }
-
   void _updateAllEntities() {
     for (var state in _protocolStates.values) {
       var doc = SerializableEntityAnalyzer.extractEntityDefinition(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -100,18 +100,6 @@ class StatefulAnalyzer {
     );
   }
 
-  /// Register a callback that is called when the errors in a file changes.
-  void registerOnErrorsChangedNotifier(
-    Function(Uri, CodeGenerationCollector) callback,
-  ) {
-    _onErrorsChangedNotifier = callback;
-  }
-
-  /// Unregister the callback that is called when the errors in a file changes.
-  void unregisterOnErrorsChangedNotifier() {
-    _onErrorsChangedNotifier = null;
-  }
-
   /// Checks if a protocol is registered in the state.
   bool isProtocolRegistered(Uri uri) {
     return _protocolStates.containsKey(uri.path);

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -19,7 +19,7 @@ class StatefulAnalyzer {
 
   StatefulAnalyzer(
     List<ProtocolSource> sources, [
-    Function(Uri, CodeGenerationCollector)? callback,
+    Function(Uri, CodeGenerationCollector)? onErrorsChangedNotifier,
   ]) {
     for (var yamlSource in sources) {
       _protocolStates[yamlSource.yamlSourceUri.path] = _ProtocolState(
@@ -27,29 +27,11 @@ class StatefulAnalyzer {
       );
     }
 
-    _onErrorsChangedNotifier = callback;
+    _onErrorsChangedNotifier = onErrorsChangedNotifier;
   }
 
-  /// Loads all yaml protocols and initializes the state. The state is preserved
-  /// to make future validations less expensive.
-  /// Subsequent validations should use [validateAll] or [validateProtocol].
-  List<SerializableEntityDefinition> initialValidation(
-      List<ProtocolSource> sources) {
-    for (var yamlSource in sources) {
-      _protocolStates[yamlSource.yamlSourceUri.path] = _ProtocolState(
-        source: yamlSource,
-      );
-    }
-
-    _updateAllEntities();
-    _validateAllProtocols();
-    return _entities;
-  }
-
-  /// Runs the validation on all protocols, assumes protocols have been added
-  /// by running [initialValidation] or adding them manually
-  /// with [addYamlProtocol]. If not protocol has been initialized this method
-  /// returns an empty list.
+  /// Runs the validation on all protocols in the state. If no protocols are
+  /// registered, this returns an empty list.
   /// Errors are reported through the [onErrorsChangedNotifier].
   List<SerializableEntityDefinition> validateAll() {
     _updateAllEntities();
@@ -57,11 +39,9 @@ class StatefulAnalyzer {
     return _entities;
   }
 
-  /// Runs the validation on a single protocol, assumes [initialValidation] has been
-  /// run before. The protocol must exist in the state, if not this returns
-  /// the last validated state. To validate a new protocol, use [addYamlProtocol]
-  /// and then run [validateAll] or [validateProtocol].
-  /// Errors are reported through the [registerOnErrorsChangedNotifier].
+  /// Runs the validation on a single protocol. The protocol must exist in the
+  /// state, if not this returns the last validated state. 
+  /// Errors are reported through the [onErrorsChangedNotifier].
   List<SerializableEntityDefinition> validateProtocol(String yaml, Uri uri) {
     var state = _protocolStates[uri.path];
     if (state == null) return _entities;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -40,7 +40,7 @@ class StatefulAnalyzer {
   }
 
   /// Runs the validation on a single protocol. The protocol must exist in the
-  /// state, if not this returns the last validated state. 
+  /// state, if not this returns the last validated state.
   /// Errors are reported through the [onErrorsChangedNotifier].
   List<SerializableEntityDefinition> validateProtocol(String yaml, Uri uri) {
     var state = _protocolStates[uri.path];

--- a/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/stateful_analyzer.dart
@@ -17,6 +17,19 @@ class StatefulAnalyzer {
 
   Function(Uri, CodeGenerationCollector)? _onErrorsChangedNotifier;
 
+  StatefulAnalyzer(
+    List<ProtocolSource> sources, [
+    Function(Uri, CodeGenerationCollector)? callback,
+  ]) {
+    for (var yamlSource in sources) {
+      _protocolStates[yamlSource.yamlSourceUri.path] = _ProtocolState(
+        source: yamlSource,
+      );
+    }
+
+    _onErrorsChangedNotifier = callback;
+  }
+
   /// Loads all yaml protocols and initializes the state. The state is preserved
   /// to make future validations less expensive.
   /// Subsequent validations should use [validateAll] or [validateProtocol].

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -10,12 +10,12 @@ import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import '../../analyzer.dart';
 import '../generator/code_generation_collector.dart';
 
-class ServerDirectory {
+class ServerProject {
   Uri serverRootUri;
   GeneratorConfig config;
   StatefulAnalyzer analyzer;
 
-  ServerDirectory({
+  ServerProject({
     required this.serverRootUri,
     required this.config,
     required this.analyzer,
@@ -25,12 +25,12 @@ class ServerDirectory {
 Future<void> runLanguageServer() async {
   var connection = Connection(stdin, stdout);
 
-  ServerDirectory? serverDirectory;
+  ServerProject? serverProject;
 
   connection.onInitialize((params) async {
     var rootUri = params.rootUri;
     if (rootUri != null) {
-      serverDirectory = await _loadServerDirectory(rootUri, connection);
+      serverProject = await _loadServerProject(rootUri, connection);
     }
 
     return InitializeResult(
@@ -41,50 +41,48 @@ Future<void> runLanguageServer() async {
   });
 
   connection.onInitialized((_) async {
-    if (serverDirectory == null) {
+    if (serverProject == null) {
       _sendServerDisabledNotification(connection);
     } else {
-      serverDirectory?.analyzer.validateAll();
+      serverProject?.analyzer.validateAll();
     }
   });
 
   connection.onShutdown(() async {
-    serverDirectory?.analyzer.unregisterOnErrorsChangedNotifier();
-    serverDirectory = null;
+    serverProject = null;
   });
 
   connection.onExit(() => exit(0));
 
   connection.onDidCloseTextDocument((params) async {
-    var serverDir = serverDirectory;
-    if (serverDir == null) return;
-    if (!serverDir.analyzer.isProtocolRegistered(params.textDocument.uri)) {
+    var project = serverProject;
+    if (project == null) return;
+    if (!project.analyzer.isProtocolRegistered(params.textDocument.uri)) {
       return;
     }
     if (_isFileOnDisk(params.textDocument.uri)) return;
 
-    serverDir.analyzer.removeYamlProtocol(params.textDocument.uri);
-
-    serverDir.analyzer.validateAll();
+    project.analyzer.removeYamlProtocol(params.textDocument.uri);
+    project.analyzer.validateAll();
   });
 
   connection.onDidOpenTextDocument((params) async {
-    var serverDir = serverDirectory;
-    if (serverDir == null) return;
-    if (serverDir.analyzer.isProtocolRegistered(params.textDocument.uri)) {
+    var project = serverProject;
+    if (project == null) return;
+    if (project.analyzer.isProtocolRegistered(params.textDocument.uri)) {
       return;
     }
     if (!_isProtocolInServerPath(
-        params.textDocument.uri, serverDir.serverRootUri)) {
+        params.textDocument.uri, project.serverRootUri)) {
       return;
     }
 
-    serverDir.analyzer.addYamlProtocol(
+    project.analyzer.addYamlProtocol(
       ProtocolSource(
         params.textDocument.text,
         params.textDocument.uri,
         ProtocolHelper.extractPathFromProtocolRoot(
-          serverDir.config,
+          project.config,
           params.textDocument.uri,
         ),
       ),
@@ -92,11 +90,11 @@ Future<void> runLanguageServer() async {
 
     // We need to validate all protocols as the new protocol might reference or
     // be referenced by other protocols.
-    serverDir.analyzer.validateAll();
+    project.analyzer.validateAll();
   });
 
   connection.onDidChangeTextDocument((params) async {
-    if (serverDirectory == null) return;
+    if (serverProject == null) return;
 
     var contentChanges = params.contentChanges.map((content) {
       return content.map(
@@ -105,27 +103,13 @@ Future<void> runLanguageServer() async {
       );
     });
 
-    serverDirectory?.analyzer.validateProtocol(
+    serverProject?.analyzer.validateProtocol(
       contentChanges.first.text,
       params.textDocument.uri,
     );
   });
 
   await connection.listen();
-}
-
-void _reportDiagnosticErrors(
-  Connection connection,
-  Uri filePath,
-  CodeGenerationCollector errors,
-) {
-  var diagnostics = _convertErrorsToDiagnostic(errors);
-  connection.sendDiagnostics(
-    PublishDiagnosticsParams(
-      diagnostics: diagnostics,
-      uri: filePath,
-    ),
-  );
 }
 
 void _sendServerDisabledNotification(Connection connection) {
@@ -139,13 +123,13 @@ void _sendServerDisabledNotification(Connection connection) {
   );
 }
 
-Future<ServerDirectory?> _loadServerDirectory(
+Future<ServerProject?> _loadServerProject(
   Uri rootUri,
   Connection connection,
 ) async {
   var rootDir = Directory.fromUri(rootUri);
 
-  var serverRootDir = findServerDirectory(rootDir);
+  var serverRootDir = _findServerDirectory(rootDir);
   if (serverRootDir == null) return null;
 
   var config = await GeneratorConfig.load(serverRootDir.path);
@@ -160,14 +144,14 @@ Future<ServerDirectory?> _loadServerDirectory(
     (filePath, errors) => _reportDiagnosticErrors(connection, filePath, errors),
   );
 
-  return ServerDirectory(
+  return ServerProject(
     serverRootUri: serverRootDir.uri,
     config: config,
     analyzer: analyzer,
   );
 }
 
-Directory? findServerDirectory(Directory root) {
+Directory? _findServerDirectory(Directory root) {
   if (isServerDirectory(root)) return root;
 
   var childDirs = root.listSync().where(
@@ -179,6 +163,20 @@ Directory? findServerDirectory(Directory root) {
   }
 
   return null;
+}
+
+void _reportDiagnosticErrors(
+  Connection connection,
+  Uri filePath,
+  CodeGenerationCollector errors,
+) {
+  var diagnostics = _convertErrorsToDiagnostic(errors);
+  connection.sendDiagnostics(
+    PublishDiagnosticsParams(
+      diagnostics: diagnostics,
+      uri: filePath,
+    ),
+  );
 }
 
 List<Diagnostic> _convertErrorsToDiagnostic(
@@ -206,9 +204,7 @@ List<Diagnostic> _convertErrorsToDiagnostic(
   }).toList();
 }
 
-bool _isProtocolInServerPath(Uri uri, Uri? serverUri) {
-  if (serverUri == null) return false;
-
+bool _isProtocolInServerPath(Uri uri, Uri serverUri) {
   var path = uri.path;
   if (path.contains(serverUri.path)) {
     return true;

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -33,7 +33,6 @@ Future<void> runLanguageServer() async {
       config = await _initializeAnalyzer(statefulAnalyzer, serverRootUri!);
     } catch (e) {
       statefulAnalyzer.unregisterOnErrorsChangedNotifier();
-      statefulAnalyzer.clearState();
       parsingEnabled = false;
 
       connection.sendNotification(
@@ -49,7 +48,6 @@ Future<void> runLanguageServer() async {
 
   connection.onShutdown(() async {
     statefulAnalyzer.unregisterOnErrorsChangedNotifier();
-    statefulAnalyzer.clearState();
     parsingEnabled = false;
   });
 

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -109,9 +109,6 @@ Future<void> runLanguageServer() async {
       contentChanges.first.text,
       params.textDocument.uri,
     );
-
-    // This can be optimized to only validate the files we know have related errors.
-    serverDirectory?.analyzer.validateAll();
   });
 
   await connection.listen();

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
@@ -67,7 +67,7 @@ fields:
     expect(entities, []);
   });
   test(
-      'Given a valid protocol class and an empty state, when running an initial validation, then the class is serialized.',
+      'Given a valid protocol class as the initial state, when validating all, then the class is serialized.',
       () {
     var protocolUri = Uri(path: 'lib/src/protocol/example.yaml');
     var yamlSource = ProtocolSource(
@@ -82,14 +82,14 @@ fields:
 
     var statefulAnalyzer = StatefulAnalyzer([yamlSource]);
 
-    var entities = statefulAnalyzer.initialValidation([yamlSource]);
+    var entities = statefulAnalyzer.validateAll();
 
     expect(entities.length, 1);
     expect(entities.first.className, 'Example');
   });
 
   test(
-      'Given a valid protocol class and an error callback is registered, when running an initial validation, then the callback is triggered.',
+      'Given a valid protocol class and an error callback is registered, when validating all, then the callback is triggered.',
       () {
     var protocolUri = Uri(path: 'lib/src/protocol/example.yaml');
     var yamlSource = ProtocolSource(
@@ -107,12 +107,12 @@ fields:
       wasCalled = true;
     });
 
-    statefulAnalyzer.initialValidation([yamlSource]);
+    statefulAnalyzer.validateAll();
     expect(wasCalled, true, reason: 'The error callback was not triggered.');
   });
 
   test(
-      'Given a protocol with invalid syntax and an error callback is registered, when running an initial validation, then the callback is triggered.',
+      'Given a protocol with invalid syntax and an error callback is registered, when validating all, then the callback is triggered.',
       () {
     var protocolUri = Uri(path: 'lib/src/protocol/example.yaml');
     var yamlSource = ProtocolSource(
@@ -126,7 +126,7 @@ fields:
       wasCalled = true;
     });
 
-    statefulAnalyzer.initialValidation([yamlSource]);
+    statefulAnalyzer.validateAll();
     expect(wasCalled, true, reason: 'The error callback was not triggered.');
   });
 
@@ -159,7 +159,7 @@ fields:
       reportedErrors = errors;
     });
 
-    statefulAnalyzer.initialValidation([invalidSource]);
+    statefulAnalyzer.validateAll();
 
     expect(reportedErrors?.errors, hasLength(1),
         reason: 'Expected an error to be reported.');
@@ -171,7 +171,7 @@ fields:
   });
 
   test(
-      'Given two yaml protocols with the same class name, when running an initial validation, then an error is reported.',
+      'Given two yaml protocols with the same class name, when validating all, then an error is reported.',
       () {
     var yamlSource1 = ProtocolSource(
       '''
@@ -200,7 +200,7 @@ fields:
       reportedErrors = errors;
     });
 
-    statefulAnalyzer.initialValidation([yamlSource1, yamlSource2]);
+    statefulAnalyzer.validateAll();
 
     expect(reportedErrors?.errors, hasLength(1),
         reason: 'Expected an error to be reported.');
@@ -235,7 +235,7 @@ fields:
       reportedErrors = errors;
     });
 
-    statefulAnalyzer.initialValidation([yamlSource1, yamlSource2]);
+    statefulAnalyzer.validateAll();
 
     expect(reportedErrors?.errors, hasLength(1),
         reason: 'Expected an error to be reported.');
@@ -276,16 +276,13 @@ fields:
       reportedErrors = errors;
     });
 
-    statefulAnalyzer.initialValidation([yamlSource1]);
+    statefulAnalyzer.validateAll();
 
     expect(reportedErrors?.errors, hasLength(0),
         reason: 'Expected no errors to be reported.');
 
     statefulAnalyzer.addYamlProtocol(yamlSource2);
 
-    // Need to validate twice to run the two pass logic.
-    statefulAnalyzer.validateProtocol(
-        yamlSource2.yaml, yamlSource2.yamlSourceUri);
     statefulAnalyzer.validateProtocol(
         yamlSource2.yaml, yamlSource2.yamlSourceUri);
 

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
@@ -15,29 +15,6 @@ void main() {
   });
 
   test(
-      'When we add a protocol and clear the state, then an empty list is returned when validating all files.',
-      () {
-    var statefulAnalyzer = StatefulAnalyzer();
-
-    var protocolUri = Uri(path: 'lib/src/protocol/example.yaml');
-    var yamlSource = ProtocolSource(
-      '''
-class: Example
-fields:
-  name: String
-''',
-      protocolUri,
-      [],
-    );
-    statefulAnalyzer.addYamlProtocol(yamlSource);
-    statefulAnalyzer.clearState();
-
-    var entities = statefulAnalyzer.validateAll();
-
-    expect(entities, []);
-  });
-
-  test(
       'When we add and remove a protocol, then an empty list is returned when validating all files.',
       () {
     var statefulAnalyzer = StatefulAnalyzer();


### PR DESCRIPTION
# Changes

Modifies the logic of the StatefulAnalyzer to be simpler and easier to work with. This in turns also made it possible to make the language server have a cleaner architecture.

# Removed

- Unnecessary tests due to above modifications

# Remarks

This PR is dependent on https://github.com/serverpod/serverpod/pull/1083.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

