### PR TITLE
fix: Restrict class names to not allow standard datatypes.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -41,10 +41,10 @@ YamlMap convertStringifiedNestedNodesToYamlMap(
     _extractSubSpan(content, contentNode.span, initRawValue),
   );
 
-  Map<dynamic, YamlNode> internalNodes =
-      fieldKeyValuePairs.fold(initNodes, (aggregate, pair) {
-    return {...aggregate, ...pair};
-  });
+  Map<dynamic, YamlNode> internalNodes = fieldKeyValuePairs.fold(
+    initNodes,
+    (aggregate, pair) => {...aggregate, ...pair},
+  );
 
   // deepEqualsMap is needed to be able to compare YamlScala as keys
   var nodes = deepEqualsMap<dynamic, YamlNode>();

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -42,8 +42,17 @@ class Restrictions {
       ];
     }
 
-    // TODO n-squared time complexity when validating all protocol files.
-    if (_countClassNames(content, entityRelations?.entities) > 1) {
+    var reservedClassNames = {'List', 'Map', 'String', 'DateTime'};
+    if (reservedClassNames.contains(content)) {
+      return [
+        SourceSpanException(
+          'The class name "$content" is reserved and cannot be used.',
+          span,
+        )
+      ];
+    }
+
+    if (entityRelations?.classNames.containsKey(content) == true) {
       return [
         SourceSpanException(
           'The $documentType name "$content" is already used by another protocol class.',
@@ -53,16 +62,6 @@ class Restrictions {
     }
 
     return [];
-  }
-
-  int _countClassNames(
-      String className, List<SerializableEntityDefinition>? protocolEntities) {
-    if (protocolEntities == null) return 0;
-
-    return protocolEntities.fold(
-      0,
-      (sum, entity) => sum += entity.className == className ? 1 : 0,
-    );
   }
 
   List<SourceSpanException> validateTableName(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -52,7 +52,8 @@ class Restrictions {
       ];
     }
 
-    if (entityRelations?.classNames.containsKey(content) == true) {
+    var classesByName = entityRelations?.classNames[content];
+    if (classesByName != null && classesByName.length > 1) {
       return [
         SourceSpanException(
           'The $documentType name "$content" is already used by another protocol class.',

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_types_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/entity_types_test.dart
@@ -161,6 +161,122 @@ values:
         'The "enum" type must be a valid class name (e.g. PascalCaseString).');
   });
 
+  test(
+      'Given a class name with reserved value List, then give an error that the class name is reserved.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+class: List
+fields:
+  name: String
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(
+      error.message,
+      'The class name "List" is reserved and cannot be used.',
+    );
+  });
+
+  test(
+      'Given a class name with reserved value Map, then give an error that the class name is reserved.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+class: Map
+fields:
+  name: String
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(
+      error.message,
+      'The class name "Map" is reserved and cannot be used.',
+    );
+  });
+
+  test(
+      'Given a class name with reserved value String, then give an error that the class name is reserved.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+class: String
+fields:
+  name: String
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(
+      error.message,
+      'The class name "String" is reserved and cannot be used.',
+    );
+  });
+
+  test(
+      'Given a class name with reserved value DateTime, then give an error that the class name is reserved.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+class: DateTime
+fields:
+  name: String
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml, protocol.yamlSourceUri.path, collector, definition, []);
+
+    expect(collector.errors.length, greaterThan(0));
+
+    var error = collector.errors.first;
+
+    expect(
+      error.message,
+      'The class name "DateTime" is reserved and cannot be used.',
+    );
+  });
+
   group('Given a protocol without any defined entity type', () {
     test(
         'Then return a human readable error message informing the user that the entity type is missing.',


### PR DESCRIPTION
# Add

Restricts the class name to not be able to use the values 'List', 'Map', 'String' and 'DateTime'.

Closes: https://github.com/serverpod/serverpod/issues/1159

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.