### PR TITLE
Fix typo in signin_button.dart

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
@@ -19,7 +19,7 @@ class SignInWithEmailButton extends StatefulWidget {
   /// The icon of the button.
   final Icon? icon;
 
-  /// Minimum allowed password length.
+  /// Maximum allowed password length.
   /// Defaults to 128.
   /// If this value is modified, the server must be updated to match.
   final int? maxPasswordLength;


### PR DESCRIPTION
Corrects wrong wording in a comment for the `maxPasswordLength` in `siginin_button.dart`.

Fixes this Issue: #1102

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] All existing and new tests are passing.
