### PR TITLE
fix: Add an entity relation resolver to the analyzer

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -184,7 +184,7 @@ class SerializableEntityAnalyzer {
       documentType: definitionType,
       documentContents: documentContents,
       documentDefinition: entity,
-      // Todo: move instance creation of EntityRelations to StatefulAnalyzer
+      // TODO: move instance creation of EntityRelations to StatefulAnalyzer
       // to resolve n-squared time complexity.
       entityRelations: entities != null ? EntityRelations(entities) : null,
     );

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -184,7 +184,7 @@ class SerializableEntityAnalyzer {
       documentType: definitionType,
       documentContents: documentContents,
       documentDefinition: entity,
-      // Todo: move instance creation of EntityRelations to StatefulAnalyzer 
+      // Todo: move instance creation of EntityRelations to StatefulAnalyzer
       // to resolve n-squared time complexity.
       entityRelations: entities != null ? EntityRelations(entities) : null,
     );

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/analyzer/entities/validation/entity_relations.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/protocol_validator.dart';
@@ -183,7 +184,9 @@ class SerializableEntityAnalyzer {
       documentType: definitionType,
       documentContents: documentContents,
       documentDefinition: entity,
-      protocolEntities: entities,
+      // Todo: move instance creation of EntityRelations to StatefulAnalyzer 
+      // to resolve n-squared time complexity.
+      entityRelations: entities != null ? EntityRelations(entities) : null,
     );
 
     Set<ValidateNode> documentStructure;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
@@ -1,0 +1,75 @@
+
+
+
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+
+/// A collection of all parsed entities, and their potential collisions.
+class EntityRelations {
+  final List<SerializableEntityDefinition> entities;
+  late final Map<String, List<SerializableEntityDefinition>> classNames;
+  late final Map<String, List<SerializableEntityDefinition>> tableNames;
+  late final Map<String, List<SerializableEntityDefinition>> indexNames;
+
+  EntityRelations(this.entities) {
+    classNames = _createClassNameMap(entities);
+    tableNames = _createTableNameMap(entities);
+    indexNames = _createIndexNameMap(entities);
+  }
+
+  Map<String, List<SerializableEntityDefinition>> _createTableNameMap(
+    List<SerializableEntityDefinition> entities,
+  ) {
+    Map<String, List<SerializableEntityDefinition>> tableNames = {};
+    for (var entity in entities) {
+      if (entity is ClassDefinition) {
+        var tableName = entity.tableName;
+        if (tableName == null) continue;
+
+        tableNames.update(
+          tableName,
+          (value) => value..add(entity),
+          ifAbsent: () => [entity],
+        );
+      }
+    }
+
+    return tableNames;
+  }
+
+  Map<String, List<SerializableEntityDefinition>> _createClassNameMap(
+    List<SerializableEntityDefinition> entities,
+  ) {
+    Map<String, List<SerializableEntityDefinition>> classNames = {};
+    for (var entity in entities) {
+      classNames.update(
+        entity.className,
+        (value) => value..add(entity),
+        ifAbsent: () => [entity],
+      );
+    }
+
+    return classNames;
+  }
+
+  Map<String, List<SerializableEntityDefinition>> _createIndexNameMap(
+    List<SerializableEntityDefinition> entities,
+  ) {
+    Map<String, List<SerializableEntityDefinition>> indexNames = {};
+    for (var entity in entities) {
+      if (entity is ClassDefinition) {
+        var indexes = entity.indexes;
+        if (indexes == null) continue;
+
+        for (var index in indexes) {
+          indexNames.update(
+            index.name,
+            (value) => value..add(entity),
+            ifAbsent: () => [entity],
+          );
+        }
+      }
+    }
+
+    return indexNames;
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
@@ -1,6 +1,3 @@
-
-
-
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 
 /// A collection of all parsed entities, and their potential collisions.

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -5,17 +5,19 @@ import 'package:yaml/yaml.dart';
 
 import 'package:serverpod_cli/src/analyzer/entities/converter/converter.dart';
 
+import 'entity_relations.dart';
+
 class Restrictions {
   String documentType;
   YamlMap documentContents;
   SerializableEntityDefinition? documentDefinition;
-  List<SerializableEntityDefinition>? protocolEntities;
+  EntityRelations? entityRelations;
 
   Restrictions({
     required this.documentType,
     required this.documentContents,
     this.documentDefinition,
-    this.protocolEntities,
+    this.entityRelations,
   });
 
   List<SourceSpanException> validateClassName(
@@ -41,7 +43,7 @@ class Restrictions {
     }
 
     // TODO n-squared time complexity when validating all protocol files.
-    if (_countClassNames(content, protocolEntities) > 1) {
+    if (_countClassNames(content, entityRelations?.entities) > 1) {
       return [
         SourceSpanException(
           'The $documentType name "$content" is already used by another protocol class.',


### PR DESCRIPTION
# Adds

A new object to keep track of relationships and collisions of keywords in protocol files. The goal is to make it easier to implement additional checks that depends on other protocol files. Right now instantiating this object means we have an n-squared time complexity, I want to move the instantiation of it to the outside so we only have to do it once for each full pass. However to do that I have to change the function declaration and with that break all tests, therefor ill complete that step in a subsequent PR.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
