### PR TITLE
fix: Correctly validate deeply nested datatypes in protocols.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -359,7 +359,7 @@ class Restrictions {
     // Checks if the type has several ??? in a row.
     if (RegExp(r'\?{2,}').hasMatch(type)) return false;
 
-    return typeComponents.any(
+    return typeComponents.every(
       (type) => StringValidators.isValidFieldType(type),
     );
   }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -917,6 +917,45 @@ fields:
       expect(collector.errors.first.message,
           'The field has an invalid datatype "invalid-type".');
     });
+
+    test(
+        'Given a class with a field with a nested invalid dart syntax for the type, then collect an error that the type is invalid.',
+        () {
+      var collector = CodeGenerationCollector();
+
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  parent: Map<int, invalid-type>
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+        protocol,
+      );
+
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        collector.errors.length,
+        greaterThan(0),
+        reason: 'Expected an error',
+      );
+
+      expect(
+        collector.errors.first.message,
+        'The field has an invalid datatype "Map<int, invalid-type>".',
+      );
+    });
   });
 
   group('Parent table tests', () {


### PR DESCRIPTION
# Fix

Add validation for deeply nested datatypes in protocols.


Example:
```yaml
class: Example
fields:
  data: Map<String, invalid-type>
```

Now reports an error on `invalid-type` where none was detected before.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
