### PR TITLE
fix: Allow complex types to be nullable.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -199,10 +199,10 @@ class Restrictions {
   }
 
   List<SourceSpanException> validateFieldDataType(
-    dynamic content,
+    dynamic type,
     SourceSpan? span,
   ) {
-    if (content is! String) {
+    if (type is! String) {
       return [
         SourceSpanException(
           'The field must have a datatype defined (e.g. field: String).',
@@ -211,18 +211,10 @@ class Restrictions {
       ];
     }
 
-    var typeComponents = content
-        .replaceAll(' ', '')
-        .replaceAll('<', ',')
-        .replaceAll('>', ',')
-        .split(',')
-        .where((t) => t.isNotEmpty);
-
-    if (typeComponents
-        .any((type) => !StringValidators.isValidFieldType(type))) {
+    if (!_isValidFieldType(type)) {
       return [
         SourceSpanException(
-          'The field has an invalid datatype "$content".',
+          'The field has an invalid datatype "$type".',
           span,
         )
       ];
@@ -342,6 +334,25 @@ class Restrictions {
     }
 
     return valueCount;
+  }
+
+  bool _isValidFieldType(String type) {
+    var typeComponents = type
+        .replaceAll('?', '')
+        .replaceAll(' ', '')
+        .replaceAll('<', ',')
+        .replaceAll('>', ',')
+        .split(',')
+        .where((t) => t.isNotEmpty);
+
+    if (typeComponents.isEmpty) return false;
+
+    // Checks if the type has several ??? in a row.
+    if (RegExp(r'\?{2,}').hasMatch(type)) return false;
+
+    return typeComponents.any(
+      (type) => StringValidators.isValidFieldType(type),
+    );
   }
 
   bool _isKeyGloballyUnique(

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -605,6 +605,158 @@ fields:
     });
 
     test(
+        'Given a class with a field with the nullable type List<String>, then a class with that field type set to List<String>? is generated.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: List<String>?
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'List<String>?');
+      expect(
+        definition.fields.first.type.nullable,
+        true,
+        reason: 'Expected the type to be nullable.',
+      );
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
+    });
+
+    test(
+        'Given a class with a field with a nested nullable type, then a class with that field type set.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: List<String?>?
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect((definition as ClassDefinition).fields.first.type.toString(),
+          'List<String?>?');
+      expect(
+        definition.fields.first.type.nullable,
+        true,
+        reason: 'Expected the type to be nullable.',
+      );
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but found some.',
+      );
+    });
+
+    test(
+        'Given a class with a field with a only ??? as the type, then collect an error that it is an invalid type.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: ???
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        collector.errors.length,
+        greaterThan(0),
+        reason: 'Expected an error, but none was found.',
+      );
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The field has an invalid datatype "???".',
+      );
+    });
+
+    test(
+        'Given a class with a field with a type of String???, then collect an error that it is an invalid type.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  name: String???
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        collector.errors.length,
+        greaterThan(0),
+        reason: 'Expected an error, but none was found.',
+      );
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The field has an invalid datatype "String???".',
+      );
+    });
+
+    test(
         'Given a class with a field with the type List, then a class with that field type is generated.',
         () {
       var collector = CodeGenerationCollector();


### PR DESCRIPTION
# Fix

Allow complex nullable types in protocol fields. 

Example:

```yaml
class: Example
fields:
  content: List<String?>?
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

