### PR TITLE
feat: Colored Error, Warning and Debug prefix.

### DIFF
--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -67,7 +67,8 @@ Future<bool> performCreate(
       await CommandLineTools.isDockerRunning();
 
   if ((!portsAvailable || !dockerConfigured) &&
-      template == ServerpodTemplateType.server) {
+      template == ServerpodTemplateType.server &&
+      !force) {
     var strIssue =
         'There are some issues with your setup that will prevent your Serverpod'
         ' project from running out of the box and without further '
@@ -109,9 +110,7 @@ Future<bool> performCreate(
         newParagraph: true,
       );
     }
-    if (!force) {
-      return false;
-    }
+    return false;
   }
 
   var dbPassword = generateRandomString();

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -27,13 +27,22 @@ class StdOutLogger extends Logger {
     bool newParagraph = false,
     LogType type = TextLogType.normal,
   }) {
-    _log(
-      message,
-      LogLevel.debug,
-      newParagraph,
-      type,
-      prefix: AnsiStyle.darkGray.wrap('DEBUG: '),
-    );
+    if (ansiSupported) {
+      _log(
+        AnsiStyle.darkGray.wrap(message),
+        LogLevel.debug,
+        newParagraph,
+        type,
+      );
+    } else {
+      _log(
+        message,
+        LogLevel.debug,
+        newParagraph,
+        type,
+        prefix: 'DEBUG: ',
+      );
+    }
   }
 
   @override
@@ -51,13 +60,22 @@ class StdOutLogger extends Logger {
     bool newParagraph = false,
     LogType type = TextLogType.normal,
   }) {
-    _log(
-      message,
-      LogLevel.warning,
-      newParagraph,
-      type,
-      prefix: AnsiStyle.yellow.wrap('WARNING: '),
-    );
+    if (ansiSupported) {
+      _log(
+        AnsiStyle.yellow.wrap(message),
+        LogLevel.warning,
+        newParagraph,
+        type,
+      );
+    } else {
+      _log(
+        message,
+        LogLevel.warning,
+        newParagraph,
+        type,
+        prefix: 'WARNING: ',
+      );
+    }
   }
 
   @override
@@ -67,16 +85,30 @@ class StdOutLogger extends Logger {
     StackTrace? stackTrace,
     LogType type = TextLogType.normal,
   }) {
-    _log(
-      message,
-      LogLevel.error,
-      newParagraph,
-      type,
-      prefix: AnsiStyle.red.wrap('ERROR: '),
-    );
+    if (ansiSupported) {
+      _log(
+        AnsiStyle.red.wrap(message),
+        LogLevel.error,
+        newParagraph,
+        type,
+      );
+    } else {
+      _log(
+        message,
+        LogLevel.error,
+        newParagraph,
+        type,
+        prefix: 'ERROR: ',
+      );
+    }
 
     if (stackTrace != null) {
-      _log(stackTrace.toString(), LogLevel.error, newParagraph, type);
+      _log(
+        AnsiStyle.red.wrap(stackTrace.toString()),
+        LogLevel.error,
+        newParagraph,
+        type,
+      );
     }
   }
 

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -245,19 +245,19 @@ String _wrapText(String text, int columnWidth) {
   var textLines = text.split('\n');
   List<String> outLines = [];
   for (var line in textLines) {
-    var replaceFirstChar = _hasLeadingTrimCharacter(line);
+    var leadingTrimChar = _tryGetLeadingTrimmableChar(line);
     // wordWrap(...) uses trim as part of its implementation which removes all
     // leading trimmable characters.
     // In order to preserve them we temporarily replace the first char with a
     // non trimmable character.
-    if (replaceFirstChar) {
+    if (leadingTrimChar != null) {
       line = '@${line.substring(1)}';
     }
 
     var wrappedLine = line.wordWrap(width: columnWidth);
 
-    if (replaceFirstChar) {
-      wrappedLine = ' ${wrappedLine.substring(1)}';
+    if (leadingTrimChar != null) {
+      wrappedLine = '$leadingTrimChar${wrappedLine.substring(1)}';
     }
     outLines.add(wrappedLine);
   }
@@ -265,12 +265,12 @@ String _wrapText(String text, int columnWidth) {
   return outLines.join('\n');
 }
 
-bool _hasLeadingTrimCharacter(String text) {
+String? _tryGetLeadingTrimmableChar(String text) {
   if (text.isNotEmpty && text.first.trim().isEmpty) {
-    return true;
+    return text.first;
   }
 
-  return false;
+  return null;
 }
 
 /// Wraps the message in a box.

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -32,7 +32,7 @@ class StdOutLogger extends Logger {
       LogLevel.debug,
       newParagraph,
       type,
-      prefix: 'DEBUG: ',
+      prefix: AnsiStyle.darkGray.wrap('DEBUG: '),
     );
   }
 
@@ -51,7 +51,13 @@ class StdOutLogger extends Logger {
     bool newParagraph = false,
     LogType type = TextLogType.normal,
   }) {
-    _log(message, LogLevel.warning, newParagraph, type, prefix: 'WARNING: ');
+    _log(
+      message,
+      LogLevel.warning,
+      newParagraph,
+      type,
+      prefix: AnsiStyle.yellow.wrap('WARNING: '),
+    );
   }
 
   @override
@@ -61,7 +67,13 @@ class StdOutLogger extends Logger {
     StackTrace? stackTrace,
     LogType type = TextLogType.normal,
   }) {
-    _log(message, LogLevel.error, newParagraph, type, prefix: 'ERROR: ');
+    _log(
+      message,
+      LogLevel.error,
+      newParagraph,
+      type,
+      prefix: AnsiStyle.red.wrap('ERROR: '),
+    );
 
     if (stackTrace != null) {
       _log(stackTrace.toString(), LogLevel.error, newParagraph, type);

--- a/tools/serverpod_cli/lib/src/util/ansi_style.dart
+++ b/tools/serverpod_cli/lib/src/util/ansi_style.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 bool? _ansiSupportedRef;
-bool get _ansiSupported {
+bool get ansiSupported {
   return _ansiSupportedRef ??= stdout.hasTerminal && stdout.supportsAnsiEscapes;
 }
 
@@ -26,7 +26,7 @@ enum AnsiStyle {
   /// Wraps text with ansi escape code for style if stdout has terminal and
   /// supports ansi escapes.
   String wrap(String text) {
-    if (!_ansiSupported) {
+    if (!ansiSupported) {
       return text;
     }
 


### PR DESCRIPTION
issue: https://github.com/serverpod/serverpod/issues/1042

## Adds:

Colors the prefixes for Error, Warning and Debug messages so that they are easier to spot.

### After
<img width="508" alt="image" src="https://github.com/serverpod/serverpod/assets/137198655/b717aea9-2f42-42ef-ac12-a54001aa52c4">
<img width="570" alt="image" src="https://github.com/serverpod/serverpod/assets/137198655/766fe491-1848-402e-82c9-509b4ea2cc58">


## Fixes:
Word wrap didn't calculate the correct width of the line. This fixes that and ensures that any trimmable characters in the beginning of a line are preserved.

### Before
<img width="619" alt="Screenshot 2023-07-28 at 10 15 58" src="https://github.com/serverpod/serverpod/assets/137198655/e82fa1da-4f8c-4e6e-a9f9-97f27b30626a">

### After
<img width="764" alt="image" src="https://github.com/serverpod/serverpod/assets/137198655/636b7b34-d901-4748-be4b-4c8d43184c1c">

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None
