### PR TITLE
fix: Report an error if an index name is not globally unique.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -118,14 +118,24 @@ class Restrictions {
   }
 
   List<SourceSpanException> validateTableIndexName(
-    dynamic content,
+    dynamic indexName,
     SourceSpan? span,
   ) {
-    if (content is! String ||
-        !StringValidators.isValidTableIndexName(content)) {
+    if (indexName is! String ||
+        !StringValidators.isValidTableIndexName(indexName)) {
       return [
         SourceSpanException(
-          'Invalid format for index "$content", must follow the format lower_snake_case.',
+          'Invalid format for index "$indexName", must follow the format lower_snake_case.',
+          span,
+        )
+      ];
+    }
+    var indexNames = entityRelations?.indexNames;
+    if (indexNames != null && !_isKeyGloballyUnique(indexName, indexNames)) {
+      var collision = _findFirstClassOtherClass(indexName, indexNames);
+      return [
+        SourceSpanException(
+          'The index name "$indexName" is already used by the protocol class "${collision?.className}".',
           span,
         )
       ];


### PR DESCRIPTION
# Changes:

Reports an error if the index name in a class protocol is not globally unique.

Example:

```yaml
# example.yaml
class: Example
table: example
fields:
  name: String
indexes:
  example_index:
    fields: name

# example2.yaml
class: example2
table: example2
fields:
  name: String
indexes:
  example_index:
    fields: name
```

Then an error that the index name "example_index" is used multiple times is generated.


Closes: #1082 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
