### PR TITLE
fix: Do not allow the id field to be used for classes that has a table defined.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -132,6 +132,17 @@ class Restrictions {
       ];
     }
 
+    if (documentDefinition is ClassDefinition &&
+        (documentDefinition as ClassDefinition).tableName != null &&
+        content == 'id') {
+      return [
+        SourceSpanException(
+          'The field name "id" is not allowed when a table is defined (the "id" field will be auto generated).',
+          span,
+        )
+      ];
+    }
+
     return [];
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -132,9 +132,8 @@ class Restrictions {
       ];
     }
 
-    if (documentDefinition is ClassDefinition &&
-        (documentDefinition as ClassDefinition).tableName != null &&
-        content == 'id') {
+    var def = documentDefinition;
+    if (content == 'id' && def is ClassDefinition && def.tableName != null) {
       return [
         SourceSpanException(
           'The field name "id" is not allowed when a table is defined (the "id" field will be auto generated).',

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -914,6 +914,40 @@ fields:
 
   group('Test id field.', () {
     test(
+      'Given a class with a table and a field called "id" defined, then collect an error that the id field is not allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          id: int
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0),
+            reason: 'Expected an error, but got none.');
+
+        expect(
+          collector.errors.first.message,
+          'The field name "id" is not allowed when a table is defined (the "id" field will be auto generated).',
+        );
+      },
+    );
+    test(
       'Given a class with a table defined, then add an id field to the generated entity.',
       () {
         var collector = CodeGenerationCollector();


### PR DESCRIPTION
# Fix
Changes the protocol validation to give an error if a field named `id` is present at the same time as a class has a table defined.

Closes: https://github.com/serverpod/serverpod/issues/1088

Depends on: https://github.com/serverpod/serverpod/pull/1083

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.