### PR TITLE
Use git version of serverpod_cli

### DIFF
--- a/util/generate_all
+++ b/util/generate_all
@@ -7,48 +7,50 @@ if [ ! -f tests/docker/tests_single_server/docker-compose.yml ]; then
 fi
 
 BASE=`pwd`
+CLI_DIR=$BASE/tools/serverpod_cli
+CLI=$CLI_DIR/bin/serverpod_cli.dart
 
 echo "pub get cli"
-cd $BASE/tools/serverpod_cli
+cd $CLI_DIR
 dart pub get
 
 echo "serverpod"
 cd $BASE/packages/serverpod
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate
 
 echo "examples/chat/chat_server"
 cd $BASE/examples/chat/chat_server
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate
 
 # Templates
 
 echo "\nmodulename_server"
 cd $BASE/templates/serverpod_templates/modulename_server
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate
 
 echo "\nprojectname_server"
 cd $BASE/templates/serverpod_templates/projectname_server
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate
 
 # Auth module
 
 echo "\nserverpod_auth_server"
 cd $BASE/modules/serverpod_auth/serverpod_auth_server
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate
 
 # Chat module
 
 echo "\nserverpod_chat_server"
 cd $BASE/modules/serverpod_chat/serverpod_chat_server
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate
 
 
 # Tests
 
 echo "\ntests/serverpod_test_server"
 cd $BASE/tests/serverpod_test_server
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate
 
 echo "\ntests/serverpod_test_module/serverpod_test_module_server"
 cd $BASE/tests/serverpod_test_module/serverpod_test_module_server
-dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
+dart $CLI generate

--- a/util/generate_all
+++ b/util/generate_all
@@ -14,41 +14,41 @@ dart pub get
 
 echo "serverpod"
 cd $BASE/packages/serverpod
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
 
 echo "examples/chat/chat_server"
 cd $BASE/examples/chat/chat_server
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
 
 # Templates
 
 echo "\nmodulename_server"
 cd $BASE/templates/serverpod_templates/modulename_server
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
 
 echo "\nprojectname_server"
 cd $BASE/templates/serverpod_templates/projectname_server
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
 
 # Auth module
 
 echo "\nserverpod_auth_server"
 cd $BASE/modules/serverpod_auth/serverpod_auth_server
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
 
 # Chat module
 
 echo "\nserverpod_chat_server"
 cd $BASE/modules/serverpod_chat/serverpod_chat_server
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
 
 
 # Tests
 
 echo "\ntests/serverpod_test_server"
 cd $BASE/tests/serverpod_test_server
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate
 
 echo "\ntests/serverpod_test_module/serverpod_test_module_server"
 cd $BASE/tests/serverpod_test_module/serverpod_test_module_server
-serverpod generate
+dart $BASE/tools/serverpod_cli/bin/serverpod_cli.dart generate

--- a/util/publish_all
+++ b/util/publish_all
@@ -7,6 +7,9 @@ if [ ! -f tests/docker/tests_single_server/docker-compose.yml ]; then
 fi
 
 BASE=`pwd`
+CLI_DIR=$BASE/tools/serverpod_cli
+CLI=$CLI_DIR/bin/serverpod_cli.dart
+
 PCOUNT_START_DEFAULT=0
 PCOUNT_START="${1:-$PCOUNT_START_DEFAULT}"
 
@@ -35,7 +38,7 @@ echo "Publish Serverpod version $VERSION"
 
 echo "Updating pubspecs"
 cd $BASE
-serverpod generate-pubspecs --version $VERSION --mode production
+dart $CLI generate-pubspecs --version $VERSION --mode production
 
 echo "Publish packages"
 

--- a/util/publish_all
+++ b/util/publish_all
@@ -7,8 +7,7 @@ if [ ! -f tests/docker/tests_single_server/docker-compose.yml ]; then
 fi
 
 BASE=`pwd`
-CLI_DIR=$BASE/tools/serverpod_cli
-CLI=$CLI_DIR/bin/serverpod_cli.dart
+CLI=$BASE/tools/serverpod_cli/bin/serverpod_cli.dart
 
 PCOUNT_START_DEFAULT=0
 PCOUNT_START="${1:-$PCOUNT_START_DEFAULT}"

--- a/util/publish_all
+++ b/util/publish_all
@@ -7,7 +7,13 @@ if [ ! -f tests/docker/tests_single_server/docker-compose.yml ]; then
 fi
 
 BASE=`pwd`
-CLI=$BASE/tools/serverpod_cli/bin/serverpod_cli.dart
+CLI_DIR=$BASE/tools/serverpod_cli
+CLI=$CLI_DIR/bin/serverpod_cli.dart
+
+echo "pub get cli"
+cd $CLI_DIR
+dart pub get
+cd $BASE
 
 PCOUNT_START_DEFAULT=0
 PCOUNT_START="${1:-$PCOUNT_START_DEFAULT}"

--- a/util/run_tests_update_pubspecs
+++ b/util/run_tests_update_pubspecs
@@ -22,6 +22,7 @@ echo "### Templates at: $TEMPLATE_DIR"
 test -d $TEMPLATE_DIR
 
 cd tools/serverpod_cli
+dart pub get
 dart pub global activate -s path .
 cd ../..
 

--- a/util/update_pubspecs
+++ b/util/update_pubspecs
@@ -10,8 +10,7 @@ VERSION=`cat VERSION`
 VERSION=$VERSION | xargs
 
 BASE=`pwd`
-CLI_DIR=$BASE/tools/serverpod_cli
-CLI=$CLI_DIR/bin/serverpod_cli.dart
+CLI=$BASE/tools/serverpod_cli/bin/serverpod_cli.dart
 
 echo "Update all pubspecs. Version is $VERSION."
 

--- a/util/update_pubspecs
+++ b/util/update_pubspecs
@@ -10,7 +10,13 @@ VERSION=`cat VERSION`
 VERSION=$VERSION | xargs
 
 BASE=`pwd`
-CLI=$BASE/tools/serverpod_cli/bin/serverpod_cli.dart
+CLI_DIR=$BASE/tools/serverpod_cli
+CLI=$CLI_DIR/bin/serverpod_cli.dart
+
+echo "pub get cli"
+cd $CLI_DIR
+dart pub get
+cd $BASE
 
 echo "Update all pubspecs. Version is $VERSION."
 

--- a/util/update_pubspecs
+++ b/util/update_pubspecs
@@ -9,9 +9,13 @@ fi
 VERSION=`cat VERSION`
 VERSION=$VERSION | xargs
 
+BASE=`pwd`
+CLI_DIR=$BASE/tools/serverpod_cli
+CLI=$CLI_DIR/bin/serverpod_cli.dart
+
 echo "Update all pubspecs. Version is $VERSION."
 
-serverpod generate-pubspecs --version $VERSION --mode development
+dart $CLI generate-pubspecs --version $VERSION --mode development
 
 echo "Copying CHANGELOG.md"
 cp CHANGELOG.md packages/serverpod/CHANGELOG.md


### PR DESCRIPTION
Make `generate_all` use the git version of `serverpod_cli`, not the `pub` version. May help with #1076.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.