### PR TITLE
feat: Syntax highlighting in protocol files.

### DIFF
--- a/tools/serverpod_vscode_extension/language-configuration.json
+++ b/tools/serverpod_vscode_extension/language-configuration.json
@@ -1,0 +1,63 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "{",
+      "close": "}"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "\"",
+      "close": "\""
+    },
+    {
+      "open": "'",
+      "close": "'"
+    }
+  ],
+  "surroundingPairs": [
+    {
+      "open": "{",
+      "close": "}"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "\"",
+      "close": "\""
+    },
+    {
+      "open": "'",
+      "close": "'"
+    }
+  ]
+}

--- a/tools/serverpod_vscode_extension/language-configuration.json
+++ b/tools/serverpod_vscode_extension/language-configuration.json
@@ -18,6 +18,10 @@
   ],
   "autoClosingPairs": [
     {
+      "open": "<",
+      "close": ">"
+    },
+    {
       "open": "{",
       "close": "}"
     },
@@ -39,6 +43,10 @@
     }
   ],
   "surroundingPairs": [
+    {
+      "open": "<",
+      "close": ">"
+    },
     {
       "open": "{",
       "close": "}"

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -12,6 +12,26 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "languages": [
+      {
+        "id": "serverpod",
+        "aliases": [
+          "Serverpod Protocol",
+          "serverpod"
+        ],
+        "extensions": [
+          ".sp.yaml"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "serverpod",
+        "scopeName": "source.serverpod",
+        "path": "./syntaxes/serverpod.tmLanguage.json"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Example configuration",

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -17,7 +17,7 @@
         "id": "serverpod",
         "aliases": [
           "Serverpod Protocol",
-          "serverpod"
+          "SP"
         ],
         "extensions": [
           ".sp.yaml"

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -54,6 +54,26 @@
     {
       "name": "string.unquoted.yaml",
       "match": "\\b(?<=\\()([^)]+)(?=\\))\\b"
+    },
+    {
+      "name": "entity.name.type.yaml",
+      "match": "\\b(?<=:\\s*)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+    },
+    {
+      "name": "entity.name.type.yaml",
+      "match": "\\b(?<=:\\s*)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
+    },
+    {
+      "name": "entity.name.type.yaml",
+      "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+    },
+    {
+      "name": "entity.name.type.yaml",
+      "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
+    },
+    {
+      "name": "entity.name.optional.yaml",
+      "match": "\\?"
     }
   ],
   "repository": {},

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -45,10 +45,13 @@
       ]
     },
     "fields": {
-      "begin": "(fields:)(\\s*$)",
+      "begin": "(fields)(:)(\\s*$)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.tag.yaml"
+        },
+        "2": {
+          "name": "punctuation.separator.mapping.key-value.yaml"
         }
       },
       "end": "(?=^\\S)",
@@ -135,10 +138,13 @@
       ]
     },
     "indexes": {
-      "begin": "(indexes:)(\\s*$)",
+      "begin": "(indexes)(:)(\\s*$)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.tag.yaml"
+        },
+        "2": {
+          "name": "punctuation.separator.mapping.key-value.yaml"
         }
       },
       "end": "(?=^\\S)",

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -41,22 +41,6 @@
     {
       "name": "constant.language.null.yaml",
       "match": "\\bnull\\b"
-    },
-    {
-      "name": "entity.name.tag.yaml",
-      "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*=)"
-    },
-    {
-      "name": "string.unquoted.yaml",
-      "match": "\\b(?<=\\s*=\\s*)([a-zA-Z0-9_-]+)\\b"
-    },
-    {
-      "name": "entity.name.tag.yaml",
-      "match": "\\b([a-zA-Z0-9_-]+)(?=\\()"
-    },
-    {
-      "name": "string.unquoted.yaml",
-      "match": "\\b(?<=\\()([^)]+)(?=\\))\\b"
     }
   ],
   "repository": {
@@ -70,6 +54,34 @@
       "end": "(?=^\\S)",
       "patterns": [
         {
+          "name": "constant.numeric.yaml",
+          "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
+        },
+        {
+          "name": "constant.language.boolean.yaml",
+          "match": "\\b(true|false)\\b"
+        },
+        {
+          "name": "constant.language.null.yaml",
+          "match": "\\bnull\\b"
+        },
+        {
+          "name": "entity.name.tag.yaml",
+          "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*=)"
+        },
+        {
+          "name": "string.unquoted.yaml",
+          "match": "\\b(?<=\\s*=\\s*)([a-zA-Z0-9_-]+)\\b"
+        },
+        {
+          "name": "entity.name.tag.yaml",
+          "match": "\\b([a-zA-Z0-9_-]+)(?=\\()"
+        },
+        {
+          "name": "string.unquoted.yaml",
+          "match": "\\b(?<=\\()([^)]+)(?=\\))\\b"
+        },
+        {
           "name": "entity.name.tag.yaml",
           "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
         },
@@ -79,7 +91,7 @@
         },
         {
           "name": "entity.name.type.yaml",
-          "match": "\\b(?<=:\\s*)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
+          "match": "\\b(?<=:\\s*)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
         },
         {
           "name": "entity.name.type.yaml",
@@ -87,7 +99,7 @@
         },
         {
           "name": "entity.name.type.yaml",
-          "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
+          "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
         }
       ]
     }

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -1,0 +1,53 @@
+{
+  "scopeName": "source.serverpod",
+  "patterns": [
+    {
+      "name": "entity.name.tag.yaml",
+      "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
+    },
+    {
+      "name": "string.quoted.double.yaml",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.yaml",
+          "match": "\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|.)"
+        }
+      ]
+    },
+    {
+      "name": "string.quoted.single.yaml",
+      "begin": "'",
+      "end": "'",
+      "patterns": [
+        {
+          "name": "constant.character.escape.yaml",
+          "match": "''"
+        }
+      ]
+    },
+    {
+      "name": "constant.numeric.yaml",
+      "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
+    },
+    {
+      "name": "constant.language.boolean.yaml",
+      "match": "\\b(true|false)\\b"
+    },
+    {
+      "name": "constant.language.null.yaml",
+      "match": "\\bnull\\b"
+    },
+    {
+      "name": "entity.name.tag.yaml",
+      "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*=)"
+    },
+    {
+      "name": "string.unquoted.yaml",
+      "match": "\\b(?<=\\s*=\\s*)([a-zA-Z0-9_-]+)\\b"
+    }
+  ],
+  "repository": {},
+  "uuid": "b9c5f4cc-b7cf-4679-848c-c8c1b5c0f5d0"
+}

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -46,6 +46,14 @@
     {
       "name": "string.unquoted.yaml",
       "match": "\\b(?<=\\s*=\\s*)([a-zA-Z0-9_-]+)\\b"
+    },
+    {
+      "name": "entity.name.tag.yaml",
+      "match": "\\b([a-zA-Z0-9_-]+)(?=\\()"
+    },
+    {
+      "name": "string.unquoted.yaml",
+      "match": "\\b(?<=\\()([^)]+)(?=\\))\\b"
     }
   ],
   "repository": {},

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -92,20 +92,41 @@
           "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
         },
         {
-          "name": "entity.name.type.yaml",
-          "match": "(?<=^\\s{2}\\S*|\\t\\S*)(:\\s*)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+          "begin": "(:\\s*)([^\\s<]*)(<)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.separator.mapping.key-value.yaml"
+            },
+            "2": {
+              "name": "entity.name.type.yaml"
+            },
+            "3": {
+              "name": "punctuation.definition.type.begin.yaml"
+            }
+          },
+          "end": "(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.type.end.yaml"
+            }
+          },
+          "patterns": [
+            {
+              "match": "[^,>\\s?]+",
+              "name": "entity.name.type.yaml"
+            }
+          ]
         },
         {
-          "name": "entity.name.type.yaml",
-          "match": "(?<=^\\s{2}\\S*|\\t\\S*)(:\\s*)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
-        },        
-        {
-          "name": "entity.name.type.yaml",
-          "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
-        },
-        {
-          "name": "entity.name.type.yaml",
-          "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
+          "match": "(:\\s*)([^<\\s?]+)",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.mapping.key-value.yaml"
+            },
+            "2": {
+              "name": "entity.name.type.yaml"
+            }
+          }
         },
         {
           "name": "string.unquoted.yaml",

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -2,6 +2,9 @@
   "scopeName": "source.serverpod",
   "patterns": [
     {
+      "include": "#fields"
+    },
+    {
       "name": "entity.name.tag.yaml",
       "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
     },
@@ -54,28 +57,40 @@
     {
       "name": "string.unquoted.yaml",
       "match": "\\b(?<=\\()([^)]+)(?=\\))\\b"
-    },
-    {
-      "name": "entity.name.type.yaml",
-      "match": "\\b(?<=:\\s*)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
-    },
-    {
-      "name": "entity.name.type.yaml",
-      "match": "\\b(?<=:\\s*)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
-    },
-    {
-      "name": "entity.name.type.yaml",
-      "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
-    },
-    {
-      "name": "entity.name.type.yaml",
-      "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
-    },
-    {
-      "name": "entity.name.optional.yaml",
-      "match": "\\?"
     }
   ],
-  "repository": {},
-  "uuid": "b9c5f4cc-b7cf-4679-848c-c8c1b5c0f5d0"
+  "repository": {
+    "fields": {
+      "begin": "(fields:)(\\s*$)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.yaml"
+        }
+      },
+      "end": "(?=^\\S)",
+      "patterns": [
+        {
+          "name": "entity.name.tag.yaml",
+          "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
+        },
+        {
+          "name": "entity.name.type.yaml",
+          "match": "\\b(?<=:\\s*)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+        },
+        {
+          "name": "entity.name.type.yaml",
+          "match": "\\b(?<=:\\s*)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
+        },
+        {
+          "name": "entity.name.type.yaml",
+          "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+        },
+        {
+          "name": "entity.name.type.yaml",
+          "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_]+)(?=\\??,|\\s|$)"
+        }
+      ]
+    }
+  },
+  "uuid": "123e4567-e89b-12d3-a456-426655440000"
 }

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -9,28 +9,6 @@
       "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
     },
     {
-      "name": "string.quoted.double.yaml",
-      "begin": "\"",
-      "end": "\"",
-      "patterns": [
-        {
-          "name": "constant.character.escape.yaml",
-          "match": "\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|.)"
-        }
-      ]
-    },
-    {
-      "name": "string.quoted.single.yaml",
-      "begin": "'",
-      "end": "'",
-      "patterns": [
-        {
-          "name": "constant.character.escape.yaml",
-          "match": "''"
-        }
-      ]
-    },
-    {
       "name": "constant.numeric.yaml",
       "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
     },
@@ -68,6 +46,14 @@
         {
           "name": "entity.name.tag.yaml",
           "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*=)"
+        },
+        {
+          "name": "entity.name.tag.yaml",
+          "match": "\\b(?<=\\()([a-zA-Z0-9_-]+)\\b"
+        },
+        {
+          "name": "string.quoted.double.yaml",
+          "match": "\\b(?<==)([a-zA-Z0-9_-]+)(?=,|\\))"
         },
         {
           "name": "string.unquoted.yaml",

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -5,6 +5,9 @@
       "include": "#fields"
     },
     {
+      "include": "#indexes"
+    },
+    {
       "name": "entity.name.tag.yaml",
       "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
     },
@@ -13,11 +16,11 @@
     },
     {
       "name": "entity.name.type.yaml",
-      "match": "\\b(?<=class:\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+      "match": "\\b(?<=(class|exception|enum):\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
     },
     {
       "name": "entity.name.type.yaml",
-      "match": "\\b(?<=class:\\s+)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
+      "match": "\\b(?<=(class|exception|enum):\\s+)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
     },
     {
       "name": "string.unquoted.yaml",
@@ -51,8 +54,15 @@
       "end": "(?=^\\S)",
       "patterns": [
         {
-          "name": "entity.name.variable.yaml",
-          "match": "\\b([a-zA-Z0-9_]+)(?=:\\s)"
+          "name": "keyword.operator.assignment.yaml",
+          "match": "="
+        },
+        {
+          "name": "punctuation.separator.comma.yaml",
+          "match": ","
+        },
+        {
+          "include": "#params"
         },
         {
           "include": "#basic_value_types"
@@ -78,21 +88,17 @@
           "match": "\\b([a-zA-Z0-9_-]+)(?=\\()"
         },
         {
-          "name": "string.unquoted.yaml",
-          "match": "\\b(?<=\\()([^)]+)(?=\\))\\b"
-        },
-        {
           "name": "entity.name.tag.yaml",
           "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
         },
         {
           "name": "entity.name.type.yaml",
-          "match": "\\b(?<=:\\s*)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+          "match": "(?<=^\\s{2}\\S*|\\t\\S*)(:\\s*)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
         },
         {
           "name": "entity.name.type.yaml",
-          "match": "\\b(?<=:\\s*)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
-        },
+          "match": "(?<=^\\s{2}\\S*|\\t\\S*)(:\\s*)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
+        },        
         {
           "name": "entity.name.type.yaml",
           "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
@@ -100,6 +106,43 @@
         {
           "name": "entity.name.type.yaml",
           "match": "\\b(?<=type:\\s+)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
+        },
+        {
+          "name": "string.unquoted.yaml",
+          "match": "\\b(?<=:\\s*|,\\s*)([a-zA-Z0-9_-]+)\\b"
+        }
+      ]
+    },
+    "indexes": {
+      "begin": "(indexes:)(\\s*$)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.yaml"
+        }
+      },
+      "end": "(?=^\\S)",
+      "patterns": [
+        {
+          "include": "#params"
+        },
+        {
+          "include": "#basic_value_types"
+        },
+        {
+          "name": "entity.name.tag.yaml",
+          "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
+        },
+        {
+          "name": "string.unquoted.yaml",
+          "match": "\\b(?<=:\\s*|,\\s*)([a-zA-Z0-9_-]+)\\b"
+        }
+      ]
+    },
+    "params": {
+      "patterns": [
+        {
+          "name": "entity.name.variable.yaml",
+          "match": "(?<=^\\s{2}|\\t)\\b([a-zA-Z0-9_]+)(?=:\\s)"
         }
       ]
     }

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -32,6 +32,10 @@
       "end": "(?=^\\S)",
       "patterns": [
         {
+          "name": "entity.name.variable.yaml",
+          "match": "\\b([a-zA-Z0-9_]+)(?=:\\s)"
+        },
+        {
           "name": "constant.numeric.yaml",
           "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
         },
@@ -49,7 +53,7 @@
         },
         {
           "name": "entity.name.tag.yaml",
-          "match": "\\b(?<=\\()([a-zA-Z0-9_-]+)\\b"
+          "match": "\\b(?<=\\(|,\\s*)([a-zA-Z0-9_-]+)(?=[,=]|\\s|\\))"
         },
         {
           "name": "string.quoted.double.yaml",

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -64,7 +64,7 @@
           "match": "\\b(?<=\\s*=\\s*)([a-zA-Z0-9_-]+)\\b"
         },
         {
-          "name": "entity.name.tag.yaml",
+          "name": "entity.name.function.yaml",
           "match": "\\b([a-zA-Z0-9_-]+)(?=\\()"
         },
         {

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -9,16 +9,7 @@
       "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
     },
     {
-      "name": "constant.numeric.yaml",
-      "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
-    },
-    {
-      "name": "constant.language.boolean.yaml",
-      "match": "\\b(true|false)\\b"
-    },
-    {
-      "name": "constant.language.null.yaml",
-      "match": "\\bnull\\b"
+      "include": "#basic_value_types"
     },
     {
       "name": "entity.name.type.yaml",
@@ -34,6 +25,22 @@
     }
   ],
   "repository": {
+    "basic_value_types": {
+      "patterns": [
+        {
+          "name": "constant.numeric.yaml",
+          "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
+        },
+        {
+          "name": "constant.language.boolean.yaml",
+          "match": "\\b(true|false)\\b"
+        },
+        {
+          "name": "constant.language.null.yaml",
+          "match": "\\bnull\\b"
+        }
+      ]
+    },
     "fields": {
       "begin": "(fields:)(\\s*$)",
       "beginCaptures": {
@@ -48,16 +55,7 @@
           "match": "\\b([a-zA-Z0-9_]+)(?=:\\s)"
         },
         {
-          "name": "constant.numeric.yaml",
-          "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
-        },
-        {
-          "name": "constant.language.boolean.yaml",
-          "match": "\\b(true|false)\\b"
-        },
-        {
-          "name": "constant.language.null.yaml",
-          "match": "\\bnull\\b"
+          "include": "#basic_value_types"
         },
         {
           "name": "entity.name.tag.yaml",

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -8,6 +8,9 @@
       "include": "#indexes"
     },
     {
+      "include": "#comments"
+    },
+    {
       "name": "entity.name.tag.yaml",
       "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
     },
@@ -56,6 +59,9 @@
       },
       "end": "(?=^\\S)",
       "patterns": [
+        {
+          "include": "#comments"
+        },
         {
           "name": "keyword.operator.assignment.yaml",
           "match": "="
@@ -170,6 +176,26 @@
         {
           "name": "entity.name.variable.yaml",
           "match": "(?<=^\\s{2}|\\t)\\b([a-zA-Z0-9_]+)(?=:\\s)"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "match": "(###.*$)",
+          "captures": {
+            "0": {
+              "name": "comment.block.documentation.yaml"
+            }
+          }
+        },
+        {
+          "match": "(#.*$)",
+          "captures": {
+            "0": {
+              "name": "comment.line.yaml"
+            }
+          }
         }
       ]
     }

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -19,6 +19,18 @@
     {
       "name": "constant.language.null.yaml",
       "match": "\\bnull\\b"
+    },
+    {
+      "name": "entity.name.type.yaml",
+      "match": "\\b(?<=class:\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+    },
+    {
+      "name": "entity.name.type.yaml",
+      "match": "\\b(?<=class:\\s+)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
+    },
+    {
+      "name": "string.unquoted.yaml",
+      "match": "\\b(?<=:\\s*)([a-zA-Z0-9_-]+)\\b"
     }
   ],
   "repository": {


### PR DESCRIPTION
# Adds

Syntax highlighting of protocol files with the vscode plugin, the file extension is required to be `.sp.yaml` to work. There has to be a file extension toggle for this to work, and we don't want to override other yaml stylings. Hence this file extension.

## Previously
<img width="484" alt="Screenshot 2023-07-31 at 09 29 57" src="https://github.com/serverpod/serverpod/assets/7395515/ccb5c201-4a00-4127-bbaa-13d390623d2e">

## With change
<img width="470" alt="Screenshot 2023-07-31 at 09 29 44" src="https://github.com/serverpod/serverpod/assets/7395515/107629be-f0c1-452a-b191-225b4c7054d9">

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.