### PR TITLE
Improve error message when serialized type is not recognized

### DIFF
--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -135,11 +135,13 @@ class DatabaseConnection {
   }) async {
     assert(orderByList == null || orderBy == null);
     var table = session.serverpod.serializationManager.getTableForType(T);
+    if (table == null) {
+      throw 'Serialization manager does not know about type $T';
+    }
     assert(table is Table, '''
 You need to specify a template type that is a subclass of TableRow.
 E.g. myRows = await session.db.find<MyTableClass>(where: ...);
 Current type was $T''');
-    table = table!;
 
     var startTime = DateTime.now();
     where ??= Expression('TRUE');


### PR DESCRIPTION
When there is a mismatch between the serialization manager and the generated types, the assert failure is cryptic. This adds a more useful error message.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.