### PR TITLE
fix: Convert relative path to absolute, resolve crash in vscode debugger.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -73,7 +73,7 @@ class EndpointsAnalyzer {
       for (var context in collection.contexts) {
         for (var changedFile in changedFiles) {
           var file = File(changedFile);
-          context.changeFile(file.absolute.path);
+          context.changeFile(p.normalize(file.absolute.path));
         }
         await context.applyPendingFileChanges();
       }


### PR DESCRIPTION
# Fix

Resolve crash when using serverpod generate from relative folder in VSCode debug launcher.

Closes: https://github.com/serverpod/serverpod/issues/1130

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
