### PR TITLE
1090

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -139,7 +139,19 @@ class Restrictions {
     dynamic content,
     SourceSpan? span,
   ) {
-    if (content != null && !StringValidators.isValidTableIndexName(content)) {
+    if (content == null) return [];
+
+    if (documentDefinition is ClassDefinition &&
+        (documentDefinition as ClassDefinition).tableName == null) {
+      return [
+        SourceSpanException(
+          'The "table" property must be defined in the class to set a parent on a field.',
+          span,
+        )
+      ];
+    }
+
+    if (!StringValidators.isValidTableIndexName(content)) {
       return [
         SourceSpanException(
           'The parent must reference a valid table name (e.g. parent=table_name). "$content" is not a valid parent name.',

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -141,8 +141,8 @@ class Restrictions {
   ) {
     if (content == null) return [];
 
-    if (documentDefinition is ClassDefinition &&
-        (documentDefinition as ClassDefinition).tableName == null) {
+    var definition = documentDefinition;
+    if (definition is ClassDefinition && definition.tableName == null) {
       return [
         SourceSpanException(
           'The "table" property must be defined in the class to set a parent on a field.',

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -336,41 +336,6 @@ fields:
     });
 
     test(
-        'Given a class with a field with the parent keyword but without a value, then collect an error that the parent has to have a valid table name.',
-        () {
-      var collector = CodeGenerationCollector();
-      var protocol = ProtocolSource(
-        '''
-class: Example
-table: example
-fields:
-  nameId: int, parent=
-''',
-        Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
-      );
-
-      var definition =
-          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-      SerializableEntityAnalyzer.validateYamlDefinition(
-        protocol.yaml,
-        protocol.yamlSourceUri.path,
-        collector,
-        definition,
-        [definition!],
-      );
-
-      expect(collector.errors.length, greaterThan(0));
-
-      var error = collector.errors.first;
-
-      expect(
-        error.message,
-        'The parent must reference a valid table name (e.g. parent=table_name). "" is not a valid parent name.',
-      );
-    });
-
-    test(
         'Given a class with a field with the type String, then a class with that field type set to String is generated.',
         () {
       var collector = CodeGenerationCollector();
@@ -625,6 +590,41 @@ fields:
 
   group('Parent table tests', () {
     test(
+        'Given a class with a field with the parent keyword but without a value, then collect an error that the parent has to have a valid table name.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  nameId: int, parent=
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The parent must reference a valid table name (e.g. parent=table_name). "" is not a valid parent name.',
+      );
+    });
+
+    test(
       'Given a class with a field with a parent, then the generated entity has a parentTable property set to the parent table name.',
       () {
         var collector = CodeGenerationCollector();
@@ -633,7 +633,7 @@ fields:
         class: Example
         table: example
         fields:
-          parentId: int, parent=parent_table
+          parentId: int, parent=example
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
           ['lib', 'src', 'protocol'],
@@ -649,8 +649,8 @@ fields:
           [definition!],
         );
 
-        expect((definition as ClassDefinition).fields.last.parentTable,
-            'parent_table');
+        expect(
+            (definition as ClassDefinition).fields.last.parentTable, 'example');
       },
     );
 
@@ -685,6 +685,41 @@ fields:
 
         expect(error.message,
             'The field option "parent" is defined more than once.');
+      },
+    );
+
+    test(
+      'Given a class without a table definition but with a field with a parent, then collect an error that the table needs to be defined.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          parentId: int, parent=example
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(
+          error.message,
+          'The "table" property must be defined in the class to set a parent on a field.',
+        );
       },
     );
   });


### PR DESCRIPTION
# Fix
Do not allow the `parent` keyword to be used unless the class defines a `table`.

Gives an error on this example:
```yaml
class: Example
fields:
  parentId: int, parent=example
```

Closes: https://github.com/serverpod/serverpod/issues/1090

Depends on: https://github.com/serverpod/serverpod/pull/1083

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
