### PR TITLE
fix: Report an error if the referenced parent table does not exist.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -172,6 +172,16 @@ class Restrictions {
       ];
     }
 
+    var relations = entityRelations;
+    if (relations != null && !relations.tableNames.containsKey(content)) {
+      return [
+        SourceSpanException(
+          'The parent table "$content" was not found in any protocol.',
+          span,
+        )
+      ];
+    }
+
     return [];
   }
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -834,6 +834,39 @@ fields:
     );
 
     test(
+      'Given a class with a field with a parent that do not exist, then collect an error that the parent table is not found.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          name: String, parent=unknown_table
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(error.message, 'The parent table "unknown_table" was not found in any protocol.');
+      },
+    );
+
+    test(
       'Given a class with a field with two parent keywords, then collect an error that only one parent is allowed.',
       () {
         var collector = CodeGenerationCollector();
@@ -842,7 +875,7 @@ fields:
         class: Example
         table: example
         fields:
-          name: String, parent=my_table, parent=second
+          parentId: int, parent=example, parent=example
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
           ['lib', 'src', 'protocol'],

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -862,7 +862,8 @@ fields:
 
         var error = collector.errors.first;
 
-        expect(error.message, 'The parent table "unknown_table" was not found in any protocol.');
+        expect(error.message,
+            'The parent table "unknown_table" was not found in any protocol.');
       },
     );
 


### PR DESCRIPTION
# Add

Validates that the referenced parent table exists in this OR another protocol class, if not reports an error.

Example:

```yaml
class: Example
table: example
fields:
  parentId: int, parent=unknown_parent
```

Will report an error for `unknown_parent`.

Closese: https://github.com/serverpod/serverpod/issues/1085

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
