### PR TITLE
fix: Command runner related fixes

### DIFF
--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -43,6 +43,10 @@ void main(List<String> args) async {
 }
 
 Future<void> _main(List<String> args) async {
+  // Need to initialize logger before building command runner because we need
+  // the terminal column width that is accessed through the logger for proper
+  // formatted usage messages.
+  initializeLogger();
   var runner = buildCommandRunner();
   await runner.run(args);
 }

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -37,13 +37,13 @@ class CreateCommand extends ServerpodCommand {
     var rest = argResults?.rest;
 
     if (rest == null || rest.isEmpty) {
-      log.info('Project name missing.');
+      log.error('Project name missing.');
       printUsage();
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 
     if (rest.length > 1) {
-      log.info('Multiple project names specified, please specify only.');
+      log.error('Multiple project names specified, please specify only.');
       printUsage();
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/create/create.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/exit_exception.dart';
 
@@ -33,7 +34,21 @@ class CreateCommand extends ServerpodCommand {
 
   @override
   Future<void> run() async {
-    var name = argResults!.arguments.last;
+    var rest = argResults?.rest;
+
+    if (rest == null || rest.isEmpty) {
+      log.info('Project name missing.');
+      printUsage();
+      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+    }
+
+    if (rest.length > 1) {
+      log.info('Multiple project names specified, please specify only.');
+      printUsage();
+      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+    }
+
+    var name = rest.last;
     var template = ServerpodTemplateType.tryParse(argResults!['template']);
     bool force = argResults!['force'];
 

--- a/tools/serverpod_cli/lib/src/logger/logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/logger.dart
@@ -8,7 +8,7 @@ import 'package:source_span/source_span.dart';
 /// The purpose is to simplify implementing and switching out concrete logger
 /// implementations.
 abstract class Logger {
-  final LogLevel logLevel;
+  LogLevel logLevel;
 
   /// If defined, defines what column width text should be wrapped.
   int? get wrapTextColumn;
@@ -138,15 +138,15 @@ Logger? _logger;
 /// Initializer for logger singleton.
 /// Runs checks to pick the best suitable logger for the environment.
 /// This should only be called once from runtime entry points.
-void initializeLogger(LogLevel logLevel) {
+void initializeLogger() {
   assert(
     _logger == null,
     'Only one logger initialization is allowed.',
   );
 
   _logger = Platform.isWindows
-      ? WindowsStdOutLogger(logLevel)
-      : StdOutLogger(logLevel);
+      ? WindowsStdOutLogger(LogLevel.info)
+      : StdOutLogger(LogLevel.info);
 }
 
 /// Initializer for logger singleton.
@@ -165,6 +165,9 @@ void initializeLoggerWith(Logger logger) {
 /// Default initializes a [StdOutLogger] if initialization is not run before
 /// this call.
 Logger get log {
-  _logger ??= StdOutLogger(LogLevel.debug);
+  if (_logger == null) {
+    initializeLogger();
+  }
+
   return _logger!;
 }

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -65,21 +65,18 @@ class ServerpodCommandRunner extends CommandRunner {
   final Analytics _analytics;
   final bool _productionMode;
   final Version _cliVersion;
-  final LoggerInit _onLoggerInit;
   final PreCommandEnvironmentCheck _onPreCommandEnvironmentCheck;
 
   ServerpodCommandRunner({
     required Analytics analytics,
     required bool productionMode,
     required Version cliVersion,
-    required LoggerInit onLoggerInit,
     required PreCommandEnvironmentCheck onPreCommandEnvironmentCheck,
     required String executableName,
     required String description,
   })  : _analytics = analytics,
         _productionMode = productionMode,
         _cliVersion = cliVersion,
-        _onLoggerInit = onLoggerInit,
         _onPreCommandEnvironmentCheck = onPreCommandEnvironmentCheck,
         super(executableName, description) {
     argParser.addFlag(
@@ -105,7 +102,6 @@ class ServerpodCommandRunner extends CommandRunner {
     Analytics analytics,
     bool productionMode,
     Version cliVersion, {
-    LoggerInit onLoggerInit = initializeLogger,
     PreCommandEnvironmentCheck onPreCommandEnvironmentCheck =
         _preCommandEnvironmentChecks,
   }) {
@@ -113,7 +109,6 @@ class ServerpodCommandRunner extends CommandRunner {
       analytics: analytics,
       productionMode: productionMode,
       cliVersion: cliVersion,
-      onLoggerInit: onLoggerInit,
       onPreCommandEnvironmentCheck: onPreCommandEnvironmentCheck,
       executableName: 'serverpod',
       description: 'Manage your serverpod app development',
@@ -133,7 +128,7 @@ class ServerpodCommandRunner extends CommandRunner {
 
   @override
   Future<void> runCommand(ArgResults topLevelResults) async {
-    _initializeLogger(topLevelResults);
+    _setLogLevel(topLevelResults);
 
     await _onPreCommandEnvironmentCheck();
     await _preCommandPrints();
@@ -161,7 +156,7 @@ class ServerpodCommandRunner extends CommandRunner {
   ArgParser get argParser => _argParser;
   final ArgParser _argParser = ArgParser(usageLineLength: log.wrapTextColumn);
 
-  void _initializeLogger(ArgResults topLevelResults) {
+  void _setLogLevel(ArgResults topLevelResults) {
     var logLevel = LogLevel.info;
 
     if (topLevelResults[GlobalFlags.verbose]) {
@@ -170,7 +165,7 @@ class ServerpodCommandRunner extends CommandRunner {
       logLevel = LogLevel.nothing;
     }
 
-    _onLoggerInit(logLevel);
+    log.logLevel = logLevel;
   }
 
   Future<void> _preCommandPrints() async {

--- a/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
+++ b/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
@@ -49,41 +49,29 @@ class MockCommand extends Command {
   }
 }
 
-class MockLoggerInitializer {
-  LogLevel? logLevel;
-
-  MockLoggerInitializer();
-}
-
 class TestFixture {
   final MockAnalytics analytics;
   final MockCommand command;
   final ServerpodCommandRunner runner;
-  final MockLoggerInitializer loggerInitializer;
 
   TestFixture(
     this.analytics,
     this.command,
     this.runner,
-    this.loggerInitializer,
   );
 }
 
 TestFixture createTestFixture() {
-  var loggerInitializer = MockLoggerInitializer();
   var analytics = MockAnalytics();
   var runner = ServerpodCommandRunner.createCommandRunner(
     analytics,
     false,
     Version(1, 1, 0),
-    onLoggerInit: (logLevel) => {
-      loggerInitializer.logLevel = logLevel,
-    },
     onPreCommandEnvironmentCheck: () => Future(() => {}),
   );
   var command = MockCommand();
   runner.addCommand(command);
-  return TestFixture(analytics, command, runner, loggerInitializer);
+  return TestFixture(analytics, command, runner);
 }
 
 void main() {
@@ -185,7 +173,7 @@ void main() {
 
       await fixture.runner.run(args);
 
-      expect(fixture.loggerInitializer.logLevel, equals(LogLevel.info));
+      expect(log.logLevel, equals(LogLevel.info));
     });
 
     test('when only --${GlobalFlags.verbose} flag is provided', () async {
@@ -195,7 +183,7 @@ void main() {
 
       await fixture.runner.run(args);
 
-      expect(fixture.loggerInitializer.logLevel, equals(LogLevel.debug));
+      expect(log.logLevel, equals(LogLevel.debug));
     });
     test('when only --${GlobalFlags.quiet} flag is provided', () async {
       List<String> args = [
@@ -204,7 +192,7 @@ void main() {
 
       await fixture.runner.run(args);
 
-      expect(fixture.loggerInitializer.logLevel, equals(LogLevel.nothing));
+      expect(log.logLevel, equals(LogLevel.nothing));
     });
 
     test(
@@ -217,7 +205,7 @@ void main() {
 
       await fixture.runner.run(args);
 
-      expect(fixture.loggerInitializer.logLevel, equals(LogLevel.debug));
+      expect(log.logLevel, equals(LogLevel.debug));
     });
   });
 }


### PR DESCRIPTION
issue: https://github.com/serverpod/serverpod/issues/1042

When playing around with the logger and build runner I noticed two important issues.

## 1. Logger initialization
The logger was accessed before it was initialized because the terminal line width is determined on initialization for the command runner.

This was fixed by initializing the logger before we build the command runner and use the flag passed by the user to only set the logger debug level.

## 2. Fatal parse error
The logic for parsing the argument for the create command could try and access a value through null. Implemented correct parsing logic now, based on the same feature in [flutter](https://github.com/flutter/flutter/blob/48f08e3db23f14e41051d672ed3da1bc65caa87d/packages/flutter_tools/lib/src/commands/create_base.dart#L182).

We now correctly inform the user if `create` is called without a project name or with two many project names.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
