### PR TITLE
feat: Introduce relation keyword, deprecate parent keyword.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -197,13 +197,7 @@ class EntityParser {
     var parent = documentContents.nodes[Keyword.parent]?.value;
     if (parent is String) return parent;
 
-
     var relationMap = documentContents.nodes[Keyword.relation];
-
-    if (relationMap != null) {
-      print(relationMap);
-    }
-    //print(relationMap);
 
     if (relationMap is! YamlMap) return null;
     parent = relationMap.nodes[Keyword.parent]?.value;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -195,6 +195,19 @@ class EntityParser {
 
   static String? _parseParentTable(YamlMap documentContents) {
     var parent = documentContents.nodes[Keyword.parent]?.value;
+    if (parent is String) return parent;
+
+
+    var relationMap = documentContents.nodes[Keyword.relation];
+
+    if (relationMap != null) {
+      print(relationMap);
+    }
+    //print(relationMap);
+
+    if (relationMap is! YamlMap) return null;
+    parent = relationMap.nodes[Keyword.parent]?.value;
+
     if (parent is! String) return null;
 
     return parent;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
@@ -12,6 +12,7 @@ class Keyword {
   static const String type = 'type';
   static const String unique = 'unique';
   static const String parent = 'parent';
+  static const String relation = 'relation';
   static const String api = 'api';
   static const String database = 'database';
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -60,6 +60,18 @@ void validateYamlProtocol(
   );
 
   for (var node in documentStructure) {
+    _collectKeyRestrictionErrors(
+      node,
+      documentContents,
+      collector,
+    );
+
+    _collectValueRestrictionErrors(
+      node,
+      documentContents,
+      collector,
+    );
+
     _collectMutuallyExclusiveKeyErrors(
       node,
       documentContents,
@@ -79,18 +91,6 @@ void validateYamlProtocol(
     );
 
     _collectDeprecatedKeyErrors(
-      node,
-      documentContents,
-      collector,
-    );
-
-    _collectKeyRestrictionErrors(
-      node,
-      documentContents,
-      collector,
-    );
-
-    _collectValueRestrictionErrors(
       node,
       documentContents,
       collector,
@@ -190,7 +190,7 @@ void _collectDeprecatedKeyErrors(
   CodeAnalysisCollector collector,
 ) {
   if (node.isDeprecated && documentContents.containsKey(node.key)) {
-    var severity = SourceSpanSeverity.warning;
+    var severity = SourceSpanSeverity.info;
     if (node.isRemoved) {
       severity = SourceSpanSeverity.error;
     }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -47,12 +47,14 @@ class ClassYamlDefinition {
               ValidateNode(
                 Keyword.parent,
                 isDeprecated: true,
+                mutuallyExclusiveKeys: {Keyword.relation},
                 alternativeUsageMessage:
                     'Use the relation keyword instead. E.g. relation(parent=parent_table)',
                 valueRestriction: restrictions.validateParentName,
               ),
               ValidateNode(
                 Keyword.relation,
+                mutuallyExclusiveKeys: {Keyword.parent},
                 nested: {
                   ValidateNode(
                     Keyword.parent,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -46,7 +46,19 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.parent,
+                isDeprecated: true,
+                alternativeUsageMessage:
+                    'Use the relation keyword instead. E.g. relation(parent=parent_table)',
                 valueRestriction: restrictions.validateParentName,
+              ),
+              ValidateNode(
+                Keyword.relation,
+                nested: {
+                  ValidateNode(
+                    Keyword.parent,
+                    valueRestriction: restrictions.validateParentName,
+                  ),
+                },
               ),
               ValidateNode(
                 Keyword.database,

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_source_location_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_source_location_test.dart
@@ -260,7 +260,7 @@ fields:
 
       expect(collector.errors.length, greaterThan(0));
 
-      var error = collector.errors.last;
+      var error = collector.errors.first;
 
       expect(
         error.span,

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -986,6 +986,42 @@ fields:
     );
 
     test(
+      'Given a class with a field with a parent, then a deprecated info is generated.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          parentId: int, parent=example
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors, isNotEmpty);
+
+        var error = collector.errors.first;
+
+        expect(
+          error.message,
+          'The "parent" property is deprecated. Use the relation keyword instead. E.g. relation(parent=parent_table)',
+        );
+      },
+    );
+
+    test(
       'Given a class with a field with a parent that do not exist, then collect an error that the parent table is not found.',
       () {
         var collector = CodeGenerationCollector();
@@ -1342,7 +1378,7 @@ fields:
           reason: 'Expected an error, none was found.',
         );
         expect(
-          collector.errors.first.message,
+          collector.errors.last.message,
           'The "api" property is mutually exclusive with the "parent" property.',
         );
       },

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -1,0 +1,128 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given a class with a field with a self relation, then the parent table is set to the specified table name.',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  parentId: int, relation(parent=example)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    );
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
+
+    expect(collector.errors, isEmpty);
+
+    expect((definition as ClassDefinition).fields.last.parentTable, 'example');
+  });
+
+  test(
+      'Given a class with a field with a relation, but the parent keyword defined twice, then an error is collected that there is a duplicated key.',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  parentId: int, relation(parent=example, parent=example)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    );
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(0),
+      reason: 'Expected an error',
+    );
+
+    expect(
+      collector.errors.first.message,
+      'The field option "parent" is defined more than once.',
+    );
+  });
+
+  test(
+      'Given a class with a field with a relation, but the parent keyword defined twice, then an error is collected that locates the second parent key.',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  parentId: int, relation(parent=example, parent=example)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    );
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(0),
+      reason: 'Expected an error',
+    );
+
+    var error = collector.errors.first;
+
+    expect(error.span, isNotNull,
+        reason: 'Expected error to have a source span.');
+
+    var startSpan = error.span!.start;
+    expect(startSpan.line, 3);
+    expect(startSpan.column, 42);
+
+    var endSpan = error.span!.end;
+    expect(endSpan.line, 3);
+    expect(endSpan.column, 48);
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -79,6 +79,46 @@ fields:
   });
 
   test(
+      'Given a class with a field with a relation and parent keyword, then an error is collected that they are mutually exclusive key.',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  parentId: int, relation(parent=example), parent=example
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    );
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(0),
+      reason: 'Expected an error',
+    );
+
+    expect(
+      collector.errors.first.message,
+      'The "parent" property is mutually exclusive with the "relation" property.',
+    );
+  });
+
+  test(
       'Given a class with a field with a relation, but the parent keyword defined twice, then an error is collected that locates the second parent key.',
       () {
     var collector = CodeGenerationCollector();


### PR DESCRIPTION
# Feat

* Adds `relation` keyword for protocol
* Deprecate `parent` keyword for protocol

Previous syntax:
```yaml
class: Example
table: example
fields:
  parentId: id, parent=parent_table
```

New syntax:
```yaml
class: Example
table: example
fields:
  parentId: id, relation(parent=parent_table)
```

<img width="377" alt="Screenshot 2023-07-14 at 17 54 25" src="https://github.com/serverpod/serverpod/assets/7395515/95be99b9-2741-4bd4-a32a-08501df991b3">

This PR is the first iteration of the `relation` keyword, and with this change only supports the old behavior.

Closese: https://github.com/serverpod/serverpod/issues/1144

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
