### PR TITLE
fix: Add ability to toggle implicit key in stringified nodes.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
@@ -31,7 +31,7 @@ Future<UserInfo?> signInWithFirebase({
                   try {
                     var idToken = await user.getIdToken();
                     var serverResponse =
-                        await caller.firebase.authenticate(idToken);
+                        await caller.firebase.authenticate(idToken!);
 
                     if (!serverResponse.success &&
                         serverResponse.userInfo != null) {

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -110,31 +110,22 @@ class SerializableEntityAnalyzer {
 
     if (definitionType == null) return null;
 
-    var restrictions = Restrictions(
-      documentType: definitionType,
-      documentContents: documentContents,
-    );
-
     switch (definitionType) {
       case Keyword.classType:
-        var yamlStructure = ClassYamlDefinition(restrictions);
         return EntityParser.serializeClassFile(
           Keyword.classType,
           protocolSource,
           outFileName,
           documentContents,
           docsExtractor,
-          yamlStructure.fieldStructure,
         );
       case Keyword.exceptionType:
-        var yamlStructure = ExceptionYamlDefinition(restrictions);
         return EntityParser.serializeClassFile(
           Keyword.exceptionType,
           protocolSource,
           outFileName,
           documentContents,
           docsExtractor,
-          yamlStructure.fieldStructure,
         );
       case Keyword.enumType:
         return EntityParser.serializeEnumFile(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -8,7 +8,6 @@ import 'package:yaml/yaml.dart';
 import '../converter/converter.dart';
 import '../definitions.dart';
 import '../validation/keywords.dart';
-import '../validation/validate_node.dart';
 
 class EntityParser {
   static SerializableEntityDefinition? serializeClassFile(
@@ -17,7 +16,6 @@ class EntityParser {
     String outFileName,
     YamlMap documentContents,
     YamlDocumentationExtractor docsExtractor,
-    ValidateNode fieldStructure,
   ) {
     YamlNode? classNode = documentContents.nodes[documentTypeName];
 
@@ -41,7 +39,6 @@ class EntityParser {
       documentContents,
       docsExtractor,
       tableName != null,
-      fieldStructure,
     );
     var indexes = _parseIndexes(documentContents, fields);
 
@@ -106,7 +103,6 @@ class EntityParser {
     YamlMap documentContents,
     YamlDocumentationExtractor docsExtractor,
     bool hasTable,
-    ValidateNode fieldStructure,
   ) {
     var fieldsNode = documentContents.nodes[Keyword.fields];
     if (fieldsNode is! YamlMap) return [];
@@ -114,7 +110,6 @@ class EntityParser {
     var parsedFields = fieldsNode.nodes.entries.map((fieldNode) {
       return _parseEntityFieldDefinition(
         fieldNode,
-        fieldStructure,
         docsExtractor,
       );
     });
@@ -145,7 +140,6 @@ class EntityParser {
 
   static SerializableEntityFieldDefinition? _parseEntityFieldDefinition(
     MapEntry<dynamic, YamlNode> fieldNode,
-    ValidateNode fieldStructure,
     YamlDocumentationExtractor docsExtractor,
   ) {
     var key = fieldNode.key;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -156,8 +156,8 @@ class EntityParser {
     if (value is String) {
       value = convertStringifiedNestedNodesToYamlMap(
         value,
-        nodeValue,
-        fieldStructure,
+        nodeValue.span,
+        firstKey: Keyword.type,
       );
     }
     if (value is! YamlMap) return null;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -258,10 +258,16 @@ void _collectNodesWithNestedNodesErrors(
     var content = contentNode?.value;
 
     if (contentNode != null && _isStringifiedNode(contentNode, node, content)) {
+      String? firstKey;
+
+      if (node.allowStringifiedNestedValue.hasImplicitFirstKey) {
+        firstKey = node.nested.first.key;
+      }
+
       content = convertStringifiedNestedNodesToYamlMap(
         content,
-        contentNode,
-        node,
+        contentNode.span,
+        firstKey: firstKey,
         onDuplicateKey: (key, span) {
           collector.addError(SourceSpanSeverityException(
             'The field option "$key" is defined more than once.',
@@ -335,7 +341,7 @@ Iterable<MapEntry<dynamic, YamlNode?>> _extractDocumentNodesToCheck(
 }
 
 bool _isStringifiedNode(YamlNode? contentNode, ValidateNode node, content) {
-  if (!node.allowStringifiedNestedValue) return false;
+  if (!node.allowStringifiedNestedValue.isAllowed) return false;
 
   return (content is String || content == null);
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
@@ -30,14 +30,15 @@ class ValidateNode {
   // A set of keys that are mutually exclusive with this key.
   late Set<String> mutuallyExclusiveKeys;
 
-  /// If true, the value can be a stringified comma seperated version of
-  /// the nested value. Will assume the first value in the nested Set is the first
-  /// value in the stringified version and does not require the key to be present.
-  /// All other values in the nested Set must have the key defined in the stringified
-  /// version and be written like this: key=value, key2=value2, etc.
+  /// If true, the value can be a stringified comma separated version of
+  /// the nested value. If implicitFirstKey is used, then assume the first value
+  /// in the nested Set is the first value in the stringified version and does
+  /// not require the key to be present. All other values in the nested Set must
+  /// have the key defined in the stringified version and be written like
+  /// this: key=value, key2=value2, etc.
   /// The order of key and key2 does not matter.
   /// Full example: nodeKey: firstValue, key=value, key2=value2.
-  bool allowStringifiedNestedValue;
+  StringifiedNestedValues allowStringifiedNestedValue;
 
   /// Any nested nodes for this key, setting any node here means the expected
   /// value is a YamlMap, unless allowStringifiedNestedValue is true.
@@ -52,10 +53,10 @@ class ValidateNode {
     this.keyRestriction,
     this.valueRestriction,
     this.mutuallyExclusiveKeys = const {},
-    this.allowStringifiedNestedValue = false,
+    this.allowStringifiedNestedValue = const StringifiedNestedValues(),
     this.nested = const {},
   }) {
-    if (allowStringifiedNestedValue && nested.isEmpty) {
+    if (allowStringifiedNestedValue.isAllowed && nested.isEmpty) {
       throw ArgumentError(
           'allowStringifiedNestedValue can only be true if nested is not empty.');
     }
@@ -65,4 +66,18 @@ class ValidateNode {
           'keyRestriction can only be set if key is ${Keyword.any}.');
     }
   }
+}
+
+class StringifiedNestedValues {
+  /// Allow nested values to be written as a stringified version of the nested nodes.
+  final bool isAllowed;
+
+  /// If true, the first value in the nested Set is the first value in the
+  /// stringified version and does not require the key to be present.
+  final bool hasImplicitFirstKey;
+
+  const StringifiedNestedValues({
+    this.isAllowed = false,
+    this.hasImplicitFirstKey = false,
+  });
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -34,7 +34,10 @@ class ClassYamlDefinition {
           ValidateNode(
             Keyword.any,
             keyRestriction: restrictions.validateFieldName,
-            allowStringifiedNestedValue: true,
+            allowStringifiedNestedValue: const StringifiedNestedValues(
+              isAllowed: true,
+              hasImplicitFirstKey: true,
+            ),
             nested: {
               ValidateNode(
                 Keyword.type,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
@@ -30,7 +30,10 @@ class ExceptionYamlDefinition {
           ValidateNode(
             Keyword.any,
             keyRestriction: restrictions.validateFieldName,
-            allowStringifiedNestedValue: true,
+            allowStringifiedNestedValue: const StringifiedNestedValues(
+              isAllowed: true,
+              hasImplicitFirstKey: true,
+            ),
             nested: {
               ValidateNode(
                 Keyword.type,


### PR DESCRIPTION
# Add

Allow us to toggle if there should be an implicit key in stringified nodes when parsing protocol files. The use-case is to allow for stringified nodes without an implicit key which we will need when implementing the `relation` key.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

