### PR TITLE
WIP: Move all exits into the bin file

### DIFF
--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -16,6 +16,8 @@ import 'package:serverpod_cli/src/generator/generator.dart';
 import 'package:serverpod_cli/src/internal_tools/analyze_pubspecs.dart';
 import 'package:serverpod_cli/src/internal_tools/generate_pubspecs.dart';
 import 'package:serverpod_cli/src/language_server/language_server.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/logger/loggers/std_out_logger.dart';
 import 'package:serverpod_cli/src/serverpod_packages_version_check/serverpod_packages_version_check.dart';
 import 'package:serverpod_cli/src/shared/environment.dart';
 import 'package:serverpod_cli/src/util/command_line_tools.dart';
@@ -39,6 +41,8 @@ final runModes = <String>['development', 'staging', 'production'];
 final Analytics _analytics = Analytics();
 
 void main(List<String> args) async {
+  logger = StdOutLogger();
+
   await runZonedGuarded(
     () async {
       try {
@@ -56,9 +60,9 @@ void main(List<String> args) async {
 
 Future<void> _main(List<String> args) async {
   if (Platform.isWindows) {
-    print(
-        'WARNING! Windows is not officially supported yet. Things may or may not work as expected.');
-    print('');
+    logger.printWarning(
+        'Windows is not officially supported yet. Things may or may not work '
+        'as expected.');
   }
 
   // Check that required tools are installed

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -398,7 +398,10 @@ Future<void> _main(List<String> args) async {
     // Analyze pubspecs command.
     if (results.command!.name == cmdAnalyzePubspecs) {
       bool checkLatestVersion = results.command!['check-latest-version'];
-      await performAnalyzePubspecs(checkLatestVersion);
+      if (!await pubspecDependenciesMatch(checkLatestVersion)) {
+        exit(1);
+      }
+
       return;
     }
   }

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -190,6 +190,11 @@ class GeneratorConfig {
       directory: Directory(dir),
       exludePackages: [serverPackage],
     );
+
+    if (automagicModules == null) {
+      return null;
+    }
+
     for (var autoModule in automagicModules) {
       bool hasOverride = false;
       for (var module in modules) {

--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -26,10 +26,10 @@ Future<void> performAnalyzePubspecs(bool checkLatestVersion) async {
     exit(1);
   }
 
-  var missmatchedDeps = _findMissmatchedDependencies(dependencies);
+  var mismatchedDeps = _findMismatchedDependencies(dependencies);
 
-  if (missmatchedDeps.isNotEmpty) {
-    _printMissmatchedDependencies(missmatchedDeps, dependencies);
+  if (mismatchedDeps.isNotEmpty) {
+    _printMismatchedDependencies(mismatchedDeps, dependencies);
     exit(1);
   }
 
@@ -69,10 +69,10 @@ Future<void> _checkLatestVersion(
   }
 }
 
-void _printMissmatchedDependencies(Set<String> missmatchedDeps,
+void _printMismatchedDependencies(Set<String> mismatchedDeps,
     Map<String, List<_ServerpodDependency>> dependencies) {
-  print('Found missmatched dependencies:');
-  for (var depName in missmatchedDeps) {
+  print('Found mismatched dependencies:');
+  for (var depName in mismatchedDeps) {
     print(depName);
     var deps = dependencies[depName]!;
     for (var dep in deps) {
@@ -81,21 +81,21 @@ void _printMissmatchedDependencies(Set<String> missmatchedDeps,
   }
 }
 
-Set<String> _findMissmatchedDependencies(
+Set<String> _findMismatchedDependencies(
   Map<String, List<_ServerpodDependency>> dependencies,
 ) {
-  var missmatchedDeps = <String>{};
+  var mismatchedDeps = <String>{};
   for (var depName in dependencies.keys) {
     var deps = dependencies[depName]!;
     String? version;
     for (var dep in deps) {
       if (version != null && version != dep.version) {
-        missmatchedDeps.add(depName);
+        mismatchedDeps.add(depName);
       }
       version = dep.version;
     }
   }
-  return missmatchedDeps;
+  return mismatchedDeps;
 }
 
 Map<String, List<_ServerpodDependency>> _getDependencies(

--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -7,11 +7,11 @@ import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 
 /// The internal tool for analyzing the pubspec.yaml files in the Serverpod
 /// repo.
-Future<void> performAnalyzePubspecs(bool checkLatestVersion) async {
+Future<bool> pubspecDependenciesMatch(bool checkLatestVersion) async {
   var directory = Directory.current;
   if (!isServerpodRootDirectory(directory)) {
     print('Must be run from the serverpod repository root');
-    exit(1);
+    return false;
   }
 
   var pubspecFiles = findPubspecsFiles(directory,
@@ -23,14 +23,14 @@ Future<void> performAnalyzePubspecs(bool checkLatestVersion) async {
   } catch (e) {
     print('Failed to get dependencies');
     print(e);
-    exit(1);
+    return false;
   }
 
   var mismatchedDeps = _findMismatchedDependencies(dependencies);
 
   if (mismatchedDeps.isNotEmpty) {
     _printMismatchedDependencies(mismatchedDeps, dependencies);
-    exit(1);
+    return false;
   }
 
   print('Dependencies match.');
@@ -38,6 +38,8 @@ Future<void> performAnalyzePubspecs(bool checkLatestVersion) async {
   if (checkLatestVersion) {
     await _checkLatestVersion(dependencies);
   }
+
+  return true;
 }
 
 Future<void> _checkLatestVersion(

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -1,0 +1,35 @@
+/// Serverpods internal logger interface.
+/// All logging output should go through this interface.
+/// The purpose is to simplify implementing and switching out concrete logger
+/// implementations.
+abstract class Logger {
+  /// Display a [message] wrapped in a box.
+  /// Commands should use this when they want to highlight a message that otherwise is easily missed.
+  void printBox(String message);
+
+  /// Display debug information to the user.
+  /// Commands should use this for information that can is important for
+  /// debugging.
+  void printDebug(String message);
+
+  /// Display an error [message] to the user.
+  /// Commands should use this if they want to inform a user that an error
+  /// has occurred.
+  void printError(String message, {StackTrace? stackTrace});
+
+  /// Display normal information to the user.
+  /// Command should use this whenever they want to communicate normal output
+  /// such as success or progress messages.
+  void printInfo(String message);
+
+  /// Display a warning to the user.
+  /// Commands should use this if they have important but not critical
+  /// information for the user.
+  void printWarning(String message);
+
+  /// Returns a [Future] that completes once all logging is complete.
+  Future<void> flush();
+}
+
+/// Singleton accessor for the logger.
+late final Logger logger;

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/util/print.dart';
+
+class StdOutLogger extends Logger {
+  @override
+  void printBox(String message) {
+    // TODO: Implement a pretty box print for stdout
+    printww(message);
+  }
+
+  @override
+  void printDebug(String message) {
+    printww('DEBUG: $message');
+  }
+
+  @override
+  void printError(String message, {StackTrace? stackTrace}) {
+    stderr.write('ERROR: $message');
+    if (stackTrace != null) {
+      stderr.write(stackTrace);
+    }
+  }
+
+  @override
+  void printInfo(String message) {
+    printww(message);
+  }
+
+  @override
+  void printWarning(String message) {
+    stderr.write('WARNING: $message');
+  }
+
+  @override
+  Future<void> flush() async {
+    await stderr.flush();
+    await stdout.flush();
+  }
+}

--- a/tools/serverpod_cli/lib/src/util/internal_error.dart
+++ b/tools/serverpod_cli/lib/src/util/internal_error.dart
@@ -1,12 +1,16 @@
-import 'print.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
 
 void printInternalError(dynamic error, StackTrace stackTrace) {
-  printww(
-    'Yikes! It is possible that this error is caused by an internal issue with '
-    'the Serverpod tooling. We would appreciate if you filed an issue over at Github. Please include the stack trace below and describe any steps you did to trigger the error.',
-  );
-  print('https://github.com/serverpod/serverpod/issues');
-  print(error);
-  print(stackTrace);
-  print('');
+  logger.printError(
+      'Yikes! It is possible that this error is caused by an'
+      ' internal issue with the Serverpod tooling. We would appreciate if you '
+      'filed an issue over at Github. Please include the stack trace below and '
+      'describe any steps you did to trigger the error.'
+      '''
+
+https://github.com/serverpod/serverpod/issues
+
+$error
+''',
+      stackTrace: stackTrace);
 }

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -7,7 +7,7 @@ import 'package:yaml/yaml.dart';
 
 const _serverSuffix = '_server';
 
-Future<List<ModuleConfig>> locateModules({
+Future<List<ModuleConfig>?> locateModules({
   required Directory directory,
   List<String> exludePackages = const [],
 }) async {
@@ -62,7 +62,7 @@ Future<List<ModuleConfig>> locateModules({
       'Failed to read your server\'s package configuration. Have you run '
       '`dart pub get` in your server directory?',
     );
-    exit(1);
+    return null;
   }
 }
 


### PR DESCRIPTION
Related to issue: https://github.com/serverpod/serverpod/issues/1042
This work depends on https://github.com/serverpod/serverpod/pull/1106.

By moving all exits into the top level bin file we can an easier control flow of the program and can more centrally control what should happen if we exit.

This work can not be completed until a new version of the LSP server has been published. the close method for the listener is required for the last exit to be moved up.

### Guidance for review
Please pay extra attention to the changes in locate_modules. I checked the implications of this for the GeneratorConfigs `load(...)` method and deemed that this change was possible. But please take an extra look there.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).
