### PR TITLE
fix: Parse the source location for all comma seperated values in field string.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
@@ -19,30 +21,32 @@ YamlMap convertStringifiedNestedNodesToYamlMap(
 
   var initRawValue = options.isNotEmpty ? options.first : null;
 
-  var fieldKeyValuePairs = _extractKeyValuePairs(options.skip(1));
+  var fieldKeyValuePairs = _extractKeyValuePairs(
+    options.skip(1),
+    content,
+    contentNode.span,
+  );
 
   var duplicates = _findDuplicateKeys(fieldKeyValuePairs);
   for (var duplicate in duplicates) {
-    onDuplicateKey?.call(duplicate, contentNode.span);
+    onDuplicateKey?.call(
+      duplicate,
+      _extractSubSpan(content, contentNode.span, duplicate),
+    );
   }
 
   Map<dynamic, YamlNode> initNodes = _createdYamlNode(
     node.nested.first.key,
     initRawValue,
-    contentNode.span,
+    _extractSubSpan(content, contentNode.span, initRawValue),
   );
 
   Map<dynamic, YamlNode> internalNodes =
       fieldKeyValuePairs.fold(initNodes, (aggregate, pair) {
-    var node = _createdYamlNode(
-      pair.key,
-      pair.value,
-      contentNode.span,
-    );
-    return {...aggregate, ...node};
+    return {...aggregate, ...pair};
   });
 
-  // deepEqialsMap is needed to be able to compare YamlScala as keys
+  // deepEqualsMap is needed to be able to compare YamlScala as keys
   var nodes = deepEqualsMap<dynamic, YamlNode>();
   nodes.addAll(internalNodes);
 
@@ -56,43 +60,84 @@ List<String> _extractOptions(String? input) {
   return input.split(RegExp(r',(?![^<]*>)')).map((e) => e.trim()).toList();
 }
 
-Iterable<MapEntry<String, dynamic>> _extractKeyValuePairs(
+Iterable<Map<YamlScalar, YamlNode>> _extractKeyValuePairs(
   Iterable<String> fieldOptions,
+  String? content,
+  SourceSpan span,
 ) {
+  if (content == null) return [];
+
   var fieldPairs = fieldOptions.map((stringifiedKeyValuePair) {
     var keyValuePair = stringifiedKeyValuePair.split('=');
 
     var key = keyValuePair.first;
     var value = keyValuePair.length == 2 ? keyValuePair.last : null;
 
-    return MapEntry(key, value);
+    var keyValueSpan = _extractSubSpan(content, span, stringifiedKeyValuePair);
+
+    return _createdYamlNode(
+      key,
+      value,
+      keyValueSpan,
+    );
   });
 
   return fieldPairs;
 }
 
-Set<String> _findDuplicateKeys(Iterable<MapEntry<String, dynamic>> list) {
+SourceSpan _extractSubSpan(
+  String? content,
+  SourceSpan contentSpan,
+  String? subContent,
+) {
+  if (content == null) return contentSpan;
+  if (subContent == null) return contentSpan;
+
+  var start = _findStartIndex(content, subContent);
+  if (start == -1) return contentSpan;
+
+  var end = start + subContent.length;
+  return contentSpan.subspan(start, end);
+}
+
+int _findStartIndex(String fullString, String subString) {
+  if (subString == '') return fullString.length;
+  return fullString.lastIndexOf(subString);
+}
+
+Set<String> _findDuplicateKeys(Iterable<Map<YamlScalar, dynamic>> list) {
   var seenStrings = <String>{};
   var duplicates = <String>{};
 
   for (var pair in list) {
-    if (seenStrings.contains(pair.key)) {
-      duplicates.add(pair.key);
+    var v = pair.entries.first;
+    if (seenStrings.contains(v.key.value)) {
+      duplicates.add(v.key.value);
     } else {
-      seenStrings.add(pair.key);
+      seenStrings.add(v.key.value);
     }
   }
 
   return duplicates;
 }
 
-Map<dynamic, YamlNode> _createdYamlNode(
+Map<YamlScalar, YamlNode> _createdYamlNode(
   String rawKey,
   dynamic rawValue,
   SourceSpan span,
 ) {
-  var key = YamlScalar.internalWithSpan(rawKey, span);
-  var value = YamlScalar.internalWithSpan(rawValue, span);
+  var fullSpanLength = span.length;
+
+  var keySpanEnd = min(rawKey.length, fullSpanLength);
+
+  var keySpan = span.subspan(0, keySpanEnd);
+  var key = YamlScalar.internalWithSpan(rawKey, keySpan);
+
+  var valueLength = rawValue?.toString().length ?? 0;
+  var valueSpanStart = fullSpanLength - valueLength;
+
+  var valueSpan = span.subspan(valueSpanStart);
+  var value = YamlScalar.internalWithSpan(rawValue, valueSpan);
 
   return {key: value};
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -42,7 +42,7 @@ List<SourceSpanException> validateTopLevelEntityType(
   return errors;
 }
 
-/// Recursivly validates a yaml document against a set of [ValidateNode]s.
+/// Recursively validates a yaml document against a set of [ValidateNode]s.
 /// The [documentType] represents the parent key of the [documentContents],
 /// in the initial processing this is expected to be the top level entity type
 /// we are checking. E.g. 'class', 'enum', 'exception', etc.

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -141,7 +141,7 @@ void _collectMutuallyExclusiveKeyErrors(
       if (documentContents.containsKey(mutuallyExclusiveKey)) {
         collector.addError(SourceSpanException(
           'The "${node.key}" property is mutually exclusive with the "$mutuallyExclusiveKey" property.',
-          documentContents.nodes[node.key]?.span,
+          documentContents.key(node.key)?.span,
         ));
       }
     }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_source_location_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_source_location_test.dart
@@ -1,0 +1,324 @@
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Source location in field values.', () {
+    test(
+        'Given a class with a field with an invalid key, then collect an error that locates the invalid key in the comma separated string.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  nameId: int, invalid
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(error.span, isNotNull,
+          reason: 'Expected error to have a source span.');
+
+      var startSpan = error.span!.start;
+      expect(startSpan.line, 2);
+      expect(startSpan.column, 15);
+
+      var endSpan = error.span!.end;
+      expect(endSpan.line, 2);
+      expect(endSpan.column, 22);
+    });
+    test(
+        'Given a class with a field with the parent keyword but without a value, then collect an error that locates the parent keyword in the comma separated string.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  nameId: int, parent=
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(error.span, isNotNull,
+          reason: 'Expected error to have a source span.');
+
+      var startSpan = error.span!.start;
+      expect(
+        startSpan.line,
+        3,
+        reason: 'Expected the start line to match.',
+      );
+      expect(
+        startSpan.column,
+        22,
+        reason: 'Expected the start column to match.',
+      );
+
+      var endSpan = error.span!.end;
+      expect(
+        endSpan.line,
+        3,
+        reason: 'Expected the end line to match.',
+      );
+      expect(
+        endSpan.column,
+        22,
+        reason: 'Expected the end column to match.',
+      );
+    });
+
+    test(
+        'Given a class with a field with the parent keyword with an invalid table name, then collect an error that locates the value in the comma separated string.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  nameId: int, parent=InvalidName_
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(
+        error.span,
+        isNotNull,
+        reason: 'Expected error to have a source span.',
+      );
+
+      var startSpan = error.span!.start;
+      expect(startSpan.line, 3);
+      expect(startSpan.column, 22);
+
+      var endSpan = error.span!.end;
+      expect(endSpan.line, 3);
+      expect(endSpan.column, 34);
+    });
+
+    test(
+        'Given a class with a field with database and api defined, then collect an error that locates the api keyword in the comma separated string.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  nameId: int, database, api
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.last;
+
+      expect(
+        error.span,
+        isNotNull,
+        reason: 'Expected error to have a source span.',
+      );
+
+      var startSpan = error.span!.start;
+      expect(startSpan.line, 3);
+      expect(startSpan.column, 25);
+
+      var endSpan = error.span!.end;
+      expect(endSpan.line, 3);
+      expect(endSpan.column, 28);
+    });
+
+    test(
+        'Given a class with a field with an empty string entry at the end, then collect an error that locates the empty string in the comma separated string.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  nameId: int, database,
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.last;
+
+      expect(
+        error.span,
+        isNotNull,
+        reason: 'Expected error to have a source span.',
+      );
+
+      var startSpan = error.span!.start;
+      expect(startSpan.line, 3);
+      expect(startSpan.column, 24);
+
+      var endSpan = error.span!.end;
+      expect(endSpan.line, 3);
+      expect(endSpan.column, 24);
+    });
+
+    test(
+        'Given a class with a field with a duplicated key value, then collect an error that locates the duplicated key in the comma separated string.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  nameId: int, database, database, parent=example
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.last;
+
+      expect(
+        error.span,
+        isNotNull,
+        reason: 'Expected error to have a source span.',
+      );
+
+      var startSpan = error.span!.start;
+      expect(startSpan.line, 3);
+      expect(startSpan.column, 25);
+
+      var endSpan = error.span!.end;
+      expect(endSpan.line, 3);
+      expect(endSpan.column, 33);
+    });
+
+    test(
+        'Given a class with a field with an invalid dart syntax for the type, then collect an error that locates the invalid type in the comma separated string.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+table: example
+fields:
+  nameId: Invalid-Type, database
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.last;
+
+      expect(
+        error.span,
+        isNotNull,
+        reason: 'Expected error to have a source span.',
+      );
+
+      var startSpan = error.span!.start;
+      expect(startSpan.line, 3);
+      expect(startSpan.column, 10);
+
+      var endSpan = error.span!.end;
+      expect(endSpan.line, 3);
+      expect(endSpan.column, 22);
+    });
+  });
+}


### PR DESCRIPTION
# Changes

Extracts the exact subspan for each key/value pair in the fields comma separated string. This means that we can specify the exact part of the string that caused an error instead of reporting an error on the entire string.

With this PR the errors are reported like this:
<img width="403" alt="Screenshot 2023-07-12 at 14 32 14" src="https://github.com/serverpod/serverpod/assets/7395515/73f635d5-9216-4fee-a175-061a10c7c79c">

Previously:
<img width="422" alt="Screenshot 2023-07-12 at 14 35 21" src="https://github.com/serverpod/serverpod/assets/7395515/794ff431-21d4-4559-898f-f6a30e3c229b">

Closese: https://github.com/serverpod/serverpod/issues/1115

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
