### PR TITLE
fix: Add automatic deprecated reporting of keys in analyzer.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -78,6 +78,12 @@ void validateYamlProtocol(
       collector,
     );
 
+    _collectDeprecatedKeyErrors(
+      node,
+      documentContents,
+      collector,
+    );
+
     _collectKeyRestrictionErrors(
       node,
       documentContents,
@@ -174,6 +180,26 @@ void _collectMissingRequiredChildrenErrors(
     collector.addError(SourceSpanSeverityException(
       'The "${node.key}" property must have at least one value.',
       span,
+    ));
+  }
+}
+
+void _collectDeprecatedKeyErrors(
+  ValidateNode node,
+  YamlMap documentContents,
+  CodeAnalysisCollector collector,
+) {
+  if (node.isDeprecated && documentContents.containsKey(node.key)) {
+    var severity = SourceSpanSeverity.warning;
+    if (node.isRemoved) {
+      severity = SourceSpanSeverity.error;
+    }
+
+    collector.addError(SourceSpanSeverityException(
+      'The "${node.key}" property is deprecated. ${node.alternativeUsageMessage}',
+      documentContents.key(node.key)?.span,
+      severity: severity,
+      tags: [SourceSpanTag.deprecated],
     ));
   }
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -46,7 +46,7 @@ class Restrictions {
     var reservedClassNames = {'List', 'Map', 'String', 'DateTime'};
     if (reservedClassNames.contains(content)) {
       return [
-        SourceSpanException(
+        SourceSpanSeverityException(
           'The class name "$content" is reserved and cannot be used.',
           span,
         )

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
@@ -8,6 +8,16 @@ class ValidateNode {
   /// If true, the key must be present in the document.
   bool isRequired;
 
+  // If true, the key will be marked as deprecated with a warning.
+  bool isDeprecated;
+
+  // If true, the key will be marked as deprecated with an error.
+  bool isRemoved;
+
+  /// Set to communicate what the alternative implementation of a deprecated
+  /// value is.
+  String alternativeUsageMessage;
+
   /// If set, the key must match the restriction if an error is returned the key
   /// is considered invalid.
   /// Should only be used together with a [Keyword.any].
@@ -36,6 +46,9 @@ class ValidateNode {
   ValidateNode(
     this.key, {
     this.isRequired = false,
+    this.isDeprecated = false,
+    this.isRemoved = false,
+    this.alternativeUsageMessage = '',
     this.keyRestriction,
     this.valueRestriction,
     this.mutuallyExclusiveKeys = const {},


### PR DESCRIPTION
# Adds

Ability to tag keys as deprecated in for the protocol and automatically give warnings / errors if usage is detected.

Closes: https://github.com/serverpod/serverpod/issues/1160

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

