### PR TITLE
Feature: Implement centralised logger

### DIFF
--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -16,6 +16,8 @@ import 'package:serverpod_cli/src/generator/generator.dart';
 import 'package:serverpod_cli/src/internal_tools/analyze_pubspecs.dart';
 import 'package:serverpod_cli/src/internal_tools/generate_pubspecs.dart';
 import 'package:serverpod_cli/src/language_server/language_server.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/logger/loggers/std_out_logger.dart';
 import 'package:serverpod_cli/src/serverpod_packages_version_check/serverpod_packages_version_check.dart';
 import 'package:serverpod_cli/src/shared/environment.dart';
 import 'package:serverpod_cli/src/util/command_line_tools.dart';
@@ -38,6 +40,8 @@ final runModes = <String>['development', 'staging', 'production'];
 final Analytics _analytics = Analytics();
 
 void main(List<String> args) async {
+  logger = StdOutLogger();
+
   await runZonedGuarded(
     () async {
       try {
@@ -55,9 +59,9 @@ void main(List<String> args) async {
 
 Future<void> _main(List<String> args) async {
   if (Platform.isWindows) {
-    print(
-        'WARNING! Windows is not officially supported yet. Things may or may not work as expected.');
-    print('');
+    logger.printWarning(
+        'Windows is not officially supported yet. Things may or may not work '
+        'as expected.');
   }
 
   // Check that required tools are installed

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -1,0 +1,35 @@
+/// Serverpods internal logger interface.
+/// All logging output should go through this interface.
+/// The purpose is to simplify implementing and switching out concrete logger
+/// implementations.
+abstract class Logger {
+  /// Display a [message] wrapped in a box.
+  /// Commands should use this when they want to highlight a message that otherwise is easily missed.
+  void printBox(String message);
+
+  /// Display debug information to the user.
+  /// Commands should use this for information that can is important for
+  /// debugging.
+  void printDebug(String message);
+
+  /// Display an error [message] to the user.
+  /// Commands should use this if they want to inform a user that an error
+  /// has occurred.
+  void printError(String message, {StackTrace? stackTrace});
+
+  /// Display normal information to the user.
+  /// Command should use this whenever they want to communicate normal output
+  /// such as success or progress messages.
+  void printInfo(String message);
+
+  /// Display a warning to the user.
+  /// Commands should use this if they have important but not critical
+  /// information for the user.
+  void printWarning(String message);
+
+  /// Returns a [Future] that completes once all logging is complete.
+  Future<void> flush();
+}
+
+/// Singleton accessor for the logger.
+late final Logger logger;

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/util/print.dart';
+
+class StdOutLogger extends Logger {
+  @override
+  void printBox(String message) {
+    // TODO: Implement a pretty box print for stdout
+    printww(message);
+  }
+
+  @override
+  void printDebug(String message) {
+    printww('DEBUG: $message');
+  }
+
+  @override
+  void printError(String message, {StackTrace? stackTrace}) {
+    stderr.write('ERROR: $message');
+    if (stackTrace != null) {
+      stderr.write(stackTrace);
+    }
+  }
+
+  @override
+  void printInfo(String message) {
+    printww(message);
+  }
+
+  @override
+  void printWarning(String message) {
+    stderr.write('WARNING: $message');
+  }
+
+  @override
+  Future<void> flush() async {
+    await stderr.flush();
+    await stdout.flush();
+  }
+}

--- a/tools/serverpod_cli/lib/src/util/internal_error.dart
+++ b/tools/serverpod_cli/lib/src/util/internal_error.dart
@@ -1,12 +1,16 @@
-import 'print.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
 
 void printInternalError(dynamic error, StackTrace stackTrace) {
-  printww(
-    'Yikes! It is possible that this error is caused by an internal issue with '
-    'the Serverpod tooling. We would appreciate if you filed an issue over at Github. Please include the stack trace below and describe any steps you did to trigger the error.',
-  );
-  print('https://github.com/serverpod/serverpod/issues');
-  print(error);
-  print(stackTrace);
-  print('');
+  logger.printError(
+      'Yikes! It is possible that this error is caused by an'
+      ' internal issue with the Serverpod tooling. We would appreciate if you '
+      'filed an issue over at Github. Please include the stack trace below and '
+      'describe any steps you did to trigger the error.'
+      '''
+
+https://github.com/serverpod/serverpod/issues
+
+$error
+''',
+      stackTrace: stackTrace);
 }


### PR DESCRIPTION
Issue: https://github.com/serverpod/serverpod/issues/1042

Introduces a centralised logger as a first step of improving the overall CLI output.

The purpose of the centralised logger is to make it easier to implement and switch out other logging solutions based on platform demands or available libraries.

Adding the interface is done in isolation so that the migration work doesn't block any work.

There will be a follow up PR that moves all existing print statement to the logger.

#### Error message
Before change in blue and after change in red:
<img width="960" alt="Screenshot 2023-07-10 at 11 51 50" src="https://github.com/serverpod/serverpod/assets/137198655/1dfcb5b3-cf46-416e-9425-bf9d6d986f62">

#### Warning message
Before change in blue and after change in red:

<img width="662" alt="Screenshot 2023-07-10 at 11 54 58" src="https://github.com/serverpod/serverpod/assets/137198655/dd9873cc-0db0-4540-abd7-bec136b36a27">



## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).