### PR TITLE
fix: Require all enum values to be unique.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -244,8 +244,11 @@ class Restrictions {
       ];
     }
 
+    var enumCount = _countDuplicatesInList(content);
+
     var nodeExceptions = content.nodes.map((node) {
-      if (node is! YamlScalar || node.value is! String) {
+      var enumValue = node.value;
+      if (node is! YamlScalar || enumValue is! String) {
         return SourceSpanException(
           'The "values" property must be a list of strings.',
           node.span,
@@ -259,12 +262,27 @@ class Restrictions {
         );
       }
 
+      if (enumCount[enumValue] != 1) {
+        return SourceSpanException(
+          'Enum values must be unique.',
+          node.span,
+        );
+      }
+
       return null;
     });
 
-    return nodeExceptions
-        .where((node) => node != null)
-        .cast<SourceSpanException>()
-        .toList();
+    return nodeExceptions.whereType<SourceSpanException>().toList();
+  }
+
+  Map<dynamic, int> _countDuplicatesInList(YamlList list) {
+    Map<dynamic, int> valueCount = {};
+    for (var enumNode in list.nodes) {
+      var enumValue = enumNode.value;
+
+      valueCount.update(enumValue, (value) => value + 1, ifAbsent: () => 1);
+    }
+
+    return valueCount;
   }
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
@@ -170,6 +170,52 @@ values:
   });
 
   test(
+      'Given an enum with two duplicated entries, then collect an error that the enum values must be unique.',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol = ProtocolSource(
+      '''
+enum: ExampleEnum
+values:
+  - duplicated
+  - duplicated
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(1),
+      reason: 'Expected an error per duplicate value.',
+    );
+
+    var error1 = collector.errors.first;
+    var error2 = collector.errors.last;
+
+    expect(
+      error1.message,
+      'Enum values must be unique.',
+    );
+    expect(
+      error2.message,
+      'Enum values must be unique.',
+    );
+  });
+
+  test(
       'Given a valid enum with two values, then the enum definition should contain two values.',
       () {
     var protocol = ProtocolSource(


### PR DESCRIPTION
# Changes

Require all enum values to be unique.

With this PR, this is now an invalid protocol file:

```yaml
enum: ExampleEnum
values:
  - duplicated
  - duplicated
```

Closes: https://github.com/serverpod/serverpod/issues/1092

Depends on: https://github.com/serverpod/serverpod/pull/1083

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
