### PR TITLE
fix: Enforce index type to be one of the valid pgsql types.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -219,10 +219,12 @@ class Restrictions {
     dynamic content,
     SourceSpan? span,
   ) {
-    if (content is! String) {
+    var validIndexTypes = {'btree', 'hash', 'gin', 'gist', 'spgist', 'brin'};
+
+    if (content is! String || !validIndexTypes.contains(content)) {
       return [
         SourceSpanException(
-          'The "type" property must be of type String.',
+          'The "type" property must be one of: ${validIndexTypes.join(', ')}.',
           span,
         )
       ];

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
@@ -685,6 +685,236 @@ indexes:
     });
 
     test(
+        'Given a class with an index type explicitly set to hash, then use that type',
+        () {
+      var collector = CodeGenerationCollector();
+
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    type: hash
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      var index = definition.indexes?.first;
+
+      expect(index?.type, 'hash');
+    });
+
+    test(
+        'Given a class with an index type explicitly set to gist, then use that type',
+        () {
+      var collector = CodeGenerationCollector();
+
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    type: gist
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      var index = definition.indexes?.first;
+
+      expect(index?.type, 'gist');
+    });
+
+    test(
+        'Given a class with an index type explicitly set to spgist, then use that type',
+        () {
+      var collector = CodeGenerationCollector();
+
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    type: spgist
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      var index = definition.indexes?.first;
+
+      expect(index?.type, 'spgist');
+    });
+
+    test(
+        'Given a class with an index type explicitly set to gin, then use that type',
+        () {
+      var collector = CodeGenerationCollector();
+
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    type: gin
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      var index = definition.indexes?.first;
+
+      expect(index?.type, 'gin');
+    });
+
+    test(
+        'Given a class with an index type explicitly set to brin, then use that type',
+        () {
+      var collector = CodeGenerationCollector();
+
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    type: brin
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      var index = definition.indexes?.first;
+
+      expect(index?.type, 'brin');
+    });
+
+    test(
+        'Given a class with an index type explicitly set to an invalid type, then collect an error that only the defined index types can be used.',
+        () {
+      var collector = CodeGenerationCollector();
+
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name
+    type: invalid_pgsql_type
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+              as ClassDefinition;
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition],
+      );
+
+      expect(
+        collector.errors.length,
+        greaterThan(0),
+        reason: 'Expected an error, but none was collected.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The "type" property must be one of: btree, hash, gin, gist, spgist, brin.',
+      );
+    });
+
+    test(
         'Given a class with an index with an invalid type, then collect an error indicating that the type is invalid.',
         () {
       var collector = CodeGenerationCollector();
@@ -715,12 +945,17 @@ indexes:
         [definition!],
       );
 
-      expect(collector.errors.length, greaterThan(0));
+      expect(
+        collector.errors.length,
+        greaterThan(0),
+        reason: 'Expected an error, but none was collected.',
+      );
 
       var error = collector.errors.first;
-
-      // todo validate the explicit list of valid types
-      expect(error.message, 'The "type" property must be of type String.');
+      expect(
+        error.message,
+        'The "type" property must be one of: btree, hash, gin, gist, spgist, brin.',
+      );
     });
   });
 }


### PR DESCRIPTION
#Fix
Only allow the index types in the protocol to be one of: 'btree', 'hash', 'gin', 'gist', 'spgist', 'brin'.

Closes: https://github.com/serverpod/serverpod/issues/1089

Depends on: https://github.com/serverpod/serverpod/pull/1083

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
