### PR TITLE
fix: Report an error if a field is referenced twice in the same index.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -231,13 +231,23 @@ class Restrictions {
         .where((field) => field.scope != SerializableEntityFieldScope.api)
         .fold(<String>{}, (output, field) => output..add(field.name));
 
-    return indexFields
+    var missingFieldErrors = indexFields
         .where((field) => !validDatabaseFieldNames.contains(field))
         .map((field) => SourceSpanException(
               'The field name "$field" is not added to the class or has an api scope.',
               span,
-            ))
-        .toList();
+            ));
+
+    var duplicatesCount = _duplicatesCount(indexFields);
+
+    var duplicateFieldErrors = duplicatesCount.entries
+        .where((entry) => entry.value > 1)
+        .map((entry) => SourceSpanException(
+              'Duplicated field name "name", can only reference a field once per index.',
+              span,
+            ));
+
+    return [...missingFieldErrors, ...duplicateFieldErrors];
   }
 
   List<SourceSpanException> validateIndexType(
@@ -271,7 +281,7 @@ class Restrictions {
       ];
     }
 
-    var enumCount = _countDuplicatesInList(content);
+    var enumCount = _duplicatesCount(content);
 
     var nodeExceptions = content.nodes.map((node) {
       var enumValue = node.value;
@@ -302,12 +312,10 @@ class Restrictions {
     return nodeExceptions.whereType<SourceSpanException>().toList();
   }
 
-  Map<dynamic, int> _countDuplicatesInList(YamlList list) {
+  Map<dynamic, int> _duplicatesCount(List<dynamic> list) {
     Map<dynamic, int> valueCount = {};
-    for (var enumNode in list.nodes) {
-      var enumValue = enumNode.value;
-
-      valueCount.update(enumValue, (value) => value + 1, ifAbsent: () => 1);
+    for (var listValue in list) {
+      valueCount.update(listValue, (value) => value + 1, ifAbsent: () => 1);
     }
 
     return valueCount;

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
@@ -240,6 +240,50 @@ indexes:
   );
 
   test(
+    'Given a class with an index with two duplicated fields, then collect an error that duplicated fields are not allowed.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  name: String
+indexes:
+  example_index:
+    fields: name, name
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        collector.errors.length,
+        greaterThan(0),
+        reason: 'Expected an error.',
+      );
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'Duplicated field name "name", can only reference a field once per index.',
+      );
+    },
+  );
+
+  test(
     'Given a class with an index with a field that has an api scope, then collect an error that the field is missing in the class.',
     () {
       var collector = CodeGenerationCollector();
@@ -435,7 +479,6 @@ indexes:
     },
   );
 
-  // todo convert!!
   test(
       'Given a class with an index with a unique key that is not a bool, then collect an error that the unique key has to be defined as a bool.',
       () {


### PR DESCRIPTION
# Add

Restrict the field list of an index to only contain unique values.

Example:
```yaml
class: Note
table: note
fields:
  name: String
indexes:
  index_format:
    fields: name, name
    unique: true
```

This will give an error on both the index fields called `name`.

Closese: https://github.com/serverpod/serverpod/issues/1084

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

