### PR TITLE
fix: Less restrictive naming of class fields.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -147,10 +147,20 @@ class Restrictions {
     dynamic content,
     SourceSpan? span,
   ) {
+    if (StringValidators.isInvalidFieldValueInfoSeverity(content)) {
+      return [
+        SourceSpanSeverityException(
+          'Field names should be valid Dart variable names (e.g. camelCaseString).',
+          span,
+          severity: SourceSpanSeverity.info,
+        )
+      ];
+    }
+
     if (!StringValidators.isValidFieldName(content)) {
       return [
         SourceSpanSeverityException(
-          'Keys of "fields" Map must be valid Dart variable names (e.g. camelCaseString).',
+          'Field names must be valid Dart variable names (e.g. camelCaseString).',
           span,
         )
       ];
@@ -333,7 +343,7 @@ class Restrictions {
         );
       }
 
-      if (StringValidators.isInvalidInfoEnumValue(node.value)) {
+      if (StringValidators.isInvalidFieldValueInfoSeverity(node.value)) {
         return SourceSpanSeverityException(
           'Enum values should be lowerCamelCase.',
           node.span,
@@ -341,7 +351,7 @@ class Restrictions {
         );
       }
 
-      if (!StringValidators.isValidEnumValue(node.value)) {
+      if (!StringValidators.isValidFieldName(node.value)) {
         return SourceSpanSeverityException(
           'Enum values must be lowerCamelCase.',
           node.span,

--- a/tools/serverpod_cli/lib/src/util/string_validators.dart
+++ b/tools/serverpod_cli/lib/src/util/string_validators.dart
@@ -14,8 +14,23 @@ class StringValidators {
       RegExp(r'^[a-z0-9]+([-][a-z0-9]+)*$');
   static final _fullUpperCaseTester = RegExp(r'^[A-Z]+$');
 
-  static bool isValidFieldName(String name) =>
-      _camelCaseTester.hasMatch(name) || _snakeCaseTester.hasMatch(name);
+  static bool isValidFieldName(String name) {
+    if (name.length == 1) return true;
+    if (_camelCaseTester.hasMatch(name)) return true;
+    if (_camelCaseWithUppercaseTester.hasMatch(name)) return true;
+
+    return false;
+  }
+
+  static bool isInvalidFieldValueInfoSeverity(String name) {
+    if (isValidFieldName(name)) return false;
+
+    if (_fullUpperCaseTester.hasMatch(name)) return true;
+    if (_pascalCaseTester.hasMatch(name)) return true;
+    if (_snakeCaseTester.hasMatch(name)) return true;
+
+    return false;
+  }
 
   static bool isValidFieldType(String type) =>
       RegExp(r'^([a-zA-Z_:][a-zA-Z0-9_:]*\??)$').hasMatch(type);
@@ -30,24 +45,6 @@ class StringValidators {
 
   static bool isValidTagName(String name) =>
       _lowerCaseWithDashesTester.hasMatch(name);
-
-  static bool isValidEnumValue(String name) {
-    if (name.length == 1) return true;
-    if (_camelCaseTester.hasMatch(name)) return true;
-    if (_camelCaseWithUppercaseTester.hasMatch(name)) return true;
-
-    return false;
-  }
-
-  static bool isInvalidInfoEnumValue(String name) {
-    if (isValidEnumValue(name)) return false;
-
-    if (_fullUpperCaseTester.hasMatch(name)) return true;
-    if (_pascalCaseTester.hasMatch(name)) return true;
-    if (_snakeCaseTester.hasMatch(name)) return true;
-
-    return false;
-  }
 
   /// This function with regex, that will let you allow only name starting with smalls
   /// and contains only `_` special char and ending with smalls or numbers

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
@@ -194,7 +195,7 @@ fields:
         '''
 class: Example
 fields:
-  InvalidFieldName: String
+  Invalid-Field-Name: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
         ['lib', 'src', 'protocol'],
@@ -207,10 +208,99 @@ fields:
 
       expect(collector.errors.length, greaterThan(0));
 
-      var error = collector.errors.first;
+      var error = collector.errors.first as SourceSpanSeverityException;
 
       expect(error.message,
-          'Keys of "fields" Map must be valid Dart variable names (e.g. camelCaseString).');
+          'Field names must be valid Dart variable names (e.g. camelCaseString).');
+
+      expect(error.severity, SourceSpanSeverity.error);
+    });
+
+    test(
+        'Given a class with a field key that is in UPPERCASE format, collect an info that the keys needs to follow the dart convention.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  UPPERCASE: String
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first as SourceSpanSeverityException;
+
+      expect(error.message,
+          'Field names should be valid Dart variable names (e.g. camelCaseString).');
+
+      expect(error.severity, SourceSpanSeverity.info);
+    });
+
+    test(
+        'Given a class with a field key that is in PascalCase format, collect an info that the keys needs to follow the dart convention.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  PascalCase: String
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first as SourceSpanSeverityException;
+
+      expect(error.message,
+          'Field names should be valid Dart variable names (e.g. camelCaseString).');
+
+      expect(error.severity, SourceSpanSeverity.info);
+    });
+
+    test(
+        'Given a class with a field key that is in snake_case format, collect an info that the keys needs to follow the dart convention.',
+        () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+class: Example
+fields:
+  snake_case: String
+''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        ['lib', 'src', 'protocol'],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(protocol.yaml,
+          protocol.yamlSourceUri.path, collector, definition, [definition!]);
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first as SourceSpanSeverityException;
+
+      expect(error.message,
+          'Field names should be valid Dart variable names (e.g. camelCaseString).');
+
+      expect(error.severity, SourceSpanSeverity.info);
     });
 
     test(


### PR DESCRIPTION
# Fix

Field name restrictions in protocol files match the default restrictions in dart. Similar too the enum values in https://github.com/serverpod/serverpod/issues/1128.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

