### PR TITLE
1042 make logs pretty

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   args: ^2.4.0
   ci: ^0.1.0
   code_builder: ^4.4.0
-  colorize: ^3.0.0
   dart_style: ^2.3.0
   http: ^0.13.5
   intl: ^0.17.0

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -2,6 +2,9 @@ import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 
 class CreateCommand extends ServerpodCommand {
+  final templateTypes =
+      ServerpodTemplateType.values.map((t) => t.name).toList();
+
   @override
   final name = 'create';
 
@@ -20,8 +23,8 @@ class CreateCommand extends ServerpodCommand {
     argParser.addOption(
       'template',
       abbr: 't',
-      defaultsTo: 'server',
-      allowed: <String>['server', 'module'],
+      defaultsTo: ServerpodTemplateType.server.name,
+      allowed: templateTypes,
       help:
           'Template to use when creating a new project, valid options are "server" or "module".',
     );
@@ -30,10 +33,10 @@ class CreateCommand extends ServerpodCommand {
   @override
   Future<void> run() async {
     var name = argResults!.arguments.last;
-    String template = argResults!['template'];
+    var template = ServerpodTemplateType.tryParse(argResults!['template']);
     bool force = argResults!['force'];
 
-    if (name == 'server' || name == 'module' || name == 'create') {
+    if (template == null || templateTypes.contains(name) || name == 'create') {
       printUsage();
       return;
     }

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+import 'package:serverpod_cli/src/util/exit_exception.dart';
 
 class CreateCommand extends ServerpodCommand {
   final templateTypes =
@@ -41,6 +42,8 @@ class CreateCommand extends ServerpodCommand {
       return;
     }
 
-    await performCreate(name, template, force);
+    if (!await performCreate(name, template, force)) {
+      throw ExitException();
+    }
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -66,8 +66,11 @@ class GenerateCommand extends ServerpodCommand {
         config: config,
         endpointsAnalyzer: endpointsAnalyzer,
       );
-    } else {
-      log.info('Done.', style: const TextLog(type: TextLogType.success));
+    } else if (!hasErrors) {
+      log.info('Project generated!',
+          style: const TextLog(
+            type: TextLogType.success,
+          ));
     }
 
     if (hasErrors) {

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -67,8 +67,7 @@ class GenerateCommand extends ServerpodCommand {
         endpointsAnalyzer: endpointsAnalyzer,
       );
     } else {
-      log.info('Done.',
-          style: const TextLogStyle(type: AbstractStyleType.success));
+      log.info('Done.', style: const TextLog(type: TextLogType.success));
     }
 
     if (hasErrors) {

--- a/tools/serverpod_cli/lib/src/commands/migrate.dart
+++ b/tools/serverpod_cli/lib/src/commands/migrate.dart
@@ -105,8 +105,7 @@ class MigrateCommand extends ServerpodCommand {
         force: force,
         priority: priority,
       );
-      log.info('Done.',
-          style: const TextLogStyle(type: AbstractStyleType.success));
+      log.info('Done.', style: const TextLog(type: TextLogType.success));
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/migrate.dart
+++ b/tools/serverpod_cli/lib/src/commands/migrate.dart
@@ -105,7 +105,8 @@ class MigrateCommand extends ServerpodCommand {
         force: force,
         priority: priority,
       );
-      log.info('Done.', style: const TextLog(type: TextLogType.success));
+      log.info('Migration created!',
+          style: const TextLog(type: TextLogType.success));
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/create/copier.dart
+++ b/tools/serverpod_cli/lib/src/create/copier.dart
@@ -51,7 +51,7 @@ class Copier {
         _replace(p.join(relativePath, fileName), fileNameReplacements);
     log.debug(
       p.join(dstDir.path, relativePath, fileName),
-      style: const TextLogStyle(type: AbstractStyleType.bullet),
+      style: const TextLog(type: TextLogType.bullet),
     );
 
     var dstFile = File(p.join(dstDir.path, dstFileName));

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -161,6 +161,7 @@ Future<void> performCreate(
       type: TextLogType.bullet,
     ),
   );
+  serverpodDirectories.clientDir.createSync();
 
   if (template == ServerpodTemplateType.server) {
     log.debug(

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -69,8 +69,16 @@ Future<void> performCreate(
     log.error(strIssue);
 
     if (!portsAvailable) {
-      log.error(strIssuePorts, style: const TextLogStyle(newParagraph: true));
-      log.error('Ports in use:', style: const TextLogStyle(newParagraph: true));
+      log.error(
+        strIssuePorts,
+        newParagraph: true,
+        style: const TextLogStyle(),
+      );
+      log.error(
+        'Ports in use:',
+        newParagraph: true,
+        style: const TextLogStyle(),
+      );
       for (var serverDescription in usedPorts.keys) {
         var port = usedPorts[serverDescription]!;
         log.error(
@@ -80,7 +88,11 @@ Future<void> performCreate(
       }
     }
     if (!dockerConfigured) {
-      log.error(strIssueDocker, style: const TextLogStyle(newParagraph: true));
+      log.error(
+        strIssueDocker,
+        newParagraph: true,
+        style: const TextLogStyle(),
+      );
     }
     if (!force) {
       return;
@@ -102,7 +114,8 @@ Future<void> performCreate(
 
   log.info(
     'Creating project $name.',
-    style: const TextLogStyle(newParagraph: true),
+    newParagraph: true,
+    style: const TextLogStyle(),
   );
 
   log.debug(
@@ -405,7 +418,8 @@ Future<void> performCreate(
       log.info(
         'cd .\\${p.join(name, '${name}_server')}\\',
         style: const TextLogStyle(
-            type: AbstractStyleType.command, newParagraph: true),
+          type: AbstractStyleType.command,
+        ),
       );
       log.info(
         '.\\setup-tables.cmd',
@@ -425,8 +439,8 @@ Future<void> performCreate(
       _logSuccessMessage();
       log.info(
         'cd ${p.join(name, '${name}_server')}',
-        style: const TextLogStyle(
-            type: AbstractStyleType.command, newParagraph: true),
+        newParagraph: true,
+        style: const TextLogStyle(type: AbstractStyleType.command),
       );
       log.info(
         'docker compose up --build --detach',
@@ -442,15 +456,16 @@ Future<void> performCreate(
 
 void _logSuccessMessage() {
   log.info('SERVERPOD CREATED 🥳',
-      style: const TextLogStyle(
-          newParagraph: true, type: AbstractStyleType.success));
+      newParagraph: true,
+      style: const TextLogStyle(type: AbstractStyleType.success));
   log.info(
     'All setup. You are ready to rock!',
-    style:
-        const TextLogStyle(newParagraph: true, type: AbstractStyleType.success),
+    newParagraph: true,
+    style: const TextLogStyle(type: AbstractStyleType.success),
   );
   log.info(
     'Start your Serverpod by running:',
-    style: const TextLogStyle(newParagraph: true),
+    newParagraph: true,
+    style: const TextLogStyle(),
   );
 }

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -142,250 +142,21 @@ Future<void> performCreate(
   _createProjectDirectories(template, serverpodDirs);
 
   if (template == ServerpodTemplateType.server) {
-    // Copy server files
-    var copier = Copier(
-      srcDir: Directory(
-          p.join(resourceManager.templateDirectory.path, 'projectname_server')),
-      dstDir: serverpodDirs.serverDir,
-      replacements: [
-        Replacement(
-          slotName: 'projectname',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: 'awsname',
-          replacement: awsName,
-        ),
-        Replacement(
-          slotName: 'randomawsid',
-          replacement: randomAwsId,
-        ),
-        Replacement(
-          slotName: '#--CONDITIONAL_COMMENT--#',
-          replacement: '',
-        ),
-        Replacement(
-          slotName: 'VERSION',
-          replacement: templateVersion,
-        ),
-        Replacement(
-          slotName: 'SERVICE_SECRET_DEVELOPMENT',
-          replacement: generateRandomString(),
-        ),
-        Replacement(
-          slotName: 'SERVICE_SECRET_STAGING',
-          replacement: generateRandomString(),
-        ),
-        Replacement(
-          slotName: 'SERVICE_SECRET_PRODUCTION',
-          replacement: generateRandomString(),
-        ),
-        Replacement(
-          slotName: 'DB_PASSWORD',
-          replacement: dbPassword,
-        ),
-        Replacement(
-          slotName: 'DB_PRODUCTION_PASSWORD',
-          replacement: dbProductionPassword,
-        ),
-        Replacement(
-          slotName: 'DB_STAGING_PASSWORD',
-          replacement: dbStagingPassword,
-        ),
-        Replacement(
-          slotName: 'REDIS_PASSWORD',
-          replacement: generateRandomString(),
-        ),
-      ],
-      fileNameReplacements: [
-        Replacement(
-          slotName: 'projectname',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: 'gitignore',
-          replacement: '.gitignore',
-        ),
-        Replacement(
-          slotName: 'gcloudignore',
-          replacement: '.gcloudignore',
-        ),
-      ],
-      removePrefixes: ['path'],
-      ignoreFileNames: ['pubspec.lock'],
+    _copyServerTemplates(
+      serverpodDirs,
+      name: name,
+      awsName: awsName,
+      randomAwsId: randomAwsId,
+      dbPassword: dbPassword,
+      dbProductionPassword: dbProductionPassword,
+      dbStagingPassword: dbStagingPassword,
     );
-    copier.copyFiles();
-
-    // Copy client files
-    copier = Copier(
-      srcDir: Directory(
-          p.join(resourceManager.templateDirectory.path, 'projectname_client')),
-      dstDir: serverpodDirs.clientDir,
-      replacements: [
-        Replacement(
-          slotName: 'projectname',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: '#--CONDITIONAL_COMMENT--#',
-          replacement: '',
-        ),
-        Replacement(
-          slotName: 'VERSION',
-          replacement: templateVersion,
-        ),
-      ],
-      fileNameReplacements: [
-        Replacement(
-          slotName: 'projectname',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: 'gitignore',
-          replacement: '.gitignore',
-        ),
-      ],
-      removePrefixes: ['path'],
-      ignoreFileNames: ['pubspec.lock'],
-    );
-    copier.copyFiles();
-
-    // Copy Flutter files
-    copier = Copier(
-      srcDir: Directory(p.join(
-          resourceManager.templateDirectory.path, 'projectname_flutter')),
-      dstDir: serverpodDirs.flutterDir,
-      replacements: [
-        Replacement(
-          slotName: 'projectname',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: '#--CONDITIONAL_COMMENT--#',
-          replacement: '',
-        ),
-        Replacement(
-          slotName: 'VERSION',
-          replacement: templateVersion,
-        ),
-      ],
-      fileNameReplacements: [
-        Replacement(
-          slotName: 'projectname',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: 'gitignore',
-          replacement: '.gitignore',
-        ),
-      ],
-      removePrefixes: [
-        'path: ../../../packages/serverpod_flutter',
-      ],
-      ignoreFileNames: [
-        'pubspec.lock',
-        'ios',
-        'android',
-        'web',
-        'macos',
-        'build',
-      ],
-    );
-    copier.copyFiles();
-
-    copier = Copier(
-      srcDir:
-          Directory(p.join(resourceManager.templateDirectory.path, 'github')),
-      dstDir: serverpodDirs.githubDir,
-      replacements: [
-        Replacement(
-          slotName: 'projectname',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: 'awsname',
-          replacement: awsName,
-        ),
-        Replacement(
-          slotName: 'randomawsid',
-          replacement: randomAwsId,
-        ),
-      ],
-      fileNameReplacements: [],
-    );
-    copier.copyFiles();
 
     CommandLineTools.dartPubGet(serverpodDirs.serverDir);
     CommandLineTools.dartPubGet(serverpodDirs.clientDir);
     CommandLineTools.flutterCreate(serverpodDirs.flutterDir);
   } else if (template == ServerpodTemplateType.module) {
-    // Copy server files
-    var copier = Copier(
-      srcDir: Directory(
-          p.join(resourceManager.templateDirectory.path, 'modulename_server')),
-      dstDir: serverpodDirs.serverDir,
-      replacements: [
-        Replacement(
-          slotName: 'modulename',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: '#--CONDITIONAL_COMMENT--#',
-          replacement: '',
-        ),
-        Replacement(
-          slotName: 'VERSION',
-          replacement: templateVersion,
-        ),
-      ],
-      fileNameReplacements: [
-        Replacement(
-          slotName: 'modulename',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: 'gitignore',
-          replacement: '.gitignore',
-        ),
-      ],
-      removePrefixes: ['path'],
-      ignoreFileNames: ['pubspec.lock'],
-    );
-    copier.copyFiles();
-
-    // Copy client files
-    copier = Copier(
-      srcDir: Directory(
-          p.join(resourceManager.templateDirectory.path, 'modulename_client')),
-      dstDir: serverpodDirs.clientDir,
-      replacements: [
-        Replacement(
-          slotName: 'modulename',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: '#--CONDITIONAL_COMMENT--#',
-          replacement: '',
-        ),
-        Replacement(
-          slotName: 'VERSION',
-          replacement: templateVersion,
-        ),
-      ],
-      fileNameReplacements: [
-        Replacement(
-          slotName: 'modulename',
-          replacement: name,
-        ),
-        Replacement(
-          slotName: 'gitignore',
-          replacement: '.gitignore',
-        ),
-      ],
-      removePrefixes: ['path'],
-      ignoreFileNames: ['pubspec.lock'],
-    );
-    copier.copyFiles();
+    _copyModuleTemplates(serverpodDirs, name: name);
   }
 
   if (dockerConfigured && template != ServerpodTemplateType.module) {
@@ -414,7 +185,6 @@ Future<void> performCreate(
         style: const TextLog(type: TextLogType.command),
       );
     } else {
-      // Create tables
       await CommandLineTools.createTables(serverpodDirs.projectDir, name);
       _logSuccessMessage();
       log.info(
@@ -485,4 +255,259 @@ void _createDirectory(Directory dir) {
     ),
   );
   dir.createSync();
+}
+
+void _copyServerTemplates(
+  ServerpodDirectories serverpodDirs, {
+  required String name,
+  required String awsName,
+  required String randomAwsId,
+  required String dbPassword,
+  required String dbProductionPassword,
+  required String dbStagingPassword,
+}) {
+  // Copy server files
+  var copier = Copier(
+    srcDir: Directory(
+        p.join(resourceManager.templateDirectory.path, 'projectname_server')),
+    dstDir: serverpodDirs.serverDir,
+    replacements: [
+      Replacement(
+        slotName: 'projectname',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: 'awsname',
+        replacement: awsName,
+      ),
+      Replacement(
+        slotName: 'randomawsid',
+        replacement: randomAwsId,
+      ),
+      Replacement(
+        slotName: '#--CONDITIONAL_COMMENT--#',
+        replacement: '',
+      ),
+      Replacement(
+        slotName: 'VERSION',
+        replacement: templateVersion,
+      ),
+      Replacement(
+        slotName: 'SERVICE_SECRET_DEVELOPMENT',
+        replacement: generateRandomString(),
+      ),
+      Replacement(
+        slotName: 'SERVICE_SECRET_STAGING',
+        replacement: generateRandomString(),
+      ),
+      Replacement(
+        slotName: 'SERVICE_SECRET_PRODUCTION',
+        replacement: generateRandomString(),
+      ),
+      Replacement(
+        slotName: 'DB_PASSWORD',
+        replacement: dbPassword,
+      ),
+      Replacement(
+        slotName: 'DB_PRODUCTION_PASSWORD',
+        replacement: dbProductionPassword,
+      ),
+      Replacement(
+        slotName: 'DB_STAGING_PASSWORD',
+        replacement: dbStagingPassword,
+      ),
+      Replacement(
+        slotName: 'REDIS_PASSWORD',
+        replacement: generateRandomString(),
+      ),
+    ],
+    fileNameReplacements: [
+      Replacement(
+        slotName: 'projectname',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: 'gitignore',
+        replacement: '.gitignore',
+      ),
+      Replacement(
+        slotName: 'gcloudignore',
+        replacement: '.gcloudignore',
+      ),
+    ],
+    removePrefixes: ['path'],
+    ignoreFileNames: ['pubspec.lock'],
+  );
+  copier.copyFiles();
+
+  // Copy client files
+  copier = Copier(
+    srcDir: Directory(
+        p.join(resourceManager.templateDirectory.path, 'projectname_client')),
+    dstDir: serverpodDirs.clientDir,
+    replacements: [
+      Replacement(
+        slotName: 'projectname',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: '#--CONDITIONAL_COMMENT--#',
+        replacement: '',
+      ),
+      Replacement(
+        slotName: 'VERSION',
+        replacement: templateVersion,
+      ),
+    ],
+    fileNameReplacements: [
+      Replacement(
+        slotName: 'projectname',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: 'gitignore',
+        replacement: '.gitignore',
+      ),
+    ],
+    removePrefixes: ['path'],
+    ignoreFileNames: ['pubspec.lock'],
+  );
+  copier.copyFiles();
+
+  // Copy Flutter files
+  copier = Copier(
+    srcDir: Directory(
+        p.join(resourceManager.templateDirectory.path, 'projectname_flutter')),
+    dstDir: serverpodDirs.flutterDir,
+    replacements: [
+      Replacement(
+        slotName: 'projectname',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: '#--CONDITIONAL_COMMENT--#',
+        replacement: '',
+      ),
+      Replacement(
+        slotName: 'VERSION',
+        replacement: templateVersion,
+      ),
+    ],
+    fileNameReplacements: [
+      Replacement(
+        slotName: 'projectname',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: 'gitignore',
+        replacement: '.gitignore',
+      ),
+    ],
+    removePrefixes: [
+      'path: ../../../packages/serverpod_flutter',
+    ],
+    ignoreFileNames: [
+      'pubspec.lock',
+      'ios',
+      'android',
+      'web',
+      'macos',
+      'build',
+    ],
+  );
+  copier.copyFiles();
+
+  copier = Copier(
+    srcDir: Directory(p.join(resourceManager.templateDirectory.path, 'github')),
+    dstDir: serverpodDirs.githubDir,
+    replacements: [
+      Replacement(
+        slotName: 'projectname',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: 'awsname',
+        replacement: awsName,
+      ),
+      Replacement(
+        slotName: 'randomawsid',
+        replacement: randomAwsId,
+      ),
+    ],
+    fileNameReplacements: [],
+  );
+  copier.copyFiles();
+}
+
+void _copyModuleTemplates(
+  ServerpodDirectories serverpodDirs, {
+  required String name,
+}) {
+  // Copy server files
+  var copier = Copier(
+    srcDir: Directory(
+        p.join(resourceManager.templateDirectory.path, 'modulename_server')),
+    dstDir: serverpodDirs.serverDir,
+    replacements: [
+      Replacement(
+        slotName: 'modulename',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: '#--CONDITIONAL_COMMENT--#',
+        replacement: '',
+      ),
+      Replacement(
+        slotName: 'VERSION',
+        replacement: templateVersion,
+      ),
+    ],
+    fileNameReplacements: [
+      Replacement(
+        slotName: 'modulename',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: 'gitignore',
+        replacement: '.gitignore',
+      ),
+    ],
+    removePrefixes: ['path'],
+    ignoreFileNames: ['pubspec.lock'],
+  );
+  copier.copyFiles();
+
+  // Copy client files
+  copier = Copier(
+    srcDir: Directory(
+        p.join(resourceManager.templateDirectory.path, 'modulename_client')),
+    dstDir: serverpodDirs.clientDir,
+    replacements: [
+      Replacement(
+        slotName: 'modulename',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: '#--CONDITIONAL_COMMENT--#',
+        replacement: '',
+      ),
+      Replacement(
+        slotName: 'VERSION',
+        replacement: templateVersion,
+      ),
+    ],
+    fileNameReplacements: [
+      Replacement(
+        slotName: 'modulename',
+        replacement: name,
+      ),
+      Replacement(
+        slotName: 'gitignore',
+        replacement: '.gitignore',
+      ),
+    ],
+    removePrefixes: ['path'],
+    ignoreFileNames: ['pubspec.lock'],
+  );
+  copier.copyFiles();
 }

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -139,47 +139,9 @@ Future<void> performCreate(
     style: const TextLog(),
   );
 
-  log.debug(
-    'Creating directory: ${serverpodDirs.projectDir.path}',
-    style: const TextLog(
-      type: TextLogType.bullet,
-    ),
-  );
-  serverpodDirs.projectDir.createSync();
-
-  log.debug(
-    'Creating directory: ${serverpodDirs.serverDir.path}',
-    style: const TextLog(
-      type: TextLogType.bullet,
-    ),
-  );
-  serverpodDirs.serverDir.createSync();
-
-  log.debug(
-    'Creating directory: ${serverpodDirs.clientDir.path}',
-    style: const TextLog(
-      type: TextLogType.bullet,
-    ),
-  );
-  serverpodDirectories.clientDir.createSync();
+  _createProjectDirectories(template, serverpodDirs);
 
   if (template == ServerpodTemplateType.server) {
-    log.debug(
-      'Creating directory: ${serverpodDirs.flutterDir.path}',
-      style: const TextLog(
-        type: TextLogType.bullet,
-      ),
-    );
-    serverpodDirs.flutterDir.createSync();
-
-    log.debug(
-      'Creating directory: ${serverpodDirs.githubDir.path}',
-      style: const TextLog(
-        type: TextLogType.bullet,
-      ),
-    );
-    serverpodDirs.githubDir.createSync();
-
     // Copy server files
     var copier = Copier(
       srcDir: Directory(
@@ -353,9 +315,9 @@ Future<void> performCreate(
     );
     copier.copyFiles();
 
-    CommandLineTools.dartPubGet(serverDir);
-    CommandLineTools.dartPubGet(clientDir);
-    CommandLineTools.flutterCreate(flutterDir);
+    CommandLineTools.dartPubGet(serverpodDirs.serverDir);
+    CommandLineTools.dartPubGet(serverpodDirs.clientDir);
+    CommandLineTools.flutterCreate(serverpodDirs.flutterDir);
   } else if (template == ServerpodTemplateType.module) {
     // Copy server files
     var copier = Copier(
@@ -499,4 +461,28 @@ class ServerpodDirectories {
         clientDir = Directory(p.join(projectDir.path, '${name}_client')),
         flutterDir = Directory(p.join(projectDir.path, '${name}_flutter')),
         githubDir = Directory(p.join(projectDir.path, '.github'));
+}
+
+void _createProjectDirectories(
+  ServerpodTemplateType template,
+  ServerpodDirectories serverpodDirs,
+) {
+  _createDirectory(serverpodDirs.projectDir);
+  _createDirectory(serverpodDirs.serverDir);
+  _createDirectory(serverpodDirs.clientDir);
+
+  if (template == ServerpodTemplateType.server) {
+    _createDirectory(serverpodDirs.flutterDir);
+    _createDirectory(serverpodDirs.githubDir);
+  }
+}
+
+void _createDirectory(Directory dir) {
+  log.debug(
+    'Creating directory: ${dir.path}',
+    style: const TextLog(
+      type: TextLogType.bullet,
+    ),
+  );
+  dir.createSync();
 }

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -152,9 +152,9 @@ Future<void> performCreate(
       dbStagingPassword: dbStagingPassword,
     );
 
-    CommandLineTools.dartPubGet(serverpodDirs.serverDir);
-    CommandLineTools.dartPubGet(serverpodDirs.clientDir);
-    CommandLineTools.flutterCreate(serverpodDirs.flutterDir);
+    await CommandLineTools.dartPubGet(serverpodDirs.serverDir);
+    await CommandLineTools.dartPubGet(serverpodDirs.clientDir);
+    await CommandLineTools.flutterCreate(serverpodDirs.flutterDir);
   } else if (template == ServerpodTemplateType.module) {
     _copyModuleTemplates(serverpodDirs, name: name);
   }

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -72,18 +72,18 @@ Future<void> performCreate(
       log.error(
         strIssuePorts,
         newParagraph: true,
-        style: const TextLogStyle(),
+        style: const TextLog(),
       );
       log.error(
         'Ports in use:',
         newParagraph: true,
-        style: const TextLogStyle(),
+        style: const TextLog(),
       );
       for (var serverDescription in usedPorts.keys) {
         var port = usedPorts[serverDescription]!;
         log.error(
           '$port: $serverDescription',
-          style: const TextLogStyle(type: AbstractStyleType.bullet),
+          style: const TextLog(type: TextLogType.bullet),
         );
       }
     }
@@ -91,7 +91,7 @@ Future<void> performCreate(
       log.error(
         strIssueDocker,
         newParagraph: true,
-        style: const TextLogStyle(),
+        style: const TextLog(),
       );
     }
     if (!force) {
@@ -115,13 +115,13 @@ Future<void> performCreate(
   log.info(
     'Creating project $name.',
     newParagraph: true,
-    style: const TextLogStyle(),
+    style: const TextLog(),
   );
 
   log.debug(
     'Creating directory: ${projectDir.path}',
-    style: const TextLogStyle(
-      type: AbstractStyleType.bullet,
+    style: const TextLog(
+      type: TextLogType.bullet,
     ),
   );
   projectDir.createSync();
@@ -129,8 +129,8 @@ Future<void> performCreate(
   var serverDir = Directory(p.join(projectDir.path, '${name}_server'));
   log.debug(
     'Creating directory: ${serverDir.path}',
-    style: const TextLogStyle(
-      type: AbstractStyleType.bullet,
+    style: const TextLog(
+      type: TextLogType.bullet,
     ),
   );
   serverDir.createSync();
@@ -138,8 +138,8 @@ Future<void> performCreate(
   var clientDir = Directory(p.join(projectDir.path, '${name}_client'));
   log.debug(
     'Creating directory: ${clientDir.path}',
-    style: const TextLogStyle(
-      type: AbstractStyleType.bullet,
+    style: const TextLog(
+      type: TextLogType.bullet,
     ),
   );
 
@@ -147,8 +147,8 @@ Future<void> performCreate(
     var flutterDir = Directory(p.join(projectDir.path, '${name}_flutter'));
     log.debug(
       'Creating directory: ${flutterDir.path}',
-      style: const TextLogStyle(
-        type: AbstractStyleType.bullet,
+      style: const TextLog(
+        type: TextLogType.bullet,
       ),
     );
     flutterDir.createSync();
@@ -156,8 +156,8 @@ Future<void> performCreate(
     var githubDir = Directory(p.join(projectDir.path, '.github'));
     log.debug(
       'Creating directory: ${githubDir.path}',
-      style: const TextLogStyle(
-        type: AbstractStyleType.bullet,
+      style: const TextLog(
+        type: TextLogType.bullet,
       ),
     );
     githubDir.createSync();
@@ -417,21 +417,21 @@ Future<void> performCreate(
       _logSuccessMessage();
       log.info(
         'cd .\\${p.join(name, '${name}_server')}\\',
-        style: const TextLogStyle(
-          type: AbstractStyleType.command,
+        style: const TextLog(
+          type: TextLogType.command,
         ),
       );
       log.info(
         '.\\setup-tables.cmd',
-        style: const TextLogStyle(type: AbstractStyleType.command),
+        style: const TextLog(type: TextLogType.command),
       );
       log.info(
         'docker compose up --build --detach',
-        style: const TextLogStyle(type: AbstractStyleType.command),
+        style: const TextLog(type: TextLogType.command),
       );
       log.info(
         'dart .\\bin\\main.dart',
-        style: const TextLogStyle(type: AbstractStyleType.command),
+        style: const TextLog(type: TextLogType.command),
       );
     } else {
       // Create tables
@@ -440,15 +440,15 @@ Future<void> performCreate(
       log.info(
         'cd ${p.join(name, '${name}_server')}',
         newParagraph: true,
-        style: const TextLogStyle(type: AbstractStyleType.command),
+        style: const TextLog(type: TextLogType.command),
       );
       log.info(
         'docker compose up --build --detach',
-        style: const TextLogStyle(type: AbstractStyleType.command),
+        style: const TextLog(type: TextLogType.command),
       );
       log.info(
         'dart dart bin/main.dart',
-        style: const TextLogStyle(type: AbstractStyleType.command),
+        style: const TextLog(type: TextLogType.command),
       );
     }
   }
@@ -456,16 +456,15 @@ Future<void> performCreate(
 
 void _logSuccessMessage() {
   log.info('SERVERPOD CREATED 🥳',
-      newParagraph: true,
-      style: const TextLogStyle(type: AbstractStyleType.success));
+      newParagraph: true, style: const TextLog(type: TextLogType.success));
   log.info(
     'All setup. You are ready to rock!',
     newParagraph: true,
-    style: const TextLogStyle(type: AbstractStyleType.success),
+    style: const TextLog(type: TextLogType.success),
   );
   log.info(
     'Start your Serverpod by running:',
     newParagraph: true,
-    style: const TextLogStyle(),
+    style: const TextLog(),
   );
 }

--- a/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
+++ b/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
@@ -46,7 +46,7 @@ class CodeGenerationCollector extends CodeAnalysisCollector {
     log.error(
       'Found ${errors.length} error${errors.length == 1 ? '' : 's'}.',
       newParagraph: true,
-      style: const TextLogStyle(),
+      style: const TextLog(),
     );
 
     for (var error in errors) {

--- a/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
+++ b/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
@@ -45,7 +45,8 @@ class CodeGenerationCollector extends CodeAnalysisCollector {
 
     log.error(
       'Found ${errors.length} error${errors.length == 1 ? '' : 's'}.',
-      style: const TextLogStyle(newParagraph: true),
+      newParagraph: true,
+      style: const TextLogStyle(),
     );
 
     for (var error in errors) {

--- a/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
@@ -20,8 +20,11 @@ Future<bool> performGenerateContinuously({
   var hasErrors = false;
   await for (WatchEvent event
       in StreamGroup.merge([watcherClasses.events, watcherEndpoints.events])) {
-    log.info('File changed: $event',
-        style: const TextLogStyle(newParagraph: true));
+    log.info(
+      'File changed: $event',
+      newParagraph: true,
+      style: const TextLogStyle(),
+    );
     hasErrors = await performGenerate(
       changedFile: event.path,
       config: config,

--- a/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
@@ -23,7 +23,7 @@ Future<bool> performGenerateContinuously({
     log.info(
       'File changed: $event',
       newParagraph: true,
-      style: const TextLogStyle(),
+      style: const TextLog(),
     );
     hasErrors = await performGenerate(
       changedFile: event.path,

--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -64,8 +64,8 @@ Future<void> _checkLatestVersion(
         for (var dep in deps) {
           log.info(
             dep.serverpodPackage,
-            style: const TextLogStyle(
-              type: AbstractStyleType.bullet,
+            style: const TextLog(
+              type: TextLogType.bullet,
             ),
           );
         }
@@ -84,14 +84,14 @@ void _printMismatchedDependencies(Set<String> mismatchedDeps,
   for (var depName in mismatchedDeps) {
     log.error(
       depName,
-      style: const LogStyle(),
+      style: const RawLog(),
     );
     var deps = dependencies[depName]!;
     for (var dep in deps) {
       log.error(
         '${dep.version} ${dep.serverpodPackage}',
-        style: const TextLogStyle(
-          type: AbstractStyleType.bullet,
+        style: const TextLog(
+          type: TextLogType.bullet,
         ),
       );
     }

--- a/tools/serverpod_cli/lib/src/logger/helpers/progress.dart
+++ b/tools/serverpod_cli/lib/src/logger/helpers/progress.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:serverpod_cli/src/util/ansi_style.dart';
+
+/// {@template progress_options}
+/// An object containing configuration for a [Progress] instance.
+/// {@endtemplate}
+class ProgressOptions {
+  /// {@macro progress_options}
+  const ProgressOptions({this.animation = const ProgressAnimation()});
+
+  /// The progress animation configuration.
+  final ProgressAnimation animation;
+}
+
+/// {@template progress_animation}
+/// An object which contains configuration for the animation
+/// of a [Progress] instance.
+/// {@endtemplate}
+class ProgressAnimation {
+  /// {@macro progress_animation}
+  const ProgressAnimation({this.frames = _defaultFrames});
+
+  static const _defaultFrames = [
+    '⠋',
+    '⠙',
+    '⠹',
+    '⠸',
+    '⠼',
+    '⠴',
+    '⠦',
+    '⠧',
+    '⠇',
+    '⠏'
+  ];
+
+  /// The list of animation frames.
+  final List<String> frames;
+}
+
+/// {@template progress}
+/// A class that can be used to display progress information to the user.
+/// {@endtemplate}
+class Progress {
+  /// {@macro progress}
+  Progress(
+    this._message,
+    this._stdout, {
+    ProgressOptions options = const ProgressOptions(),
+  })  : _stopwatch = Stopwatch(),
+        _options = options {
+    _stopwatch
+      ..reset()
+      ..start();
+
+    // The animation is only shown when it would be meaningful.
+    // Do not animate if the stdio type is not a terminal.
+    // Do not animate if the log level is lower than info since other logs
+    // might interrupt the animation
+    if (!_stdout.hasTerminal) {
+      var frames = _options.animation.frames;
+      var char = frames.isEmpty ? '' : frames.first;
+      var prefix = char.isEmpty ? char : '${AnsiStyle.lightGreen.wrap(char)} ';
+      _write('$prefix$_message...\n');
+      return;
+    }
+
+    _timer = Timer.periodic(const Duration(milliseconds: 80), _onTick);
+  }
+
+  final ProgressOptions _options;
+
+  final Stdout _stdout;
+
+  final Stopwatch _stopwatch;
+
+  Timer? _timer;
+
+  String _message;
+
+  int _index = 0;
+
+  /// End the progress and mark it as a successful completion.
+  ///
+  /// See also:
+  ///
+  /// * [fail], to end the progress and mark it as failed.
+  /// * [cancel], to cancel the progress entirely and remove the written line.
+  void complete([String? update]) {
+    _stopwatch.stop();
+    _write(
+      '''$_clearLine${AnsiStyle.lightGreen.wrap('✓')} ${update ?? _message} $_time\n''',
+    );
+    _timer?.cancel();
+  }
+
+  /// End the progress and mark it as failed.
+  ///
+  /// See also:
+  ///
+  /// * [complete], to end the progress and mark it as a successful completion.
+  /// * [cancel], to cancel the progress entirely and remove the written line.
+  void fail([String? update]) {
+    _timer?.cancel();
+    _write(
+        '$_clearLine${AnsiStyle.red.wrap('✗')} ${update ?? _message} $_time\n');
+    _stopwatch.stop();
+  }
+
+  /// Update the progress message.
+  void update(String update) {
+    if (_timer != null) _write(_clearLine);
+    _message = update;
+    _onTick(_timer);
+  }
+
+  /// Cancel the progress and remove the written line.
+  void cancel() {
+    _timer?.cancel();
+    _write(_clearLine);
+    _stopwatch.stop();
+  }
+
+  // Stops timer from calling [_onTick(...)].
+  void stopAnimation() {
+    _timer?.cancel();
+  }
+
+  String get _clearLine {
+    return '\u001b[2K' // clear current line
+        '\r'; // bring cursor to the start of the current line
+  }
+
+  void _onTick(Timer? _) {
+    _index++;
+    var frames = _options.animation.frames;
+    var char = frames.isEmpty ? '' : frames[_index % frames.length];
+    var prefix = char.isEmpty ? char : '${AnsiStyle.lightGreen.wrap(char)} ';
+
+    _write('$_clearLine$prefix$_message... $_time');
+  }
+
+  void _write(String object) {
+    _stdout.write(object);
+  }
+
+  String get _time {
+    var elapsedTime = _stopwatch.elapsed.inMilliseconds;
+    var displayInMilliseconds = elapsedTime < 100;
+    var time = displayInMilliseconds ? elapsedTime : elapsedTime / 1000;
+    var formattedTime =
+        displayInMilliseconds ? '${time}ms' : '${time.toStringAsFixed(1)}s';
+    return AnsiStyle.darkGray.wrap('($formattedTime)');
+  }
+}

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -60,6 +60,15 @@ abstract class Logger {
     bool newParagraph,
   });
 
+  // Display a progress message on [LogLevel.info] while running [run] function.
+  // Uses return value from [run] to print set progress success status.
+  // Returns return value from [run].
+  Future<bool> progress(
+    String message,
+    Future<bool> Function() run, {
+    bool newParagraph,
+  });
+
   /// Returns a [Future] that completes once all logging is complete.
   Future<void> flush();
 }

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -21,7 +21,7 @@ abstract class Logger {
   void debug(
     String message, {
     bool newParagraph,
-    RawLog style,
+    LogStyle style,
   });
 
   /// Display a normal [message] to the user.
@@ -30,7 +30,7 @@ abstract class Logger {
   void info(
     String message, {
     bool newParagraph,
-    RawLog style,
+    LogStyle style,
   });
 
   /// Display a warning [message] to the user.
@@ -39,7 +39,7 @@ abstract class Logger {
   void warning(
     String message, {
     bool newParagraph,
-    RawLog style,
+    LogStyle style,
   });
 
   /// Display an error [message] to the user.
@@ -49,7 +49,7 @@ abstract class Logger {
     String message, {
     bool newParagraph,
     StackTrace? stackTrace,
-    RawLog style,
+    LogStyle style,
   });
 
   /// Display a [SourceSpanException] to the user.
@@ -83,14 +83,19 @@ enum TextLogType {
   command,
 }
 
-/// Minimum formatting for style.
-class RawLog {
+abstract class LogStyle {
+  const LogStyle();
+}
+
+/// Does not apply any formatting to the log before logging.
+/// Assumes log is formatted with end line symbol.
+class RawLog extends LogStyle {
   const RawLog();
 }
 
 /// Box style console formatting.
 /// If [title] is set the box will have a title row.
-class BoxLog extends RawLog {
+class BoxLog extends LogStyle {
   final String? title;
   const BoxLog({
     this.title,
@@ -100,7 +105,7 @@ class BoxLog extends RawLog {
 
 /// Abstract style console formatting.
 /// Enables more precise settings for log message.
-class TextLog extends RawLog {
+class TextLog extends LogStyle {
   final bool wordWrap;
   final TextLogType type;
 

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -20,6 +20,7 @@ abstract class Logger {
   /// debugging purposes.
   void debug(
     String message, {
+    bool newParagraph,
     LogStyle style,
   });
 
@@ -28,6 +29,7 @@ abstract class Logger {
   /// success, progress or information messages.
   void info(
     String message, {
+    bool newParagraph,
     LogStyle style,
   });
 
@@ -36,6 +38,7 @@ abstract class Logger {
   /// information for the user.
   void warning(
     String message, {
+    bool newParagraph,
     LogStyle style,
   });
 
@@ -44,6 +47,7 @@ abstract class Logger {
   /// has occurred.
   void error(
     String message, {
+    bool newParagraph,
     StackTrace? stackTrace,
     LogStyle style,
   });
@@ -81,11 +85,7 @@ enum AbstractStyleType {
 
 /// Minimum formatting for style.
 class LogStyle {
-  final bool newParagraph;
-
-  const LogStyle({
-    this.newParagraph = false,
-  });
+  const LogStyle();
 }
 
 /// Box style console formatting.
@@ -95,7 +95,7 @@ class BoxLogStyle extends LogStyle {
   const BoxLogStyle({
     this.title,
     bool newParagraph = true,
-  }) : super(newParagraph: newParagraph);
+  });
 }
 
 /// Abstract style console formatting.
@@ -107,8 +107,7 @@ class TextLogStyle extends LogStyle {
   const TextLogStyle({
     this.type = AbstractStyleType.normal,
     this.wordWrap = true,
-    bool newParagraph = false,
-  }) : super(newParagraph: newParagraph);
+  });
 }
 
 /// Singleton instance of logger.

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -76,11 +76,13 @@ enum LogLevel {
 }
 
 enum TextLogType {
+  init,
   normal,
   hint,
-  success,
+  header,
   bullet,
   command,
+  success,
 }
 
 abstract class LogStyle {

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -21,7 +21,7 @@ abstract class Logger {
   void debug(
     String message, {
     bool newParagraph,
-    LogStyle style,
+    RawLog style,
   });
 
   /// Display a normal [message] to the user.
@@ -30,7 +30,7 @@ abstract class Logger {
   void info(
     String message, {
     bool newParagraph,
-    LogStyle style,
+    RawLog style,
   });
 
   /// Display a warning [message] to the user.
@@ -39,7 +39,7 @@ abstract class Logger {
   void warning(
     String message, {
     bool newParagraph,
-    LogStyle style,
+    RawLog style,
   });
 
   /// Display an error [message] to the user.
@@ -49,7 +49,7 @@ abstract class Logger {
     String message, {
     bool newParagraph,
     StackTrace? stackTrace,
-    LogStyle style,
+    RawLog style,
   });
 
   /// Display a [SourceSpanException] to the user.
@@ -75,7 +75,7 @@ enum LogLevel {
   final String name;
 }
 
-enum AbstractStyleType {
+enum TextLogType {
   normal,
   hint,
   success,
@@ -84,15 +84,15 @@ enum AbstractStyleType {
 }
 
 /// Minimum formatting for style.
-class LogStyle {
-  const LogStyle();
+class RawLog {
+  const RawLog();
 }
 
 /// Box style console formatting.
 /// If [title] is set the box will have a title row.
-class BoxLogStyle extends LogStyle {
+class BoxLog extends RawLog {
   final String? title;
-  const BoxLogStyle({
+  const BoxLog({
     this.title,
     bool newParagraph = true,
   });
@@ -100,12 +100,12 @@ class BoxLogStyle extends LogStyle {
 
 /// Abstract style console formatting.
 /// Enables more precise settings for log message.
-class TextLogStyle extends LogStyle {
+class TextLog extends RawLog {
   final bool wordWrap;
-  final AbstractStyleType type;
+  final TextLogType type;
 
-  const TextLogStyle({
-    this.type = AbstractStyleType.normal,
+  const TextLog({
+    this.type = TextLogType.normal,
     this.wordWrap = true,
   });
 }

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -123,7 +123,7 @@ class StdOutLogger extends Logger {
 
       switch (style.type) {
         case TextLogType.command:
-          message = '  \$ $message';
+          message = '   ${AnsiStyle.yellow.wrap('\$ $message')}';
           break;
         case TextLogType.bullet:
           message = ' • $message';
@@ -131,7 +131,15 @@ class StdOutLogger extends Logger {
         case TextLogType.normal:
           message = '$prefix$message';
           break;
+        case TextLogType.init:
+          message = AnsiStyle.cyan.wrap(AnsiStyle.bold.wrap(message));
+          break;
+        case TextLogType.header:
+          message = AnsiStyle.bold.wrap(message);
+          break;
         case TextLogType.success:
+          message =
+              '✅ ${AnsiStyle.lightGreen.wrap(AnsiStyle.bold.wrap(message))}\n';
           break;
         case TextLogType.hint:
           message = AnsiStyle.italic.wrap(message);
@@ -171,7 +179,7 @@ class WindowsStdOutLogger extends StdOutLogger {
     String message,
     LogLevel logLevel,
   ) {
-    message.replaceAll('🥳', '=D');
+    message.replaceAll('🥳', '=D').replaceAll('✅', '√');
     super._write(message, logLevel);
   }
 }

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -19,11 +19,13 @@ class StdOutLogger extends Logger {
   @override
   void debug(
     String message, {
+    bool newParagraph = false,
     LogStyle style = const TextLogStyle(),
   }) {
     _log(
       message,
       LogLevel.debug,
+      newParagraph,
       style,
       prefix: 'DEBUG: ',
     );
@@ -32,29 +34,32 @@ class StdOutLogger extends Logger {
   @override
   void info(
     String message, {
+    bool newParagraph = false,
     LogStyle style = const TextLogStyle(),
   }) {
-    _log(message, LogLevel.info, style);
+    _log(message, LogLevel.info, newParagraph, style);
   }
 
   @override
   void warning(
     String message, {
+    bool newParagraph = false,
     LogStyle style = const TextLogStyle(),
   }) {
-    _log(message, LogLevel.warning, style, prefix: 'WARNING: ');
+    _log(message, LogLevel.warning, newParagraph, style, prefix: 'WARNING: ');
   }
 
   @override
   void error(
     String message, {
+    bool newParagraph = false,
     StackTrace? stackTrace,
     LogStyle style = const TextLogStyle(),
   }) {
-    _log(message, LogLevel.error, style, prefix: 'ERROR: ');
+    _log(message, LogLevel.error, newParagraph, style, prefix: 'ERROR: ');
 
     if (stackTrace != null) {
-      _log(stackTrace.toString(), LogLevel.error, style);
+      _log(stackTrace.toString(), LogLevel.error, newParagraph, style);
     }
   }
 
@@ -98,6 +103,7 @@ class StdOutLogger extends Logger {
   void _log(
     String message,
     LogLevel logLevel,
+    bool newParagraph,
     LogStyle style, {
     String prefix = '',
   }) {
@@ -132,7 +138,7 @@ class StdOutLogger extends Logger {
       }
     }
 
-    if (style.newParagraph) {
+    if (newParagraph) {
       message = '\n$message';
     }
 

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -143,14 +143,19 @@ class StdOutLogger extends Logger {
       message = '\n$message';
     }
 
+    if (style is! RawLog) {
+      // If it is not a raw log we append a new line after the message.
+      message = '$message\n';
+    }
+
     _write(message, logLevel);
   }
 
   void _write(String message, LogLevel logLevel) {
     if (logLevel.index >= LogLevel.warning.index) {
-      stderr.writeln(message);
+      stderr.write(message);
     } else {
-      stdout.writeln(message);
+      stdout.write(message);
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -20,7 +20,7 @@ class StdOutLogger extends Logger {
   void debug(
     String message, {
     bool newParagraph = false,
-    LogStyle style = const TextLogStyle(),
+    RawLog style = const TextLog(),
   }) {
     _log(
       message,
@@ -35,7 +35,7 @@ class StdOutLogger extends Logger {
   void info(
     String message, {
     bool newParagraph = false,
-    LogStyle style = const TextLogStyle(),
+    RawLog style = const TextLog(),
   }) {
     _log(message, LogLevel.info, newParagraph, style);
   }
@@ -44,7 +44,7 @@ class StdOutLogger extends Logger {
   void warning(
     String message, {
     bool newParagraph = false,
-    LogStyle style = const TextLogStyle(),
+    RawLog style = const TextLog(),
   }) {
     _log(message, LogLevel.warning, newParagraph, style, prefix: 'WARNING: ');
   }
@@ -54,7 +54,7 @@ class StdOutLogger extends Logger {
     String message, {
     bool newParagraph = false,
     StackTrace? stackTrace,
-    LogStyle style = const TextLogStyle(),
+    RawLog style = const TextLog(),
   }) {
     _log(message, LogLevel.error, newParagraph, style, prefix: 'ERROR: ');
 
@@ -104,35 +104,35 @@ class StdOutLogger extends Logger {
     String message,
     LogLevel logLevel,
     bool newParagraph,
-    LogStyle style, {
+    RawLog style, {
     String prefix = '',
   }) {
     if (message == '') return;
     if (!shouldLog(logLevel)) return;
 
-    if (style is BoxLogStyle) {
+    if (style is BoxLog) {
       message = _formatAsBox(
         message: message,
         title: style.title,
       );
-    } else if (style is TextLogStyle) {
+    } else if (style is TextLog) {
       if (wrapTextColumn != null && style.wordWrap) {
         message = _wrapText(message, wrapTextColumn!);
       }
 
       switch (style.type) {
-        case AbstractStyleType.command:
+        case TextLogType.command:
           message = '  \$ $message';
           break;
-        case AbstractStyleType.bullet:
+        case TextLogType.bullet:
           message = ' • $message';
           break;
-        case AbstractStyleType.normal:
+        case TextLogType.normal:
           message = '$prefix$message';
           break;
-        case AbstractStyleType.success:
+        case TextLogType.success:
           break;
-        case AbstractStyleType.hint:
+        case TextLogType.hint:
           message = '${Colorize(message)..italic()}';
           break;
       }

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -20,7 +20,7 @@ class StdOutLogger extends Logger {
   void debug(
     String message, {
     bool newParagraph = false,
-    RawLog style = const TextLog(),
+    LogStyle style = const TextLog(),
   }) {
     _log(
       message,
@@ -35,7 +35,7 @@ class StdOutLogger extends Logger {
   void info(
     String message, {
     bool newParagraph = false,
-    RawLog style = const TextLog(),
+    LogStyle style = const TextLog(),
   }) {
     _log(message, LogLevel.info, newParagraph, style);
   }
@@ -44,7 +44,7 @@ class StdOutLogger extends Logger {
   void warning(
     String message, {
     bool newParagraph = false,
-    RawLog style = const TextLog(),
+    LogStyle style = const TextLog(),
   }) {
     _log(message, LogLevel.warning, newParagraph, style, prefix: 'WARNING: ');
   }
@@ -54,7 +54,7 @@ class StdOutLogger extends Logger {
     String message, {
     bool newParagraph = false,
     StackTrace? stackTrace,
-    RawLog style = const TextLog(),
+    LogStyle style = const TextLog(),
   }) {
     _log(message, LogLevel.error, newParagraph, style, prefix: 'ERROR: ');
 
@@ -104,7 +104,7 @@ class StdOutLogger extends Logger {
     String message,
     LogLevel logLevel,
     bool newParagraph,
-    RawLog style, {
+    LogStyle style, {
     String prefix = '',
   }) {
     if (message == '') return;

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -209,7 +209,11 @@ class WindowsStdOutLogger extends StdOutLogger {
     String message,
     LogLevel logLevel,
   ) {
-    message.replaceAll('🥳', '=D').replaceAll('✅', '√');
+    message
+        .replaceAll('🥳', '=D')
+        .replaceAll('✅', '√')
+        .replaceAll('🚀', '')
+        .replaceAll('📦', '');
     super._write(message, logLevel);
   }
 }

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -112,6 +112,7 @@ class StdOutLogger extends Logger {
 
     if (style is BoxLog) {
       message = _formatAsBox(
+        wrapColumn: wrapTextColumn ?? 100,
         message: message,
         title: style.title,
       );
@@ -193,11 +194,11 @@ String _wrapText(String text, int columnWidth) {
 String _formatAsBox({
   required String message,
   String? title,
+  required int wrapColumn,
 }) {
   const int kPaddingLeftRight = 1;
   const int kEdges = 2;
 
-  var wrapColumn = stdout.hasTerminal ? stdout.terminalColumns : 100;
   var maxTextWidthPerLine = wrapColumn - kEdges - kPaddingLeftRight * 2;
   var lines = _wrapText(message, maxTextWidthPerLine).split('\n');
   var lineWidth = lines.map((String line) => line.length).toList();

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 import 'dart:math' as math;
 
-import 'package:colorize/colorize.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/util/ansi_style.dart';
 import 'package:source_span/source_span.dart';
 import 'package:super_string/super_string.dart';
 
@@ -134,7 +134,7 @@ class StdOutLogger extends Logger {
         case TextLogType.success:
           break;
         case TextLogType.hint:
-          message = '${Colorize(message)..italic()}';
+          message = AnsiStyle.italic.wrap(message);
           break;
       }
     }
@@ -245,17 +245,6 @@ String _formatAsBox({
   return buffer.toString();
 }
 
-enum TextColor {
-  terminalDefault('\x1B[39m'),
-  red('\x1B[31m'),
-  yellow('\x1B[33m'),
-  blue('\x1B[34m'),
-  cyan('\x1B[36m');
-
-  const TextColor(this.ansiCode);
-  final String ansiCode;
-}
-
 abstract class _SeveritySpanHelpers {
   static LogLevel severityToLogLevel(SourceSpanSeverity severity) {
     switch (severity) {
@@ -271,22 +260,22 @@ abstract class _SeveritySpanHelpers {
 
   static String highlightAnsiCode(LogLevel severity, bool isHint) {
     if (severity == LogLevel.info && isHint) {
-      return TextColor.cyan.ansiCode;
+      return AnsiStyle.cyan.ansiCode;
     }
 
     switch (severity) {
       case LogLevel.nothing:
         assert(
             false, 'Log level nothing should never be used for a log message');
-        return TextColor.terminalDefault.ansiCode;
+        return AnsiStyle.terminalDefault.ansiCode;
       case LogLevel.error:
-        return TextColor.red.ansiCode;
+        return AnsiStyle.red.ansiCode;
       case LogLevel.warning:
-        return TextColor.yellow.ansiCode;
+        return AnsiStyle.yellow.ansiCode;
       case LogLevel.info:
-        return TextColor.blue.ansiCode;
+        return AnsiStyle.blue.ansiCode;
       case LogLevel.debug:
-        return TextColor.cyan.ansiCode;
+        return AnsiStyle.cyan.ansiCode;
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
@@ -14,21 +14,21 @@ class VoidLogger extends Logger {
   void debug(
     String message, {
     bool newParagraph = false,
-    RawLog style = const RawLog(),
+    LogStyle style = const RawLog(),
   }) {}
 
   @override
   void info(
     String message, {
     bool newParagraph = false,
-    RawLog style = const RawLog(),
+    LogStyle style = const RawLog(),
   }) {}
 
   @override
   void warning(
     String message, {
     bool newParagraph = false,
-    RawLog style = const RawLog(),
+    LogStyle style = const RawLog(),
   }) {}
 
   @override
@@ -36,7 +36,7 @@ class VoidLogger extends Logger {
     String message, {
     bool newParagraph = false,
     StackTrace? stackTrace,
-    RawLog style = const RawLog(),
+    LogStyle style = const RawLog(),
   }) {}
 
   @override

--- a/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
@@ -47,4 +47,13 @@ class VoidLogger extends Logger {
   Future<void> flush() {
     return Future(() => {});
   }
+
+  @override
+  Future<bool> progress(
+    String message,
+    Future<bool> Function() run, {
+    bool newParagraph = true,
+  }) async {
+    return await run();
+  }
 }

--- a/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
@@ -14,21 +14,21 @@ class VoidLogger extends Logger {
   void debug(
     String message, {
     bool newParagraph = false,
-    LogStyle style = const LogStyle(),
+    RawLog style = const RawLog(),
   }) {}
 
   @override
   void info(
     String message, {
     bool newParagraph = false,
-    LogStyle style = const LogStyle(),
+    RawLog style = const RawLog(),
   }) {}
 
   @override
   void warning(
     String message, {
     bool newParagraph = false,
-    LogStyle style = const LogStyle(),
+    RawLog style = const RawLog(),
   }) {}
 
   @override
@@ -36,7 +36,7 @@ class VoidLogger extends Logger {
     String message, {
     bool newParagraph = false,
     StackTrace? stackTrace,
-    LogStyle style = const LogStyle(),
+    RawLog style = const RawLog(),
   }) {}
 
   @override

--- a/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/void_logger.dart
@@ -11,17 +11,33 @@ class VoidLogger extends Logger {
   int? get wrapTextColumn => null;
 
   @override
-  void debug(String message, {LogStyle style = const LogStyle()}) {}
+  void debug(
+    String message, {
+    bool newParagraph = false,
+    LogStyle style = const LogStyle(),
+  }) {}
 
   @override
-  void info(String message, {LogStyle style = const LogStyle()}) {}
+  void info(
+    String message, {
+    bool newParagraph = false,
+    LogStyle style = const LogStyle(),
+  }) {}
 
   @override
-  void warning(String message, {LogStyle style = const LogStyle()}) {}
+  void warning(
+    String message, {
+    bool newParagraph = false,
+    LogStyle style = const LogStyle(),
+  }) {}
 
   @override
-  void error(String message,
-      {StackTrace? stackTrace, LogStyle style = const LogStyle()}) {}
+  void error(
+    String message, {
+    bool newParagraph = false,
+    StackTrace? stackTrace,
+    LogStyle style = const LogStyle(),
+  }) {}
 
   @override
   void sourceSpanException(SourceSpanException sourceSpan,

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -225,7 +225,7 @@ class MigrationGenerator {
       for (var warning in warnings) {
         log.warning(
           warning.message,
-          style: const TextLogStyle(type: AbstractStyleType.bullet),
+          style: const TextLog(type: TextLogType.bullet),
         );
       }
     }

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
@@ -5,7 +5,7 @@ import 'package:serverpod_cli/src/logger/logger.dart';
 abstract class ServerpodCommand extends Command {
   @override
   void printUsage() {
-    log.info(usage, style: const LogStyle());
+    log.info(usage, style: const RawLog());
   }
 
   @override

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -126,7 +126,7 @@ class ServerpodCommandRunner extends CommandRunner {
       return super.parse(args);
     } on UsageException catch (e) {
       _analytics.track(event: 'invalid');
-      log.error(e.toString(), style: const LogStyle());
+      log.error(e.toString(), style: const RawLog());
       throw ExitException(ExitCodeType.commandNotFound);
     }
   }
@@ -146,7 +146,7 @@ class ServerpodCommandRunner extends CommandRunner {
         _analytics.track(event: topLevelResults.command!.name!);
       }
     } on UsageException catch (e) {
-      log.error(e.toString(), style: const LogStyle());
+      log.error(e.toString(), style: const RawLog());
       _analytics.track(event: 'invalid');
       throw ExitException(ExitCodeType.commandNotFound);
     }
@@ -154,7 +154,7 @@ class ServerpodCommandRunner extends CommandRunner {
 
   @override
   void printUsage() {
-    log.info(usage, style: const LogStyle());
+    log.info(usage, style: const RawLog());
   }
 
   @override

--- a/tools/serverpod_cli/lib/src/update_prompt/prompt_to_update.dart
+++ b/tools/serverpod_cli/lib/src/update_prompt/prompt_to_update.dart
@@ -20,6 +20,6 @@ Also, do not forget to update packages in your server, client, and flutter proje
 
   log.info(
     message,
-    style: const BoxLogStyle(newParagraph: true),
+    style: const BoxLog(newParagraph: true),
   );
 }

--- a/tools/serverpod_cli/lib/src/util/ansi_style.dart
+++ b/tools/serverpod_cli/lib/src/util/ansi_style.dart
@@ -1,0 +1,20 @@
+/// Standard ANSI escape code for customizing terminal text output.
+///
+/// [Source](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
+enum AnsiStyle {
+  terminalDefault('\x1B[39m'),
+  red('\x1B[31m'),
+  yellow('\x1B[33m'),
+  blue('\x1B[34m'),
+  cyan('\x1B[36m'),
+  lightGreen('\x1B[92m'),
+  darkGray('\x1B[90m'),
+  bold('\x1B[1m'),
+  italic('\x1B[3m'),
+  _reset('\x1B[0m');
+
+  const AnsiStyle(this.ansiCode);
+  final String ansiCode;
+
+  String wrap(String value) => '$ansiCode$value${AnsiStyle._reset.ansiCode}';
+}

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -10,7 +10,8 @@ class CommandLineTools {
   static void dartPubGet(Directory dir) {
     log.info(
       'Running `dart pub get` in ${dir.path}',
-      style: const TextLogStyle(newParagraph: true),
+      newParagraph: true,
+      style: const TextLogStyle(),
     );
     var cf = _CommandFormatter('dart', ['pub', 'get']);
     var result = Process.runSync(
@@ -77,9 +78,8 @@ class CommandLineTools {
       );
       log.debug(
         result.stdout,
-        style: const LogStyle(
-          newParagraph: true,
-        ),
+        newParagraph: true,
+        style: const LogStyle(),
       );
 
       if (result.exitCode != 0) {
@@ -112,9 +112,8 @@ class CommandLineTools {
     );
     log.debug(
       result.stdout,
-      style: const LogStyle(
-        newParagraph: true,
-      ),
+      newParagraph: true,
+      style: const LogStyle(),
     );
 
     if (result.exitCode != 0) {
@@ -128,9 +127,8 @@ class CommandLineTools {
     );
     log.debug(
       result.stdout,
-      style: const LogStyle(
-        newParagraph: true,
-      ),
+      newParagraph: true,
+      style: const LogStyle(),
     );
 
     if (result.exitCode != 0) {

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -8,7 +8,7 @@ import 'package:serverpod_cli/src/logger/logger.dart';
 import 'windows.dart';
 
 class CommandLineTools {
-  static Future<void> dartPubGet(Directory dir) async {
+  static Future<bool> dartPubGet(Directory dir) async {
     log.info(
       'Running `dart pub get` in ${dir.path}',
       newParagraph: true,
@@ -24,10 +24,13 @@ class CommandLineTools {
 
     if (exitCode != 0) {
       log.error('Failed to run `dart pub get` in ${dir.path}');
+      return false;
     }
+
+    return true;
   }
 
-  static Future<void> flutterCreate(Directory dir) async {
+  static Future<bool> flutterCreate(Directory dir) async {
     log.info('Running `flutter create .` in ${dir.path}');
 
     var cf = _CommandFormatter('flutter', ['create', '.']);
@@ -39,7 +42,10 @@ class CommandLineTools {
 
     if (exitCode != 0) {
       log.error('Failed to run `flutter create .` in ${dir.path}');
+      return false;
     }
+
+    return true;
   }
 
   static Future<bool> existsCommand(String command) async {
@@ -63,7 +69,7 @@ class CommandLineTools {
     return exitCode == 0;
   }
 
-  static Future<void> createTables(Directory dir, String name) async {
+  static Future<bool> createTables(Directory dir, String name) async {
     var serverPath = p.join(dir.path, '${name}_server');
     log.info('Setting up Docker and default database tables in $serverPath');
     log.info(
@@ -108,9 +114,11 @@ class CommandLineTools {
       arguments: ['setup-tables.cmd'],
       workingDirectory: serverPath,
     );
+
+    return exitCode == 0;
   }
 
-  static Future<void> cleanupForWindows(Directory dir, String name) async {
+  static Future<bool> cleanupForWindows(Directory dir, String name) async {
     var serverPath = p.join(dir.path, '${name}_server');
     log.info('Cleaning up');
     var file = File(p.join(serverPath, 'setup-tables'));
@@ -122,7 +130,10 @@ class CommandLineTools {
         'file: $file',
         style: const RawLog(),
       );
+      return false;
     }
+
+    return true;
   }
 }
 

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -11,7 +11,7 @@ class CommandLineTools {
     log.info(
       'Running `dart pub get` in ${dir.path}',
       newParagraph: true,
-      style: const TextLogStyle(),
+      style: const TextLog(),
     );
     var cf = _CommandFormatter('dart', ['pub', 'get']);
     var result = Process.runSync(
@@ -20,10 +20,10 @@ class CommandLineTools {
       workingDirectory: dir.path,
     );
 
-    log.debug(result.stdout, style: const LogStyle());
+    log.debug(result.stdout, style: const RawLog());
 
     if (result.exitCode != 0) {
-      log.error(result.stderr, style: const LogStyle());
+      log.error(result.stderr, style: const RawLog());
     }
   }
 
@@ -36,10 +36,10 @@ class CommandLineTools {
       workingDirectory: dir.path,
     );
 
-    log.debug(result.stdout, style: const LogStyle());
+    log.debug(result.stdout, style: const RawLog());
 
     if (result.exitCode != 0) {
-      log.error(result.stderr, style: const LogStyle());
+      log.error(result.stderr, style: const RawLog());
     }
   }
 
@@ -67,7 +67,7 @@ class CommandLineTools {
       'Postgres. If you get stuck at this step, make sure that you '
       'have the latest version of Docker Desktop and that it is '
       'currently running.',
-      style: const TextLogStyle(type: AbstractStyleType.hint),
+      style: const TextLog(type: TextLogType.hint),
     );
     late ProcessResult result;
     if (!Platform.isWindows) {
@@ -79,11 +79,11 @@ class CommandLineTools {
       log.debug(
         result.stdout,
         newParagraph: true,
-        style: const LogStyle(),
+        style: const RawLog(),
       );
 
       if (result.exitCode != 0) {
-        log.error(result.stderr, style: const LogStyle());
+        log.error(result.stderr, style: const RawLog());
       }
     }
 
@@ -113,11 +113,11 @@ class CommandLineTools {
     log.debug(
       result.stdout,
       newParagraph: true,
-      style: const LogStyle(),
+      style: const RawLog(),
     );
 
     if (result.exitCode != 0) {
-      log.error(result.stderr, style: const LogStyle());
+      log.error(result.stderr, style: const RawLog());
     }
 
     result = await Process.run(
@@ -128,11 +128,11 @@ class CommandLineTools {
     log.debug(
       result.stdout,
       newParagraph: true,
-      style: const LogStyle(),
+      style: const RawLog(),
     );
 
     if (result.exitCode != 0) {
-      log.error(result.stderr, style: const LogStyle());
+      log.error(result.stderr, style: const RawLog());
     }
   }
 
@@ -146,7 +146,7 @@ class CommandLineTools {
       log.error('Failed cleanup: $e');
       log.error(
         'file: $file',
-        style: const LogStyle(),
+        style: const RawLog(),
       );
     }
   }

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -9,11 +9,7 @@ import 'windows.dart';
 
 class CommandLineTools {
   static Future<bool> dartPubGet(Directory dir) async {
-    log.info(
-      'Running `dart pub get` in ${dir.path}',
-      newParagraph: true,
-      style: const TextLog(),
-    );
+    log.debug('Running `dart pub get` in ${dir.path}', newParagraph: true);
 
     var cf = _CommandFormatter('dart', ['pub', 'get']);
     var exitCode = await _runProcessWithLoggerAttached(
@@ -31,7 +27,7 @@ class CommandLineTools {
   }
 
   static Future<bool> flutterCreate(Directory dir) async {
-    log.info('Running `flutter create .` in ${dir.path}');
+    log.debug('Running `flutter create .` in ${dir.path}', newParagraph: true);
 
     var cf = _CommandFormatter('flutter', ['create', '.']);
     var exitCode = await _runProcessWithLoggerAttached(
@@ -70,17 +66,15 @@ class CommandLineTools {
   }
 
   static Future<bool> createTables(Directory dir, String name) async {
-    var serverPath = p.join(dir.path, '${name}_server');
-    log.info('Setting up Docker and default database tables in $serverPath');
-    log.info(
+    log.debug(
       'If you run serverpod create for the first time, this can take '
       'a few minutes as Docker is downloading the images for '
       'Postgres. If you get stuck at this step, make sure that you '
       'have the latest version of Docker Desktop and that it is '
       'currently running.',
-      style: const TextLog(type: TextLogType.hint),
     );
-    late ProcessResult result;
+    var serverPath = p.join(dir.path, '${name}_server');
+
     if (!Platform.isWindows) {
       await _runProcessWithLoggerAttached(
         executable: 'chmod',
@@ -99,10 +93,10 @@ class CommandLineTools {
     if (exitCode != 0) {
       log.error('Failed to set up tables');
     } else {
-      log.info('Completed table setup');
+      log.debug('Completed table setup');
     }
 
-    log.info('Cleaning up');
+    log.debug('Cleaning up');
     await _runProcessWithLoggerAttached(
       executable: 'rm',
       arguments: ['setup-tables'],
@@ -120,7 +114,7 @@ class CommandLineTools {
 
   static Future<bool> cleanupForWindows(Directory dir, String name) async {
     var serverPath = p.join(dir.path, '${name}_server');
-    log.info('Cleaning up');
+    log.debug('Cleaning up');
     var file = File(p.join(serverPath, 'setup-tables'));
     try {
       await file.delete();

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   args: ^2.4.0
   ci: ^0.1.0
   code_builder: ^4.4.0
-  colorize: ^3.0.0
   dart_style: ^2.3.0
   http: ^0.13.5
   intl: ^0.17.0


### PR DESCRIPTION
Issue: https://github.com/serverpod/serverpod/issues/1042


## Adds
- Progress message that displays the time spent for the method invoked along with nice formatting.
  - If a message is printed during a progress message the progress message updates stops and only a final message is printed with the time once the call is completed.
- Proper exit codes for the `create`, `migrate` and `generate` commands.
- Improved messaging on the `info` debug level so that users only get information that is relevant for them.

### Old

https://github.com/SandPod/serverpod/assets/137198655/9aeafb42-c1ac-4359-a8de-31f3decc4342

### New

https://github.com/SandPod/serverpod/assets/137198655/5605a593-3f9d-4981-9cf1-007afe4354bd


https://github.com/SandPod/serverpod/assets/137198655/e8fca09b-3258-405e-990a-84c7395a45b0


## Guidance for review
Along with introducing new functionality, this PR also contains the necessary refactors required to add them.

Since it is quite a big PR, the commit history has been crafted to isolate each change for best audibility. I would recommend looking through this PR commit by coming and using the headers below as a general guideline for what you should find in each commit.

### New features and improvements
1ea155f0 fix: use progress message for create command + improved logging output
d6ec46db feat: introduce progress log message
4a1dc107 fix: update print message for generate and migrate + only print success message when no errors for generate
56dfdbdf fix: exit code now reflects create success for "serverpod create"
da1486ab fix: run processes with attached logger for direct process output

### Create refactors and preparations
93112535 refactor: move copy templates into functions
02c398dd refactor: extract creating folder structure into method
1513c927 fix: create client dir with the rest of the directories
51d0c7ab refactor: introduce class to hold paths to all serverpod directories
690a90cc refactor: use enum type instead of string comparisons for create command

### Logger refactors, cleanups and preparations
6da4fb47 fix: add init and header style type and update formatting
0d319e4c fix: introduce ansi style and remove dependency on Colorize
7695091d fix: add raw log support
4426e580 refactor: use same source of truth for terminal column width.
80a67bb5 refactor: use abstract as base for log style and separate raw log
beb8e59c refactor: renaming of logger types for better clarity
6ff5512c refactor: break out new paragraph parameter from log style


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
