### PR TITLE
give possibility to developer to add his own icon and text in SignInWithEmailButton

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
@@ -13,6 +13,12 @@ class SignInWithEmailButton extends StatefulWidget {
   /// The style of the button.
   final ButtonStyle? style;
 
+  /// The style of the button.
+  final Text? label;
+
+  /// The style of the button.
+  final Icon? icon;
+
   /// Minimum allowed password length.
   /// Defaults to 128.
   /// If this value is modified, the server must be updated to match.
@@ -28,6 +34,8 @@ class SignInWithEmailButton extends StatefulWidget {
     required this.caller,
     this.onSignedIn,
     this.style,
+    this.label,
+    this.icon,
     this.maxPasswordLength,
     this.minPasswordLength,
     Key? key,
@@ -62,8 +70,8 @@ class SignInWithEmailButtonState extends State<SignInWithEmailButton> {
           },
         );
       },
-      label: const Text('Sign in with Email'),
-      icon: const Icon(Icons.email),
+      label: widget.label ?? const Text('Sign in with Email'),
+      icon: widget.icon ?? const Icon(Icons.email),
     );
   }
 }


### PR DESCRIPTION
Make  possible for developer to add his own icon and text in SignInWithEmailButton

**Here is the screenshot before adding my code**
<img width="644" alt="Capture d’écran 2023-07-07 à 17 51 57" src="https://github.com/serverpod/serverpod/assets/37194177/c2be7ec8-6825-4d8b-ac59-afd2aa057861">



**Here is the screenshot After adding my code**

<img width="555" alt="Capture d’écran 2023-07-07 à 17 52 43" src="https://github.com/serverpod/serverpod/assets/37194177/1e3d9c93-8c93-433f-a908-cb3190e99579">



## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
