### PR TITLE
1086

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -151,7 +151,7 @@ class Restrictions {
     return [];
   }
 
-  List<SourceSpanException> validateFieldType(
+  List<SourceSpanException> validateFieldDataType(
     dynamic content,
     SourceSpan? span,
   ) {
@@ -164,17 +164,18 @@ class Restrictions {
       ];
     }
 
-    return [];
-  }
+    var typeComponents = content
+        .replaceAll(' ', '')
+        .replaceAll('<', ',')
+        .replaceAll('>', ',')
+        .split(',')
+        .where((t) => t.isNotEmpty);
 
-  List<SourceSpanException> validateFieldDataType(
-    dynamic content,
-    SourceSpan? span,
-  ) {
-    if (content is! String) {
+    if (typeComponents
+        .any((type) => !StringValidators.isValidFieldType(type))) {
       return [
         SourceSpanException(
-          'The field must have a datatype defined (e.g. field: String).',
+          'The field has an invalid datatype "$content".',
           span,
         )
       ];

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -39,7 +39,7 @@ class ClassYamlDefinition {
               ValidateNode(
                 Keyword.type,
                 isRequired: true,
-                valueRestriction: restrictions.validateFieldType,
+                valueRestriction: restrictions.validateFieldDataType,
               ),
               ValidateNode(
                 Keyword.parent,

--- a/tools/serverpod_cli/lib/src/util/string_validators.dart
+++ b/tools/serverpod_cli/lib/src/util/string_validators.dart
@@ -12,6 +12,9 @@ class StringValidators {
   static bool isValidFieldName(String name) =>
       _camelCaseTester.hasMatch(name) || _snakeCaseTester.hasMatch(name);
 
+  static bool isValidFieldType(String type) =>
+      RegExp(r'^([a-zA-Z_][a-zA-Z0-9_]*\??)$').hasMatch(type);
+
   static bool isValidClassName(String name) =>
       _pascalCaseWithUppercaseTester.hasMatch(name);
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -364,6 +364,8 @@ fields:
 
       var error = collector.errors.first;
 
+      print(collector.errors);
+
       expect(
         error.message,
         'The parent must reference a valid table name (e.g. parent=table_name). "" is not a valid parent name.',
@@ -396,6 +398,11 @@ fields:
 
       expect((definition as ClassDefinition).fields.first.type.toString(),
           'String');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -424,6 +431,11 @@ fields:
 
       expect(
           (definition as ClassDefinition).fields.first.type.toString(), 'int');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -452,6 +464,11 @@ fields:
 
       expect(
           (definition as ClassDefinition).fields.first.type.toString(), 'bool');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -480,6 +497,11 @@ fields:
 
       expect((definition as ClassDefinition).fields.first.type.toString(),
           'double');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -508,6 +530,11 @@ fields:
 
       expect((definition as ClassDefinition).fields.first.type.toString(),
           'DateTime');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -536,6 +563,11 @@ fields:
 
       expect(
           (definition as ClassDefinition).fields.first.type.toString(), 'Uuid');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -564,6 +596,11 @@ fields:
 
       expect((definition as ClassDefinition).fields.first.type.toString(),
           'dart:typed_data:ByteData');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -592,6 +629,11 @@ fields:
 
       expect((definition as ClassDefinition).fields.first.type.toString(),
           'List<String>');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
 
     test(
@@ -620,6 +662,11 @@ fields:
 
       expect((definition as ClassDefinition).fields.first.type.toString(),
           'Map<String,String>');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
     });
   });
 


### PR DESCRIPTION
# Adds

Validate that the field datatype follows valid dart syntax.

I.E. `invalid-type` will give an error.

Note: This PR is not checking if the type actually exists and is usable only that the string follows the correct syntax.

Dependent on: https://github.com/serverpod/serverpod/pull/1083

Closes: https://github.com/serverpod/serverpod/issues/1086

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
