### PR TITLE
1091

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -51,7 +51,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.api,
-                mutuallyExclusiveKeys: {Keyword.database},
+                mutuallyExclusiveKeys: {Keyword.database, Keyword.parent},
               ),
             },
           ),

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -880,37 +880,74 @@ fields:
             SerializableEntityFieldScope.database);
       },
     );
-  });
 
-  test(
-    'Given a class with a field with the scope set to api, then the generated entity has the api scope.',
-    () {
-      var collector = CodeGenerationCollector();
-      var protocol = ProtocolSource(
-        '''
+    test(
+      'Given a class with a field with the scope set to api, then the generated entity has the api scope.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
       class: Example
       table: example
       fields:
         name: String, api
       ''',
-        Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
-      );
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
 
-      var definition =
-          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-      SerializableEntityAnalyzer.validateYamlDefinition(
-        protocol.yaml,
-        protocol.yamlSourceUri.path,
-        collector,
-        definition,
-        [definition!],
-      );
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
 
-      expect((definition as ClassDefinition).fields.last.scope,
-          SerializableEntityFieldScope.api);
-    },
-  );
+        expect((definition as ClassDefinition).fields.last.scope,
+            SerializableEntityFieldScope.api);
+      },
+    );
+
+    test(
+      'Given a class with a field with the scope set to api and a parent table, then report an error that the parent keyword and api scope is not valid together.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+      class: Example
+      table: example
+      fields:
+        nextId: int, parent=example, api
+      ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(
+          collector.errors.length,
+          greaterThan(0),
+          reason: 'Expected an error, none was found.',
+        );
+        expect(
+          collector.errors.first.message,
+          'The "api" property is mutually exclusive with the "parent" property.',
+        );
+      },
+    );
+  });
 
   group('Test id field.', () {
     test(


### PR DESCRIPTION
# Fix

Do not allow the `api` keyword to be used together with the `parent` keyword.

Closes: https://github.com/serverpod/serverpod/issues/1091

Dependent on: https://github.com/serverpod/serverpod/pull/1083

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
