### PR TITLE
fix: Enum value restrictions matches default linting in dart.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -333,7 +333,15 @@ class Restrictions {
         );
       }
 
-      if (!StringValidators.isValidFieldName(node.value)) {
+      if (StringValidators.isInvalidInfoEnumValue(node.value)) {
+        return SourceSpanSeverityException(
+          'Enum values should be lowerCamelCase.',
+          node.span,
+          severity: SourceSpanSeverity.info,
+        );
+      }
+
+      if (!StringValidators.isValidEnumValue(node.value)) {
         return SourceSpanSeverityException(
           'Enum values must be lowerCamelCase.',
           node.span,
@@ -403,4 +411,8 @@ class Restrictions {
 
     return classes.firstWhere((c) => c != documentDefinition);
   }
+}
+
+enum Enum {
+  FULLCAPS,
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -412,7 +412,3 @@ class Restrictions {
     return classes.firstWhere((c) => c != documentDefinition);
   }
 }
-
-enum Enum {
-  FULLCAPS,
-}

--- a/tools/serverpod_cli/lib/src/util/string_validators.dart
+++ b/tools/serverpod_cli/lib/src/util/string_validators.dart
@@ -1,13 +1,18 @@
 class StringValidators {
+  static final _pascalCaseTester =
+      RegExp(r'^[A-Z][a-zA-Z0-9]*((?<=.)([A-Z][a-z0-9]*)+)?$');
   static final _pascalCaseWithUppercaseTester =
       RegExp(r'^[A-Z]([A-Z0-9]*[a-z0-9]*)*([A-Z])?$');
   static final _camelCaseTester =
       RegExp(r'^[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?$');
+  static final _camelCaseWithUppercaseTester =
+      RegExp(r'^[a-z]+([A-Z][a-z0-9]*)*$');
   static final _snakeCaseTester = RegExp(r'^[a-z]+[a-z0-9_]*$');
   static final _mixedSnakeCaseTester =
       RegExp(r'^[a-z]+((\d)|([A-Z0-9_][a-z0-9_]+))*([A-Z])?$');
   static final _lowerCaseWithDashesTester =
       RegExp(r'^[a-z0-9]+([-][a-z0-9]+)*$');
+  static final _fullUpperCaseTester = RegExp(r'^[A-Z]+$');
 
   static bool isValidFieldName(String name) =>
       _camelCaseTester.hasMatch(name) || _snakeCaseTester.hasMatch(name);
@@ -25,6 +30,24 @@ class StringValidators {
 
   static bool isValidTagName(String name) =>
       _lowerCaseWithDashesTester.hasMatch(name);
+
+  static bool isValidEnumValue(String name) {
+    if (name.length == 1) return true;
+    if (_camelCaseTester.hasMatch(name)) return true;
+    if (_camelCaseWithUppercaseTester.hasMatch(name)) return true;
+
+    return false;
+  }
+
+  static bool isInvalidInfoEnumValue(String name) {
+    if (isValidEnumValue(name)) return false;
+
+    if (_fullUpperCaseTester.hasMatch(name)) return true;
+    if (_pascalCaseTester.hasMatch(name)) return true;
+    if (_snakeCaseTester.hasMatch(name)) return true;
+
+    return false;
+  }
 
   /// This function with regex, that will let you allow only name starting with smalls
   /// and contains only `_` special char and ending with smalls or numbers

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
@@ -249,9 +249,7 @@ values:
     );
   });
 
-  test(
-      'Given a a value with a single uppercase char, no errors is given.',
-      () {
+  test('Given a a value with a single uppercase char, no errors is given.', () {
     var collector = CodeGenerationCollector();
     var protocol = ProtocolSource(
       '''

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/enum_values_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
@@ -145,7 +146,7 @@ values:
       '''
 enum: ExampleEnum
 values:
-  - InvalidValue
+  - Invalid-Value
 ''',
       Uri(path: 'lib/src/protocol/example.yaml'),
       ['lib', 'src', 'protocol'],
@@ -212,6 +213,206 @@ values:
     expect(
       error2.message,
       'Enum values must be unique.',
+    );
+  });
+
+  test(
+      'Given a a value with multiple uppercase chars after a lowercase, no errors is given.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+enum: ExampleEnum
+values:
+  - lowerCAPS
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as EnumDefinition;
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
+
+    expect(
+      collector.errors,
+      isEmpty,
+      reason: 'Expected no errors.',
+    );
+  });
+
+  test(
+      'Given a a value with a single uppercase char, no errors is given.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+enum: ExampleEnum
+values:
+  - M
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as EnumDefinition;
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
+
+    expect(
+      collector.errors,
+      isEmpty,
+      reason: 'Expected no errors.',
+    );
+  });
+
+  test(
+      'Given a a value with snake_case value, an error of info level is given.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+enum: ExampleEnum
+values:
+  - snake_case
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as EnumDefinition;
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(0),
+      reason: 'Expected an error with info.',
+    );
+
+    var error = collector.errors.first as SourceSpanSeverityException;
+
+    expect(
+      error.message,
+      'Enum values should be lowerCamelCase.',
+    );
+
+    expect(
+      error.severity,
+      SourceSpanSeverity.info,
+    );
+  });
+
+  test(
+      'Given a a value with PascalCase value, an error of info level is given.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+enum: ExampleEnum
+values:
+  - PascalCase
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as EnumDefinition;
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(0),
+      reason: 'Expected an error with info.',
+    );
+
+    var error = collector.errors.first as SourceSpanSeverityException;
+
+    expect(
+      error.message,
+      'Enum values should be lowerCamelCase.',
+    );
+
+    expect(
+      error.severity,
+      SourceSpanSeverity.info,
+    );
+  });
+
+  test('Given a a value with UPPERCASE value, an error of info level is given.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+enum: ExampleEnum
+values:
+  - UPPERCASE
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var definition =
+        SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+            as EnumDefinition;
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
+
+    expect(
+      collector.errors.length,
+      greaterThan(0),
+      reason: 'Expected an error with info.',
+    );
+
+    var error = collector.errors.first as SourceSpanSeverityException;
+
+    expect(
+      error.message,
+      'Enum values should be lowerCamelCase.',
+    );
+
+    expect(
+      error.severity,
+      SourceSpanSeverity.info,
     );
   });
 


### PR DESCRIPTION
# Fix

Changes the allowed enum values to match the linting rules in dart.

Closes: https://github.com/serverpod/serverpod/issues/1128

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

