### PR TITLE
refactor: Remove polluting variable from extracted entities.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -5,7 +5,6 @@ import 'package:serverpod_cli/src/generator/types.dart';
 /// An abstract representation of a yaml file in the
 /// protocol directory.
 abstract class SerializableEntityDefinition {
-  final String yamlProtocol;
   final String fileName;
   final String sourceFileName;
   final String className;
@@ -13,7 +12,6 @@ abstract class SerializableEntityDefinition {
   final bool serverOnly;
 
   SerializableEntityDefinition({
-    required this.yamlProtocol,
     required this.fileName,
     required this.sourceFileName,
     required this.className,
@@ -56,7 +54,6 @@ class ClassDefinition extends SerializableEntityDefinition {
 
   /// Create a new [ClassDefinition].
   ClassDefinition({
-    required super.yamlProtocol,
     required super.fileName,
     required super.sourceFileName,
     required super.className,
@@ -199,7 +196,6 @@ class EnumDefinition extends SerializableEntityDefinition {
 
   /// Create a new [EnumDefinition].
   EnumDefinition({
-    required super.yamlProtocol,
     required super.fileName,
     required super.sourceFileName,
     required super.className,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -21,13 +21,13 @@ String _transformFileNameWithoutPathOrExtension(String path) {
   return p.basenameWithoutExtension(path);
 }
 
-class _ProtocolEntityDefinitionSource {
+class _ProtocolClassDefinitionSource {
   final ProtocolSource protocolSource;
-  final SerializableEntityDefinition entityDefinition;
+  final SerializableEntityDefinition classDefinition;
 
-  _ProtocolEntityDefinitionSource({
+  _ProtocolClassDefinitionSource({
     required this.protocolSource,
-    required this.entityDefinition,
+    required this.classDefinition,
   });
 }
 
@@ -47,19 +47,19 @@ class SerializableEntityAnalyzer {
     var protocols =
         await ProtocolHelper.loadProjectYamlProtocolsFromDisk(config);
 
-    var entityProtocolDef = _convertProtocolToEntityDefinitions(
+    var classProtocolDefinitions = _createClassProtocolDefinitions(
       protocols,
     );
 
     var classDefinitions =
-        entityProtocolDef.map((e) => e.entityDefinition).toList();
+        classProtocolDefinitions.map((e) => e.classDefinition).toList();
 
-    for (var classDefinition in entityProtocolDef) {
+    for (var definition in classProtocolDefinitions) {
       SerializableEntityAnalyzer.validateYamlDefinition(
-        classDefinition.protocolSource.yaml,
-        classDefinition.entityDefinition.sourceFileName,
+        definition.protocolSource.yaml,
+        definition.classDefinition.sourceFileName,
         collector,
-        classDefinition.entityDefinition,
+        definition.classDefinition,
         classDefinitions,
       );
     }
@@ -91,8 +91,8 @@ class SerializableEntityAnalyzer {
     return classDefinitions;
   }
 
-  static List<_ProtocolEntityDefinitionSource>
-      _convertProtocolToEntityDefinitions(List<ProtocolSource> protocols) {
+  static List<_ProtocolClassDefinitionSource> _createClassProtocolDefinitions(
+      List<ProtocolSource> protocols) {
     return protocols
         .map((protocol) {
           var entity = SerializableEntityAnalyzer.extractEntityDefinition(
@@ -101,12 +101,12 @@ class SerializableEntityAnalyzer {
 
           if (entity == null) return null;
 
-          return _ProtocolEntityDefinitionSource(
+          return _ProtocolClassDefinitionSource(
             protocolSource: protocol,
-            entityDefinition: entity,
+            classDefinition: entity,
           );
         })
-        .whereType<_ProtocolEntityDefinitionSource>()
+        .whereType<_ProtocolClassDefinitionSource>()
         .toList();
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -47,34 +47,35 @@ class SerializableEntityAnalyzer {
     var protocols =
         await ProtocolHelper.loadProjectYamlProtocolsFromDisk(config);
 
-    var classDefinitions = _convertProtocolToEntityDefinitions(
+    var entityProtocolDef = _convertProtocolToEntityDefinitions(
       protocols,
     );
 
-    var definitions = classDefinitions.map((e) => e.entityDefinition).toList();
+    var classDefinitions =
+        entityProtocolDef.map((e) => e.entityDefinition).toList();
 
-    for (var classDefinition in classDefinitions) {
+    for (var classDefinition in entityProtocolDef) {
       SerializableEntityAnalyzer.validateYamlDefinition(
         classDefinition.protocolSource.yaml,
         classDefinition.entityDefinition.sourceFileName,
         collector,
         classDefinition.entityDefinition,
-        definitions,
+        classDefinitions,
       );
     }
 
     // Detect protocol references
-    for (var classDefinition in definitions) {
+    for (var classDefinition in classDefinitions) {
       if (classDefinition is ClassDefinition) {
         for (var fieldDefinition in classDefinition.fields) {
           fieldDefinition.type =
-              fieldDefinition.type.applyProtocolReferences(definitions);
+              fieldDefinition.type.applyProtocolReferences(classDefinitions);
         }
       }
     }
 
     // Detect enum fields
-    for (var classDefinition in definitions) {
+    for (var classDefinition in classDefinitions) {
       if (classDefinition is ClassDefinition) {
         for (var fieldDefinition in classDefinition.fields) {
           if (fieldDefinition.type.url == 'protocol' &&
@@ -87,7 +88,7 @@ class SerializableEntityAnalyzer {
       }
     }
 
-    return definitions;
+    return classDefinitions;
   }
 
   static List<_ProtocolEntityDefinitionSource>

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -43,7 +43,6 @@ class EntityParser {
     var indexes = _parseIndexes(documentContents, fields);
 
     return ClassDefinition(
-      yamlProtocol: protocolSource.yaml,
       className: className,
       sourceFileName: protocolSource.yamlSourceUri.path,
       tableName: tableName,
@@ -74,7 +73,6 @@ class EntityParser {
     var values = _parseEnumValues(documentContents, docsExtractor);
 
     return EnumDefinition(
-      yamlProtocol: protocolSource.yaml,
       fileName: outFileName,
       sourceFileName: protocolSource.yamlSourceUri.path,
       className: className,


### PR DESCRIPTION
# Refactor

Remove the yaml string content from extracted entities. Reason for this is to not pass things forward that will be unused in the code generator, this simplifies the interface and makes it much more intuitive/cleaner to write tests for. I.E. we do not have to define a yaml structure in tests where they would otherwise not be used.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
