### PR TITLE
fix: fix trailing chard for source span exception prints + deterministic progress print

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
+++ b/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
@@ -49,7 +49,7 @@ class CodeGenerationCollector extends CodeAnalysisCollector {
     );
 
     for (var error in errors) {
-      log.sourceSpanException(error, newParagraph: true);
+      log.sourceSpanException(error);
     }
   }
 

--- a/tools/serverpod_cli/lib/src/logger/helpers/progress.dart
+++ b/tools/serverpod_cli/lib/src/logger/helpers/progress.dart
@@ -83,6 +83,7 @@ class Progress {
     }
 
     _timer = Timer.periodic(const Duration(milliseconds: 80), _onTick);
+    _onTick(_timer);
   }
 
   final ProgressOptions _options;

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -122,10 +122,11 @@ class StdOutLogger extends Logger {
       return await runner();
     }
 
+    _stopAnimationInProgress();
+
     if (newParagraph) _write('', LogLevel.info, newParagraph: newParagraph);
 
     var progress = Progress(message, stdout);
-    _stopAnimationInProgress();
     trackedAnimationInProgress = progress;
     bool success = await runner();
     trackedAnimationInProgress = null;

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -122,7 +122,7 @@ class StdOutLogger extends Logger {
       return await runner();
     }
 
-    if (newParagraph) _write('\n', LogLevel.info);
+    if (newParagraph) _write('', LogLevel.info, newParagraph: newParagraph);
 
     var progress = Progress(message, stdout);
     _stopAnimationInProgress();
@@ -153,11 +153,7 @@ class StdOutLogger extends Logger {
         _SeveritySpanHelpers.highlightAnsiCode(logLevel, isHint);
     var message = sourceSpan.toString(color: highlightAnsiCode);
 
-    if (newParagraph) {
-      message = '\n$message';
-    }
-
-    _write(message, logLevel);
+    _write(message, logLevel, newParagraph: newParagraph);
   }
 
   @override
@@ -215,24 +211,25 @@ class StdOutLogger extends Logger {
       message = _wrapText(message, wrapTextColumn ?? _defaultColumnWrap);
     }
 
-    if (newParagraph) {
-      message = '\n$message';
-    }
-
-    if (type is! RawLogType) {
-      // If it is not a raw log we append a new line after the message.
-      message = '$message\n';
-    }
-
-    _write(message, logLevel);
+    _write(
+      message,
+      logLevel,
+      newParagraph: newParagraph,
+      newLine: type is! RawLogType,
+    );
   }
 
-  void _write(String message, LogLevel logLevel) {
+  void _write(
+    String message,
+    LogLevel logLevel, {
+    required newParagraph,
+    newLine = true,
+  }) {
     _stopAnimationInProgress();
     if (logLevel.index >= LogLevel.warning.index) {
-      stderr.write(message);
+      stderr.write('${newParagraph ? '\n' : ''}$message${newLine ? '\n' : ''}');
     } else {
-      stdout.write(message);
+      stdout.write('${newParagraph ? '\n' : ''}$message${newLine ? '\n' : ''}');
     }
   }
 
@@ -257,18 +254,23 @@ class WindowsStdOutLogger extends StdOutLogger {
   @override
   void _write(
     String message,
-    LogLevel logLevel,
-  ) {
+    LogLevel logLevel, {
+    required newParagraph,
+    newLine = true,
+  }) {
     super._write(
-        message
-            .replaceAll('🥳', '=D')
-            .replaceAll(
-              '✅',
-              AnsiStyle.bold.wrap(AnsiStyle.lightGreen.wrap('✓')),
-            )
-            .replaceAll('🚀', '')
-            .replaceAll('📦', ''),
-        logLevel);
+      message
+          .replaceAll('🥳', '=D')
+          .replaceAll(
+            '✅',
+            AnsiStyle.bold.wrap(AnsiStyle.lightGreen.wrap('✓')),
+          )
+          .replaceAll('🚀', '')
+          .replaceAll('📦', ''),
+      logLevel,
+      newParagraph: newParagraph,
+      newLine: newLine,
+    );
   }
 }
 


### PR DESCRIPTION
### Trailing char for source span exception

Before:
<img width="1074" alt="Screenshot 2023-08-01 at 11 29 06" src="https://github.com/serverpod/serverpod/assets/137198655/4807c563-e236-4276-943f-cc78fc82013c">

After:
<img width="1074" alt="Screenshot 2023-08-01 at 11 29 02" src="https://github.com/serverpod/serverpod/assets/137198655/3f0c4b49-d536-4a41-8d70-c8202023df25">


### Deterministic progress print

Given this print output
``` dart
void main() {
  log.progress('This should be the outer message', () async {
    return log.progress('This is the inner message', () async {
      await Future.delayed(Duration(seconds: 5));
      return true;
    });
  });
}
```

Before:
<img width="1256" alt="image" src="https://github.com/serverpod/serverpod/assets/137198655/b09ae57e-c989-4170-8ea0-d6abc53739f9">

After:
<img width="1256" alt="image" src="https://github.com/serverpod/serverpod/assets/137198655/f55b0269-2f72-4493-8a09-97fa419e7064">


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None