### PR TITLE
fix: Do not report errors for module datatypes in fields.

### DIFF
--- a/tools/serverpod_cli/lib/src/util/string_validators.dart
+++ b/tools/serverpod_cli/lib/src/util/string_validators.dart
@@ -13,7 +13,7 @@ class StringValidators {
       _camelCaseTester.hasMatch(name) || _snakeCaseTester.hasMatch(name);
 
   static bool isValidFieldType(String type) =>
-      RegExp(r'^([a-zA-Z_][a-zA-Z0-9_]*\??)$').hasMatch(type);
+      RegExp(r'^([a-zA-Z_:][a-zA-Z0-9_:]*\??)$').hasMatch(type);
 
   static bool isValidClassName(String name) =>
       _pascalCaseWithUppercaseTester.hasMatch(name);

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -704,6 +704,39 @@ fields:
     });
 
     test(
+        'Given a class with a complex nested field datatype, then a class with that field type is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: module:auth:UserInfo
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'module:auth:UserInfo');
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
+    });
+
+    test(
         'Given a class with a field with an invalid dart syntax for the type, then collect an error that the type is invalid.',
         () {
       var collector = CodeGenerationCollector();


### PR DESCRIPTION
# Fix
Previously we reported errors for datatypes referencing a module.

I.E:

```yaml
class: Example
fields:
  user: module:auth:UserInfo
```

This PR removes this error.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

