### PR TITLE
fix: Introduce Pub API Client to consolidate our pub.dev interactions

### DIFF
--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:pub_api_client/pub_api_client.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/util/directory.dart';
+import 'package:serverpod_cli/src/util/pub_api_client.dart';
 import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 
 /// The internal tool for analyzing the pubspec.yaml files in the Serverpod
@@ -48,15 +48,14 @@ Future<void> _checkLatestVersion(
     Map<String, List<_ServerpodDependency>> dependencies) async {
   log.info('Checking latest pub versions.');
   try {
-    var pub = PubClient();
+    var pub = PubApiClient();
     for (var depName in dependencies.keys) {
       var deps = dependencies[depName]!;
       var depVersion = deps.first.version;
-      var latestPubVersion = _latestStableVersion(
-        await pub.packageVersions(depName),
-      );
+      var latestPubVersion = await pub.tryFetchLatestStableVersion(depName);
 
-      if (depVersion != '^$latestPubVersion') {
+      if (latestPubVersion != null &&
+          depVersion != '^${latestPubVersion.toString()}') {
         log.info(depName);
         log.info('local: $depVersion');
         log.info('pub:   ^$latestPubVersion');
@@ -69,7 +68,6 @@ Future<void> _checkLatestVersion(
         }
       }
     }
-    pub.close();
   } catch (e) {
     log.error('Version check failed.');
     log.error(e.toString());
@@ -154,15 +152,6 @@ Map<String, List<_ServerpodDependency>> _getDependencies(
   }
 
   return dependencies;
-}
-
-String _latestStableVersion(List<String> packageVersions) {
-  for (var version in packageVersions) {
-    if (!version.contains('-') && !version.contains('+')) {
-      return version;
-    }
-  }
-  return packageVersions.first;
 }
 
 class _ServerpodDependency {

--- a/tools/serverpod_cli/lib/src/util/latest_cli_version.dart
+++ b/tools/serverpod_cli/lib/src/util/latest_cli_version.dart
@@ -1,27 +1,24 @@
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:http/http.dart' as http;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/downloads/resource_manager.dart';
+import 'package:serverpod_cli/src/util/pub_api_client.dart';
 
 abstract class LatestCliVersionConstants {
-  static const pubDevUri = 'https://pub.dev/api/packages/serverpod_cli';
+  static const serverpodPackageName = 'serverpod_cli';
   static const badConnectionRetryTimeout = Duration(hours: 1);
   static const localStorageValidityTime = Duration(days: 1);
-  static const pubDevConnectionTimeout = Duration(seconds: 2);
 }
 
 /// Attempts to fetch the latest cli version from either local storage of pub.dev
 Future<Version?> tryFetchLatestValidCliVersion({
   localStorageService = const CliVersionStorageService(),
-  pubDevService = const PubDevService(),
+  PubDevService? pubDevService,
 }) async {
   var latestCliVersion = await localStorageService.fetchLatestCliVersion();
 
   if (latestCliVersion != null) return latestCliVersion;
 
-  latestCliVersion = await pubDevService.tryFetchAndStoreLatestVersion();
+  var service = pubDevService ?? PubDevService();
+  latestCliVersion = await service.tryFetchAndStoreLatestVersion();
 
   return latestCliVersion;
 }
@@ -44,18 +41,19 @@ class CliVersionStorageService {
 }
 
 class PubDevService {
-  final String? optionalLocalStoragePath;
-  final http.Client? client;
-  final Duration timeout;
+  final String? _optionalLocalStoragePath;
+  final PubApiClient _client;
 
-  const PubDevService({
-    this.optionalLocalStoragePath,
-    this.client,
-    this.timeout = LatestCliVersionConstants.pubDevConnectionTimeout,
-  });
+  PubDevService({
+    String? optionalLocalStoragePath,
+    PubApiClient? pubDevClient,
+  })  : _optionalLocalStoragePath = optionalLocalStoragePath,
+        _client = pubDevClient ?? PubApiClient();
 
   Future<Version?> tryFetchAndStoreLatestVersion() async {
-    var pubDevLatestVersion = await _tryFetchLatestCliVersion();
+    var pubDevLatestVersion = await _client.tryFetchLatestStableVersion(
+      LatestCliVersionConstants.serverpodPackageName,
+    );
 
     CliVersionData versionArtefact;
     Version? returnVersion;
@@ -73,24 +71,7 @@ class PubDevService {
     }
 
     await resourceManager.storeLatestCliVersion(versionArtefact,
-        localStoragePath: optionalLocalStoragePath);
+        localStoragePath: _optionalLocalStoragePath);
     return returnVersion;
-  }
-
-  Future<Version?> _tryFetchLatestCliVersion() async {
-    try {
-      var uri = Uri.parse(
-        LatestCliVersionConstants.pubDevUri,
-      );
-      var httpClient = client ?? http.Client();
-
-      var response = await httpClient.get(uri).timeout(timeout);
-      if (response.statusCode != HttpStatus.ok) return null;
-
-      Map<String, dynamic> map = jsonDecode(response.body);
-      return Version.parse(map['latest']['version']);
-    } catch (e) {
-      return null;
-    }
   }
 }

--- a/tools/serverpod_cli/lib/src/util/pub_api_client.dart
+++ b/tools/serverpod_cli/lib/src/util/pub_api_client.dart
@@ -12,6 +12,10 @@ class PubApiClient {
       : _pubClient = PubClient(client: httpClient),
         _requestTimeout = requestTimeout;
 
+  /// Tries to fetch the latest stable version, version does not include '-' or '+',
+  /// for the package named [packageName].
+  ///
+  /// If it fails [Null] is returned.
   Future<Version?> tryFetchLatestStableVersion(String packageName) async {
     String? latestStableVersion;
     try {
@@ -47,7 +51,8 @@ class PubApiClient {
     return null;
   }
 
-  /// Required because https://github.com/leoafarias/pub_api_client/issues/35
+  /// Required because of an issue with the pub_api_client package.
+  /// Issue: https://github.com/leoafarias/pub_api_client/issues/35
   void _logPubClientException(Object exception) {
     try {
       log.error(exception.toString());

--- a/tools/serverpod_cli/lib/src/util/pub_api_client.dart
+++ b/tools/serverpod_cli/lib/src/util/pub_api_client.dart
@@ -1,0 +1,58 @@
+import 'package:http/http.dart' as http;
+import 'package:pub_api_client/pub_api_client.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
+
+class PubApiClient {
+  final PubClient _pubClient;
+  final Duration _requestTimeout;
+
+  PubApiClient(
+      {http.Client? httpClient, requestTimeout = const Duration(seconds: 2)})
+      : _pubClient = PubClient(client: httpClient),
+        _requestTimeout = requestTimeout;
+
+  Future<Version?> tryFetchLatestStableVersion(String packageName) async {
+    String? latestStableVersion;
+    try {
+      var packageVersions = await _pubClient
+          .packageVersions(packageName)
+          .timeout(_requestTimeout);
+      latestStableVersion = _tryGetLatestStableVersion(packageVersions);
+      _pubClient.close();
+    } catch (e) {
+      log.error('Failed to fetch latest version for $packageName.');
+      _logPubClientException(e);
+      return null;
+    }
+
+    if (latestStableVersion == null) return null;
+
+    try {
+      return Version.parse(latestStableVersion);
+    } catch (e) {
+      log.error('Failed to parse version for $packageName');
+      log.error(e.toString());
+      return null;
+    }
+  }
+
+  String? _tryGetLatestStableVersion(List<String> packageVersions) {
+    for (var version in packageVersions) {
+      if (!version.contains('-') && !version.contains('+')) {
+        return version;
+      }
+    }
+
+    return null;
+  }
+
+  /// Required because https://github.com/leoafarias/pub_api_client/issues/35
+  void _logPubClientException(Object exception) {
+    try {
+      log.error(exception.toString());
+    } catch (_) {
+      log.error(exception.runtimeType.toString());
+    }
+  }
+}

--- a/tools/serverpod_cli/test/util/pub_api_client_test.dart
+++ b/tools/serverpod_cli/test/util/pub_api_client_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/logger/loggers/void_logger.dart';
+import 'package:serverpod_cli/src/util/pub_api_client.dart';
+import 'package:test/test.dart';
+
+MockClient createMockClient({
+  required String body,
+  required int status,
+  Duration responseDelay = const Duration(seconds: 0),
+}) {
+  return MockClient((request) {
+    if (request.method != 'GET') throw NoSuchMethodError;
+    return Future<http.Response>(() async {
+      await Future.delayed(responseDelay);
+      return http.Response(body, status);
+    });
+  });
+}
+
+abstract class PubApiClientTestConstants {
+  static const String testPackageName = 'serverpod_cli';
+}
+
+void main() {
+  initializeLoggerWith(VoidLogger());
+  test(
+      'Empty body and not found status response when fetching latest version then does not throw.',
+      () async {
+    // Issue: https://github.com/leoafarias/pub_api_client/issues/35
+    var httpClient = createMockClient(
+      body: '',
+      status: HttpStatus.notFound,
+    );
+    var pubApiClient = PubApiClient(httpClient: httpClient);
+
+    var version = await pubApiClient
+        .tryFetchLatestStableVersion(PubApiClientTestConstants.testPackageName);
+
+    expect(version, isNull);
+  });
+
+  test(
+      'Empty body and not found status response when fetching latest version then returns null.',
+      () async {
+    // Issue: https://github.com/leoafarias/pub_api_client/issues/35
+    var httpClient = createMockClient(
+      body: '',
+      status: HttpStatus.notFound,
+    );
+    var pubApiClient = PubApiClient(httpClient: httpClient);
+
+    var version = await pubApiClient
+        .tryFetchLatestStableVersion(PubApiClientTestConstants.testPackageName);
+
+    expect(version, isNull);
+  });
+
+  test('Timeout is reached when fetching latest version then returns null.',
+      () async {
+    var timeout = const Duration(milliseconds: 1);
+    var httpClient = createMockClient(
+      body: '',
+      status: HttpStatus.ok,
+      responseDelay:
+          timeout * 10, // Messaged is delayed longer than the timeout
+    );
+    var pubApiClient =
+        PubApiClient(httpClient: httpClient, requestTimeout: timeout);
+
+    var version = await pubApiClient
+        .tryFetchLatestStableVersion(PubApiClientTestConstants.testPackageName);
+
+    expect(version, isNull);
+  });
+
+  test(
+      'Non stable version before stable version when fetching latest then returns first stable',
+      () async {
+    var expectedVersion = Version(1, 2, 3);
+    var httpClient = createMockClient(
+      body: '''
+{
+    "name": "${PubApiClientTestConstants.testPackageName}",
+    "versions": ["1.2.5-b", "1.2.4+a", "${expectedVersion.toString()}"]
+}
+''',
+      status: HttpStatus.ok,
+    );
+    var pubApiClient = PubApiClient(httpClient: httpClient);
+
+    var version = await pubApiClient
+        .tryFetchLatestStableVersion(PubApiClientTestConstants.testPackageName);
+
+    expect(version, isNotNull);
+    expect(version, expectedVersion);
+  });
+
+  test('Only non stable versions when fetching latest then returns null',
+      () async {
+    var httpClient = createMockClient(
+      body: '''
+{
+    "name": "${PubApiClientTestConstants.testPackageName}",
+    "versions": ["1.2.5-b", "1.2.4+a"]
+}
+''',
+      status: HttpStatus.ok,
+    );
+    var pubApiClient = PubApiClient(httpClient: httpClient);
+
+    var version = await pubApiClient
+        .tryFetchLatestStableVersion(PubApiClientTestConstants.testPackageName);
+
+    expect(version, isNull);
+  });
+
+  test(
+      'Invalid version format when fetching latest from pub.dev then returns null',
+      () async {
+    var httpClient = createMockClient(
+      body: '''
+{
+    "name": "${PubApiClientTestConstants.testPackageName}",
+    "versions": ["invalid_format"]
+}
+''',
+      status: HttpStatus.ok,
+    );
+    var pubApiClient = PubApiClient(httpClient: httpClient);
+
+    var version = await pubApiClient
+        .tryFetchLatestStableVersion(PubApiClientTestConstants.testPackageName);
+
+    expect(version, isNull);
+  });
+}


### PR DESCRIPTION
issue: https://github.com/serverpod/serverpod/issues/611

## Adds
- Pub API Client - The CLI shared client to get the latest version package version from pub.dev.

After introducing the update prompt I noticed that we already used a package to fetch the latest version from pub.dev. This is a cleanup PR that consolidates our way of fetching the package.

After this PR we are ready to close the issue.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).
