### PR TITLE
fix: Exclude Serverpod when placed in vendor folder from serverpod package version check

### DIFF
--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:pub_api_client/pub_api_client.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:serverpod_cli/src/util/directory.dart';
@@ -15,7 +16,7 @@ Future<void> performAnalyzePubspecs(bool checkLatestVersion) async {
   }
 
   var pubspecFiles = findPubspecsFiles(directory,
-      ignorePaths: ['/templates/pubspecs/', '/test_assets/']);
+      ignorePaths: [p.join('templates', 'pubspecs'), 'test_assets']);
 
   Map<String, List<_ServerpodDependency>> dependencies;
   try {

--- a/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
+++ b/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
@@ -26,7 +26,7 @@ List<SourceSpanException> performServerpodPackagesAndCliVersionCheck(
 
   var pubspecFiles = findPubspecsFiles(
     directory,
-    ignorePaths: ['vendor/serverpod'],
+    ignorePaths: ['vendor', 'serverpod'],
   );
   if (pubspecFiles.isEmpty) {
     return accumulatedWarnings;

--- a/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
+++ b/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
@@ -24,7 +24,10 @@ List<SourceSpanException> performServerpodPackagesAndCliVersionCheck(
 ) {
   List<SourceSpanException> accumulatedWarnings = [];
 
-  var pubspecFiles = findPubspecsFiles(directory);
+  var pubspecFiles = findPubspecsFiles(
+    directory,
+    ignorePaths: ['vendor/serverpod'],
+  );
   if (pubspecFiles.isEmpty) {
     return accumulatedWarnings;
   }

--- a/tools/serverpod_cli/lib/src/util/pubspec_helpers.dart
+++ b/tools/serverpod_cli/lib/src/util/pubspec_helpers.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:path/path.dart';
+import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
 Pubspec parsePubspec(File pubspecFile) {
@@ -18,9 +18,9 @@ List<File> findPubspecsFiles(Directory dir,
     {List<String> ignorePaths = const []}) {
   var pubspecFiles = <File>[];
   for (var file in dir.listSync(recursive: true)) {
-    if (_shouldBeIgnored(file.path, ignorePaths)) continue;
+    if (shouldBeIgnored(file.path, ignorePaths)) continue;
 
-    if (file is File && basename(file.path) == 'pubspec.yaml') {
+    if (file is File && p.basename(file.path) == 'pubspec.yaml') {
       pubspecFiles.add(file);
     }
   }
@@ -28,9 +28,12 @@ List<File> findPubspecsFiles(Directory dir,
   return pubspecFiles;
 }
 
-bool _shouldBeIgnored(String path, List<String> ignorePaths) {
+bool shouldBeIgnored(String filePath, List<String> ignorePaths) {
   for (var ignorePath in ignorePaths) {
-    if (path.contains(ignorePath)) {
+    // Add separator for file system to exclude partial matches.
+    var ignorePathAsFolder = ignorePath + p.separator;
+
+    if (filePath.contains(ignorePathAsFolder)) {
       return true;
     }
   }

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -220,5 +220,20 @@ void main() {
         expect(packageWarnings.isEmpty, isTrue);
       });
     });
+
+    group('With approximate serverpod package version in vendor folder', () {
+      var vendorPubspecPath = Directory(p.join(testAssetsPath, 'vendor'));
+
+      test('performServerpodPackagesAndCliVersionCheck() with same version',
+          () {
+        var cliVersion = Version(1, 1, 0);
+        var packageWarnings = performServerpodPackagesAndCliVersionCheck(
+          cliVersion,
+          vendorPubspecPath,
+        );
+
+        expect(packageWarnings.isEmpty, isTrue);
+      });
+    });
   });
 }

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/vendor/serverpod/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/vendor/serverpod/pubspec.yaml
@@ -1,0 +1,13 @@
+# Test asset
+publish_to: none
+
+name: serverpod_cli
+version: 1.1.0
+description: Command line tools for Serverpod.
+repository: https://github.com/serverpod/serverpod
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  serverpod_shared: ^1.1.0

--- a/tools/serverpod_cli/test/util/pubspec_helpers_test.dart
+++ b/tools/serverpod_cli/test/util/pubspec_helpers_test.dart
@@ -24,4 +24,53 @@ void main() {
       expect(files.length, equals(0));
     });
   });
+
+  group('shouldBeIgnored', () {
+    test('should return true when path is within an ignorePath', () {
+      var ignorePaths = [p.join('path', 'subdirectory')];
+      var path = p.join('ignore', 'path', 'subdirectory', 'file.txt');
+
+      var result = shouldBeIgnored(path, ignorePaths);
+
+      expect(result, isTrue);
+    });
+
+    test('should return true when folder is within an ignorePath but not root',
+        () {
+      var ignorePaths = ['path'];
+      var path = p.join('ignore', 'path', 'subdirectory', 'file.txt');
+
+      var result = shouldBeIgnored(path, ignorePaths);
+
+      expect(result, isTrue);
+    });
+
+    test('should return false when path is not within any ignorePath', () {
+      var ignorePaths = [p.join('ignore', 'path')];
+      var path = p.join('another', 'path', 'subdirectory', 'file.txt');
+
+      var result = shouldBeIgnored(path, ignorePaths);
+
+      expect(result, isFalse);
+    });
+
+    test('should return false when ignorePaths is empty', () {
+      List<String> ignorePaths = [];
+      var path = p.join('any', 'path', 'subdirectory', 'file.txt');
+
+      var result = shouldBeIgnored(path, ignorePaths);
+
+      expect(result, isFalse);
+    });
+
+    test('should return false when ignorePaths is part of folder name in path',
+        () {
+      List<String> ignorePaths = ['part'];
+      var path = p.join('any', 'path', 'part_of', 'subdirectory', 'file.txt');
+
+      var result = shouldBeIgnored(path, ignorePaths);
+
+      expect(result, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Issue: https://github.com/serverpod/serverpod/issues/1079

Excludes any Serverpod or vendor folder that is placed next to the Serverpod server folder from the Serverpod package version check.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).