### PR TITLE
feat: Support for filtering bulk data fetched from Serverpod Insights.

### DIFF
--- a/packages/serverpod/lib/src/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/database/bulk_data.dart
@@ -46,8 +46,9 @@ class DatabaseBulkData {
     for (var column in columns) {
       if (column.columnType.name == 'bytea') {
         columnSelects.add('octet_length("${column.name}")');
+      } else {
+        columnSelects.add('"${column.name}"');
       }
-      columnSelects.add('"${column.name}"');
     }
 
     var filterQuery = '';

--- a/packages/serverpod/lib/src/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/database/bulk_data.dart
@@ -52,14 +52,28 @@ class DatabaseBulkData {
     }
 
     var filterQuery = '';
-    if (filter != null) {
-      filterQuery = filter.toQuery(targetTableDefinition);
-      filterQuery = ' AND $filterQuery';
+    try {
+      if (filter != null) {
+        filterQuery = filter.toQuery(targetTableDefinition);
+        filterQuery = ' AND $filterQuery';
+      }
+    } catch (e) {
+      throw BulkDataException(
+        message: 'Failed to create filter query ($e).',
+      );
     }
 
+    List<List<dynamic>> data;
     var query = 'SELECT ${columnSelects.join(', ')} FROM "$table" '
         'WHERE id > $lastId$filterQuery ORDER BY "id" LIMIT $limit';
-    var data = await database.query(query);
+    try {
+      data = await database.query(query);
+    } catch (e) {
+      throw BulkDataException(
+        message: 'Failed to query database ($e).',
+        query: query,
+      );
+    }
 
     return BulkData(
       tableDefinition: targetTableDefinition,

--- a/packages/serverpod/lib/src/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/database/bulk_data.dart
@@ -17,6 +17,7 @@ class DatabaseBulkData {
     required String table,
     int lastId = 0,
     int limit = 100,
+    Filter? filter,
   }) async {
     var liveTableDefinition = await _getLiveTableDefinition(database, table);
     if (liveTableDefinition == null) {
@@ -49,8 +50,14 @@ class DatabaseBulkData {
       columnSelects.add('"${column.name}"');
     }
 
+    var filterQuery = '';
+    if (filter != null) {
+      filterQuery = filter.toQuery(targetTableDefinition);
+      filterQuery = ' AND $filterQuery';
+    }
+
     var query = 'SELECT ${columnSelects.join(', ')} FROM "$table" '
-        'WHERE id > $lastId ORDER BY "id" LIMIT $limit';
+        'WHERE id > $lastId$filterQuery ORDER BY "id" LIMIT $limit';
     var data = await database.query(query);
 
     return BulkData(

--- a/packages/serverpod/lib/src/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/database/bulk_data.dart
@@ -1,19 +1,127 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:collection/collection.dart';
+import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/database/analyze.dart';
 import 'package:serverpod/src/database/database.dart';
+import 'package:serverpod/src/database/extensions.dart';
 
 /// Provides a way to export raw data from the database. The data is serialized
 /// using JSON. Primarily used for Serverpod Insights.
 class DatabaseBulkData {
   /// Exports data from the provided [table].
-  static Future<String> exportTableData({
+  static Future<BulkData> exportTableData({
     required Database database,
     required String table,
-    int startingId = 0,
+    int lastId = 0,
     int limit = 100,
   }) async {
-    var query = 'SELECT * FROM "$table" WHERE id >= $startingId LIMIT $limit';
+    var liveTableDefinition = await _getLiveTableDefinition(database, table);
+    if (liveTableDefinition == null) {
+      throw BulkDataException(
+        message: 'The "$table" table was not found in the live database.',
+      );
+    }
+    var targetTableDefinition =
+        await _getTargetTableDefinition(database, table);
+    if (targetTableDefinition == null) {
+      throw BulkDataException(
+        message: 'The "$table" table was not found in the database definition.',
+      );
+    }
+
+    if (!liveTableDefinition.like(targetTableDefinition)) {
+      throw BulkDataException(
+        message: 'The "$table" table definition does not match the live '
+            'database.',
+      );
+    }
+
+    var columns = liveTableDefinition.columns;
+    var columnSelects = <String>[];
+
+    for (var column in columns) {
+      if (column.columnType.name == 'bytea') {
+        columnSelects.add('octet_length("${column.name}")');
+      }
+      columnSelects.add('"${column.name}"');
+    }
+
+    var query = 'SELECT ${columnSelects.join(', ')} FROM "$table" '
+        'WHERE id > $lastId ORDER BY "id" LIMIT $limit';
     var data = await database.query(query);
 
-    return SerializationManager.encode(data);
+    return BulkData(
+      tableDefinition: targetTableDefinition,
+      data: SerializationManager.encode(data),
+    );
+  }
+
+  /// Returns the approximate number of rows in the provided [table].
+  static Future<int> approximateRowCount({
+    required Database database,
+    required String table,
+  }) async {
+    var tableDefinition = await _getLiveTableDefinition(database, table);
+    if (tableDefinition == null) {
+      throw BulkDataException(
+        message: 'The "$table" table was not found in the live database.',
+      );
+    }
+
+    var query = 'SELECT reltuples::bigint AS estimate FROM pg_class '
+        'JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace '
+        'WHERE relname = \'$table\' AND nspname = \'public\'';
+
+    var result = await database.query(query);
+
+    if (result.isEmpty) {
+      return 0;
+    }
+    var count = result.first.first as int;
+    return max(count, 0);
+  }
+
+  static Future<TableDefinition?> _getTargetTableDefinition(
+    Database database,
+    String table,
+  ) async {
+    var databaseDefinition =
+        Serverpod.instance!.serializationManager.getTargetDatabaseDefinition();
+
+    var tableDefinition =
+        databaseDefinition.tables.firstWhereOrNull((e) => e.name == table);
+
+    return tableDefinition;
+  }
+
+  static Future<TableDefinition?> _getLiveTableDefinition(
+    Database database,
+    String table,
+  ) async {
+    var databaseDefinition = await _getLiveDatabaseDefinition(database);
+
+    var tableDefinition =
+        databaseDefinition.tables.firstWhereOrNull((e) => e.name == table);
+
+    return tableDefinition;
+  }
+
+  static DatabaseDefinition? _cachedDatabaseDefinition;
+
+  static Future<DatabaseDefinition> _getLiveDatabaseDefinition(
+    Database database,
+  ) async {
+    if (_cachedDatabaseDefinition == null) {
+      _cachedDatabaseDefinition = await DatabaseAnalyzer.analyze(database);
+
+      // Invalidate the cache after 1 minute.
+      Timer(const Duration(minutes: 1), () {
+        _cachedDatabaseDefinition = null;
+      });
+    }
+    return _cachedDatabaseDefinition!;
   }
 }

--- a/packages/serverpod/lib/src/database/extensions.dart
+++ b/packages/serverpod/lib/src/database/extensions.dart
@@ -303,28 +303,36 @@ extension FilterConstraintGenerator on FilterConstraint {
       );
     }
 
-    if (type == FilterConstraintType.equals) {
-      return '"$column" = $formattedValue';
-    } else if (type == FilterConstraintType.notEquals) {
-      return '"$column" != $formattedValue';
-    } else if (type == FilterConstraintType.greaterThan) {
-      return '"$column" > $formattedValue';
-    } else if (type == FilterConstraintType.greaterThanOrEquals) {
-      return '"$column" >= $formattedValue';
-    } else if (type == FilterConstraintType.lessThan) {
-      return '"$column" < $formattedValue';
-    } else if (type == FilterConstraintType.lessThanOrEquals) {
-      return '"$column" <= $formattedValue';
-    } else if (type == FilterConstraintType.between) {
-      return '"$column" BETWEEN $formattedValue AND $value2';
-    } else if (type == FilterConstraintType.inThePast) {
-      return '"$column" > (NOW() - $formattedValue)';
-    } else if (type == FilterConstraintType.isNull) {
-      return '"$column" IS NULL';
-    } else if (type == FilterConstraintType.isNotNull) {
-      return '"$column" IS NOT NULL';
+    switch (type) {
+      case FilterConstraintType.equals:
+        return '"$column" = $formattedValue';
+      case FilterConstraintType.notEquals:
+        return '"$column" != $formattedValue';
+      case FilterConstraintType.greaterThan:
+        return '"$column" > $formattedValue';
+      case FilterConstraintType.greaterThanOrEquals:
+        return '"$column" >= $formattedValue';
+      case FilterConstraintType.lessThan:
+        return '"$column" < $formattedValue';
+      case FilterConstraintType.lessThanOrEquals:
+        return '"$column" <= $formattedValue';
+      case FilterConstraintType.like:
+        return '"$column" LIKE $formattedValue';
+      case FilterConstraintType.notLike:
+        return '"$column" NOT LIKE $formattedValue';
+      case FilterConstraintType.iLike:
+        return '"$column" ILIKE $formattedValue';
+      case FilterConstraintType.notILike:
+        return '"$column" NOT ILIKE $formattedValue';
+      case FilterConstraintType.between:
+        return '"$column" BETWEEN $formattedValue AND $value2';
+      case FilterConstraintType.inThePast:
+        return '"$column" > (NOW() - $formattedValue)';
+      case FilterConstraintType.isNull:
+        return '"$column" IS NULL';
+      case FilterConstraintType.isNotNull:
+        return '"$column" IS NOT NULL';
     }
-    throw Exception('Unsupported constraint type $type for column "$column."');
   }
 }
 

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -220,7 +220,7 @@ class InsightsEndpoint extends Endpoint {
   }
 
   /// Exports raw data serialized in JSON from the database.
-  Future<String> fetchDatabaseBulkData(
+  Future<BulkData> fetchDatabaseBulkData(
     Session session, {
     required String table,
     required int startingId,
@@ -229,8 +229,19 @@ class InsightsEndpoint extends Endpoint {
     return DatabaseBulkData.exportTableData(
       database: session.db,
       table: table,
-      startingId: startingId,
+      lastId: startingId,
       limit: limit,
+    );
+  }
+
+  /// Returns the approximate number of rows in the provided [table].
+  Future<int> getDatabaseRowCount(
+    Session session, {
+    required String table,
+  }) async {
+    return DatabaseBulkData.approximateRowCount(
+      database: session.db,
+      table: table,
     );
   }
 

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -225,6 +225,7 @@ class InsightsEndpoint extends Endpoint {
     required String table,
     required int startingId,
     required int limit,
+    Filter? filter,
   }) async {
     return DatabaseBulkData.exportTableData(
       database: session.db,

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -227,13 +227,19 @@ class InsightsEndpoint extends Endpoint {
     required int limit,
     Filter? filter,
   }) async {
-    return DatabaseBulkData.exportTableData(
-      database: session.db,
-      table: table,
-      lastId: startingId,
-      limit: limit,
-      filter: filter,
-    );
+    try {
+      return DatabaseBulkData.exportTableData(
+        database: session.db,
+        table: table,
+        lastId: startingId,
+        limit: limit,
+        filter: filter,
+      );
+    } catch (e) {
+      throw BulkDataException(
+        message: 'Failed to fetch bulk data. ($e)',
+      );
+    }
   }
 
   /// Returns the approximate number of rows in the provided [table].

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -232,6 +232,7 @@ class InsightsEndpoint extends Endpoint {
       table: table,
       lastId: startingId,
       limit: limit,
+      filter: filter,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data.dart
@@ -1,0 +1,48 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+class BulkData extends _i1.SerializableEntity {
+  BulkData({
+    required this.tableDefinition,
+    required this.data,
+  });
+
+  factory BulkData.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return BulkData(
+      tableDefinition: serializationManager.deserialize<_i2.TableDefinition>(
+          jsonSerialization['tableDefinition']),
+      data: serializationManager.deserialize<String>(jsonSerialization['data']),
+    );
+  }
+
+  _i2.TableDefinition tableDefinition;
+
+  String data;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'tableDefinition': tableDefinition,
+      'data': data,
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'tableDefinition': tableDefinition,
+      'data': data,
+    };
+  }
+}

--- a/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
@@ -10,26 +10,40 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 class BulkDataException extends _i1.SerializableEntity
     implements _i1.SerializableException {
-  BulkDataException({required this.message});
+  BulkDataException({
+    required this.message,
+    this.query,
+  });
 
   factory BulkDataException.fromJson(
     Map<String, dynamic> jsonSerialization,
     _i1.SerializationManager serializationManager,
   ) {
     return BulkDataException(
-        message: serializationManager
-            .deserialize<String>(jsonSerialization['message']));
+      message: serializationManager
+          .deserialize<String>(jsonSerialization['message']),
+      query:
+          serializationManager.deserialize<String?>(jsonSerialization['query']),
+    );
   }
 
   String message;
 
+  String? query;
+
   @override
   Map<String, dynamic> toJson() {
-    return {'message': message};
+    return {
+      'message': message,
+      'query': query,
+    };
   }
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'message': message};
+    return {
+      'message': message,
+      'query': query,
+    };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
@@ -1,0 +1,35 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+class BulkDataException extends _i1.SerializableEntity
+    implements _i1.SerializableException {
+  BulkDataException({required this.message});
+
+  factory BulkDataException.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return BulkDataException(
+        message: serializationManager
+            .deserialize<String>(jsonSerialization['message']));
+  }
+
+  String message;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {'message': message};
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {'message': message};
+  }
+}

--- a/packages/serverpod/lib/src/generated/database/filter/filter.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter.dart
@@ -1,0 +1,55 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../../protocol.dart' as _i2;
+
+class Filter extends _i1.SerializableEntity {
+  Filter({
+    required this.name,
+    required this.table,
+    required this.constraints,
+  });
+
+  factory Filter.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return Filter(
+      name: serializationManager.deserialize<String>(jsonSerialization['name']),
+      table:
+          serializationManager.deserialize<String>(jsonSerialization['table']),
+      constraints: serializationManager.deserialize<List<_i2.FilterConstraint>>(
+          jsonSerialization['constraints']),
+    );
+  }
+
+  String name;
+
+  String table;
+
+  List<_i2.FilterConstraint> constraints;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'table': table,
+      'constraints': constraints,
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'name': name,
+      'table': table,
+      'constraints': constraints,
+    };
+  }
+}

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
@@ -1,0 +1,63 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../../protocol.dart' as _i2;
+
+class FilterConstraint extends _i1.SerializableEntity {
+  FilterConstraint({
+    required this.type,
+    required this.column,
+    required this.value,
+    this.value2,
+  });
+
+  factory FilterConstraint.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return FilterConstraint(
+      type: serializationManager
+          .deserialize<_i2.FilterConstraintType>(jsonSerialization['type']),
+      column:
+          serializationManager.deserialize<String>(jsonSerialization['column']),
+      value:
+          serializationManager.deserialize<String>(jsonSerialization['value']),
+      value2: serializationManager
+          .deserialize<String?>(jsonSerialization['value2']),
+    );
+  }
+
+  _i2.FilterConstraintType type;
+
+  String column;
+
+  String value;
+
+  String? value2;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type,
+      'column': column,
+      'value': value,
+      'value2': value2,
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'type': type,
+      'column': column,
+      'value': value,
+      'value2': value2,
+    };
+  }
+}

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
@@ -1,0 +1,64 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+enum FilterConstraintType with _i1.SerializableEntity {
+  equals,
+  notEquals,
+  like,
+  lessThan,
+  lessThanOrEquals,
+  greaterThan,
+  greaterThanOrEquals,
+  between,
+  contains,
+  notContains,
+  startsWith,
+  endsWith,
+  isNull,
+  isNotNull;
+
+  static FilterConstraintType? fromJson(int index) {
+    switch (index) {
+      case 0:
+        return equals;
+      case 1:
+        return notEquals;
+      case 2:
+        return like;
+      case 3:
+        return lessThan;
+      case 4:
+        return lessThanOrEquals;
+      case 5:
+        return greaterThan;
+      case 6:
+        return greaterThanOrEquals;
+      case 7:
+        return between;
+      case 8:
+        return contains;
+      case 9:
+        return notContains;
+      case 10:
+        return startsWith;
+      case 11:
+        return endsWith;
+      case 12:
+        return isNull;
+      case 13:
+        return isNotNull;
+      default:
+        return null;
+    }
+  }
+
+  @override
+  int toJson() => index;
+}

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
@@ -17,6 +17,7 @@ enum FilterConstraintType with _i1.SerializableEntity {
   greaterThan,
   greaterThanOrEquals,
   between,
+  inThePast,
   contains,
   notContains,
   startsWith,
@@ -43,16 +44,18 @@ enum FilterConstraintType with _i1.SerializableEntity {
       case 7:
         return between;
       case 8:
-        return contains;
+        return inThePast;
       case 9:
-        return notContains;
+        return contains;
       case 10:
-        return startsWith;
+        return notContains;
       case 11:
-        return endsWith;
+        return startsWith;
       case 12:
-        return isNull;
+        return endsWith;
       case 13:
+        return isNull;
+      case 14:
         return isNotNull;
       default:
         return null;

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint_type.dart
@@ -12,16 +12,15 @@ enum FilterConstraintType with _i1.SerializableEntity {
   equals,
   notEquals,
   like,
+  iLike,
+  notLike,
+  notILike,
   lessThan,
   lessThanOrEquals,
   greaterThan,
   greaterThanOrEquals,
   between,
   inThePast,
-  contains,
-  notContains,
-  startsWith,
-  endsWith,
   isNull,
   isNotNull;
 
@@ -34,28 +33,26 @@ enum FilterConstraintType with _i1.SerializableEntity {
       case 2:
         return like;
       case 3:
-        return lessThan;
+        return iLike;
       case 4:
-        return lessThanOrEquals;
+        return notLike;
       case 5:
-        return greaterThan;
+        return notILike;
       case 6:
-        return greaterThanOrEquals;
+        return lessThan;
       case 7:
-        return between;
+        return lessThanOrEquals;
       case 8:
-        return inThePast;
+        return greaterThan;
       case 9:
-        return contains;
+        return greaterThanOrEquals;
       case 10:
-        return notContains;
+        return between;
       case 11:
-        return startsWith;
+        return inThePast;
       case 12:
-        return endsWith;
-      case 13:
         return isNull;
-      case 14:
+      case 13:
         return isNotNull;
       default:
         return null;

--- a/packages/serverpod/lib/src/generated/endpoints.dart
+++ b/packages/serverpod/lib/src/generated/endpoints.dart
@@ -10,6 +10,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import '../endpoints/insights.dart' as _i2;
 import 'package:serverpod/src/generated/runtime_settings.dart' as _i3;
 import 'package:serverpod/src/generated/session_log_filter.dart' as _i4;
+import 'package:serverpod/src/generated/database/filter/filter.dart' as _i5;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -222,6 +223,11 @@ class Endpoints extends _i1.EndpointDispatch {
               type: _i1.getType<int>(),
               nullable: false,
             ),
+            'filter': _i1.ParameterDescription(
+              name: 'filter',
+              type: _i1.getType<_i5.Filter?>(),
+              nullable: true,
+            ),
           },
           call: (
             _i1.Session session,
@@ -233,6 +239,7 @@ class Endpoints extends _i1.EndpointDispatch {
             table: params['table'],
             startingId: params['startingId'],
             limit: params['limit'],
+            filter: params['filter'],
           ),
         ),
         'getDatabaseRowCount': _i1.MethodConnector(

--- a/packages/serverpod/lib/src/generated/endpoints.dart
+++ b/packages/serverpod/lib/src/generated/endpoints.dart
@@ -235,6 +235,25 @@ class Endpoints extends _i1.EndpointDispatch {
             limit: params['limit'],
           ),
         ),
+        'getDatabaseRowCount': _i1.MethodConnector(
+          name: 'getDatabaseRowCount',
+          params: {
+            'table': _i1.ParameterDescription(
+              name: 'table',
+              type: _i1.getType<String>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['insights'] as _i2.InsightsEndpoint)
+                  .getDatabaseRowCount(
+            session,
+            table: params['table'],
+          ),
+        ),
         'executeSql': _i1.MethodConnector(
           name: 'executeSql',
           params: {

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -16,44 +16,46 @@ import 'cloud_storage.dart' as _i6;
 import 'cloud_storage_direct_upload.dart' as _i7;
 import 'cluster_info.dart' as _i8;
 import 'cluster_server_info.dart' as _i9;
-import 'database/column_definition.dart' as _i10;
-import 'database/column_migration.dart' as _i11;
-import 'database/column_type.dart' as _i12;
-import 'database/database_definition.dart' as _i13;
-import 'database/database_migration.dart' as _i14;
-import 'database/database_migration_action.dart' as _i15;
-import 'database/database_migration_action_type.dart' as _i16;
-import 'database/database_migration_warning.dart' as _i17;
-import 'database/database_migration_warning_type.dart' as _i18;
-import 'database/foreign_key_action.dart' as _i19;
-import 'database/foreign_key_definition.dart' as _i20;
-import 'database/foreign_key_match_type.dart' as _i21;
-import 'database/index_definition.dart' as _i22;
-import 'database/index_element_definition.dart' as _i23;
-import 'database/index_element_definition_type.dart' as _i24;
-import 'database/table_definition.dart' as _i25;
-import 'database/table_migration.dart' as _i26;
-import 'distributed_cache_entry.dart' as _i27;
-import 'future_call_entry.dart' as _i28;
-import 'log_entry.dart' as _i29;
-import 'log_level.dart' as _i30;
-import 'log_result.dart' as _i31;
-import 'log_settings.dart' as _i32;
-import 'log_settings_override.dart' as _i33;
-import 'message_log_entry.dart' as _i34;
-import 'method_info.dart' as _i35;
-import 'query_log_entry.dart' as _i36;
-import 'readwrite_test.dart' as _i37;
-import 'runtime_settings.dart' as _i38;
-import 'server_health_connection_info.dart' as _i39;
-import 'server_health_metric.dart' as _i40;
-import 'server_health_result.dart' as _i41;
-import 'serverpod_sql_exception.dart' as _i42;
-import 'session_log_entry.dart' as _i43;
-import 'session_log_filter.dart' as _i44;
-import 'session_log_info.dart' as _i45;
-import 'session_log_result.dart' as _i46;
-import 'protocol.dart' as _i47;
+import 'database/bulk_data.dart' as _i10;
+import 'database/bulk_data_exception.dart' as _i11;
+import 'database/column_definition.dart' as _i12;
+import 'database/column_migration.dart' as _i13;
+import 'database/column_type.dart' as _i14;
+import 'database/database_definition.dart' as _i15;
+import 'database/database_migration.dart' as _i16;
+import 'database/database_migration_action.dart' as _i17;
+import 'database/database_migration_action_type.dart' as _i18;
+import 'database/database_migration_warning.dart' as _i19;
+import 'database/database_migration_warning_type.dart' as _i20;
+import 'database/foreign_key_action.dart' as _i21;
+import 'database/foreign_key_definition.dart' as _i22;
+import 'database/foreign_key_match_type.dart' as _i23;
+import 'database/index_definition.dart' as _i24;
+import 'database/index_element_definition.dart' as _i25;
+import 'database/index_element_definition_type.dart' as _i26;
+import 'database/table_definition.dart' as _i27;
+import 'database/table_migration.dart' as _i28;
+import 'distributed_cache_entry.dart' as _i29;
+import 'future_call_entry.dart' as _i30;
+import 'log_entry.dart' as _i31;
+import 'log_level.dart' as _i32;
+import 'log_result.dart' as _i33;
+import 'log_settings.dart' as _i34;
+import 'log_settings_override.dart' as _i35;
+import 'message_log_entry.dart' as _i36;
+import 'method_info.dart' as _i37;
+import 'query_log_entry.dart' as _i38;
+import 'readwrite_test.dart' as _i39;
+import 'runtime_settings.dart' as _i40;
+import 'server_health_connection_info.dart' as _i41;
+import 'server_health_metric.dart' as _i42;
+import 'server_health_result.dart' as _i43;
+import 'serverpod_sql_exception.dart' as _i44;
+import 'session_log_entry.dart' as _i45;
+import 'session_log_filter.dart' as _i46;
+import 'session_log_info.dart' as _i47;
+import 'session_log_result.dart' as _i48;
+import 'protocol.dart' as _i49;
 export 'auth_key.dart';
 export 'cache_info.dart';
 export 'caches_info.dart';
@@ -61,6 +63,8 @@ export 'cloud_storage.dart';
 export 'cloud_storage_direct_upload.dart';
 export 'cluster_info.dart';
 export 'cluster_server_info.dart';
+export 'database/bulk_data.dart';
+export 'database/bulk_data_exception.dart';
 export 'database/column_definition.dart';
 export 'database/column_migration.dart';
 export 'database/column_type.dart';
@@ -1309,116 +1313,122 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i9.ClusterServerInfo) {
       return _i9.ClusterServerInfo.fromJson(data, this) as T;
     }
-    if (t == _i10.ColumnDefinition) {
-      return _i10.ColumnDefinition.fromJson(data, this) as T;
+    if (t == _i10.BulkData) {
+      return _i10.BulkData.fromJson(data, this) as T;
     }
-    if (t == _i11.ColumnMigration) {
-      return _i11.ColumnMigration.fromJson(data, this) as T;
+    if (t == _i11.BulkDataException) {
+      return _i11.BulkDataException.fromJson(data, this) as T;
     }
-    if (t == _i12.ColumnType) {
-      return _i12.ColumnType.fromJson(data) as T;
+    if (t == _i12.ColumnDefinition) {
+      return _i12.ColumnDefinition.fromJson(data, this) as T;
     }
-    if (t == _i13.DatabaseDefinition) {
-      return _i13.DatabaseDefinition.fromJson(data, this) as T;
+    if (t == _i13.ColumnMigration) {
+      return _i13.ColumnMigration.fromJson(data, this) as T;
     }
-    if (t == _i14.DatabaseMigration) {
-      return _i14.DatabaseMigration.fromJson(data, this) as T;
+    if (t == _i14.ColumnType) {
+      return _i14.ColumnType.fromJson(data) as T;
     }
-    if (t == _i15.DatabaseMigrationAction) {
-      return _i15.DatabaseMigrationAction.fromJson(data, this) as T;
+    if (t == _i15.DatabaseDefinition) {
+      return _i15.DatabaseDefinition.fromJson(data, this) as T;
     }
-    if (t == _i16.DatabaseMigrationActionType) {
-      return _i16.DatabaseMigrationActionType.fromJson(data) as T;
+    if (t == _i16.DatabaseMigration) {
+      return _i16.DatabaseMigration.fromJson(data, this) as T;
     }
-    if (t == _i17.DatabaseMigrationWarning) {
-      return _i17.DatabaseMigrationWarning.fromJson(data, this) as T;
+    if (t == _i17.DatabaseMigrationAction) {
+      return _i17.DatabaseMigrationAction.fromJson(data, this) as T;
     }
-    if (t == _i18.DatabaseMigrationWarningType) {
-      return _i18.DatabaseMigrationWarningType.fromJson(data) as T;
+    if (t == _i18.DatabaseMigrationActionType) {
+      return _i18.DatabaseMigrationActionType.fromJson(data) as T;
     }
-    if (t == _i19.ForeignKeyAction) {
-      return _i19.ForeignKeyAction.fromJson(data) as T;
+    if (t == _i19.DatabaseMigrationWarning) {
+      return _i19.DatabaseMigrationWarning.fromJson(data, this) as T;
     }
-    if (t == _i20.ForeignKeyDefinition) {
-      return _i20.ForeignKeyDefinition.fromJson(data, this) as T;
+    if (t == _i20.DatabaseMigrationWarningType) {
+      return _i20.DatabaseMigrationWarningType.fromJson(data) as T;
     }
-    if (t == _i21.ForeignKeyMatchType) {
-      return _i21.ForeignKeyMatchType.fromJson(data) as T;
+    if (t == _i21.ForeignKeyAction) {
+      return _i21.ForeignKeyAction.fromJson(data) as T;
     }
-    if (t == _i22.IndexDefinition) {
-      return _i22.IndexDefinition.fromJson(data, this) as T;
+    if (t == _i22.ForeignKeyDefinition) {
+      return _i22.ForeignKeyDefinition.fromJson(data, this) as T;
     }
-    if (t == _i23.IndexElementDefinition) {
-      return _i23.IndexElementDefinition.fromJson(data, this) as T;
+    if (t == _i23.ForeignKeyMatchType) {
+      return _i23.ForeignKeyMatchType.fromJson(data) as T;
     }
-    if (t == _i24.IndexElementDefinitionType) {
-      return _i24.IndexElementDefinitionType.fromJson(data) as T;
+    if (t == _i24.IndexDefinition) {
+      return _i24.IndexDefinition.fromJson(data, this) as T;
     }
-    if (t == _i25.TableDefinition) {
-      return _i25.TableDefinition.fromJson(data, this) as T;
+    if (t == _i25.IndexElementDefinition) {
+      return _i25.IndexElementDefinition.fromJson(data, this) as T;
     }
-    if (t == _i26.TableMigration) {
-      return _i26.TableMigration.fromJson(data, this) as T;
+    if (t == _i26.IndexElementDefinitionType) {
+      return _i26.IndexElementDefinitionType.fromJson(data) as T;
     }
-    if (t == _i27.DistributedCacheEntry) {
-      return _i27.DistributedCacheEntry.fromJson(data, this) as T;
+    if (t == _i27.TableDefinition) {
+      return _i27.TableDefinition.fromJson(data, this) as T;
     }
-    if (t == _i28.FutureCallEntry) {
-      return _i28.FutureCallEntry.fromJson(data, this) as T;
+    if (t == _i28.TableMigration) {
+      return _i28.TableMigration.fromJson(data, this) as T;
     }
-    if (t == _i29.LogEntry) {
-      return _i29.LogEntry.fromJson(data, this) as T;
+    if (t == _i29.DistributedCacheEntry) {
+      return _i29.DistributedCacheEntry.fromJson(data, this) as T;
     }
-    if (t == _i30.LogLevel) {
-      return _i30.LogLevel.fromJson(data) as T;
+    if (t == _i30.FutureCallEntry) {
+      return _i30.FutureCallEntry.fromJson(data, this) as T;
     }
-    if (t == _i31.LogResult) {
-      return _i31.LogResult.fromJson(data, this) as T;
+    if (t == _i31.LogEntry) {
+      return _i31.LogEntry.fromJson(data, this) as T;
     }
-    if (t == _i32.LogSettings) {
-      return _i32.LogSettings.fromJson(data, this) as T;
+    if (t == _i32.LogLevel) {
+      return _i32.LogLevel.fromJson(data) as T;
     }
-    if (t == _i33.LogSettingsOverride) {
-      return _i33.LogSettingsOverride.fromJson(data, this) as T;
+    if (t == _i33.LogResult) {
+      return _i33.LogResult.fromJson(data, this) as T;
     }
-    if (t == _i34.MessageLogEntry) {
-      return _i34.MessageLogEntry.fromJson(data, this) as T;
+    if (t == _i34.LogSettings) {
+      return _i34.LogSettings.fromJson(data, this) as T;
     }
-    if (t == _i35.MethodInfo) {
-      return _i35.MethodInfo.fromJson(data, this) as T;
+    if (t == _i35.LogSettingsOverride) {
+      return _i35.LogSettingsOverride.fromJson(data, this) as T;
     }
-    if (t == _i36.QueryLogEntry) {
-      return _i36.QueryLogEntry.fromJson(data, this) as T;
+    if (t == _i36.MessageLogEntry) {
+      return _i36.MessageLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i37.ReadWriteTestEntry) {
-      return _i37.ReadWriteTestEntry.fromJson(data, this) as T;
+    if (t == _i37.MethodInfo) {
+      return _i37.MethodInfo.fromJson(data, this) as T;
     }
-    if (t == _i38.RuntimeSettings) {
-      return _i38.RuntimeSettings.fromJson(data, this) as T;
+    if (t == _i38.QueryLogEntry) {
+      return _i38.QueryLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i39.ServerHealthConnectionInfo) {
-      return _i39.ServerHealthConnectionInfo.fromJson(data, this) as T;
+    if (t == _i39.ReadWriteTestEntry) {
+      return _i39.ReadWriteTestEntry.fromJson(data, this) as T;
     }
-    if (t == _i40.ServerHealthMetric) {
-      return _i40.ServerHealthMetric.fromJson(data, this) as T;
+    if (t == _i40.RuntimeSettings) {
+      return _i40.RuntimeSettings.fromJson(data, this) as T;
     }
-    if (t == _i41.ServerHealthResult) {
-      return _i41.ServerHealthResult.fromJson(data, this) as T;
+    if (t == _i41.ServerHealthConnectionInfo) {
+      return _i41.ServerHealthConnectionInfo.fromJson(data, this) as T;
     }
-    if (t == _i42.ServerpodSqlException) {
-      return _i42.ServerpodSqlException.fromJson(data, this) as T;
+    if (t == _i42.ServerHealthMetric) {
+      return _i42.ServerHealthMetric.fromJson(data, this) as T;
     }
-    if (t == _i43.SessionLogEntry) {
-      return _i43.SessionLogEntry.fromJson(data, this) as T;
+    if (t == _i43.ServerHealthResult) {
+      return _i43.ServerHealthResult.fromJson(data, this) as T;
     }
-    if (t == _i44.SessionLogFilter) {
-      return _i44.SessionLogFilter.fromJson(data, this) as T;
+    if (t == _i44.ServerpodSqlException) {
+      return _i44.ServerpodSqlException.fromJson(data, this) as T;
     }
-    if (t == _i45.SessionLogInfo) {
-      return _i45.SessionLogInfo.fromJson(data, this) as T;
+    if (t == _i45.SessionLogEntry) {
+      return _i45.SessionLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i46.SessionLogResult) {
-      return _i46.SessionLogResult.fromJson(data, this) as T;
+    if (t == _i46.SessionLogFilter) {
+      return _i46.SessionLogFilter.fromJson(data, this) as T;
+    }
+    if (t == _i47.SessionLogInfo) {
+      return _i47.SessionLogInfo.fromJson(data, this) as T;
+    }
+    if (t == _i48.SessionLogResult) {
+      return _i48.SessionLogResult.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i3.AuthKey?>()) {
       return (data != null ? _i3.AuthKey.fromJson(data, this) : null) as T;
@@ -1445,160 +1455,167 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i9.ClusterServerInfo.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i10.ColumnDefinition?>()) {
-      return (data != null ? _i10.ColumnDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i10.BulkData?>()) {
+      return (data != null ? _i10.BulkData.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i11.BulkDataException?>()) {
+      return (data != null ? _i11.BulkDataException.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i11.ColumnMigration?>()) {
-      return (data != null ? _i11.ColumnMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i12.ColumnDefinition?>()) {
+      return (data != null ? _i12.ColumnDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i12.ColumnType?>()) {
-      return (data != null ? _i12.ColumnType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.DatabaseDefinition?>()) {
-      return (data != null
-          ? _i13.DatabaseDefinition.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i14.DatabaseMigration?>()) {
-      return (data != null ? _i14.DatabaseMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i13.ColumnMigration?>()) {
+      return (data != null ? _i13.ColumnMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i15.DatabaseMigrationAction?>()) {
+    if (t == _i1.getType<_i14.ColumnType?>()) {
+      return (data != null ? _i14.ColumnType.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i15.DatabaseDefinition?>()) {
       return (data != null
-          ? _i15.DatabaseMigrationAction.fromJson(data, this)
+          ? _i15.DatabaseDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i16.DatabaseMigrationActionType?>()) {
-      return (data != null
-          ? _i16.DatabaseMigrationActionType.fromJson(data)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i17.DatabaseMigrationWarning?>()) {
-      return (data != null
-          ? _i17.DatabaseMigrationWarning.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i18.DatabaseMigrationWarningType?>()) {
-      return (data != null
-          ? _i18.DatabaseMigrationWarningType.fromJson(data)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i19.ForeignKeyAction?>()) {
-      return (data != null ? _i19.ForeignKeyAction.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i20.ForeignKeyDefinition?>()) {
-      return (data != null
-          ? _i20.ForeignKeyDefinition.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i21.ForeignKeyMatchType?>()) {
-      return (data != null ? _i21.ForeignKeyMatchType.fromJson(data) : null)
+    if (t == _i1.getType<_i16.DatabaseMigration?>()) {
+      return (data != null ? _i16.DatabaseMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i22.IndexDefinition?>()) {
-      return (data != null ? _i22.IndexDefinition.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i23.IndexElementDefinition?>()) {
+    if (t == _i1.getType<_i17.DatabaseMigrationAction?>()) {
       return (data != null
-          ? _i23.IndexElementDefinition.fromJson(data, this)
+          ? _i17.DatabaseMigrationAction.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i24.IndexElementDefinitionType?>()) {
+    if (t == _i1.getType<_i18.DatabaseMigrationActionType?>()) {
       return (data != null
-          ? _i24.IndexElementDefinitionType.fromJson(data)
+          ? _i18.DatabaseMigrationActionType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i25.TableDefinition?>()) {
-      return (data != null ? _i25.TableDefinition.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.TableMigration?>()) {
-      return (data != null ? _i26.TableMigration.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i27.DistributedCacheEntry?>()) {
+    if (t == _i1.getType<_i19.DatabaseMigrationWarning?>()) {
       return (data != null
-          ? _i27.DistributedCacheEntry.fromJson(data, this)
+          ? _i19.DatabaseMigrationWarning.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i28.FutureCallEntry?>()) {
-      return (data != null ? _i28.FutureCallEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i29.LogEntry?>()) {
-      return (data != null ? _i29.LogEntry.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i30.LogLevel?>()) {
-      return (data != null ? _i30.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.LogResult?>()) {
-      return (data != null ? _i31.LogResult.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i32.LogSettings?>()) {
-      return (data != null ? _i32.LogSettings.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i33.LogSettingsOverride?>()) {
+    if (t == _i1.getType<_i20.DatabaseMigrationWarningType?>()) {
       return (data != null
-          ? _i33.LogSettingsOverride.fromJson(data, this)
+          ? _i20.DatabaseMigrationWarningType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i34.MessageLogEntry?>()) {
-      return (data != null ? _i34.MessageLogEntry.fromJson(data, this) : null)
-          as T;
+    if (t == _i1.getType<_i21.ForeignKeyAction?>()) {
+      return (data != null ? _i21.ForeignKeyAction.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i35.MethodInfo?>()) {
-      return (data != null ? _i35.MethodInfo.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i36.QueryLogEntry?>()) {
-      return (data != null ? _i36.QueryLogEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i37.ReadWriteTestEntry?>()) {
+    if (t == _i1.getType<_i22.ForeignKeyDefinition?>()) {
       return (data != null
-          ? _i37.ReadWriteTestEntry.fromJson(data, this)
+          ? _i22.ForeignKeyDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i38.RuntimeSettings?>()) {
-      return (data != null ? _i38.RuntimeSettings.fromJson(data, this) : null)
+    if (t == _i1.getType<_i23.ForeignKeyMatchType?>()) {
+      return (data != null ? _i23.ForeignKeyMatchType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i39.ServerHealthConnectionInfo?>()) {
-      return (data != null
-          ? _i39.ServerHealthConnectionInfo.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i40.ServerHealthMetric?>()) {
-      return (data != null
-          ? _i40.ServerHealthMetric.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i41.ServerHealthResult?>()) {
-      return (data != null
-          ? _i41.ServerHealthResult.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i42.ServerpodSqlException?>()) {
-      return (data != null
-          ? _i42.ServerpodSqlException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i43.SessionLogEntry?>()) {
-      return (data != null ? _i43.SessionLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i24.IndexDefinition?>()) {
+      return (data != null ? _i24.IndexDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i44.SessionLogFilter?>()) {
-      return (data != null ? _i44.SessionLogFilter.fromJson(data, this) : null)
+    if (t == _i1.getType<_i25.IndexElementDefinition?>()) {
+      return (data != null
+          ? _i25.IndexElementDefinition.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i26.IndexElementDefinitionType?>()) {
+      return (data != null
+          ? _i26.IndexElementDefinitionType.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i27.TableDefinition?>()) {
+      return (data != null ? _i27.TableDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i45.SessionLogInfo?>()) {
-      return (data != null ? _i45.SessionLogInfo.fromJson(data, this) : null)
+    if (t == _i1.getType<_i28.TableMigration?>()) {
+      return (data != null ? _i28.TableMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i46.SessionLogResult?>()) {
-      return (data != null ? _i46.SessionLogResult.fromJson(data, this) : null)
+    if (t == _i1.getType<_i29.DistributedCacheEntry?>()) {
+      return (data != null
+          ? _i29.DistributedCacheEntry.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i30.FutureCallEntry?>()) {
+      return (data != null ? _i30.FutureCallEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i31.LogEntry?>()) {
+      return (data != null ? _i31.LogEntry.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i32.LogLevel?>()) {
+      return (data != null ? _i32.LogLevel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i33.LogResult?>()) {
+      return (data != null ? _i33.LogResult.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i34.LogSettings?>()) {
+      return (data != null ? _i34.LogSettings.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i35.LogSettingsOverride?>()) {
+      return (data != null
+          ? _i35.LogSettingsOverride.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i36.MessageLogEntry?>()) {
+      return (data != null ? _i36.MessageLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i37.MethodInfo?>()) {
+      return (data != null ? _i37.MethodInfo.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i38.QueryLogEntry?>()) {
+      return (data != null ? _i38.QueryLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i39.ReadWriteTestEntry?>()) {
+      return (data != null
+          ? _i39.ReadWriteTestEntry.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i40.RuntimeSettings?>()) {
+      return (data != null ? _i40.RuntimeSettings.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i41.ServerHealthConnectionInfo?>()) {
+      return (data != null
+          ? _i41.ServerHealthConnectionInfo.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i42.ServerHealthMetric?>()) {
+      return (data != null
+          ? _i42.ServerHealthMetric.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i43.ServerHealthResult?>()) {
+      return (data != null
+          ? _i43.ServerHealthResult.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i44.ServerpodSqlException?>()) {
+      return (data != null
+          ? _i44.ServerpodSqlException.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i45.SessionLogEntry?>()) {
+      return (data != null ? _i45.SessionLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i46.SessionLogFilter?>()) {
+      return (data != null ? _i46.SessionLogFilter.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i47.SessionLogInfo?>()) {
+      return (data != null ? _i47.SessionLogInfo.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i48.SessionLogResult?>()) {
+      return (data != null ? _i48.SessionLogResult.fromJson(data, this) : null)
           as T;
     }
     if (t == List<String>) {
@@ -1610,14 +1627,14 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i47.ClusterServerInfo>) {
+    if (t == List<_i49.ClusterServerInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i47.ClusterServerInfo>(e))
+          .map((e) => deserialize<_i49.ClusterServerInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.TableDefinition>) {
+    if (t == List<_i49.TableDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i47.TableDefinition>(e))
+          .map((e) => deserialize<_i49.TableDefinition>(e))
           .toList() as dynamic;
     }
     if (t == _i1.getType<Map<String, String>?>()) {
@@ -1626,73 +1643,73 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i47.DatabaseMigrationAction>) {
+    if (t == List<_i49.DatabaseMigrationAction>) {
       return (data as List)
-          .map((e) => deserialize<_i47.DatabaseMigrationAction>(e))
+          .map((e) => deserialize<_i49.DatabaseMigrationAction>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.DatabaseMigrationWarning>) {
+    if (t == List<_i49.DatabaseMigrationWarning>) {
       return (data as List)
-          .map((e) => deserialize<_i47.DatabaseMigrationWarning>(e))
+          .map((e) => deserialize<_i49.DatabaseMigrationWarning>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.IndexElementDefinition>) {
+    if (t == List<_i49.IndexElementDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i47.IndexElementDefinition>(e))
+          .map((e) => deserialize<_i49.IndexElementDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.ColumnDefinition>) {
+    if (t == List<_i49.ColumnDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i47.ColumnDefinition>(e))
+          .map((e) => deserialize<_i49.ColumnDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.ForeignKeyDefinition>) {
+    if (t == List<_i49.ForeignKeyDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i47.ForeignKeyDefinition>(e))
+          .map((e) => deserialize<_i49.ForeignKeyDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.IndexDefinition>) {
+    if (t == List<_i49.IndexDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i47.IndexDefinition>(e))
+          .map((e) => deserialize<_i49.IndexDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.ColumnMigration>) {
+    if (t == List<_i49.ColumnMigration>) {
       return (data as List)
-          .map((e) => deserialize<_i47.ColumnMigration>(e))
+          .map((e) => deserialize<_i49.ColumnMigration>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i47.LogEntry>(e)).toList()
+    if (t == List<_i49.LogEntry>) {
+      return (data as List).map((e) => deserialize<_i49.LogEntry>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i47.LogSettingsOverride>) {
+    if (t == List<_i49.LogSettingsOverride>) {
       return (data as List)
-          .map((e) => deserialize<_i47.LogSettingsOverride>(e))
+          .map((e) => deserialize<_i49.LogSettingsOverride>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.ServerHealthMetric>) {
+    if (t == List<_i49.ServerHealthMetric>) {
       return (data as List)
-          .map((e) => deserialize<_i47.ServerHealthMetric>(e))
+          .map((e) => deserialize<_i49.ServerHealthMetric>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.ServerHealthConnectionInfo>) {
+    if (t == List<_i49.ServerHealthConnectionInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i47.ServerHealthConnectionInfo>(e))
+          .map((e) => deserialize<_i49.ServerHealthConnectionInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.QueryLogEntry>) {
+    if (t == List<_i49.QueryLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i47.QueryLogEntry>(e))
+          .map((e) => deserialize<_i49.QueryLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.MessageLogEntry>) {
+    if (t == List<_i49.MessageLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i47.MessageLogEntry>(e))
+          .map((e) => deserialize<_i49.MessageLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i47.SessionLogInfo>) {
+    if (t == List<_i49.SessionLogInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i47.SessionLogInfo>(e))
+          .map((e) => deserialize<_i49.SessionLogInfo>(e))
           .toList() as dynamic;
     }
     return super.deserialize<T>(data, t);
@@ -1721,115 +1738,121 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i9.ClusterServerInfo) {
       return 'ClusterServerInfo';
     }
-    if (data is _i10.ColumnDefinition) {
+    if (data is _i10.BulkData) {
+      return 'BulkData';
+    }
+    if (data is _i11.BulkDataException) {
+      return 'BulkDataException';
+    }
+    if (data is _i12.ColumnDefinition) {
       return 'ColumnDefinition';
     }
-    if (data is _i11.ColumnMigration) {
+    if (data is _i13.ColumnMigration) {
       return 'ColumnMigration';
     }
-    if (data is _i12.ColumnType) {
+    if (data is _i14.ColumnType) {
       return 'ColumnType';
     }
-    if (data is _i13.DatabaseDefinition) {
+    if (data is _i15.DatabaseDefinition) {
       return 'DatabaseDefinition';
     }
-    if (data is _i14.DatabaseMigration) {
+    if (data is _i16.DatabaseMigration) {
       return 'DatabaseMigration';
     }
-    if (data is _i15.DatabaseMigrationAction) {
+    if (data is _i17.DatabaseMigrationAction) {
       return 'DatabaseMigrationAction';
     }
-    if (data is _i16.DatabaseMigrationActionType) {
+    if (data is _i18.DatabaseMigrationActionType) {
       return 'DatabaseMigrationActionType';
     }
-    if (data is _i17.DatabaseMigrationWarning) {
+    if (data is _i19.DatabaseMigrationWarning) {
       return 'DatabaseMigrationWarning';
     }
-    if (data is _i18.DatabaseMigrationWarningType) {
+    if (data is _i20.DatabaseMigrationWarningType) {
       return 'DatabaseMigrationWarningType';
     }
-    if (data is _i19.ForeignKeyAction) {
+    if (data is _i21.ForeignKeyAction) {
       return 'ForeignKeyAction';
     }
-    if (data is _i20.ForeignKeyDefinition) {
+    if (data is _i22.ForeignKeyDefinition) {
       return 'ForeignKeyDefinition';
     }
-    if (data is _i21.ForeignKeyMatchType) {
+    if (data is _i23.ForeignKeyMatchType) {
       return 'ForeignKeyMatchType';
     }
-    if (data is _i22.IndexDefinition) {
+    if (data is _i24.IndexDefinition) {
       return 'IndexDefinition';
     }
-    if (data is _i23.IndexElementDefinition) {
+    if (data is _i25.IndexElementDefinition) {
       return 'IndexElementDefinition';
     }
-    if (data is _i24.IndexElementDefinitionType) {
+    if (data is _i26.IndexElementDefinitionType) {
       return 'IndexElementDefinitionType';
     }
-    if (data is _i25.TableDefinition) {
+    if (data is _i27.TableDefinition) {
       return 'TableDefinition';
     }
-    if (data is _i26.TableMigration) {
+    if (data is _i28.TableMigration) {
       return 'TableMigration';
     }
-    if (data is _i27.DistributedCacheEntry) {
+    if (data is _i29.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i28.FutureCallEntry) {
+    if (data is _i30.FutureCallEntry) {
       return 'FutureCallEntry';
     }
-    if (data is _i29.LogEntry) {
+    if (data is _i31.LogEntry) {
       return 'LogEntry';
     }
-    if (data is _i30.LogLevel) {
+    if (data is _i32.LogLevel) {
       return 'LogLevel';
     }
-    if (data is _i31.LogResult) {
+    if (data is _i33.LogResult) {
       return 'LogResult';
     }
-    if (data is _i32.LogSettings) {
+    if (data is _i34.LogSettings) {
       return 'LogSettings';
     }
-    if (data is _i33.LogSettingsOverride) {
+    if (data is _i35.LogSettingsOverride) {
       return 'LogSettingsOverride';
     }
-    if (data is _i34.MessageLogEntry) {
+    if (data is _i36.MessageLogEntry) {
       return 'MessageLogEntry';
     }
-    if (data is _i35.MethodInfo) {
+    if (data is _i37.MethodInfo) {
       return 'MethodInfo';
     }
-    if (data is _i36.QueryLogEntry) {
+    if (data is _i38.QueryLogEntry) {
       return 'QueryLogEntry';
     }
-    if (data is _i37.ReadWriteTestEntry) {
+    if (data is _i39.ReadWriteTestEntry) {
       return 'ReadWriteTestEntry';
     }
-    if (data is _i38.RuntimeSettings) {
+    if (data is _i40.RuntimeSettings) {
       return 'RuntimeSettings';
     }
-    if (data is _i39.ServerHealthConnectionInfo) {
+    if (data is _i41.ServerHealthConnectionInfo) {
       return 'ServerHealthConnectionInfo';
     }
-    if (data is _i40.ServerHealthMetric) {
+    if (data is _i42.ServerHealthMetric) {
       return 'ServerHealthMetric';
     }
-    if (data is _i41.ServerHealthResult) {
+    if (data is _i43.ServerHealthResult) {
       return 'ServerHealthResult';
     }
-    if (data is _i42.ServerpodSqlException) {
+    if (data is _i44.ServerpodSqlException) {
       return 'ServerpodSqlException';
     }
-    if (data is _i43.SessionLogEntry) {
+    if (data is _i45.SessionLogEntry) {
       return 'SessionLogEntry';
     }
-    if (data is _i44.SessionLogFilter) {
+    if (data is _i46.SessionLogFilter) {
       return 'SessionLogFilter';
     }
-    if (data is _i45.SessionLogInfo) {
+    if (data is _i47.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i46.SessionLogResult) {
+    if (data is _i48.SessionLogResult) {
       return 'SessionLogResult';
     }
     return super.getClassNameForObject(data);
@@ -1858,116 +1881,122 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'ClusterServerInfo') {
       return deserialize<_i9.ClusterServerInfo>(data['data']);
     }
+    if (data['className'] == 'BulkData') {
+      return deserialize<_i10.BulkData>(data['data']);
+    }
+    if (data['className'] == 'BulkDataException') {
+      return deserialize<_i11.BulkDataException>(data['data']);
+    }
     if (data['className'] == 'ColumnDefinition') {
-      return deserialize<_i10.ColumnDefinition>(data['data']);
+      return deserialize<_i12.ColumnDefinition>(data['data']);
     }
     if (data['className'] == 'ColumnMigration') {
-      return deserialize<_i11.ColumnMigration>(data['data']);
+      return deserialize<_i13.ColumnMigration>(data['data']);
     }
     if (data['className'] == 'ColumnType') {
-      return deserialize<_i12.ColumnType>(data['data']);
+      return deserialize<_i14.ColumnType>(data['data']);
     }
     if (data['className'] == 'DatabaseDefinition') {
-      return deserialize<_i13.DatabaseDefinition>(data['data']);
+      return deserialize<_i15.DatabaseDefinition>(data['data']);
     }
     if (data['className'] == 'DatabaseMigration') {
-      return deserialize<_i14.DatabaseMigration>(data['data']);
+      return deserialize<_i16.DatabaseMigration>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationAction') {
-      return deserialize<_i15.DatabaseMigrationAction>(data['data']);
+      return deserialize<_i17.DatabaseMigrationAction>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationActionType') {
-      return deserialize<_i16.DatabaseMigrationActionType>(data['data']);
+      return deserialize<_i18.DatabaseMigrationActionType>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationWarning') {
-      return deserialize<_i17.DatabaseMigrationWarning>(data['data']);
+      return deserialize<_i19.DatabaseMigrationWarning>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationWarningType') {
-      return deserialize<_i18.DatabaseMigrationWarningType>(data['data']);
+      return deserialize<_i20.DatabaseMigrationWarningType>(data['data']);
     }
     if (data['className'] == 'ForeignKeyAction') {
-      return deserialize<_i19.ForeignKeyAction>(data['data']);
+      return deserialize<_i21.ForeignKeyAction>(data['data']);
     }
     if (data['className'] == 'ForeignKeyDefinition') {
-      return deserialize<_i20.ForeignKeyDefinition>(data['data']);
+      return deserialize<_i22.ForeignKeyDefinition>(data['data']);
     }
     if (data['className'] == 'ForeignKeyMatchType') {
-      return deserialize<_i21.ForeignKeyMatchType>(data['data']);
+      return deserialize<_i23.ForeignKeyMatchType>(data['data']);
     }
     if (data['className'] == 'IndexDefinition') {
-      return deserialize<_i22.IndexDefinition>(data['data']);
+      return deserialize<_i24.IndexDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinition') {
-      return deserialize<_i23.IndexElementDefinition>(data['data']);
+      return deserialize<_i25.IndexElementDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinitionType') {
-      return deserialize<_i24.IndexElementDefinitionType>(data['data']);
+      return deserialize<_i26.IndexElementDefinitionType>(data['data']);
     }
     if (data['className'] == 'TableDefinition') {
-      return deserialize<_i25.TableDefinition>(data['data']);
+      return deserialize<_i27.TableDefinition>(data['data']);
     }
     if (data['className'] == 'TableMigration') {
-      return deserialize<_i26.TableMigration>(data['data']);
+      return deserialize<_i28.TableMigration>(data['data']);
     }
     if (data['className'] == 'DistributedCacheEntry') {
-      return deserialize<_i27.DistributedCacheEntry>(data['data']);
+      return deserialize<_i29.DistributedCacheEntry>(data['data']);
     }
     if (data['className'] == 'FutureCallEntry') {
-      return deserialize<_i28.FutureCallEntry>(data['data']);
+      return deserialize<_i30.FutureCallEntry>(data['data']);
     }
     if (data['className'] == 'LogEntry') {
-      return deserialize<_i29.LogEntry>(data['data']);
+      return deserialize<_i31.LogEntry>(data['data']);
     }
     if (data['className'] == 'LogLevel') {
-      return deserialize<_i30.LogLevel>(data['data']);
+      return deserialize<_i32.LogLevel>(data['data']);
     }
     if (data['className'] == 'LogResult') {
-      return deserialize<_i31.LogResult>(data['data']);
+      return deserialize<_i33.LogResult>(data['data']);
     }
     if (data['className'] == 'LogSettings') {
-      return deserialize<_i32.LogSettings>(data['data']);
+      return deserialize<_i34.LogSettings>(data['data']);
     }
     if (data['className'] == 'LogSettingsOverride') {
-      return deserialize<_i33.LogSettingsOverride>(data['data']);
+      return deserialize<_i35.LogSettingsOverride>(data['data']);
     }
     if (data['className'] == 'MessageLogEntry') {
-      return deserialize<_i34.MessageLogEntry>(data['data']);
+      return deserialize<_i36.MessageLogEntry>(data['data']);
     }
     if (data['className'] == 'MethodInfo') {
-      return deserialize<_i35.MethodInfo>(data['data']);
+      return deserialize<_i37.MethodInfo>(data['data']);
     }
     if (data['className'] == 'QueryLogEntry') {
-      return deserialize<_i36.QueryLogEntry>(data['data']);
+      return deserialize<_i38.QueryLogEntry>(data['data']);
     }
     if (data['className'] == 'ReadWriteTestEntry') {
-      return deserialize<_i37.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i39.ReadWriteTestEntry>(data['data']);
     }
     if (data['className'] == 'RuntimeSettings') {
-      return deserialize<_i38.RuntimeSettings>(data['data']);
+      return deserialize<_i40.RuntimeSettings>(data['data']);
     }
     if (data['className'] == 'ServerHealthConnectionInfo') {
-      return deserialize<_i39.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i41.ServerHealthConnectionInfo>(data['data']);
     }
     if (data['className'] == 'ServerHealthMetric') {
-      return deserialize<_i40.ServerHealthMetric>(data['data']);
+      return deserialize<_i42.ServerHealthMetric>(data['data']);
     }
     if (data['className'] == 'ServerHealthResult') {
-      return deserialize<_i41.ServerHealthResult>(data['data']);
+      return deserialize<_i43.ServerHealthResult>(data['data']);
     }
     if (data['className'] == 'ServerpodSqlException') {
-      return deserialize<_i42.ServerpodSqlException>(data['data']);
+      return deserialize<_i44.ServerpodSqlException>(data['data']);
     }
     if (data['className'] == 'SessionLogEntry') {
-      return deserialize<_i43.SessionLogEntry>(data['data']);
+      return deserialize<_i45.SessionLogEntry>(data['data']);
     }
     if (data['className'] == 'SessionLogFilter') {
-      return deserialize<_i44.SessionLogFilter>(data['data']);
+      return deserialize<_i46.SessionLogFilter>(data['data']);
     }
     if (data['className'] == 'SessionLogInfo') {
-      return deserialize<_i45.SessionLogInfo>(data['data']);
+      return deserialize<_i47.SessionLogInfo>(data['data']);
     }
     if (data['className'] == 'SessionLogResult') {
-      return deserialize<_i46.SessionLogResult>(data['data']);
+      return deserialize<_i48.SessionLogResult>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -1981,26 +2010,26 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i6.CloudStorageEntry.t;
       case _i7.CloudStorageDirectUploadEntry:
         return _i7.CloudStorageDirectUploadEntry.t;
-      case _i28.FutureCallEntry:
-        return _i28.FutureCallEntry.t;
-      case _i29.LogEntry:
-        return _i29.LogEntry.t;
-      case _i34.MessageLogEntry:
-        return _i34.MessageLogEntry.t;
-      case _i35.MethodInfo:
-        return _i35.MethodInfo.t;
-      case _i36.QueryLogEntry:
-        return _i36.QueryLogEntry.t;
-      case _i37.ReadWriteTestEntry:
-        return _i37.ReadWriteTestEntry.t;
-      case _i38.RuntimeSettings:
-        return _i38.RuntimeSettings.t;
-      case _i39.ServerHealthConnectionInfo:
-        return _i39.ServerHealthConnectionInfo.t;
-      case _i40.ServerHealthMetric:
-        return _i40.ServerHealthMetric.t;
-      case _i43.SessionLogEntry:
-        return _i43.SessionLogEntry.t;
+      case _i30.FutureCallEntry:
+        return _i30.FutureCallEntry.t;
+      case _i31.LogEntry:
+        return _i31.LogEntry.t;
+      case _i36.MessageLogEntry:
+        return _i36.MessageLogEntry.t;
+      case _i37.MethodInfo:
+        return _i37.MethodInfo.t;
+      case _i38.QueryLogEntry:
+        return _i38.QueryLogEntry.t;
+      case _i39.ReadWriteTestEntry:
+        return _i39.ReadWriteTestEntry.t;
+      case _i40.RuntimeSettings:
+        return _i40.RuntimeSettings.t;
+      case _i41.ServerHealthConnectionInfo:
+        return _i41.ServerHealthConnectionInfo.t;
+      case _i42.ServerHealthMetric:
+        return _i42.ServerHealthMetric.t;
+      case _i45.SessionLogEntry:
+        return _i45.SessionLogEntry.t;
     }
     return null;
   }

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -27,35 +27,38 @@ import 'database/database_migration_action.dart' as _i17;
 import 'database/database_migration_action_type.dart' as _i18;
 import 'database/database_migration_warning.dart' as _i19;
 import 'database/database_migration_warning_type.dart' as _i20;
-import 'database/foreign_key_action.dart' as _i21;
-import 'database/foreign_key_definition.dart' as _i22;
-import 'database/foreign_key_match_type.dart' as _i23;
-import 'database/index_definition.dart' as _i24;
-import 'database/index_element_definition.dart' as _i25;
-import 'database/index_element_definition_type.dart' as _i26;
-import 'database/table_definition.dart' as _i27;
-import 'database/table_migration.dart' as _i28;
-import 'distributed_cache_entry.dart' as _i29;
-import 'future_call_entry.dart' as _i30;
-import 'log_entry.dart' as _i31;
-import 'log_level.dart' as _i32;
-import 'log_result.dart' as _i33;
-import 'log_settings.dart' as _i34;
-import 'log_settings_override.dart' as _i35;
-import 'message_log_entry.dart' as _i36;
-import 'method_info.dart' as _i37;
-import 'query_log_entry.dart' as _i38;
-import 'readwrite_test.dart' as _i39;
-import 'runtime_settings.dart' as _i40;
-import 'server_health_connection_info.dart' as _i41;
-import 'server_health_metric.dart' as _i42;
-import 'server_health_result.dart' as _i43;
-import 'serverpod_sql_exception.dart' as _i44;
-import 'session_log_entry.dart' as _i45;
-import 'session_log_filter.dart' as _i46;
-import 'session_log_info.dart' as _i47;
-import 'session_log_result.dart' as _i48;
-import 'protocol.dart' as _i49;
+import 'database/filter/filter.dart' as _i21;
+import 'database/filter/filter_constraint.dart' as _i22;
+import 'database/filter/filter_constraint_type.dart' as _i23;
+import 'database/foreign_key_action.dart' as _i24;
+import 'database/foreign_key_definition.dart' as _i25;
+import 'database/foreign_key_match_type.dart' as _i26;
+import 'database/index_definition.dart' as _i27;
+import 'database/index_element_definition.dart' as _i28;
+import 'database/index_element_definition_type.dart' as _i29;
+import 'database/table_definition.dart' as _i30;
+import 'database/table_migration.dart' as _i31;
+import 'distributed_cache_entry.dart' as _i32;
+import 'future_call_entry.dart' as _i33;
+import 'log_entry.dart' as _i34;
+import 'log_level.dart' as _i35;
+import 'log_result.dart' as _i36;
+import 'log_settings.dart' as _i37;
+import 'log_settings_override.dart' as _i38;
+import 'message_log_entry.dart' as _i39;
+import 'method_info.dart' as _i40;
+import 'query_log_entry.dart' as _i41;
+import 'readwrite_test.dart' as _i42;
+import 'runtime_settings.dart' as _i43;
+import 'server_health_connection_info.dart' as _i44;
+import 'server_health_metric.dart' as _i45;
+import 'server_health_result.dart' as _i46;
+import 'serverpod_sql_exception.dart' as _i47;
+import 'session_log_entry.dart' as _i48;
+import 'session_log_filter.dart' as _i49;
+import 'session_log_info.dart' as _i50;
+import 'session_log_result.dart' as _i51;
+import 'protocol.dart' as _i52;
 export 'auth_key.dart';
 export 'cache_info.dart';
 export 'caches_info.dart';
@@ -74,6 +77,9 @@ export 'database/database_migration_action.dart';
 export 'database/database_migration_action_type.dart';
 export 'database/database_migration_warning.dart';
 export 'database/database_migration_warning_type.dart';
+export 'database/filter/filter.dart';
+export 'database/filter/filter_constraint.dart';
+export 'database/filter/filter_constraint_type.dart';
 export 'database/foreign_key_action.dart';
 export 'database/foreign_key_definition.dart';
 export 'database/foreign_key_match_type.dart';
@@ -1346,89 +1352,98 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i20.DatabaseMigrationWarningType) {
       return _i20.DatabaseMigrationWarningType.fromJson(data) as T;
     }
-    if (t == _i21.ForeignKeyAction) {
-      return _i21.ForeignKeyAction.fromJson(data) as T;
+    if (t == _i21.Filter) {
+      return _i21.Filter.fromJson(data, this) as T;
     }
-    if (t == _i22.ForeignKeyDefinition) {
-      return _i22.ForeignKeyDefinition.fromJson(data, this) as T;
+    if (t == _i22.FilterConstraint) {
+      return _i22.FilterConstraint.fromJson(data, this) as T;
     }
-    if (t == _i23.ForeignKeyMatchType) {
-      return _i23.ForeignKeyMatchType.fromJson(data) as T;
+    if (t == _i23.FilterConstraintType) {
+      return _i23.FilterConstraintType.fromJson(data) as T;
     }
-    if (t == _i24.IndexDefinition) {
-      return _i24.IndexDefinition.fromJson(data, this) as T;
+    if (t == _i24.ForeignKeyAction) {
+      return _i24.ForeignKeyAction.fromJson(data) as T;
     }
-    if (t == _i25.IndexElementDefinition) {
-      return _i25.IndexElementDefinition.fromJson(data, this) as T;
+    if (t == _i25.ForeignKeyDefinition) {
+      return _i25.ForeignKeyDefinition.fromJson(data, this) as T;
     }
-    if (t == _i26.IndexElementDefinitionType) {
-      return _i26.IndexElementDefinitionType.fromJson(data) as T;
+    if (t == _i26.ForeignKeyMatchType) {
+      return _i26.ForeignKeyMatchType.fromJson(data) as T;
     }
-    if (t == _i27.TableDefinition) {
-      return _i27.TableDefinition.fromJson(data, this) as T;
+    if (t == _i27.IndexDefinition) {
+      return _i27.IndexDefinition.fromJson(data, this) as T;
     }
-    if (t == _i28.TableMigration) {
-      return _i28.TableMigration.fromJson(data, this) as T;
+    if (t == _i28.IndexElementDefinition) {
+      return _i28.IndexElementDefinition.fromJson(data, this) as T;
     }
-    if (t == _i29.DistributedCacheEntry) {
-      return _i29.DistributedCacheEntry.fromJson(data, this) as T;
+    if (t == _i29.IndexElementDefinitionType) {
+      return _i29.IndexElementDefinitionType.fromJson(data) as T;
     }
-    if (t == _i30.FutureCallEntry) {
-      return _i30.FutureCallEntry.fromJson(data, this) as T;
+    if (t == _i30.TableDefinition) {
+      return _i30.TableDefinition.fromJson(data, this) as T;
     }
-    if (t == _i31.LogEntry) {
-      return _i31.LogEntry.fromJson(data, this) as T;
+    if (t == _i31.TableMigration) {
+      return _i31.TableMigration.fromJson(data, this) as T;
     }
-    if (t == _i32.LogLevel) {
-      return _i32.LogLevel.fromJson(data) as T;
+    if (t == _i32.DistributedCacheEntry) {
+      return _i32.DistributedCacheEntry.fromJson(data, this) as T;
     }
-    if (t == _i33.LogResult) {
-      return _i33.LogResult.fromJson(data, this) as T;
+    if (t == _i33.FutureCallEntry) {
+      return _i33.FutureCallEntry.fromJson(data, this) as T;
     }
-    if (t == _i34.LogSettings) {
-      return _i34.LogSettings.fromJson(data, this) as T;
+    if (t == _i34.LogEntry) {
+      return _i34.LogEntry.fromJson(data, this) as T;
     }
-    if (t == _i35.LogSettingsOverride) {
-      return _i35.LogSettingsOverride.fromJson(data, this) as T;
+    if (t == _i35.LogLevel) {
+      return _i35.LogLevel.fromJson(data) as T;
     }
-    if (t == _i36.MessageLogEntry) {
-      return _i36.MessageLogEntry.fromJson(data, this) as T;
+    if (t == _i36.LogResult) {
+      return _i36.LogResult.fromJson(data, this) as T;
     }
-    if (t == _i37.MethodInfo) {
-      return _i37.MethodInfo.fromJson(data, this) as T;
+    if (t == _i37.LogSettings) {
+      return _i37.LogSettings.fromJson(data, this) as T;
     }
-    if (t == _i38.QueryLogEntry) {
-      return _i38.QueryLogEntry.fromJson(data, this) as T;
+    if (t == _i38.LogSettingsOverride) {
+      return _i38.LogSettingsOverride.fromJson(data, this) as T;
     }
-    if (t == _i39.ReadWriteTestEntry) {
-      return _i39.ReadWriteTestEntry.fromJson(data, this) as T;
+    if (t == _i39.MessageLogEntry) {
+      return _i39.MessageLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i40.RuntimeSettings) {
-      return _i40.RuntimeSettings.fromJson(data, this) as T;
+    if (t == _i40.MethodInfo) {
+      return _i40.MethodInfo.fromJson(data, this) as T;
     }
-    if (t == _i41.ServerHealthConnectionInfo) {
-      return _i41.ServerHealthConnectionInfo.fromJson(data, this) as T;
+    if (t == _i41.QueryLogEntry) {
+      return _i41.QueryLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i42.ServerHealthMetric) {
-      return _i42.ServerHealthMetric.fromJson(data, this) as T;
+    if (t == _i42.ReadWriteTestEntry) {
+      return _i42.ReadWriteTestEntry.fromJson(data, this) as T;
     }
-    if (t == _i43.ServerHealthResult) {
-      return _i43.ServerHealthResult.fromJson(data, this) as T;
+    if (t == _i43.RuntimeSettings) {
+      return _i43.RuntimeSettings.fromJson(data, this) as T;
     }
-    if (t == _i44.ServerpodSqlException) {
-      return _i44.ServerpodSqlException.fromJson(data, this) as T;
+    if (t == _i44.ServerHealthConnectionInfo) {
+      return _i44.ServerHealthConnectionInfo.fromJson(data, this) as T;
     }
-    if (t == _i45.SessionLogEntry) {
-      return _i45.SessionLogEntry.fromJson(data, this) as T;
+    if (t == _i45.ServerHealthMetric) {
+      return _i45.ServerHealthMetric.fromJson(data, this) as T;
     }
-    if (t == _i46.SessionLogFilter) {
-      return _i46.SessionLogFilter.fromJson(data, this) as T;
+    if (t == _i46.ServerHealthResult) {
+      return _i46.ServerHealthResult.fromJson(data, this) as T;
     }
-    if (t == _i47.SessionLogInfo) {
-      return _i47.SessionLogInfo.fromJson(data, this) as T;
+    if (t == _i47.ServerpodSqlException) {
+      return _i47.ServerpodSqlException.fromJson(data, this) as T;
     }
-    if (t == _i48.SessionLogResult) {
-      return _i48.SessionLogResult.fromJson(data, this) as T;
+    if (t == _i48.SessionLogEntry) {
+      return _i48.SessionLogEntry.fromJson(data, this) as T;
+    }
+    if (t == _i49.SessionLogFilter) {
+      return _i49.SessionLogFilter.fromJson(data, this) as T;
+    }
+    if (t == _i50.SessionLogInfo) {
+      return _i50.SessionLogInfo.fromJson(data, this) as T;
+    }
+    if (t == _i51.SessionLogResult) {
+      return _i51.SessionLogResult.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i3.AuthKey?>()) {
       return (data != null ? _i3.AuthKey.fromJson(data, this) : null) as T;
@@ -1502,120 +1517,131 @@ class Protocol extends _i1.SerializationManagerServer {
           ? _i20.DatabaseMigrationWarningType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i21.ForeignKeyAction?>()) {
-      return (data != null ? _i21.ForeignKeyAction.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i21.Filter?>()) {
+      return (data != null ? _i21.Filter.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i22.ForeignKeyDefinition?>()) {
+    if (t == _i1.getType<_i22.FilterConstraint?>()) {
+      return (data != null ? _i22.FilterConstraint.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i23.FilterConstraintType?>()) {
+      return (data != null ? _i23.FilterConstraintType.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i24.ForeignKeyAction?>()) {
+      return (data != null ? _i24.ForeignKeyAction.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i25.ForeignKeyDefinition?>()) {
       return (data != null
-          ? _i22.ForeignKeyDefinition.fromJson(data, this)
+          ? _i25.ForeignKeyDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i23.ForeignKeyMatchType?>()) {
-      return (data != null ? _i23.ForeignKeyMatchType.fromJson(data) : null)
+    if (t == _i1.getType<_i26.ForeignKeyMatchType?>()) {
+      return (data != null ? _i26.ForeignKeyMatchType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i24.IndexDefinition?>()) {
-      return (data != null ? _i24.IndexDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i27.IndexDefinition?>()) {
+      return (data != null ? _i27.IndexDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i25.IndexElementDefinition?>()) {
+    if (t == _i1.getType<_i28.IndexElementDefinition?>()) {
       return (data != null
-          ? _i25.IndexElementDefinition.fromJson(data, this)
+          ? _i28.IndexElementDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i26.IndexElementDefinitionType?>()) {
+    if (t == _i1.getType<_i29.IndexElementDefinitionType?>()) {
       return (data != null
-          ? _i26.IndexElementDefinitionType.fromJson(data)
+          ? _i29.IndexElementDefinitionType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i27.TableDefinition?>()) {
-      return (data != null ? _i27.TableDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i30.TableDefinition?>()) {
+      return (data != null ? _i30.TableDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i28.TableMigration?>()) {
-      return (data != null ? _i28.TableMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i31.TableMigration?>()) {
+      return (data != null ? _i31.TableMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i29.DistributedCacheEntry?>()) {
+    if (t == _i1.getType<_i32.DistributedCacheEntry?>()) {
       return (data != null
-          ? _i29.DistributedCacheEntry.fromJson(data, this)
+          ? _i32.DistributedCacheEntry.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i30.FutureCallEntry?>()) {
-      return (data != null ? _i30.FutureCallEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i33.FutureCallEntry?>()) {
+      return (data != null ? _i33.FutureCallEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i31.LogEntry?>()) {
-      return (data != null ? _i31.LogEntry.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i34.LogEntry?>()) {
+      return (data != null ? _i34.LogEntry.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i32.LogLevel?>()) {
-      return (data != null ? _i32.LogLevel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i35.LogLevel?>()) {
+      return (data != null ? _i35.LogLevel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i33.LogResult?>()) {
-      return (data != null ? _i33.LogResult.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i36.LogResult?>()) {
+      return (data != null ? _i36.LogResult.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i34.LogSettings?>()) {
-      return (data != null ? _i34.LogSettings.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i37.LogSettings?>()) {
+      return (data != null ? _i37.LogSettings.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i35.LogSettingsOverride?>()) {
+    if (t == _i1.getType<_i38.LogSettingsOverride?>()) {
       return (data != null
-          ? _i35.LogSettingsOverride.fromJson(data, this)
+          ? _i38.LogSettingsOverride.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i36.MessageLogEntry?>()) {
-      return (data != null ? _i36.MessageLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i39.MessageLogEntry?>()) {
+      return (data != null ? _i39.MessageLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i37.MethodInfo?>()) {
-      return (data != null ? _i37.MethodInfo.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i40.MethodInfo?>()) {
+      return (data != null ? _i40.MethodInfo.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i38.QueryLogEntry?>()) {
-      return (data != null ? _i38.QueryLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i41.QueryLogEntry?>()) {
+      return (data != null ? _i41.QueryLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i39.ReadWriteTestEntry?>()) {
+    if (t == _i1.getType<_i42.ReadWriteTestEntry?>()) {
       return (data != null
-          ? _i39.ReadWriteTestEntry.fromJson(data, this)
+          ? _i42.ReadWriteTestEntry.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i40.RuntimeSettings?>()) {
-      return (data != null ? _i40.RuntimeSettings.fromJson(data, this) : null)
+    if (t == _i1.getType<_i43.RuntimeSettings?>()) {
+      return (data != null ? _i43.RuntimeSettings.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i41.ServerHealthConnectionInfo?>()) {
+    if (t == _i1.getType<_i44.ServerHealthConnectionInfo?>()) {
       return (data != null
-          ? _i41.ServerHealthConnectionInfo.fromJson(data, this)
+          ? _i44.ServerHealthConnectionInfo.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i42.ServerHealthMetric?>()) {
+    if (t == _i1.getType<_i45.ServerHealthMetric?>()) {
       return (data != null
-          ? _i42.ServerHealthMetric.fromJson(data, this)
+          ? _i45.ServerHealthMetric.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i43.ServerHealthResult?>()) {
+    if (t == _i1.getType<_i46.ServerHealthResult?>()) {
       return (data != null
-          ? _i43.ServerHealthResult.fromJson(data, this)
+          ? _i46.ServerHealthResult.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i44.ServerpodSqlException?>()) {
+    if (t == _i1.getType<_i47.ServerpodSqlException?>()) {
       return (data != null
-          ? _i44.ServerpodSqlException.fromJson(data, this)
+          ? _i47.ServerpodSqlException.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i45.SessionLogEntry?>()) {
-      return (data != null ? _i45.SessionLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i48.SessionLogEntry?>()) {
+      return (data != null ? _i48.SessionLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i46.SessionLogFilter?>()) {
-      return (data != null ? _i46.SessionLogFilter.fromJson(data, this) : null)
+    if (t == _i1.getType<_i49.SessionLogFilter?>()) {
+      return (data != null ? _i49.SessionLogFilter.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i47.SessionLogInfo?>()) {
-      return (data != null ? _i47.SessionLogInfo.fromJson(data, this) : null)
+    if (t == _i1.getType<_i50.SessionLogInfo?>()) {
+      return (data != null ? _i50.SessionLogInfo.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i48.SessionLogResult?>()) {
-      return (data != null ? _i48.SessionLogResult.fromJson(data, this) : null)
+    if (t == _i1.getType<_i51.SessionLogResult?>()) {
+      return (data != null ? _i51.SessionLogResult.fromJson(data, this) : null)
           as T;
     }
     if (t == List<String>) {
@@ -1627,14 +1653,14 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i49.ClusterServerInfo>) {
+    if (t == List<_i52.ClusterServerInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i49.ClusterServerInfo>(e))
+          .map((e) => deserialize<_i52.ClusterServerInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.TableDefinition>) {
+    if (t == List<_i52.TableDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i49.TableDefinition>(e))
+          .map((e) => deserialize<_i52.TableDefinition>(e))
           .toList() as dynamic;
     }
     if (t == _i1.getType<Map<String, String>?>()) {
@@ -1643,73 +1669,78 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i49.DatabaseMigrationAction>) {
+    if (t == List<_i52.DatabaseMigrationAction>) {
       return (data as List)
-          .map((e) => deserialize<_i49.DatabaseMigrationAction>(e))
+          .map((e) => deserialize<_i52.DatabaseMigrationAction>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.DatabaseMigrationWarning>) {
+    if (t == List<_i52.DatabaseMigrationWarning>) {
       return (data as List)
-          .map((e) => deserialize<_i49.DatabaseMigrationWarning>(e))
+          .map((e) => deserialize<_i52.DatabaseMigrationWarning>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.IndexElementDefinition>) {
+    if (t == List<_i52.FilterConstraint>) {
       return (data as List)
-          .map((e) => deserialize<_i49.IndexElementDefinition>(e))
+          .map((e) => deserialize<_i52.FilterConstraint>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.ColumnDefinition>) {
+    if (t == List<_i52.IndexElementDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i49.ColumnDefinition>(e))
+          .map((e) => deserialize<_i52.IndexElementDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.ForeignKeyDefinition>) {
+    if (t == List<_i52.ColumnDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i49.ForeignKeyDefinition>(e))
+          .map((e) => deserialize<_i52.ColumnDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.IndexDefinition>) {
+    if (t == List<_i52.ForeignKeyDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i49.IndexDefinition>(e))
+          .map((e) => deserialize<_i52.ForeignKeyDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.ColumnMigration>) {
+    if (t == List<_i52.IndexDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i49.ColumnMigration>(e))
+          .map((e) => deserialize<_i52.IndexDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i49.LogEntry>(e)).toList()
+    if (t == List<_i52.ColumnMigration>) {
+      return (data as List)
+          .map((e) => deserialize<_i52.ColumnMigration>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i52.LogEntry>) {
+      return (data as List).map((e) => deserialize<_i52.LogEntry>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i49.LogSettingsOverride>) {
+    if (t == List<_i52.LogSettingsOverride>) {
       return (data as List)
-          .map((e) => deserialize<_i49.LogSettingsOverride>(e))
+          .map((e) => deserialize<_i52.LogSettingsOverride>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.ServerHealthMetric>) {
+    if (t == List<_i52.ServerHealthMetric>) {
       return (data as List)
-          .map((e) => deserialize<_i49.ServerHealthMetric>(e))
+          .map((e) => deserialize<_i52.ServerHealthMetric>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.ServerHealthConnectionInfo>) {
+    if (t == List<_i52.ServerHealthConnectionInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i49.ServerHealthConnectionInfo>(e))
+          .map((e) => deserialize<_i52.ServerHealthConnectionInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.QueryLogEntry>) {
+    if (t == List<_i52.QueryLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i49.QueryLogEntry>(e))
+          .map((e) => deserialize<_i52.QueryLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.MessageLogEntry>) {
+    if (t == List<_i52.MessageLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i49.MessageLogEntry>(e))
+          .map((e) => deserialize<_i52.MessageLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i49.SessionLogInfo>) {
+    if (t == List<_i52.SessionLogInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i49.SessionLogInfo>(e))
+          .map((e) => deserialize<_i52.SessionLogInfo>(e))
           .toList() as dynamic;
     }
     return super.deserialize<T>(data, t);
@@ -1771,88 +1802,97 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i20.DatabaseMigrationWarningType) {
       return 'DatabaseMigrationWarningType';
     }
-    if (data is _i21.ForeignKeyAction) {
+    if (data is _i21.Filter) {
+      return 'Filter';
+    }
+    if (data is _i22.FilterConstraint) {
+      return 'FilterConstraint';
+    }
+    if (data is _i23.FilterConstraintType) {
+      return 'FilterConstraintType';
+    }
+    if (data is _i24.ForeignKeyAction) {
       return 'ForeignKeyAction';
     }
-    if (data is _i22.ForeignKeyDefinition) {
+    if (data is _i25.ForeignKeyDefinition) {
       return 'ForeignKeyDefinition';
     }
-    if (data is _i23.ForeignKeyMatchType) {
+    if (data is _i26.ForeignKeyMatchType) {
       return 'ForeignKeyMatchType';
     }
-    if (data is _i24.IndexDefinition) {
+    if (data is _i27.IndexDefinition) {
       return 'IndexDefinition';
     }
-    if (data is _i25.IndexElementDefinition) {
+    if (data is _i28.IndexElementDefinition) {
       return 'IndexElementDefinition';
     }
-    if (data is _i26.IndexElementDefinitionType) {
+    if (data is _i29.IndexElementDefinitionType) {
       return 'IndexElementDefinitionType';
     }
-    if (data is _i27.TableDefinition) {
+    if (data is _i30.TableDefinition) {
       return 'TableDefinition';
     }
-    if (data is _i28.TableMigration) {
+    if (data is _i31.TableMigration) {
       return 'TableMigration';
     }
-    if (data is _i29.DistributedCacheEntry) {
+    if (data is _i32.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i30.FutureCallEntry) {
+    if (data is _i33.FutureCallEntry) {
       return 'FutureCallEntry';
     }
-    if (data is _i31.LogEntry) {
+    if (data is _i34.LogEntry) {
       return 'LogEntry';
     }
-    if (data is _i32.LogLevel) {
+    if (data is _i35.LogLevel) {
       return 'LogLevel';
     }
-    if (data is _i33.LogResult) {
+    if (data is _i36.LogResult) {
       return 'LogResult';
     }
-    if (data is _i34.LogSettings) {
+    if (data is _i37.LogSettings) {
       return 'LogSettings';
     }
-    if (data is _i35.LogSettingsOverride) {
+    if (data is _i38.LogSettingsOverride) {
       return 'LogSettingsOverride';
     }
-    if (data is _i36.MessageLogEntry) {
+    if (data is _i39.MessageLogEntry) {
       return 'MessageLogEntry';
     }
-    if (data is _i37.MethodInfo) {
+    if (data is _i40.MethodInfo) {
       return 'MethodInfo';
     }
-    if (data is _i38.QueryLogEntry) {
+    if (data is _i41.QueryLogEntry) {
       return 'QueryLogEntry';
     }
-    if (data is _i39.ReadWriteTestEntry) {
+    if (data is _i42.ReadWriteTestEntry) {
       return 'ReadWriteTestEntry';
     }
-    if (data is _i40.RuntimeSettings) {
+    if (data is _i43.RuntimeSettings) {
       return 'RuntimeSettings';
     }
-    if (data is _i41.ServerHealthConnectionInfo) {
+    if (data is _i44.ServerHealthConnectionInfo) {
       return 'ServerHealthConnectionInfo';
     }
-    if (data is _i42.ServerHealthMetric) {
+    if (data is _i45.ServerHealthMetric) {
       return 'ServerHealthMetric';
     }
-    if (data is _i43.ServerHealthResult) {
+    if (data is _i46.ServerHealthResult) {
       return 'ServerHealthResult';
     }
-    if (data is _i44.ServerpodSqlException) {
+    if (data is _i47.ServerpodSqlException) {
       return 'ServerpodSqlException';
     }
-    if (data is _i45.SessionLogEntry) {
+    if (data is _i48.SessionLogEntry) {
       return 'SessionLogEntry';
     }
-    if (data is _i46.SessionLogFilter) {
+    if (data is _i49.SessionLogFilter) {
       return 'SessionLogFilter';
     }
-    if (data is _i47.SessionLogInfo) {
+    if (data is _i50.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i48.SessionLogResult) {
+    if (data is _i51.SessionLogResult) {
       return 'SessionLogResult';
     }
     return super.getClassNameForObject(data);
@@ -1914,89 +1954,98 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'DatabaseMigrationWarningType') {
       return deserialize<_i20.DatabaseMigrationWarningType>(data['data']);
     }
+    if (data['className'] == 'Filter') {
+      return deserialize<_i21.Filter>(data['data']);
+    }
+    if (data['className'] == 'FilterConstraint') {
+      return deserialize<_i22.FilterConstraint>(data['data']);
+    }
+    if (data['className'] == 'FilterConstraintType') {
+      return deserialize<_i23.FilterConstraintType>(data['data']);
+    }
     if (data['className'] == 'ForeignKeyAction') {
-      return deserialize<_i21.ForeignKeyAction>(data['data']);
+      return deserialize<_i24.ForeignKeyAction>(data['data']);
     }
     if (data['className'] == 'ForeignKeyDefinition') {
-      return deserialize<_i22.ForeignKeyDefinition>(data['data']);
+      return deserialize<_i25.ForeignKeyDefinition>(data['data']);
     }
     if (data['className'] == 'ForeignKeyMatchType') {
-      return deserialize<_i23.ForeignKeyMatchType>(data['data']);
+      return deserialize<_i26.ForeignKeyMatchType>(data['data']);
     }
     if (data['className'] == 'IndexDefinition') {
-      return deserialize<_i24.IndexDefinition>(data['data']);
+      return deserialize<_i27.IndexDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinition') {
-      return deserialize<_i25.IndexElementDefinition>(data['data']);
+      return deserialize<_i28.IndexElementDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinitionType') {
-      return deserialize<_i26.IndexElementDefinitionType>(data['data']);
+      return deserialize<_i29.IndexElementDefinitionType>(data['data']);
     }
     if (data['className'] == 'TableDefinition') {
-      return deserialize<_i27.TableDefinition>(data['data']);
+      return deserialize<_i30.TableDefinition>(data['data']);
     }
     if (data['className'] == 'TableMigration') {
-      return deserialize<_i28.TableMigration>(data['data']);
+      return deserialize<_i31.TableMigration>(data['data']);
     }
     if (data['className'] == 'DistributedCacheEntry') {
-      return deserialize<_i29.DistributedCacheEntry>(data['data']);
+      return deserialize<_i32.DistributedCacheEntry>(data['data']);
     }
     if (data['className'] == 'FutureCallEntry') {
-      return deserialize<_i30.FutureCallEntry>(data['data']);
+      return deserialize<_i33.FutureCallEntry>(data['data']);
     }
     if (data['className'] == 'LogEntry') {
-      return deserialize<_i31.LogEntry>(data['data']);
+      return deserialize<_i34.LogEntry>(data['data']);
     }
     if (data['className'] == 'LogLevel') {
-      return deserialize<_i32.LogLevel>(data['data']);
+      return deserialize<_i35.LogLevel>(data['data']);
     }
     if (data['className'] == 'LogResult') {
-      return deserialize<_i33.LogResult>(data['data']);
+      return deserialize<_i36.LogResult>(data['data']);
     }
     if (data['className'] == 'LogSettings') {
-      return deserialize<_i34.LogSettings>(data['data']);
+      return deserialize<_i37.LogSettings>(data['data']);
     }
     if (data['className'] == 'LogSettingsOverride') {
-      return deserialize<_i35.LogSettingsOverride>(data['data']);
+      return deserialize<_i38.LogSettingsOverride>(data['data']);
     }
     if (data['className'] == 'MessageLogEntry') {
-      return deserialize<_i36.MessageLogEntry>(data['data']);
+      return deserialize<_i39.MessageLogEntry>(data['data']);
     }
     if (data['className'] == 'MethodInfo') {
-      return deserialize<_i37.MethodInfo>(data['data']);
+      return deserialize<_i40.MethodInfo>(data['data']);
     }
     if (data['className'] == 'QueryLogEntry') {
-      return deserialize<_i38.QueryLogEntry>(data['data']);
+      return deserialize<_i41.QueryLogEntry>(data['data']);
     }
     if (data['className'] == 'ReadWriteTestEntry') {
-      return deserialize<_i39.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i42.ReadWriteTestEntry>(data['data']);
     }
     if (data['className'] == 'RuntimeSettings') {
-      return deserialize<_i40.RuntimeSettings>(data['data']);
+      return deserialize<_i43.RuntimeSettings>(data['data']);
     }
     if (data['className'] == 'ServerHealthConnectionInfo') {
-      return deserialize<_i41.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i44.ServerHealthConnectionInfo>(data['data']);
     }
     if (data['className'] == 'ServerHealthMetric') {
-      return deserialize<_i42.ServerHealthMetric>(data['data']);
+      return deserialize<_i45.ServerHealthMetric>(data['data']);
     }
     if (data['className'] == 'ServerHealthResult') {
-      return deserialize<_i43.ServerHealthResult>(data['data']);
+      return deserialize<_i46.ServerHealthResult>(data['data']);
     }
     if (data['className'] == 'ServerpodSqlException') {
-      return deserialize<_i44.ServerpodSqlException>(data['data']);
+      return deserialize<_i47.ServerpodSqlException>(data['data']);
     }
     if (data['className'] == 'SessionLogEntry') {
-      return deserialize<_i45.SessionLogEntry>(data['data']);
+      return deserialize<_i48.SessionLogEntry>(data['data']);
     }
     if (data['className'] == 'SessionLogFilter') {
-      return deserialize<_i46.SessionLogFilter>(data['data']);
+      return deserialize<_i49.SessionLogFilter>(data['data']);
     }
     if (data['className'] == 'SessionLogInfo') {
-      return deserialize<_i47.SessionLogInfo>(data['data']);
+      return deserialize<_i50.SessionLogInfo>(data['data']);
     }
     if (data['className'] == 'SessionLogResult') {
-      return deserialize<_i48.SessionLogResult>(data['data']);
+      return deserialize<_i51.SessionLogResult>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -2010,26 +2059,26 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i6.CloudStorageEntry.t;
       case _i7.CloudStorageDirectUploadEntry:
         return _i7.CloudStorageDirectUploadEntry.t;
-      case _i30.FutureCallEntry:
-        return _i30.FutureCallEntry.t;
-      case _i31.LogEntry:
-        return _i31.LogEntry.t;
-      case _i36.MessageLogEntry:
-        return _i36.MessageLogEntry.t;
-      case _i37.MethodInfo:
-        return _i37.MethodInfo.t;
-      case _i38.QueryLogEntry:
-        return _i38.QueryLogEntry.t;
-      case _i39.ReadWriteTestEntry:
-        return _i39.ReadWriteTestEntry.t;
-      case _i40.RuntimeSettings:
-        return _i40.RuntimeSettings.t;
-      case _i41.ServerHealthConnectionInfo:
-        return _i41.ServerHealthConnectionInfo.t;
-      case _i42.ServerHealthMetric:
-        return _i42.ServerHealthMetric.t;
-      case _i45.SessionLogEntry:
-        return _i45.SessionLogEntry.t;
+      case _i33.FutureCallEntry:
+        return _i33.FutureCallEntry.t;
+      case _i34.LogEntry:
+        return _i34.LogEntry.t;
+      case _i39.MessageLogEntry:
+        return _i39.MessageLogEntry.t;
+      case _i40.MethodInfo:
+        return _i40.MethodInfo.t;
+      case _i41.QueryLogEntry:
+        return _i41.QueryLogEntry.t;
+      case _i42.ReadWriteTestEntry:
+        return _i42.ReadWriteTestEntry.t;
+      case _i43.RuntimeSettings:
+        return _i43.RuntimeSettings.t;
+      case _i44.ServerHealthConnectionInfo:
+        return _i44.ServerHealthConnectionInfo.t;
+      case _i45.ServerHealthMetric:
+        return _i45.ServerHealthMetric.t;
+      case _i48.SessionLogEntry:
+        return _i48.SessionLogEntry.t;
     }
     return null;
   }

--- a/packages/serverpod/lib/src/protocol/database/bulk_data.yaml
+++ b/packages/serverpod/lib/src/protocol/database/bulk_data.yaml
@@ -1,0 +1,4 @@
+class: BulkData
+fields:
+  tableDefinition: TableDefinition
+  data: String

--- a/packages/serverpod/lib/src/protocol/database/bulk_data_exception.yaml
+++ b/packages/serverpod/lib/src/protocol/database/bulk_data_exception.yaml
@@ -1,3 +1,4 @@
 exception: BulkDataException
 fields:
   message: String
+  query: String?

--- a/packages/serverpod/lib/src/protocol/database/bulk_data_exception.yaml
+++ b/packages/serverpod/lib/src/protocol/database/bulk_data_exception.yaml
@@ -1,0 +1,3 @@
+exception: BulkDataException
+fields:
+  message: String

--- a/packages/serverpod/lib/src/protocol/database/filter/filter.yaml
+++ b/packages/serverpod/lib/src/protocol/database/filter/filter.yaml
@@ -1,0 +1,5 @@
+class: Filter
+fields:
+  name: String
+  table: String
+  constraints: List<FilterConstraint>

--- a/packages/serverpod/lib/src/protocol/database/filter/filter_constraint.yaml
+++ b/packages/serverpod/lib/src/protocol/database/filter/filter_constraint.yaml
@@ -1,0 +1,6 @@
+class: FilterConstraint
+fields:
+  type: FilterConstraintType
+  column: String
+  value: String
+  value2: String?

--- a/packages/serverpod/lib/src/protocol/database/filter/filter_constraint_type.yaml
+++ b/packages/serverpod/lib/src/protocol/database/filter/filter_constraint_type.yaml
@@ -1,0 +1,16 @@
+enum: FilterConstraintType
+values:
+  - equals
+  - notEquals
+  - like
+  - lessThan
+  - lessThanOrEquals
+  - greaterThan
+  - greaterThanOrEquals
+  - between
+  - contains
+  - notContains
+  - startsWith
+  - endsWith
+  - isNull
+  - isNotNull

--- a/packages/serverpod/lib/src/protocol/database/filter/filter_constraint_type.yaml
+++ b/packages/serverpod/lib/src/protocol/database/filter/filter_constraint_type.yaml
@@ -8,6 +8,7 @@ values:
   - greaterThan
   - greaterThanOrEquals
   - between
+  - inThePast
   - contains
   - notContains
   - startsWith

--- a/packages/serverpod/lib/src/protocol/database/filter/filter_constraint_type.yaml
+++ b/packages/serverpod/lib/src/protocol/database/filter/filter_constraint_type.yaml
@@ -3,15 +3,14 @@ values:
   - equals
   - notEquals
   - like
+  - iLike
+  - notLike
+  - notILike
   - lessThan
   - lessThanOrEquals
   - greaterThan
   - greaterThanOrEquals
   - between
   - inThePast
-  - contains
-  - notContains
-  - startsWith
-  - endsWith
   - isNull
   - isNotNull

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -19,8 +19,10 @@ import 'package:serverpod_service_client/src/protocol/server_health_result.dart'
     as _i7;
 import 'package:serverpod_service_client/src/protocol/database/database_definition.dart'
     as _i8;
-import 'dart:io' as _i9;
-import 'protocol.dart' as _i10;
+import 'package:serverpod_service_client/src/protocol/database/bulk_data.dart'
+    as _i9;
+import 'dart:io' as _i10;
+import 'protocol.dart' as _i11;
 
 /// The [InsightsEndpoint] provides a way to access real time information from
 /// the running server or to change settings.
@@ -157,12 +159,12 @@ class EndpointInsights extends _i1.EndpointRef {
       );
 
   /// Exports raw data serialized in JSON from the database.
-  _i2.Future<String> fetchDatabaseBulkData({
+  _i2.Future<_i9.BulkData> fetchDatabaseBulkData({
     required String table,
     required int startingId,
     required int limit,
   }) =>
-      caller.callServerEndpoint<String>(
+      caller.callServerEndpoint<_i9.BulkData>(
         'insights',
         'fetchDatabaseBulkData',
         {
@@ -170,6 +172,14 @@ class EndpointInsights extends _i1.EndpointRef {
           'startingId': startingId,
           'limit': limit,
         },
+      );
+
+  /// Returns the approximate number of rows in the provided [table].
+  _i2.Future<int> getDatabaseRowCount({required String table}) =>
+      caller.callServerEndpoint<int>(
+        'insights',
+        'getDatabaseRowCount',
+        {'table': table},
       );
 
   /// Executes SQL commands. Returns the number of rows affected.
@@ -183,11 +193,11 @@ class EndpointInsights extends _i1.EndpointRef {
 class Client extends _i1.ServerpodClient {
   Client(
     String host, {
-    _i9.SecurityContext? context,
+    _i10.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
   }) : super(
           host,
-          _i10.Protocol(),
+          _i11.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
         ) {

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -21,8 +21,10 @@ import 'package:serverpod_service_client/src/protocol/database/database_definiti
     as _i8;
 import 'package:serverpod_service_client/src/protocol/database/bulk_data.dart'
     as _i9;
-import 'dart:io' as _i10;
-import 'protocol.dart' as _i11;
+import 'package:serverpod_service_client/src/protocol/database/filter/filter.dart'
+    as _i10;
+import 'dart:io' as _i11;
+import 'protocol.dart' as _i12;
 
 /// The [InsightsEndpoint] provides a way to access real time information from
 /// the running server or to change settings.
@@ -163,6 +165,7 @@ class EndpointInsights extends _i1.EndpointRef {
     required String table,
     required int startingId,
     required int limit,
+    _i10.Filter? filter,
   }) =>
       caller.callServerEndpoint<_i9.BulkData>(
         'insights',
@@ -171,6 +174,7 @@ class EndpointInsights extends _i1.EndpointRef {
           'table': table,
           'startingId': startingId,
           'limit': limit,
+          'filter': filter,
         },
       );
 
@@ -193,11 +197,11 @@ class EndpointInsights extends _i1.EndpointRef {
 class Client extends _i1.ServerpodClient {
   Client(
     String host, {
-    _i10.SecurityContext? context,
+    _i11.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
   }) : super(
           host,
-          _i11.Protocol(),
+          _i12.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
         ) {

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_data.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_data.dart
@@ -1,0 +1,40 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+class BulkData extends _i1.SerializableEntity {
+  BulkData({
+    required this.tableDefinition,
+    required this.data,
+  });
+
+  factory BulkData.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return BulkData(
+      tableDefinition: serializationManager.deserialize<_i2.TableDefinition>(
+          jsonSerialization['tableDefinition']),
+      data: serializationManager.deserialize<String>(jsonSerialization['data']),
+    );
+  }
+
+  _i2.TableDefinition tableDefinition;
+
+  String data;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'tableDefinition': tableDefinition,
+      'data': data,
+    };
+  }
+}

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
@@ -1,0 +1,30 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+class BulkDataException extends _i1.SerializableEntity
+    implements _i1.SerializableException {
+  BulkDataException({required this.message});
+
+  factory BulkDataException.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return BulkDataException(
+        message: serializationManager
+            .deserialize<String>(jsonSerialization['message']));
+  }
+
+  String message;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {'message': message};
+  }
+}

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
@@ -10,21 +10,32 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 class BulkDataException extends _i1.SerializableEntity
     implements _i1.SerializableException {
-  BulkDataException({required this.message});
+  BulkDataException({
+    required this.message,
+    this.query,
+  });
 
   factory BulkDataException.fromJson(
     Map<String, dynamic> jsonSerialization,
     _i1.SerializationManager serializationManager,
   ) {
     return BulkDataException(
-        message: serializationManager
-            .deserialize<String>(jsonSerialization['message']));
+      message: serializationManager
+          .deserialize<String>(jsonSerialization['message']),
+      query:
+          serializationManager.deserialize<String?>(jsonSerialization['query']),
+    );
   }
 
   String message;
 
+  String? query;
+
   @override
   Map<String, dynamic> toJson() {
-    return {'message': message};
+    return {
+      'message': message,
+      'query': query,
+    };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
@@ -1,0 +1,46 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../../protocol.dart' as _i2;
+
+class Filter extends _i1.SerializableEntity {
+  Filter({
+    required this.name,
+    required this.table,
+    required this.constraints,
+  });
+
+  factory Filter.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return Filter(
+      name: serializationManager.deserialize<String>(jsonSerialization['name']),
+      table:
+          serializationManager.deserialize<String>(jsonSerialization['table']),
+      constraints: serializationManager.deserialize<List<_i2.FilterConstraint>>(
+          jsonSerialization['constraints']),
+    );
+  }
+
+  String name;
+
+  String table;
+
+  List<_i2.FilterConstraint> constraints;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'table': table,
+      'constraints': constraints,
+    };
+  }
+}

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
@@ -1,0 +1,53 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../../protocol.dart' as _i2;
+
+class FilterConstraint extends _i1.SerializableEntity {
+  FilterConstraint({
+    required this.type,
+    required this.column,
+    required this.value,
+    this.value2,
+  });
+
+  factory FilterConstraint.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return FilterConstraint(
+      type: serializationManager
+          .deserialize<_i2.FilterConstraintType>(jsonSerialization['type']),
+      column:
+          serializationManager.deserialize<String>(jsonSerialization['column']),
+      value:
+          serializationManager.deserialize<String>(jsonSerialization['value']),
+      value2: serializationManager
+          .deserialize<String?>(jsonSerialization['value2']),
+    );
+  }
+
+  _i2.FilterConstraintType type;
+
+  String column;
+
+  String value;
+
+  String? value2;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type,
+      'column': column,
+      'value': value,
+      'value2': value2,
+    };
+  }
+}

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
@@ -17,6 +17,7 @@ enum FilterConstraintType with _i1.SerializableEntity {
   greaterThan,
   greaterThanOrEquals,
   between,
+  inThePast,
   contains,
   notContains,
   startsWith,
@@ -43,16 +44,18 @@ enum FilterConstraintType with _i1.SerializableEntity {
       case 7:
         return between;
       case 8:
-        return contains;
+        return inThePast;
       case 9:
-        return notContains;
+        return contains;
       case 10:
-        return startsWith;
+        return notContains;
       case 11:
-        return endsWith;
+        return startsWith;
       case 12:
-        return isNull;
+        return endsWith;
       case 13:
+        return isNull;
+      case 14:
         return isNotNull;
       default:
         return null;

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
@@ -1,0 +1,64 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+enum FilterConstraintType with _i1.SerializableEntity {
+  equals,
+  notEquals,
+  like,
+  lessThan,
+  lessThanOrEquals,
+  greaterThan,
+  greaterThanOrEquals,
+  between,
+  contains,
+  notContains,
+  startsWith,
+  endsWith,
+  isNull,
+  isNotNull;
+
+  static FilterConstraintType? fromJson(int index) {
+    switch (index) {
+      case 0:
+        return equals;
+      case 1:
+        return notEquals;
+      case 2:
+        return like;
+      case 3:
+        return lessThan;
+      case 4:
+        return lessThanOrEquals;
+      case 5:
+        return greaterThan;
+      case 6:
+        return greaterThanOrEquals;
+      case 7:
+        return between;
+      case 8:
+        return contains;
+      case 9:
+        return notContains;
+      case 10:
+        return startsWith;
+      case 11:
+        return endsWith;
+      case 12:
+        return isNull;
+      case 13:
+        return isNotNull;
+      default:
+        return null;
+    }
+  }
+
+  @override
+  int toJson() => index;
+}

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint_type.dart
@@ -12,16 +12,15 @@ enum FilterConstraintType with _i1.SerializableEntity {
   equals,
   notEquals,
   like,
+  iLike,
+  notLike,
+  notILike,
   lessThan,
   lessThanOrEquals,
   greaterThan,
   greaterThanOrEquals,
   between,
   inThePast,
-  contains,
-  notContains,
-  startsWith,
-  endsWith,
   isNull,
   isNotNull;
 
@@ -34,28 +33,26 @@ enum FilterConstraintType with _i1.SerializableEntity {
       case 2:
         return like;
       case 3:
-        return lessThan;
+        return iLike;
       case 4:
-        return lessThanOrEquals;
+        return notLike;
       case 5:
-        return greaterThan;
+        return notILike;
       case 6:
-        return greaterThanOrEquals;
+        return lessThan;
       case 7:
-        return between;
+        return lessThanOrEquals;
       case 8:
-        return inThePast;
+        return greaterThan;
       case 9:
-        return contains;
+        return greaterThanOrEquals;
       case 10:
-        return notContains;
+        return between;
       case 11:
-        return startsWith;
+        return inThePast;
       case 12:
-        return endsWith;
-      case 13:
         return isNull;
-      case 14:
+      case 13:
         return isNotNull;
       default:
         return null;

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -26,35 +26,38 @@ import 'database/database_migration_action.dart' as _i16;
 import 'database/database_migration_action_type.dart' as _i17;
 import 'database/database_migration_warning.dart' as _i18;
 import 'database/database_migration_warning_type.dart' as _i19;
-import 'database/foreign_key_action.dart' as _i20;
-import 'database/foreign_key_definition.dart' as _i21;
-import 'database/foreign_key_match_type.dart' as _i22;
-import 'database/index_definition.dart' as _i23;
-import 'database/index_element_definition.dart' as _i24;
-import 'database/index_element_definition_type.dart' as _i25;
-import 'database/table_definition.dart' as _i26;
-import 'database/table_migration.dart' as _i27;
-import 'distributed_cache_entry.dart' as _i28;
-import 'future_call_entry.dart' as _i29;
-import 'log_entry.dart' as _i30;
-import 'log_level.dart' as _i31;
-import 'log_result.dart' as _i32;
-import 'log_settings.dart' as _i33;
-import 'log_settings_override.dart' as _i34;
-import 'message_log_entry.dart' as _i35;
-import 'method_info.dart' as _i36;
-import 'query_log_entry.dart' as _i37;
-import 'readwrite_test.dart' as _i38;
-import 'runtime_settings.dart' as _i39;
-import 'server_health_connection_info.dart' as _i40;
-import 'server_health_metric.dart' as _i41;
-import 'server_health_result.dart' as _i42;
-import 'serverpod_sql_exception.dart' as _i43;
-import 'session_log_entry.dart' as _i44;
-import 'session_log_filter.dart' as _i45;
-import 'session_log_info.dart' as _i46;
-import 'session_log_result.dart' as _i47;
-import 'protocol.dart' as _i48;
+import 'database/filter/filter.dart' as _i20;
+import 'database/filter/filter_constraint.dart' as _i21;
+import 'database/filter/filter_constraint_type.dart' as _i22;
+import 'database/foreign_key_action.dart' as _i23;
+import 'database/foreign_key_definition.dart' as _i24;
+import 'database/foreign_key_match_type.dart' as _i25;
+import 'database/index_definition.dart' as _i26;
+import 'database/index_element_definition.dart' as _i27;
+import 'database/index_element_definition_type.dart' as _i28;
+import 'database/table_definition.dart' as _i29;
+import 'database/table_migration.dart' as _i30;
+import 'distributed_cache_entry.dart' as _i31;
+import 'future_call_entry.dart' as _i32;
+import 'log_entry.dart' as _i33;
+import 'log_level.dart' as _i34;
+import 'log_result.dart' as _i35;
+import 'log_settings.dart' as _i36;
+import 'log_settings_override.dart' as _i37;
+import 'message_log_entry.dart' as _i38;
+import 'method_info.dart' as _i39;
+import 'query_log_entry.dart' as _i40;
+import 'readwrite_test.dart' as _i41;
+import 'runtime_settings.dart' as _i42;
+import 'server_health_connection_info.dart' as _i43;
+import 'server_health_metric.dart' as _i44;
+import 'server_health_result.dart' as _i45;
+import 'serverpod_sql_exception.dart' as _i46;
+import 'session_log_entry.dart' as _i47;
+import 'session_log_filter.dart' as _i48;
+import 'session_log_info.dart' as _i49;
+import 'session_log_result.dart' as _i50;
+import 'protocol.dart' as _i51;
 export 'auth_key.dart';
 export 'cache_info.dart';
 export 'caches_info.dart';
@@ -73,6 +76,9 @@ export 'database/database_migration_action.dart';
 export 'database/database_migration_action_type.dart';
 export 'database/database_migration_warning.dart';
 export 'database/database_migration_warning_type.dart';
+export 'database/filter/filter.dart';
+export 'database/filter/filter_constraint.dart';
+export 'database/filter/filter_constraint_type.dart';
 export 'database/foreign_key_action.dart';
 export 'database/foreign_key_definition.dart';
 export 'database/foreign_key_match_type.dart';
@@ -175,89 +181,98 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i19.DatabaseMigrationWarningType) {
       return _i19.DatabaseMigrationWarningType.fromJson(data) as T;
     }
-    if (t == _i20.ForeignKeyAction) {
-      return _i20.ForeignKeyAction.fromJson(data) as T;
+    if (t == _i20.Filter) {
+      return _i20.Filter.fromJson(data, this) as T;
     }
-    if (t == _i21.ForeignKeyDefinition) {
-      return _i21.ForeignKeyDefinition.fromJson(data, this) as T;
+    if (t == _i21.FilterConstraint) {
+      return _i21.FilterConstraint.fromJson(data, this) as T;
     }
-    if (t == _i22.ForeignKeyMatchType) {
-      return _i22.ForeignKeyMatchType.fromJson(data) as T;
+    if (t == _i22.FilterConstraintType) {
+      return _i22.FilterConstraintType.fromJson(data) as T;
     }
-    if (t == _i23.IndexDefinition) {
-      return _i23.IndexDefinition.fromJson(data, this) as T;
+    if (t == _i23.ForeignKeyAction) {
+      return _i23.ForeignKeyAction.fromJson(data) as T;
     }
-    if (t == _i24.IndexElementDefinition) {
-      return _i24.IndexElementDefinition.fromJson(data, this) as T;
+    if (t == _i24.ForeignKeyDefinition) {
+      return _i24.ForeignKeyDefinition.fromJson(data, this) as T;
     }
-    if (t == _i25.IndexElementDefinitionType) {
-      return _i25.IndexElementDefinitionType.fromJson(data) as T;
+    if (t == _i25.ForeignKeyMatchType) {
+      return _i25.ForeignKeyMatchType.fromJson(data) as T;
     }
-    if (t == _i26.TableDefinition) {
-      return _i26.TableDefinition.fromJson(data, this) as T;
+    if (t == _i26.IndexDefinition) {
+      return _i26.IndexDefinition.fromJson(data, this) as T;
     }
-    if (t == _i27.TableMigration) {
-      return _i27.TableMigration.fromJson(data, this) as T;
+    if (t == _i27.IndexElementDefinition) {
+      return _i27.IndexElementDefinition.fromJson(data, this) as T;
     }
-    if (t == _i28.DistributedCacheEntry) {
-      return _i28.DistributedCacheEntry.fromJson(data, this) as T;
+    if (t == _i28.IndexElementDefinitionType) {
+      return _i28.IndexElementDefinitionType.fromJson(data) as T;
     }
-    if (t == _i29.FutureCallEntry) {
-      return _i29.FutureCallEntry.fromJson(data, this) as T;
+    if (t == _i29.TableDefinition) {
+      return _i29.TableDefinition.fromJson(data, this) as T;
     }
-    if (t == _i30.LogEntry) {
-      return _i30.LogEntry.fromJson(data, this) as T;
+    if (t == _i30.TableMigration) {
+      return _i30.TableMigration.fromJson(data, this) as T;
     }
-    if (t == _i31.LogLevel) {
-      return _i31.LogLevel.fromJson(data) as T;
+    if (t == _i31.DistributedCacheEntry) {
+      return _i31.DistributedCacheEntry.fromJson(data, this) as T;
     }
-    if (t == _i32.LogResult) {
-      return _i32.LogResult.fromJson(data, this) as T;
+    if (t == _i32.FutureCallEntry) {
+      return _i32.FutureCallEntry.fromJson(data, this) as T;
     }
-    if (t == _i33.LogSettings) {
-      return _i33.LogSettings.fromJson(data, this) as T;
+    if (t == _i33.LogEntry) {
+      return _i33.LogEntry.fromJson(data, this) as T;
     }
-    if (t == _i34.LogSettingsOverride) {
-      return _i34.LogSettingsOverride.fromJson(data, this) as T;
+    if (t == _i34.LogLevel) {
+      return _i34.LogLevel.fromJson(data) as T;
     }
-    if (t == _i35.MessageLogEntry) {
-      return _i35.MessageLogEntry.fromJson(data, this) as T;
+    if (t == _i35.LogResult) {
+      return _i35.LogResult.fromJson(data, this) as T;
     }
-    if (t == _i36.MethodInfo) {
-      return _i36.MethodInfo.fromJson(data, this) as T;
+    if (t == _i36.LogSettings) {
+      return _i36.LogSettings.fromJson(data, this) as T;
     }
-    if (t == _i37.QueryLogEntry) {
-      return _i37.QueryLogEntry.fromJson(data, this) as T;
+    if (t == _i37.LogSettingsOverride) {
+      return _i37.LogSettingsOverride.fromJson(data, this) as T;
     }
-    if (t == _i38.ReadWriteTestEntry) {
-      return _i38.ReadWriteTestEntry.fromJson(data, this) as T;
+    if (t == _i38.MessageLogEntry) {
+      return _i38.MessageLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i39.RuntimeSettings) {
-      return _i39.RuntimeSettings.fromJson(data, this) as T;
+    if (t == _i39.MethodInfo) {
+      return _i39.MethodInfo.fromJson(data, this) as T;
     }
-    if (t == _i40.ServerHealthConnectionInfo) {
-      return _i40.ServerHealthConnectionInfo.fromJson(data, this) as T;
+    if (t == _i40.QueryLogEntry) {
+      return _i40.QueryLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i41.ServerHealthMetric) {
-      return _i41.ServerHealthMetric.fromJson(data, this) as T;
+    if (t == _i41.ReadWriteTestEntry) {
+      return _i41.ReadWriteTestEntry.fromJson(data, this) as T;
     }
-    if (t == _i42.ServerHealthResult) {
-      return _i42.ServerHealthResult.fromJson(data, this) as T;
+    if (t == _i42.RuntimeSettings) {
+      return _i42.RuntimeSettings.fromJson(data, this) as T;
     }
-    if (t == _i43.ServerpodSqlException) {
-      return _i43.ServerpodSqlException.fromJson(data, this) as T;
+    if (t == _i43.ServerHealthConnectionInfo) {
+      return _i43.ServerHealthConnectionInfo.fromJson(data, this) as T;
     }
-    if (t == _i44.SessionLogEntry) {
-      return _i44.SessionLogEntry.fromJson(data, this) as T;
+    if (t == _i44.ServerHealthMetric) {
+      return _i44.ServerHealthMetric.fromJson(data, this) as T;
     }
-    if (t == _i45.SessionLogFilter) {
-      return _i45.SessionLogFilter.fromJson(data, this) as T;
+    if (t == _i45.ServerHealthResult) {
+      return _i45.ServerHealthResult.fromJson(data, this) as T;
     }
-    if (t == _i46.SessionLogInfo) {
-      return _i46.SessionLogInfo.fromJson(data, this) as T;
+    if (t == _i46.ServerpodSqlException) {
+      return _i46.ServerpodSqlException.fromJson(data, this) as T;
     }
-    if (t == _i47.SessionLogResult) {
-      return _i47.SessionLogResult.fromJson(data, this) as T;
+    if (t == _i47.SessionLogEntry) {
+      return _i47.SessionLogEntry.fromJson(data, this) as T;
+    }
+    if (t == _i48.SessionLogFilter) {
+      return _i48.SessionLogFilter.fromJson(data, this) as T;
+    }
+    if (t == _i49.SessionLogInfo) {
+      return _i49.SessionLogInfo.fromJson(data, this) as T;
+    }
+    if (t == _i50.SessionLogResult) {
+      return _i50.SessionLogResult.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.AuthKey?>()) {
       return (data != null ? _i2.AuthKey.fromJson(data, this) : null) as T;
@@ -331,120 +346,131 @@ class Protocol extends _i1.SerializationManager {
           ? _i19.DatabaseMigrationWarningType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i20.ForeignKeyAction?>()) {
-      return (data != null ? _i20.ForeignKeyAction.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i20.Filter?>()) {
+      return (data != null ? _i20.Filter.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i21.ForeignKeyDefinition?>()) {
+    if (t == _i1.getType<_i21.FilterConstraint?>()) {
+      return (data != null ? _i21.FilterConstraint.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i22.FilterConstraintType?>()) {
+      return (data != null ? _i22.FilterConstraintType.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i23.ForeignKeyAction?>()) {
+      return (data != null ? _i23.ForeignKeyAction.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i24.ForeignKeyDefinition?>()) {
       return (data != null
-          ? _i21.ForeignKeyDefinition.fromJson(data, this)
+          ? _i24.ForeignKeyDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i22.ForeignKeyMatchType?>()) {
-      return (data != null ? _i22.ForeignKeyMatchType.fromJson(data) : null)
+    if (t == _i1.getType<_i25.ForeignKeyMatchType?>()) {
+      return (data != null ? _i25.ForeignKeyMatchType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i23.IndexDefinition?>()) {
-      return (data != null ? _i23.IndexDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i26.IndexDefinition?>()) {
+      return (data != null ? _i26.IndexDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i24.IndexElementDefinition?>()) {
+    if (t == _i1.getType<_i27.IndexElementDefinition?>()) {
       return (data != null
-          ? _i24.IndexElementDefinition.fromJson(data, this)
+          ? _i27.IndexElementDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i25.IndexElementDefinitionType?>()) {
+    if (t == _i1.getType<_i28.IndexElementDefinitionType?>()) {
       return (data != null
-          ? _i25.IndexElementDefinitionType.fromJson(data)
+          ? _i28.IndexElementDefinitionType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i26.TableDefinition?>()) {
-      return (data != null ? _i26.TableDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i29.TableDefinition?>()) {
+      return (data != null ? _i29.TableDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i27.TableMigration?>()) {
-      return (data != null ? _i27.TableMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i30.TableMigration?>()) {
+      return (data != null ? _i30.TableMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i28.DistributedCacheEntry?>()) {
+    if (t == _i1.getType<_i31.DistributedCacheEntry?>()) {
       return (data != null
-          ? _i28.DistributedCacheEntry.fromJson(data, this)
+          ? _i31.DistributedCacheEntry.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i29.FutureCallEntry?>()) {
-      return (data != null ? _i29.FutureCallEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i32.FutureCallEntry?>()) {
+      return (data != null ? _i32.FutureCallEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i30.LogEntry?>()) {
-      return (data != null ? _i30.LogEntry.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i33.LogEntry?>()) {
+      return (data != null ? _i33.LogEntry.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i31.LogLevel?>()) {
-      return (data != null ? _i31.LogLevel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i34.LogLevel?>()) {
+      return (data != null ? _i34.LogLevel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i32.LogResult?>()) {
-      return (data != null ? _i32.LogResult.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i35.LogResult?>()) {
+      return (data != null ? _i35.LogResult.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i33.LogSettings?>()) {
-      return (data != null ? _i33.LogSettings.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i36.LogSettings?>()) {
+      return (data != null ? _i36.LogSettings.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i34.LogSettingsOverride?>()) {
+    if (t == _i1.getType<_i37.LogSettingsOverride?>()) {
       return (data != null
-          ? _i34.LogSettingsOverride.fromJson(data, this)
+          ? _i37.LogSettingsOverride.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i35.MessageLogEntry?>()) {
-      return (data != null ? _i35.MessageLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i38.MessageLogEntry?>()) {
+      return (data != null ? _i38.MessageLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i36.MethodInfo?>()) {
-      return (data != null ? _i36.MethodInfo.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i39.MethodInfo?>()) {
+      return (data != null ? _i39.MethodInfo.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i37.QueryLogEntry?>()) {
-      return (data != null ? _i37.QueryLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i40.QueryLogEntry?>()) {
+      return (data != null ? _i40.QueryLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i38.ReadWriteTestEntry?>()) {
+    if (t == _i1.getType<_i41.ReadWriteTestEntry?>()) {
       return (data != null
-          ? _i38.ReadWriteTestEntry.fromJson(data, this)
+          ? _i41.ReadWriteTestEntry.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i39.RuntimeSettings?>()) {
-      return (data != null ? _i39.RuntimeSettings.fromJson(data, this) : null)
+    if (t == _i1.getType<_i42.RuntimeSettings?>()) {
+      return (data != null ? _i42.RuntimeSettings.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i40.ServerHealthConnectionInfo?>()) {
+    if (t == _i1.getType<_i43.ServerHealthConnectionInfo?>()) {
       return (data != null
-          ? _i40.ServerHealthConnectionInfo.fromJson(data, this)
+          ? _i43.ServerHealthConnectionInfo.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i41.ServerHealthMetric?>()) {
+    if (t == _i1.getType<_i44.ServerHealthMetric?>()) {
       return (data != null
-          ? _i41.ServerHealthMetric.fromJson(data, this)
+          ? _i44.ServerHealthMetric.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i42.ServerHealthResult?>()) {
+    if (t == _i1.getType<_i45.ServerHealthResult?>()) {
       return (data != null
-          ? _i42.ServerHealthResult.fromJson(data, this)
+          ? _i45.ServerHealthResult.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i43.ServerpodSqlException?>()) {
+    if (t == _i1.getType<_i46.ServerpodSqlException?>()) {
       return (data != null
-          ? _i43.ServerpodSqlException.fromJson(data, this)
+          ? _i46.ServerpodSqlException.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i44.SessionLogEntry?>()) {
-      return (data != null ? _i44.SessionLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i47.SessionLogEntry?>()) {
+      return (data != null ? _i47.SessionLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i45.SessionLogFilter?>()) {
-      return (data != null ? _i45.SessionLogFilter.fromJson(data, this) : null)
+    if (t == _i1.getType<_i48.SessionLogFilter?>()) {
+      return (data != null ? _i48.SessionLogFilter.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i46.SessionLogInfo?>()) {
-      return (data != null ? _i46.SessionLogInfo.fromJson(data, this) : null)
+    if (t == _i1.getType<_i49.SessionLogInfo?>()) {
+      return (data != null ? _i49.SessionLogInfo.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i47.SessionLogResult?>()) {
-      return (data != null ? _i47.SessionLogResult.fromJson(data, this) : null)
+    if (t == _i1.getType<_i50.SessionLogResult?>()) {
+      return (data != null ? _i50.SessionLogResult.fromJson(data, this) : null)
           as T;
     }
     if (t == List<String>) {
@@ -456,14 +482,14 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i48.ClusterServerInfo>) {
+    if (t == List<_i51.ClusterServerInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i48.ClusterServerInfo>(e))
+          .map((e) => deserialize<_i51.ClusterServerInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.TableDefinition>) {
+    if (t == List<_i51.TableDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i48.TableDefinition>(e))
+          .map((e) => deserialize<_i51.TableDefinition>(e))
           .toList() as dynamic;
     }
     if (t == _i1.getType<Map<String, String>?>()) {
@@ -472,73 +498,78 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i48.DatabaseMigrationAction>) {
+    if (t == List<_i51.DatabaseMigrationAction>) {
       return (data as List)
-          .map((e) => deserialize<_i48.DatabaseMigrationAction>(e))
+          .map((e) => deserialize<_i51.DatabaseMigrationAction>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.DatabaseMigrationWarning>) {
+    if (t == List<_i51.DatabaseMigrationWarning>) {
       return (data as List)
-          .map((e) => deserialize<_i48.DatabaseMigrationWarning>(e))
+          .map((e) => deserialize<_i51.DatabaseMigrationWarning>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.IndexElementDefinition>) {
+    if (t == List<_i51.FilterConstraint>) {
       return (data as List)
-          .map((e) => deserialize<_i48.IndexElementDefinition>(e))
+          .map((e) => deserialize<_i51.FilterConstraint>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.ColumnDefinition>) {
+    if (t == List<_i51.IndexElementDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i48.ColumnDefinition>(e))
+          .map((e) => deserialize<_i51.IndexElementDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.ForeignKeyDefinition>) {
+    if (t == List<_i51.ColumnDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i48.ForeignKeyDefinition>(e))
+          .map((e) => deserialize<_i51.ColumnDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.IndexDefinition>) {
+    if (t == List<_i51.ForeignKeyDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i48.IndexDefinition>(e))
+          .map((e) => deserialize<_i51.ForeignKeyDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.ColumnMigration>) {
+    if (t == List<_i51.IndexDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i48.ColumnMigration>(e))
+          .map((e) => deserialize<_i51.IndexDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i48.LogEntry>(e)).toList()
+    if (t == List<_i51.ColumnMigration>) {
+      return (data as List)
+          .map((e) => deserialize<_i51.ColumnMigration>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i51.LogEntry>) {
+      return (data as List).map((e) => deserialize<_i51.LogEntry>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i48.LogSettingsOverride>) {
+    if (t == List<_i51.LogSettingsOverride>) {
       return (data as List)
-          .map((e) => deserialize<_i48.LogSettingsOverride>(e))
+          .map((e) => deserialize<_i51.LogSettingsOverride>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.ServerHealthMetric>) {
+    if (t == List<_i51.ServerHealthMetric>) {
       return (data as List)
-          .map((e) => deserialize<_i48.ServerHealthMetric>(e))
+          .map((e) => deserialize<_i51.ServerHealthMetric>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.ServerHealthConnectionInfo>) {
+    if (t == List<_i51.ServerHealthConnectionInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i48.ServerHealthConnectionInfo>(e))
+          .map((e) => deserialize<_i51.ServerHealthConnectionInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.QueryLogEntry>) {
+    if (t == List<_i51.QueryLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i48.QueryLogEntry>(e))
+          .map((e) => deserialize<_i51.QueryLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.MessageLogEntry>) {
+    if (t == List<_i51.MessageLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i48.MessageLogEntry>(e))
+          .map((e) => deserialize<_i51.MessageLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i48.SessionLogInfo>) {
+    if (t == List<_i51.SessionLogInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i48.SessionLogInfo>(e))
+          .map((e) => deserialize<_i51.SessionLogInfo>(e))
           .toList() as dynamic;
     }
     return super.deserialize<T>(data, t);
@@ -600,88 +631,97 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i19.DatabaseMigrationWarningType) {
       return 'DatabaseMigrationWarningType';
     }
-    if (data is _i20.ForeignKeyAction) {
+    if (data is _i20.Filter) {
+      return 'Filter';
+    }
+    if (data is _i21.FilterConstraint) {
+      return 'FilterConstraint';
+    }
+    if (data is _i22.FilterConstraintType) {
+      return 'FilterConstraintType';
+    }
+    if (data is _i23.ForeignKeyAction) {
       return 'ForeignKeyAction';
     }
-    if (data is _i21.ForeignKeyDefinition) {
+    if (data is _i24.ForeignKeyDefinition) {
       return 'ForeignKeyDefinition';
     }
-    if (data is _i22.ForeignKeyMatchType) {
+    if (data is _i25.ForeignKeyMatchType) {
       return 'ForeignKeyMatchType';
     }
-    if (data is _i23.IndexDefinition) {
+    if (data is _i26.IndexDefinition) {
       return 'IndexDefinition';
     }
-    if (data is _i24.IndexElementDefinition) {
+    if (data is _i27.IndexElementDefinition) {
       return 'IndexElementDefinition';
     }
-    if (data is _i25.IndexElementDefinitionType) {
+    if (data is _i28.IndexElementDefinitionType) {
       return 'IndexElementDefinitionType';
     }
-    if (data is _i26.TableDefinition) {
+    if (data is _i29.TableDefinition) {
       return 'TableDefinition';
     }
-    if (data is _i27.TableMigration) {
+    if (data is _i30.TableMigration) {
       return 'TableMigration';
     }
-    if (data is _i28.DistributedCacheEntry) {
+    if (data is _i31.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i29.FutureCallEntry) {
+    if (data is _i32.FutureCallEntry) {
       return 'FutureCallEntry';
     }
-    if (data is _i30.LogEntry) {
+    if (data is _i33.LogEntry) {
       return 'LogEntry';
     }
-    if (data is _i31.LogLevel) {
+    if (data is _i34.LogLevel) {
       return 'LogLevel';
     }
-    if (data is _i32.LogResult) {
+    if (data is _i35.LogResult) {
       return 'LogResult';
     }
-    if (data is _i33.LogSettings) {
+    if (data is _i36.LogSettings) {
       return 'LogSettings';
     }
-    if (data is _i34.LogSettingsOverride) {
+    if (data is _i37.LogSettingsOverride) {
       return 'LogSettingsOverride';
     }
-    if (data is _i35.MessageLogEntry) {
+    if (data is _i38.MessageLogEntry) {
       return 'MessageLogEntry';
     }
-    if (data is _i36.MethodInfo) {
+    if (data is _i39.MethodInfo) {
       return 'MethodInfo';
     }
-    if (data is _i37.QueryLogEntry) {
+    if (data is _i40.QueryLogEntry) {
       return 'QueryLogEntry';
     }
-    if (data is _i38.ReadWriteTestEntry) {
+    if (data is _i41.ReadWriteTestEntry) {
       return 'ReadWriteTestEntry';
     }
-    if (data is _i39.RuntimeSettings) {
+    if (data is _i42.RuntimeSettings) {
       return 'RuntimeSettings';
     }
-    if (data is _i40.ServerHealthConnectionInfo) {
+    if (data is _i43.ServerHealthConnectionInfo) {
       return 'ServerHealthConnectionInfo';
     }
-    if (data is _i41.ServerHealthMetric) {
+    if (data is _i44.ServerHealthMetric) {
       return 'ServerHealthMetric';
     }
-    if (data is _i42.ServerHealthResult) {
+    if (data is _i45.ServerHealthResult) {
       return 'ServerHealthResult';
     }
-    if (data is _i43.ServerpodSqlException) {
+    if (data is _i46.ServerpodSqlException) {
       return 'ServerpodSqlException';
     }
-    if (data is _i44.SessionLogEntry) {
+    if (data is _i47.SessionLogEntry) {
       return 'SessionLogEntry';
     }
-    if (data is _i45.SessionLogFilter) {
+    if (data is _i48.SessionLogFilter) {
       return 'SessionLogFilter';
     }
-    if (data is _i46.SessionLogInfo) {
+    if (data is _i49.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i47.SessionLogResult) {
+    if (data is _i50.SessionLogResult) {
       return 'SessionLogResult';
     }
     return super.getClassNameForObject(data);
@@ -743,89 +783,98 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'DatabaseMigrationWarningType') {
       return deserialize<_i19.DatabaseMigrationWarningType>(data['data']);
     }
+    if (data['className'] == 'Filter') {
+      return deserialize<_i20.Filter>(data['data']);
+    }
+    if (data['className'] == 'FilterConstraint') {
+      return deserialize<_i21.FilterConstraint>(data['data']);
+    }
+    if (data['className'] == 'FilterConstraintType') {
+      return deserialize<_i22.FilterConstraintType>(data['data']);
+    }
     if (data['className'] == 'ForeignKeyAction') {
-      return deserialize<_i20.ForeignKeyAction>(data['data']);
+      return deserialize<_i23.ForeignKeyAction>(data['data']);
     }
     if (data['className'] == 'ForeignKeyDefinition') {
-      return deserialize<_i21.ForeignKeyDefinition>(data['data']);
+      return deserialize<_i24.ForeignKeyDefinition>(data['data']);
     }
     if (data['className'] == 'ForeignKeyMatchType') {
-      return deserialize<_i22.ForeignKeyMatchType>(data['data']);
+      return deserialize<_i25.ForeignKeyMatchType>(data['data']);
     }
     if (data['className'] == 'IndexDefinition') {
-      return deserialize<_i23.IndexDefinition>(data['data']);
+      return deserialize<_i26.IndexDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinition') {
-      return deserialize<_i24.IndexElementDefinition>(data['data']);
+      return deserialize<_i27.IndexElementDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinitionType') {
-      return deserialize<_i25.IndexElementDefinitionType>(data['data']);
+      return deserialize<_i28.IndexElementDefinitionType>(data['data']);
     }
     if (data['className'] == 'TableDefinition') {
-      return deserialize<_i26.TableDefinition>(data['data']);
+      return deserialize<_i29.TableDefinition>(data['data']);
     }
     if (data['className'] == 'TableMigration') {
-      return deserialize<_i27.TableMigration>(data['data']);
+      return deserialize<_i30.TableMigration>(data['data']);
     }
     if (data['className'] == 'DistributedCacheEntry') {
-      return deserialize<_i28.DistributedCacheEntry>(data['data']);
+      return deserialize<_i31.DistributedCacheEntry>(data['data']);
     }
     if (data['className'] == 'FutureCallEntry') {
-      return deserialize<_i29.FutureCallEntry>(data['data']);
+      return deserialize<_i32.FutureCallEntry>(data['data']);
     }
     if (data['className'] == 'LogEntry') {
-      return deserialize<_i30.LogEntry>(data['data']);
+      return deserialize<_i33.LogEntry>(data['data']);
     }
     if (data['className'] == 'LogLevel') {
-      return deserialize<_i31.LogLevel>(data['data']);
+      return deserialize<_i34.LogLevel>(data['data']);
     }
     if (data['className'] == 'LogResult') {
-      return deserialize<_i32.LogResult>(data['data']);
+      return deserialize<_i35.LogResult>(data['data']);
     }
     if (data['className'] == 'LogSettings') {
-      return deserialize<_i33.LogSettings>(data['data']);
+      return deserialize<_i36.LogSettings>(data['data']);
     }
     if (data['className'] == 'LogSettingsOverride') {
-      return deserialize<_i34.LogSettingsOverride>(data['data']);
+      return deserialize<_i37.LogSettingsOverride>(data['data']);
     }
     if (data['className'] == 'MessageLogEntry') {
-      return deserialize<_i35.MessageLogEntry>(data['data']);
+      return deserialize<_i38.MessageLogEntry>(data['data']);
     }
     if (data['className'] == 'MethodInfo') {
-      return deserialize<_i36.MethodInfo>(data['data']);
+      return deserialize<_i39.MethodInfo>(data['data']);
     }
     if (data['className'] == 'QueryLogEntry') {
-      return deserialize<_i37.QueryLogEntry>(data['data']);
+      return deserialize<_i40.QueryLogEntry>(data['data']);
     }
     if (data['className'] == 'ReadWriteTestEntry') {
-      return deserialize<_i38.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i41.ReadWriteTestEntry>(data['data']);
     }
     if (data['className'] == 'RuntimeSettings') {
-      return deserialize<_i39.RuntimeSettings>(data['data']);
+      return deserialize<_i42.RuntimeSettings>(data['data']);
     }
     if (data['className'] == 'ServerHealthConnectionInfo') {
-      return deserialize<_i40.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i43.ServerHealthConnectionInfo>(data['data']);
     }
     if (data['className'] == 'ServerHealthMetric') {
-      return deserialize<_i41.ServerHealthMetric>(data['data']);
+      return deserialize<_i44.ServerHealthMetric>(data['data']);
     }
     if (data['className'] == 'ServerHealthResult') {
-      return deserialize<_i42.ServerHealthResult>(data['data']);
+      return deserialize<_i45.ServerHealthResult>(data['data']);
     }
     if (data['className'] == 'ServerpodSqlException') {
-      return deserialize<_i43.ServerpodSqlException>(data['data']);
+      return deserialize<_i46.ServerpodSqlException>(data['data']);
     }
     if (data['className'] == 'SessionLogEntry') {
-      return deserialize<_i44.SessionLogEntry>(data['data']);
+      return deserialize<_i47.SessionLogEntry>(data['data']);
     }
     if (data['className'] == 'SessionLogFilter') {
-      return deserialize<_i45.SessionLogFilter>(data['data']);
+      return deserialize<_i48.SessionLogFilter>(data['data']);
     }
     if (data['className'] == 'SessionLogInfo') {
-      return deserialize<_i46.SessionLogInfo>(data['data']);
+      return deserialize<_i49.SessionLogInfo>(data['data']);
     }
     if (data['className'] == 'SessionLogResult') {
-      return deserialize<_i47.SessionLogResult>(data['data']);
+      return deserialize<_i50.SessionLogResult>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -15,44 +15,46 @@ import 'cloud_storage.dart' as _i5;
 import 'cloud_storage_direct_upload.dart' as _i6;
 import 'cluster_info.dart' as _i7;
 import 'cluster_server_info.dart' as _i8;
-import 'database/column_definition.dart' as _i9;
-import 'database/column_migration.dart' as _i10;
-import 'database/column_type.dart' as _i11;
-import 'database/database_definition.dart' as _i12;
-import 'database/database_migration.dart' as _i13;
-import 'database/database_migration_action.dart' as _i14;
-import 'database/database_migration_action_type.dart' as _i15;
-import 'database/database_migration_warning.dart' as _i16;
-import 'database/database_migration_warning_type.dart' as _i17;
-import 'database/foreign_key_action.dart' as _i18;
-import 'database/foreign_key_definition.dart' as _i19;
-import 'database/foreign_key_match_type.dart' as _i20;
-import 'database/index_definition.dart' as _i21;
-import 'database/index_element_definition.dart' as _i22;
-import 'database/index_element_definition_type.dart' as _i23;
-import 'database/table_definition.dart' as _i24;
-import 'database/table_migration.dart' as _i25;
-import 'distributed_cache_entry.dart' as _i26;
-import 'future_call_entry.dart' as _i27;
-import 'log_entry.dart' as _i28;
-import 'log_level.dart' as _i29;
-import 'log_result.dart' as _i30;
-import 'log_settings.dart' as _i31;
-import 'log_settings_override.dart' as _i32;
-import 'message_log_entry.dart' as _i33;
-import 'method_info.dart' as _i34;
-import 'query_log_entry.dart' as _i35;
-import 'readwrite_test.dart' as _i36;
-import 'runtime_settings.dart' as _i37;
-import 'server_health_connection_info.dart' as _i38;
-import 'server_health_metric.dart' as _i39;
-import 'server_health_result.dart' as _i40;
-import 'serverpod_sql_exception.dart' as _i41;
-import 'session_log_entry.dart' as _i42;
-import 'session_log_filter.dart' as _i43;
-import 'session_log_info.dart' as _i44;
-import 'session_log_result.dart' as _i45;
-import 'protocol.dart' as _i46;
+import 'database/bulk_data.dart' as _i9;
+import 'database/bulk_data_exception.dart' as _i10;
+import 'database/column_definition.dart' as _i11;
+import 'database/column_migration.dart' as _i12;
+import 'database/column_type.dart' as _i13;
+import 'database/database_definition.dart' as _i14;
+import 'database/database_migration.dart' as _i15;
+import 'database/database_migration_action.dart' as _i16;
+import 'database/database_migration_action_type.dart' as _i17;
+import 'database/database_migration_warning.dart' as _i18;
+import 'database/database_migration_warning_type.dart' as _i19;
+import 'database/foreign_key_action.dart' as _i20;
+import 'database/foreign_key_definition.dart' as _i21;
+import 'database/foreign_key_match_type.dart' as _i22;
+import 'database/index_definition.dart' as _i23;
+import 'database/index_element_definition.dart' as _i24;
+import 'database/index_element_definition_type.dart' as _i25;
+import 'database/table_definition.dart' as _i26;
+import 'database/table_migration.dart' as _i27;
+import 'distributed_cache_entry.dart' as _i28;
+import 'future_call_entry.dart' as _i29;
+import 'log_entry.dart' as _i30;
+import 'log_level.dart' as _i31;
+import 'log_result.dart' as _i32;
+import 'log_settings.dart' as _i33;
+import 'log_settings_override.dart' as _i34;
+import 'message_log_entry.dart' as _i35;
+import 'method_info.dart' as _i36;
+import 'query_log_entry.dart' as _i37;
+import 'readwrite_test.dart' as _i38;
+import 'runtime_settings.dart' as _i39;
+import 'server_health_connection_info.dart' as _i40;
+import 'server_health_metric.dart' as _i41;
+import 'server_health_result.dart' as _i42;
+import 'serverpod_sql_exception.dart' as _i43;
+import 'session_log_entry.dart' as _i44;
+import 'session_log_filter.dart' as _i45;
+import 'session_log_info.dart' as _i46;
+import 'session_log_result.dart' as _i47;
+import 'protocol.dart' as _i48;
 export 'auth_key.dart';
 export 'cache_info.dart';
 export 'caches_info.dart';
@@ -60,6 +62,8 @@ export 'cloud_storage.dart';
 export 'cloud_storage_direct_upload.dart';
 export 'cluster_info.dart';
 export 'cluster_server_info.dart';
+export 'database/bulk_data.dart';
+export 'database/bulk_data_exception.dart';
 export 'database/column_definition.dart';
 export 'database/column_migration.dart';
 export 'database/column_type.dart';
@@ -138,116 +142,122 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i8.ClusterServerInfo) {
       return _i8.ClusterServerInfo.fromJson(data, this) as T;
     }
-    if (t == _i9.ColumnDefinition) {
-      return _i9.ColumnDefinition.fromJson(data, this) as T;
+    if (t == _i9.BulkData) {
+      return _i9.BulkData.fromJson(data, this) as T;
     }
-    if (t == _i10.ColumnMigration) {
-      return _i10.ColumnMigration.fromJson(data, this) as T;
+    if (t == _i10.BulkDataException) {
+      return _i10.BulkDataException.fromJson(data, this) as T;
     }
-    if (t == _i11.ColumnType) {
-      return _i11.ColumnType.fromJson(data) as T;
+    if (t == _i11.ColumnDefinition) {
+      return _i11.ColumnDefinition.fromJson(data, this) as T;
     }
-    if (t == _i12.DatabaseDefinition) {
-      return _i12.DatabaseDefinition.fromJson(data, this) as T;
+    if (t == _i12.ColumnMigration) {
+      return _i12.ColumnMigration.fromJson(data, this) as T;
     }
-    if (t == _i13.DatabaseMigration) {
-      return _i13.DatabaseMigration.fromJson(data, this) as T;
+    if (t == _i13.ColumnType) {
+      return _i13.ColumnType.fromJson(data) as T;
     }
-    if (t == _i14.DatabaseMigrationAction) {
-      return _i14.DatabaseMigrationAction.fromJson(data, this) as T;
+    if (t == _i14.DatabaseDefinition) {
+      return _i14.DatabaseDefinition.fromJson(data, this) as T;
     }
-    if (t == _i15.DatabaseMigrationActionType) {
-      return _i15.DatabaseMigrationActionType.fromJson(data) as T;
+    if (t == _i15.DatabaseMigration) {
+      return _i15.DatabaseMigration.fromJson(data, this) as T;
     }
-    if (t == _i16.DatabaseMigrationWarning) {
-      return _i16.DatabaseMigrationWarning.fromJson(data, this) as T;
+    if (t == _i16.DatabaseMigrationAction) {
+      return _i16.DatabaseMigrationAction.fromJson(data, this) as T;
     }
-    if (t == _i17.DatabaseMigrationWarningType) {
-      return _i17.DatabaseMigrationWarningType.fromJson(data) as T;
+    if (t == _i17.DatabaseMigrationActionType) {
+      return _i17.DatabaseMigrationActionType.fromJson(data) as T;
     }
-    if (t == _i18.ForeignKeyAction) {
-      return _i18.ForeignKeyAction.fromJson(data) as T;
+    if (t == _i18.DatabaseMigrationWarning) {
+      return _i18.DatabaseMigrationWarning.fromJson(data, this) as T;
     }
-    if (t == _i19.ForeignKeyDefinition) {
-      return _i19.ForeignKeyDefinition.fromJson(data, this) as T;
+    if (t == _i19.DatabaseMigrationWarningType) {
+      return _i19.DatabaseMigrationWarningType.fromJson(data) as T;
     }
-    if (t == _i20.ForeignKeyMatchType) {
-      return _i20.ForeignKeyMatchType.fromJson(data) as T;
+    if (t == _i20.ForeignKeyAction) {
+      return _i20.ForeignKeyAction.fromJson(data) as T;
     }
-    if (t == _i21.IndexDefinition) {
-      return _i21.IndexDefinition.fromJson(data, this) as T;
+    if (t == _i21.ForeignKeyDefinition) {
+      return _i21.ForeignKeyDefinition.fromJson(data, this) as T;
     }
-    if (t == _i22.IndexElementDefinition) {
-      return _i22.IndexElementDefinition.fromJson(data, this) as T;
+    if (t == _i22.ForeignKeyMatchType) {
+      return _i22.ForeignKeyMatchType.fromJson(data) as T;
     }
-    if (t == _i23.IndexElementDefinitionType) {
-      return _i23.IndexElementDefinitionType.fromJson(data) as T;
+    if (t == _i23.IndexDefinition) {
+      return _i23.IndexDefinition.fromJson(data, this) as T;
     }
-    if (t == _i24.TableDefinition) {
-      return _i24.TableDefinition.fromJson(data, this) as T;
+    if (t == _i24.IndexElementDefinition) {
+      return _i24.IndexElementDefinition.fromJson(data, this) as T;
     }
-    if (t == _i25.TableMigration) {
-      return _i25.TableMigration.fromJson(data, this) as T;
+    if (t == _i25.IndexElementDefinitionType) {
+      return _i25.IndexElementDefinitionType.fromJson(data) as T;
     }
-    if (t == _i26.DistributedCacheEntry) {
-      return _i26.DistributedCacheEntry.fromJson(data, this) as T;
+    if (t == _i26.TableDefinition) {
+      return _i26.TableDefinition.fromJson(data, this) as T;
     }
-    if (t == _i27.FutureCallEntry) {
-      return _i27.FutureCallEntry.fromJson(data, this) as T;
+    if (t == _i27.TableMigration) {
+      return _i27.TableMigration.fromJson(data, this) as T;
     }
-    if (t == _i28.LogEntry) {
-      return _i28.LogEntry.fromJson(data, this) as T;
+    if (t == _i28.DistributedCacheEntry) {
+      return _i28.DistributedCacheEntry.fromJson(data, this) as T;
     }
-    if (t == _i29.LogLevel) {
-      return _i29.LogLevel.fromJson(data) as T;
+    if (t == _i29.FutureCallEntry) {
+      return _i29.FutureCallEntry.fromJson(data, this) as T;
     }
-    if (t == _i30.LogResult) {
-      return _i30.LogResult.fromJson(data, this) as T;
+    if (t == _i30.LogEntry) {
+      return _i30.LogEntry.fromJson(data, this) as T;
     }
-    if (t == _i31.LogSettings) {
-      return _i31.LogSettings.fromJson(data, this) as T;
+    if (t == _i31.LogLevel) {
+      return _i31.LogLevel.fromJson(data) as T;
     }
-    if (t == _i32.LogSettingsOverride) {
-      return _i32.LogSettingsOverride.fromJson(data, this) as T;
+    if (t == _i32.LogResult) {
+      return _i32.LogResult.fromJson(data, this) as T;
     }
-    if (t == _i33.MessageLogEntry) {
-      return _i33.MessageLogEntry.fromJson(data, this) as T;
+    if (t == _i33.LogSettings) {
+      return _i33.LogSettings.fromJson(data, this) as T;
     }
-    if (t == _i34.MethodInfo) {
-      return _i34.MethodInfo.fromJson(data, this) as T;
+    if (t == _i34.LogSettingsOverride) {
+      return _i34.LogSettingsOverride.fromJson(data, this) as T;
     }
-    if (t == _i35.QueryLogEntry) {
-      return _i35.QueryLogEntry.fromJson(data, this) as T;
+    if (t == _i35.MessageLogEntry) {
+      return _i35.MessageLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i36.ReadWriteTestEntry) {
-      return _i36.ReadWriteTestEntry.fromJson(data, this) as T;
+    if (t == _i36.MethodInfo) {
+      return _i36.MethodInfo.fromJson(data, this) as T;
     }
-    if (t == _i37.RuntimeSettings) {
-      return _i37.RuntimeSettings.fromJson(data, this) as T;
+    if (t == _i37.QueryLogEntry) {
+      return _i37.QueryLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i38.ServerHealthConnectionInfo) {
-      return _i38.ServerHealthConnectionInfo.fromJson(data, this) as T;
+    if (t == _i38.ReadWriteTestEntry) {
+      return _i38.ReadWriteTestEntry.fromJson(data, this) as T;
     }
-    if (t == _i39.ServerHealthMetric) {
-      return _i39.ServerHealthMetric.fromJson(data, this) as T;
+    if (t == _i39.RuntimeSettings) {
+      return _i39.RuntimeSettings.fromJson(data, this) as T;
     }
-    if (t == _i40.ServerHealthResult) {
-      return _i40.ServerHealthResult.fromJson(data, this) as T;
+    if (t == _i40.ServerHealthConnectionInfo) {
+      return _i40.ServerHealthConnectionInfo.fromJson(data, this) as T;
     }
-    if (t == _i41.ServerpodSqlException) {
-      return _i41.ServerpodSqlException.fromJson(data, this) as T;
+    if (t == _i41.ServerHealthMetric) {
+      return _i41.ServerHealthMetric.fromJson(data, this) as T;
     }
-    if (t == _i42.SessionLogEntry) {
-      return _i42.SessionLogEntry.fromJson(data, this) as T;
+    if (t == _i42.ServerHealthResult) {
+      return _i42.ServerHealthResult.fromJson(data, this) as T;
     }
-    if (t == _i43.SessionLogFilter) {
-      return _i43.SessionLogFilter.fromJson(data, this) as T;
+    if (t == _i43.ServerpodSqlException) {
+      return _i43.ServerpodSqlException.fromJson(data, this) as T;
     }
-    if (t == _i44.SessionLogInfo) {
-      return _i44.SessionLogInfo.fromJson(data, this) as T;
+    if (t == _i44.SessionLogEntry) {
+      return _i44.SessionLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i45.SessionLogResult) {
-      return _i45.SessionLogResult.fromJson(data, this) as T;
+    if (t == _i45.SessionLogFilter) {
+      return _i45.SessionLogFilter.fromJson(data, this) as T;
+    }
+    if (t == _i46.SessionLogInfo) {
+      return _i46.SessionLogInfo.fromJson(data, this) as T;
+    }
+    if (t == _i47.SessionLogResult) {
+      return _i47.SessionLogResult.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.AuthKey?>()) {
       return (data != null ? _i2.AuthKey.fromJson(data, this) : null) as T;
@@ -274,160 +284,167 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i8.ClusterServerInfo.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i9.ColumnDefinition?>()) {
-      return (data != null ? _i9.ColumnDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i9.BulkData?>()) {
+      return (data != null ? _i9.BulkData.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i10.BulkDataException?>()) {
+      return (data != null ? _i10.BulkDataException.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i10.ColumnMigration?>()) {
-      return (data != null ? _i10.ColumnMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i11.ColumnDefinition?>()) {
+      return (data != null ? _i11.ColumnDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i11.ColumnType?>()) {
-      return (data != null ? _i11.ColumnType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i12.DatabaseDefinition?>()) {
-      return (data != null
-          ? _i12.DatabaseDefinition.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i13.DatabaseMigration?>()) {
-      return (data != null ? _i13.DatabaseMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i12.ColumnMigration?>()) {
+      return (data != null ? _i12.ColumnMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i14.DatabaseMigrationAction?>()) {
+    if (t == _i1.getType<_i13.ColumnType?>()) {
+      return (data != null ? _i13.ColumnType.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i14.DatabaseDefinition?>()) {
       return (data != null
-          ? _i14.DatabaseMigrationAction.fromJson(data, this)
+          ? _i14.DatabaseDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i15.DatabaseMigrationActionType?>()) {
-      return (data != null
-          ? _i15.DatabaseMigrationActionType.fromJson(data)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i16.DatabaseMigrationWarning?>()) {
-      return (data != null
-          ? _i16.DatabaseMigrationWarning.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i17.DatabaseMigrationWarningType?>()) {
-      return (data != null
-          ? _i17.DatabaseMigrationWarningType.fromJson(data)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i18.ForeignKeyAction?>()) {
-      return (data != null ? _i18.ForeignKeyAction.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.ForeignKeyDefinition?>()) {
-      return (data != null
-          ? _i19.ForeignKeyDefinition.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i20.ForeignKeyMatchType?>()) {
-      return (data != null ? _i20.ForeignKeyMatchType.fromJson(data) : null)
+    if (t == _i1.getType<_i15.DatabaseMigration?>()) {
+      return (data != null ? _i15.DatabaseMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i21.IndexDefinition?>()) {
-      return (data != null ? _i21.IndexDefinition.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i22.IndexElementDefinition?>()) {
+    if (t == _i1.getType<_i16.DatabaseMigrationAction?>()) {
       return (data != null
-          ? _i22.IndexElementDefinition.fromJson(data, this)
+          ? _i16.DatabaseMigrationAction.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i23.IndexElementDefinitionType?>()) {
+    if (t == _i1.getType<_i17.DatabaseMigrationActionType?>()) {
       return (data != null
-          ? _i23.IndexElementDefinitionType.fromJson(data)
+          ? _i17.DatabaseMigrationActionType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i24.TableDefinition?>()) {
-      return (data != null ? _i24.TableDefinition.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i25.TableMigration?>()) {
-      return (data != null ? _i25.TableMigration.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i26.DistributedCacheEntry?>()) {
+    if (t == _i1.getType<_i18.DatabaseMigrationWarning?>()) {
       return (data != null
-          ? _i26.DistributedCacheEntry.fromJson(data, this)
+          ? _i18.DatabaseMigrationWarning.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i27.FutureCallEntry?>()) {
-      return (data != null ? _i27.FutureCallEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.LogEntry?>()) {
-      return (data != null ? _i28.LogEntry.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i29.LogLevel?>()) {
-      return (data != null ? _i29.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.LogResult?>()) {
-      return (data != null ? _i30.LogResult.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i31.LogSettings?>()) {
-      return (data != null ? _i31.LogSettings.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i32.LogSettingsOverride?>()) {
+    if (t == _i1.getType<_i19.DatabaseMigrationWarningType?>()) {
       return (data != null
-          ? _i32.LogSettingsOverride.fromJson(data, this)
+          ? _i19.DatabaseMigrationWarningType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i33.MessageLogEntry?>()) {
-      return (data != null ? _i33.MessageLogEntry.fromJson(data, this) : null)
-          as T;
+    if (t == _i1.getType<_i20.ForeignKeyAction?>()) {
+      return (data != null ? _i20.ForeignKeyAction.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i34.MethodInfo?>()) {
-      return (data != null ? _i34.MethodInfo.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i35.QueryLogEntry?>()) {
-      return (data != null ? _i35.QueryLogEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i36.ReadWriteTestEntry?>()) {
+    if (t == _i1.getType<_i21.ForeignKeyDefinition?>()) {
       return (data != null
-          ? _i36.ReadWriteTestEntry.fromJson(data, this)
+          ? _i21.ForeignKeyDefinition.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i37.RuntimeSettings?>()) {
-      return (data != null ? _i37.RuntimeSettings.fromJson(data, this) : null)
+    if (t == _i1.getType<_i22.ForeignKeyMatchType?>()) {
+      return (data != null ? _i22.ForeignKeyMatchType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i38.ServerHealthConnectionInfo?>()) {
-      return (data != null
-          ? _i38.ServerHealthConnectionInfo.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i39.ServerHealthMetric?>()) {
-      return (data != null
-          ? _i39.ServerHealthMetric.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i40.ServerHealthResult?>()) {
-      return (data != null
-          ? _i40.ServerHealthResult.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i41.ServerpodSqlException?>()) {
-      return (data != null
-          ? _i41.ServerpodSqlException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i42.SessionLogEntry?>()) {
-      return (data != null ? _i42.SessionLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i23.IndexDefinition?>()) {
+      return (data != null ? _i23.IndexDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i43.SessionLogFilter?>()) {
-      return (data != null ? _i43.SessionLogFilter.fromJson(data, this) : null)
+    if (t == _i1.getType<_i24.IndexElementDefinition?>()) {
+      return (data != null
+          ? _i24.IndexElementDefinition.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i25.IndexElementDefinitionType?>()) {
+      return (data != null
+          ? _i25.IndexElementDefinitionType.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i26.TableDefinition?>()) {
+      return (data != null ? _i26.TableDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i44.SessionLogInfo?>()) {
-      return (data != null ? _i44.SessionLogInfo.fromJson(data, this) : null)
+    if (t == _i1.getType<_i27.TableMigration?>()) {
+      return (data != null ? _i27.TableMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i45.SessionLogResult?>()) {
-      return (data != null ? _i45.SessionLogResult.fromJson(data, this) : null)
+    if (t == _i1.getType<_i28.DistributedCacheEntry?>()) {
+      return (data != null
+          ? _i28.DistributedCacheEntry.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i29.FutureCallEntry?>()) {
+      return (data != null ? _i29.FutureCallEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i30.LogEntry?>()) {
+      return (data != null ? _i30.LogEntry.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i31.LogLevel?>()) {
+      return (data != null ? _i31.LogLevel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i32.LogResult?>()) {
+      return (data != null ? _i32.LogResult.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i33.LogSettings?>()) {
+      return (data != null ? _i33.LogSettings.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i34.LogSettingsOverride?>()) {
+      return (data != null
+          ? _i34.LogSettingsOverride.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i35.MessageLogEntry?>()) {
+      return (data != null ? _i35.MessageLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i36.MethodInfo?>()) {
+      return (data != null ? _i36.MethodInfo.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i37.QueryLogEntry?>()) {
+      return (data != null ? _i37.QueryLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i38.ReadWriteTestEntry?>()) {
+      return (data != null
+          ? _i38.ReadWriteTestEntry.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i39.RuntimeSettings?>()) {
+      return (data != null ? _i39.RuntimeSettings.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i40.ServerHealthConnectionInfo?>()) {
+      return (data != null
+          ? _i40.ServerHealthConnectionInfo.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i41.ServerHealthMetric?>()) {
+      return (data != null
+          ? _i41.ServerHealthMetric.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i42.ServerHealthResult?>()) {
+      return (data != null
+          ? _i42.ServerHealthResult.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i43.ServerpodSqlException?>()) {
+      return (data != null
+          ? _i43.ServerpodSqlException.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i44.SessionLogEntry?>()) {
+      return (data != null ? _i44.SessionLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i45.SessionLogFilter?>()) {
+      return (data != null ? _i45.SessionLogFilter.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i46.SessionLogInfo?>()) {
+      return (data != null ? _i46.SessionLogInfo.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i47.SessionLogResult?>()) {
+      return (data != null ? _i47.SessionLogResult.fromJson(data, this) : null)
           as T;
     }
     if (t == List<String>) {
@@ -439,14 +456,14 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i46.ClusterServerInfo>) {
+    if (t == List<_i48.ClusterServerInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i46.ClusterServerInfo>(e))
+          .map((e) => deserialize<_i48.ClusterServerInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.TableDefinition>) {
+    if (t == List<_i48.TableDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i46.TableDefinition>(e))
+          .map((e) => deserialize<_i48.TableDefinition>(e))
           .toList() as dynamic;
     }
     if (t == _i1.getType<Map<String, String>?>()) {
@@ -455,73 +472,73 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i46.DatabaseMigrationAction>) {
+    if (t == List<_i48.DatabaseMigrationAction>) {
       return (data as List)
-          .map((e) => deserialize<_i46.DatabaseMigrationAction>(e))
+          .map((e) => deserialize<_i48.DatabaseMigrationAction>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.DatabaseMigrationWarning>) {
+    if (t == List<_i48.DatabaseMigrationWarning>) {
       return (data as List)
-          .map((e) => deserialize<_i46.DatabaseMigrationWarning>(e))
+          .map((e) => deserialize<_i48.DatabaseMigrationWarning>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.IndexElementDefinition>) {
+    if (t == List<_i48.IndexElementDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i46.IndexElementDefinition>(e))
+          .map((e) => deserialize<_i48.IndexElementDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.ColumnDefinition>) {
+    if (t == List<_i48.ColumnDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i46.ColumnDefinition>(e))
+          .map((e) => deserialize<_i48.ColumnDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.ForeignKeyDefinition>) {
+    if (t == List<_i48.ForeignKeyDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i46.ForeignKeyDefinition>(e))
+          .map((e) => deserialize<_i48.ForeignKeyDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.IndexDefinition>) {
+    if (t == List<_i48.IndexDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i46.IndexDefinition>(e))
+          .map((e) => deserialize<_i48.IndexDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.ColumnMigration>) {
+    if (t == List<_i48.ColumnMigration>) {
       return (data as List)
-          .map((e) => deserialize<_i46.ColumnMigration>(e))
+          .map((e) => deserialize<_i48.ColumnMigration>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i46.LogEntry>(e)).toList()
+    if (t == List<_i48.LogEntry>) {
+      return (data as List).map((e) => deserialize<_i48.LogEntry>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i46.LogSettingsOverride>) {
+    if (t == List<_i48.LogSettingsOverride>) {
       return (data as List)
-          .map((e) => deserialize<_i46.LogSettingsOverride>(e))
+          .map((e) => deserialize<_i48.LogSettingsOverride>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.ServerHealthMetric>) {
+    if (t == List<_i48.ServerHealthMetric>) {
       return (data as List)
-          .map((e) => deserialize<_i46.ServerHealthMetric>(e))
+          .map((e) => deserialize<_i48.ServerHealthMetric>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.ServerHealthConnectionInfo>) {
+    if (t == List<_i48.ServerHealthConnectionInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i46.ServerHealthConnectionInfo>(e))
+          .map((e) => deserialize<_i48.ServerHealthConnectionInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.QueryLogEntry>) {
+    if (t == List<_i48.QueryLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i46.QueryLogEntry>(e))
+          .map((e) => deserialize<_i48.QueryLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.MessageLogEntry>) {
+    if (t == List<_i48.MessageLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i46.MessageLogEntry>(e))
+          .map((e) => deserialize<_i48.MessageLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i46.SessionLogInfo>) {
+    if (t == List<_i48.SessionLogInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i46.SessionLogInfo>(e))
+          .map((e) => deserialize<_i48.SessionLogInfo>(e))
           .toList() as dynamic;
     }
     return super.deserialize<T>(data, t);
@@ -550,115 +567,121 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i8.ClusterServerInfo) {
       return 'ClusterServerInfo';
     }
-    if (data is _i9.ColumnDefinition) {
+    if (data is _i9.BulkData) {
+      return 'BulkData';
+    }
+    if (data is _i10.BulkDataException) {
+      return 'BulkDataException';
+    }
+    if (data is _i11.ColumnDefinition) {
       return 'ColumnDefinition';
     }
-    if (data is _i10.ColumnMigration) {
+    if (data is _i12.ColumnMigration) {
       return 'ColumnMigration';
     }
-    if (data is _i11.ColumnType) {
+    if (data is _i13.ColumnType) {
       return 'ColumnType';
     }
-    if (data is _i12.DatabaseDefinition) {
+    if (data is _i14.DatabaseDefinition) {
       return 'DatabaseDefinition';
     }
-    if (data is _i13.DatabaseMigration) {
+    if (data is _i15.DatabaseMigration) {
       return 'DatabaseMigration';
     }
-    if (data is _i14.DatabaseMigrationAction) {
+    if (data is _i16.DatabaseMigrationAction) {
       return 'DatabaseMigrationAction';
     }
-    if (data is _i15.DatabaseMigrationActionType) {
+    if (data is _i17.DatabaseMigrationActionType) {
       return 'DatabaseMigrationActionType';
     }
-    if (data is _i16.DatabaseMigrationWarning) {
+    if (data is _i18.DatabaseMigrationWarning) {
       return 'DatabaseMigrationWarning';
     }
-    if (data is _i17.DatabaseMigrationWarningType) {
+    if (data is _i19.DatabaseMigrationWarningType) {
       return 'DatabaseMigrationWarningType';
     }
-    if (data is _i18.ForeignKeyAction) {
+    if (data is _i20.ForeignKeyAction) {
       return 'ForeignKeyAction';
     }
-    if (data is _i19.ForeignKeyDefinition) {
+    if (data is _i21.ForeignKeyDefinition) {
       return 'ForeignKeyDefinition';
     }
-    if (data is _i20.ForeignKeyMatchType) {
+    if (data is _i22.ForeignKeyMatchType) {
       return 'ForeignKeyMatchType';
     }
-    if (data is _i21.IndexDefinition) {
+    if (data is _i23.IndexDefinition) {
       return 'IndexDefinition';
     }
-    if (data is _i22.IndexElementDefinition) {
+    if (data is _i24.IndexElementDefinition) {
       return 'IndexElementDefinition';
     }
-    if (data is _i23.IndexElementDefinitionType) {
+    if (data is _i25.IndexElementDefinitionType) {
       return 'IndexElementDefinitionType';
     }
-    if (data is _i24.TableDefinition) {
+    if (data is _i26.TableDefinition) {
       return 'TableDefinition';
     }
-    if (data is _i25.TableMigration) {
+    if (data is _i27.TableMigration) {
       return 'TableMigration';
     }
-    if (data is _i26.DistributedCacheEntry) {
+    if (data is _i28.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i27.FutureCallEntry) {
+    if (data is _i29.FutureCallEntry) {
       return 'FutureCallEntry';
     }
-    if (data is _i28.LogEntry) {
+    if (data is _i30.LogEntry) {
       return 'LogEntry';
     }
-    if (data is _i29.LogLevel) {
+    if (data is _i31.LogLevel) {
       return 'LogLevel';
     }
-    if (data is _i30.LogResult) {
+    if (data is _i32.LogResult) {
       return 'LogResult';
     }
-    if (data is _i31.LogSettings) {
+    if (data is _i33.LogSettings) {
       return 'LogSettings';
     }
-    if (data is _i32.LogSettingsOverride) {
+    if (data is _i34.LogSettingsOverride) {
       return 'LogSettingsOverride';
     }
-    if (data is _i33.MessageLogEntry) {
+    if (data is _i35.MessageLogEntry) {
       return 'MessageLogEntry';
     }
-    if (data is _i34.MethodInfo) {
+    if (data is _i36.MethodInfo) {
       return 'MethodInfo';
     }
-    if (data is _i35.QueryLogEntry) {
+    if (data is _i37.QueryLogEntry) {
       return 'QueryLogEntry';
     }
-    if (data is _i36.ReadWriteTestEntry) {
+    if (data is _i38.ReadWriteTestEntry) {
       return 'ReadWriteTestEntry';
     }
-    if (data is _i37.RuntimeSettings) {
+    if (data is _i39.RuntimeSettings) {
       return 'RuntimeSettings';
     }
-    if (data is _i38.ServerHealthConnectionInfo) {
+    if (data is _i40.ServerHealthConnectionInfo) {
       return 'ServerHealthConnectionInfo';
     }
-    if (data is _i39.ServerHealthMetric) {
+    if (data is _i41.ServerHealthMetric) {
       return 'ServerHealthMetric';
     }
-    if (data is _i40.ServerHealthResult) {
+    if (data is _i42.ServerHealthResult) {
       return 'ServerHealthResult';
     }
-    if (data is _i41.ServerpodSqlException) {
+    if (data is _i43.ServerpodSqlException) {
       return 'ServerpodSqlException';
     }
-    if (data is _i42.SessionLogEntry) {
+    if (data is _i44.SessionLogEntry) {
       return 'SessionLogEntry';
     }
-    if (data is _i43.SessionLogFilter) {
+    if (data is _i45.SessionLogFilter) {
       return 'SessionLogFilter';
     }
-    if (data is _i44.SessionLogInfo) {
+    if (data is _i46.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i45.SessionLogResult) {
+    if (data is _i47.SessionLogResult) {
       return 'SessionLogResult';
     }
     return super.getClassNameForObject(data);
@@ -687,116 +710,122 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'ClusterServerInfo') {
       return deserialize<_i8.ClusterServerInfo>(data['data']);
     }
+    if (data['className'] == 'BulkData') {
+      return deserialize<_i9.BulkData>(data['data']);
+    }
+    if (data['className'] == 'BulkDataException') {
+      return deserialize<_i10.BulkDataException>(data['data']);
+    }
     if (data['className'] == 'ColumnDefinition') {
-      return deserialize<_i9.ColumnDefinition>(data['data']);
+      return deserialize<_i11.ColumnDefinition>(data['data']);
     }
     if (data['className'] == 'ColumnMigration') {
-      return deserialize<_i10.ColumnMigration>(data['data']);
+      return deserialize<_i12.ColumnMigration>(data['data']);
     }
     if (data['className'] == 'ColumnType') {
-      return deserialize<_i11.ColumnType>(data['data']);
+      return deserialize<_i13.ColumnType>(data['data']);
     }
     if (data['className'] == 'DatabaseDefinition') {
-      return deserialize<_i12.DatabaseDefinition>(data['data']);
+      return deserialize<_i14.DatabaseDefinition>(data['data']);
     }
     if (data['className'] == 'DatabaseMigration') {
-      return deserialize<_i13.DatabaseMigration>(data['data']);
+      return deserialize<_i15.DatabaseMigration>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationAction') {
-      return deserialize<_i14.DatabaseMigrationAction>(data['data']);
+      return deserialize<_i16.DatabaseMigrationAction>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationActionType') {
-      return deserialize<_i15.DatabaseMigrationActionType>(data['data']);
+      return deserialize<_i17.DatabaseMigrationActionType>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationWarning') {
-      return deserialize<_i16.DatabaseMigrationWarning>(data['data']);
+      return deserialize<_i18.DatabaseMigrationWarning>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationWarningType') {
-      return deserialize<_i17.DatabaseMigrationWarningType>(data['data']);
+      return deserialize<_i19.DatabaseMigrationWarningType>(data['data']);
     }
     if (data['className'] == 'ForeignKeyAction') {
-      return deserialize<_i18.ForeignKeyAction>(data['data']);
+      return deserialize<_i20.ForeignKeyAction>(data['data']);
     }
     if (data['className'] == 'ForeignKeyDefinition') {
-      return deserialize<_i19.ForeignKeyDefinition>(data['data']);
+      return deserialize<_i21.ForeignKeyDefinition>(data['data']);
     }
     if (data['className'] == 'ForeignKeyMatchType') {
-      return deserialize<_i20.ForeignKeyMatchType>(data['data']);
+      return deserialize<_i22.ForeignKeyMatchType>(data['data']);
     }
     if (data['className'] == 'IndexDefinition') {
-      return deserialize<_i21.IndexDefinition>(data['data']);
+      return deserialize<_i23.IndexDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinition') {
-      return deserialize<_i22.IndexElementDefinition>(data['data']);
+      return deserialize<_i24.IndexElementDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinitionType') {
-      return deserialize<_i23.IndexElementDefinitionType>(data['data']);
+      return deserialize<_i25.IndexElementDefinitionType>(data['data']);
     }
     if (data['className'] == 'TableDefinition') {
-      return deserialize<_i24.TableDefinition>(data['data']);
+      return deserialize<_i26.TableDefinition>(data['data']);
     }
     if (data['className'] == 'TableMigration') {
-      return deserialize<_i25.TableMigration>(data['data']);
+      return deserialize<_i27.TableMigration>(data['data']);
     }
     if (data['className'] == 'DistributedCacheEntry') {
-      return deserialize<_i26.DistributedCacheEntry>(data['data']);
+      return deserialize<_i28.DistributedCacheEntry>(data['data']);
     }
     if (data['className'] == 'FutureCallEntry') {
-      return deserialize<_i27.FutureCallEntry>(data['data']);
+      return deserialize<_i29.FutureCallEntry>(data['data']);
     }
     if (data['className'] == 'LogEntry') {
-      return deserialize<_i28.LogEntry>(data['data']);
+      return deserialize<_i30.LogEntry>(data['data']);
     }
     if (data['className'] == 'LogLevel') {
-      return deserialize<_i29.LogLevel>(data['data']);
+      return deserialize<_i31.LogLevel>(data['data']);
     }
     if (data['className'] == 'LogResult') {
-      return deserialize<_i30.LogResult>(data['data']);
+      return deserialize<_i32.LogResult>(data['data']);
     }
     if (data['className'] == 'LogSettings') {
-      return deserialize<_i31.LogSettings>(data['data']);
+      return deserialize<_i33.LogSettings>(data['data']);
     }
     if (data['className'] == 'LogSettingsOverride') {
-      return deserialize<_i32.LogSettingsOverride>(data['data']);
+      return deserialize<_i34.LogSettingsOverride>(data['data']);
     }
     if (data['className'] == 'MessageLogEntry') {
-      return deserialize<_i33.MessageLogEntry>(data['data']);
+      return deserialize<_i35.MessageLogEntry>(data['data']);
     }
     if (data['className'] == 'MethodInfo') {
-      return deserialize<_i34.MethodInfo>(data['data']);
+      return deserialize<_i36.MethodInfo>(data['data']);
     }
     if (data['className'] == 'QueryLogEntry') {
-      return deserialize<_i35.QueryLogEntry>(data['data']);
+      return deserialize<_i37.QueryLogEntry>(data['data']);
     }
     if (data['className'] == 'ReadWriteTestEntry') {
-      return deserialize<_i36.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i38.ReadWriteTestEntry>(data['data']);
     }
     if (data['className'] == 'RuntimeSettings') {
-      return deserialize<_i37.RuntimeSettings>(data['data']);
+      return deserialize<_i39.RuntimeSettings>(data['data']);
     }
     if (data['className'] == 'ServerHealthConnectionInfo') {
-      return deserialize<_i38.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i40.ServerHealthConnectionInfo>(data['data']);
     }
     if (data['className'] == 'ServerHealthMetric') {
-      return deserialize<_i39.ServerHealthMetric>(data['data']);
+      return deserialize<_i41.ServerHealthMetric>(data['data']);
     }
     if (data['className'] == 'ServerHealthResult') {
-      return deserialize<_i40.ServerHealthResult>(data['data']);
+      return deserialize<_i42.ServerHealthResult>(data['data']);
     }
     if (data['className'] == 'ServerpodSqlException') {
-      return deserialize<_i41.ServerpodSqlException>(data['data']);
+      return deserialize<_i43.ServerpodSqlException>(data['data']);
     }
     if (data['className'] == 'SessionLogEntry') {
-      return deserialize<_i42.SessionLogEntry>(data['data']);
+      return deserialize<_i44.SessionLogEntry>(data['data']);
     }
     if (data['className'] == 'SessionLogFilter') {
-      return deserialize<_i43.SessionLogFilter>(data['data']);
+      return deserialize<_i45.SessionLogFilter>(data['data']);
     }
     if (data['className'] == 'SessionLogInfo') {
-      return deserialize<_i44.SessionLogInfo>(data['data']);
+      return deserialize<_i46.SessionLogInfo>(data['data']);
     }
     if (data['className'] == 'SessionLogResult') {
-      return deserialize<_i45.SessionLogResult>(data['data']);
+      return deserialize<_i47.SessionLogResult>(data['data']);
     }
     return super.deserializeByClassName(data);
   }


### PR DESCRIPTION
This adds improved fetching of bulk data for Serverpod Insights.

- Support for filters.
- Better error checks.
- Doesn't fetch binary data (instead just number of bytes).

It's still work in progress, so no tests yet. The code only affects Insights though, so should be safe.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

