### PR TITLE
fix: Validate that a table is defined  on a class with a relation.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -211,9 +211,22 @@ void _collectKeyRestrictionErrors(
 ) {
   if (node.keyRestriction == null) return;
 
-  for (var document in documentContents.nodes.entries) {
-    var errors =
-        node.keyRestriction?.call(document.key.toString(), document.key.span);
+  if (node.key == Keyword.any) {
+    for (var document in documentContents.nodes.entries) {
+      var errors = node.keyRestriction?.call(
+        document.key.toString(),
+        document.key.span,
+      );
+
+      if (errors != null) {
+        collector.addErrors(errors);
+      }
+    }
+  } else if (documentContents.containsKey(node.key)) {
+    var errors = node.keyRestriction?.call(
+      node.key,
+      documentContents.key(node.key)?.span,
+    );
 
     if (errors != null) {
       collector.addErrors(errors);

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -296,7 +296,6 @@ class Restrictions {
     String relation,
     SourceSpan? span,
   ) {
-    
     var definition = documentDefinition;
     if (definition is ClassDefinition && definition.tableName == null) {
       return [

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -292,6 +292,24 @@ class Restrictions {
     return [];
   }
 
+  List<SourceSpanSeverityException> validateRelationKey(
+    String relation,
+    SourceSpan? span,
+  ) {
+    
+    var definition = documentDefinition;
+    if (definition is ClassDefinition && definition.tableName == null) {
+      return [
+        SourceSpanSeverityException(
+          'The "table" property must be defined in the class to set a relation on a field.',
+          span,
+        )
+      ];
+    }
+
+    return [];
+  }
+
   List<SourceSpanSeverityException> validateEnumValues(
     dynamic content,
     SourceSpan? span,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/validate_node.dart
@@ -60,11 +60,6 @@ class ValidateNode {
       throw ArgumentError(
           'allowStringifiedNestedValue can only be true if nested is not empty.');
     }
-
-    if (key != Keyword.any && keyRestriction != null) {
-      throw ArgumentError(
-          'keyRestriction can only be set if key is ${Keyword.any}.');
-    }
   }
 }
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -54,6 +54,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.relation,
+                keyRestriction: restrictions.validateRelationKey,
                 mutuallyExclusiveKeys: {Keyword.parent},
                 nested: {
                   ValidateNode(

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -165,4 +165,41 @@ fields:
     expect(endSpan.line, 3);
     expect(endSpan.column, 48);
   });
+
+  test('Given a class .', () {
+    var collector = CodeGenerationCollector();
+
+    var protocol = ProtocolSource(
+      '''
+class: Example
+fields:
+  parentId: int, relation(parent=example)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    );
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition!],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(0),
+      reason: 'Expected an error',
+    );
+
+    expect(
+      collector.errors.first.message,
+      'The "table" property must be defined in the class to set a relation on a field.',
+    );
+  });
 }


### PR DESCRIPTION
# Fix

Validate that the current class has a table if the relation key is in use.

example that will give an error:
```yaml
class: Example
# table: example <- this needs to be defined or we get an error
fields:
  parentId: int, relation(parent=parent_table)
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.