### PR TITLE
fix: Allow whitespace around "=" in protocol.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -37,7 +37,7 @@ YamlMap convertStringifiedNestedNodesToYamlMap(
         nestedContent,
         nestedSpan,
         onDuplicateKey: onDuplicateKey,
-      ); 
+      );
     },
   );
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
@@ -33,11 +31,14 @@ YamlMap convertStringifiedNestedNodesToYamlMap(
     stringifiedNodes.skip(startNodeIndex),
     content,
     span,
-    handleDeepNestedNodes: (a, b) => convertStringifiedNestedNodesToYamlMap(
-      a,
-      b,
-      onDuplicateKey: onDuplicateKey,
-    ), // recursion
+    handleDeepNestedNodes: (nestedContent, nestedSpan) {
+      // recursion
+      return convertStringifiedNestedNodesToYamlMap(
+        nestedContent,
+        nestedSpan,
+        onDuplicateKey: onDuplicateKey,
+      ); 
+    },
   );
 
   var duplicates = _findDuplicateKeys(fieldKeyValuePairs);
@@ -112,8 +113,8 @@ Iterable<Map<YamlScalar, YamlNode>> _extractKeyValuePairs(
 
     List<String> keyValuePair = stringifiedKeyValuePair.split('=');
 
-    var key = keyValuePair.first;
-    dynamic value = keyValuePair.length == 2 ? keyValuePair.last : null;
+    String key = keyValuePair.first;
+    String? value = keyValuePair.length == 2 ? keyValuePair.last : null;
 
     return _createdYamlScalarNode(
       key,
@@ -166,21 +167,16 @@ Set<String> _findDuplicateKeys(Iterable<Map<YamlScalar, dynamic>> list) {
 
 Map<YamlScalar, YamlScalar> _createdYamlScalarNode(
   String rawKey,
-  dynamic rawValue,
+  String? rawValue,
   SourceSpan span,
 ) {
-  var fullSpanLength = span.length;
+  var trimmedKey = rawKey.trim();
+  var keySpan = _extractSubSpan(span.text, span, trimmedKey);
+  var key = YamlScalar.internalWithSpan(trimmedKey, keySpan);
 
-  var keySpanEnd = min(rawKey.length, fullSpanLength);
-
-  var keySpan = span.subspan(0, keySpanEnd);
-  var key = YamlScalar.internalWithSpan(rawKey, keySpan);
-
-  var valueLength = rawValue?.toString().length ?? 0;
-  var valueSpanStart = fullSpanLength - valueLength;
-
-  var valueSpan = span.subspan(valueSpanStart);
-  var value = YamlScalar.internalWithSpan(rawValue, valueSpan);
+  var trimmedValue = rawValue?.trim();
+  var valueSpan = _extractSubSpan(span.text, span, trimmedValue);
+  var value = YamlScalar.internalWithSpan(trimmedValue, valueSpan);
 
   return {key: value};
 }
@@ -190,12 +186,9 @@ Map<YamlScalar, YamlMap> _createYamlMapNode(
   YamlMap value,
   SourceSpan span,
 ) {
-  var fullSpanLength = span.length;
-
-  var keySpanEnd = min(rawKey.length, fullSpanLength);
-
-  var keySpan = span.subspan(0, keySpanEnd);
-  var key = YamlScalar.internalWithSpan(rawKey, keySpan);
+  var trimmedKey = rawKey.trim();
+  var keySpan = _extractSubSpan(span.text, span, trimmedKey);
+  var key = YamlScalar.internalWithSpan(trimmedKey, keySpan);
 
   return {key: value};
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -986,6 +986,36 @@ fields:
     );
 
     test(
+      'Given a class with a field with a parent with whitespace in the syntax, then the generated entity has a parentTable property set to the parent table name.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          parentId: int, parent = example
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          ['lib', 'src', 'protocol'],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(
+            (definition as ClassDefinition).fields.last.parentTable, 'example');
+      },
+    );
+
+    test(
       'Given a class with a field with a parent, then a deprecated info is generated.',
       () {
         var collector = CodeGenerationCollector();


### PR DESCRIPTION
# Fix

Allow whitespace around =. 

Example:
```yaml
class: Example
table: example
fields:
  parentId: int, parent = parent_table
```

Closes: https://github.com/serverpod/serverpod/issues/1177

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
