### PR TITLE
test: Add tests for enum dart code generator

### DIFF
--- a/tools/serverpod_cli/lib/src/test_util/builders/enum_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/enum_definition_builder.dart
@@ -65,6 +65,11 @@ class EnumDefinitionBuilder {
     return this;
   }
 
+  EnumDefinitionBuilder withValue(String value) {
+    _values.add(ProtocolEnumValueDefinition(value));
+    return this;
+  }
+
   EnumDefinitionBuilder withDocumentation(List<String>? documentation) {
     _documentation = documentation;
     return this;

--- a/tools/serverpod_cli/lib/src/test_util/builders/enum_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/enum_definition_builder.dart
@@ -1,0 +1,72 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+
+class EnumDefinitionBuilder {
+  String _fileName;
+  String _sourceFileName;
+  String _className;
+  List<String> _subDirParts;
+  bool _serverOnly;
+
+  List<ProtocolEnumValueDefinition> _values;
+  List<String>? _documentation;
+
+  EnumDefinitionBuilder()
+      : _fileName = 'example',
+        _sourceFileName = 'example.yaml',
+        _className = 'Example',
+        _subDirParts = [],
+        _serverOnly = false,
+        _values = [
+          ProtocolEnumValueDefinition('A'),
+          ProtocolEnumValueDefinition('B'),
+          ProtocolEnumValueDefinition('C'),
+        ],
+        _documentation = [];
+
+  EnumDefinition build() {
+    return EnumDefinition(
+      fileName: _fileName,
+      sourceFileName: _sourceFileName,
+      className: _className,
+      values: _values,
+      subDirParts: _subDirParts,
+      serverOnly: _serverOnly,
+      documentation: _documentation,
+    );
+  }
+
+  EnumDefinitionBuilder withFileName(String fileName) {
+    _fileName = fileName;
+    return this;
+  }
+
+  EnumDefinitionBuilder withSourceFileName(String sourceFileName) {
+    _sourceFileName = sourceFileName;
+    return this;
+  }
+
+  EnumDefinitionBuilder withClassName(String className) {
+    _className = className;
+    return this;
+  }
+
+  EnumDefinitionBuilder withSubDirParts(List<String> subDirParts) {
+    _subDirParts = subDirParts;
+    return this;
+  }
+
+  EnumDefinitionBuilder withServerOnly(bool serverOnly) {
+    _serverOnly = serverOnly;
+    return this;
+  }
+
+  EnumDefinitionBuilder withValues(List<ProtocolEnumValueDefinition> values) {
+    _values = values;
+    return this;
+  }
+
+  EnumDefinitionBuilder withDocumentation(List<String>? documentation) {
+    _documentation = documentation;
+    return this;
+  }
+}

--- a/tools/serverpod_cli/test/generator/dart/client_generator_dart/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_generator_dart/enum_field_test.dart
@@ -1,0 +1,111 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartClientCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    '..',
+    'example_project_client',
+    'lib',
+    'src',
+    'protocol',
+    'example.dart',
+  );
+  group('Given enum named Example when generating code', () {
+    var entities = [
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then generated enum name is Example', () {
+      expect(codeMap[expectedFileName], contains('enum Example'));
+    });
+
+    test('then generated enum inherits from SerializableEntity', () {
+      expect(codeMap[expectedFileName],
+          contains('enum Example with _i1.SerializableEntity {'));
+    });
+
+    test('then generated enum has static fromJson method', () {
+      expect(codeMap[expectedFileName],
+          contains('static Example? fromJson(int index)'));
+    });
+
+    test('then generated enum has toJson method', () {
+      expect(codeMap[expectedFileName], contains('int toJson() => index;'));
+    });
+  });
+
+  group('Given enum with documentation when generating code', () {
+    var documentation = [
+      '// This is an example documentation',
+      '// This is another example'
+    ];
+    var entities = [
+      EnumDefinitionBuilder()
+          .withFileName('example')
+          .withDocumentation(documentation)
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then documentation is included in code', () {
+      for (var comment in documentation) {
+        expect(codeMap[expectedFileName], contains(comment));
+      }
+    });
+  });
+
+  group('Given enum with two values with documentation when generating code',
+      () {
+    var entities = [
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .withValues([
+        ProtocolEnumValueDefinition(
+            'one', ['// This is a comment for the first value']),
+        ProtocolEnumValueDefinition(
+            'two', ['// This is a comment for the second value'])
+      ]).build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then generated enum includes first value', () {
+      expect(codeMap[expectedFileName], contains('one'));
+    });
+
+    test('then generated enum includes first value comment', () {
+      expect(codeMap[expectedFileName],
+          contains('// This is a comment for the first value'));
+    });
+
+    test('then generated enum includes second value', () {
+      expect(codeMap[expectedFileName],
+          contains('// This is a comment for the second value'));
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/client_generator_dart/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_generator_dart/enum_field_test.dart
@@ -41,6 +41,13 @@ void main() {
           contains('enum Example with _i1.SerializableEntity {'));
     });
 
+    test('then generated enum imports client version of serverpod client', () {
+      expect(
+          codeMap[expectedFileName],
+          contains(
+              "import 'package:serverpod_client/serverpod_client.dart' as"));
+    });
+
     test('then generated enum has static fromJson method', () {
       expect(codeMap[expectedFileName],
           contains('static Example? fromJson(int index)'));

--- a/tools/serverpod_cli/test/generator/dart/client_generator_dart/expected_files_created_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_generator_dart/expected_files_created_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
 import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
 
@@ -39,6 +40,35 @@ void main() {
     });
   });
 
+  group('Given a single enum when generating the code', () {
+    var entities = [
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then the client-side file is created', () {
+      expect(
+        codeMap.keys,
+        contains(path.join(
+          '..',
+          'example_project_client',
+          'lib',
+          'src',
+          'protocol',
+          'example.dart',
+        )),
+        reason: 'Expected client-side file to be present, found none.',
+      );
+    });
+  });
+
   group('Given a multiple classes when generating the code', () {
     var entities = [
       ClassDefinitionBuilder()
@@ -48,7 +78,15 @@ void main() {
       ClassDefinitionBuilder()
           .withClassName('User')
           .withFileName('user')
-          .build()
+          .build(),
+      EnumDefinitionBuilder()
+          .withClassName('Animal')
+          .withFileName('animal')
+          .build(),
+      EnumDefinitionBuilder()
+          .withClassName('Color')
+          .withFileName('color')
+          .build(),
     ];
 
     var codeMap = generator.generateSerializableEntitiesCode(
@@ -82,6 +120,32 @@ void main() {
         )),
         reason: 'Expected client-side file to be present, found none.',
       );
+
+      expect(
+        codeMap.keys,
+        contains(path.join(
+          '..',
+          'example_project_client',
+          'lib',
+          'src',
+          'protocol',
+          'animal.dart',
+        )),
+        reason: 'Expected client-side file to be present, found none.',
+      );
+
+      expect(
+        codeMap.keys,
+        contains(path.join(
+          '..',
+          'example_project_client',
+          'lib',
+          'src',
+          'protocol',
+          'color.dart',
+        )),
+        reason: 'Expected client-side file to be present, found none.',
+      );
     });
   });
 
@@ -90,6 +154,38 @@ void main() {
       () {
     var entities = [
       ClassDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .withServerOnly(true)
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    expect(
+      codeMap.keys,
+      isNot(
+        contains(path.join(
+          '..',
+          'example_project_client',
+          'lib',
+          'src',
+          'protocol',
+          'example.dart',
+        )),
+      ),
+      reason: 'Expected client-side file to NOT be present, found one.',
+    );
+  });
+
+  test(
+      'Given a server-side only enum when generating the code then the client-side file is NOT created',
+      () {
+    var entities = [
+      EnumDefinitionBuilder()
           .withClassName('Example')
           .withFileName('example')
           .withServerOnly(true)

--- a/tools/serverpod_cli/test/generator/dart/client_generator_dart/static_comment_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_generator_dart/static_comment_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
 import 'package:test/test.dart';
 
 import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
@@ -15,6 +16,10 @@ void main() {
           .withClassName('Example')
           .withFileName('example')
           .withSimpleField('title', 'String')
+          .build(),
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
           .build()
     ];
 

--- a/tools/serverpod_cli/test/generator/dart/client_generator_dart/unsupported_entity_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_generator_dart/unsupported_entity_test.dart
@@ -1,0 +1,38 @@
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:test/test.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartClientCodeGenerator();
+
+class UnsupportedEntity extends SerializableEntityDefinition {
+  UnsupportedEntity(
+      {required super.fileName,
+      required super.sourceFileName,
+      required super.className,
+      required super.serverOnly});
+}
+
+void main() {
+  test('Given unsupported entity when generating code then exception is thrown',
+      () {
+    var entities = [
+      UnsupportedEntity(
+          fileName: 'example',
+          sourceFileName: 'example',
+          className: 'Example',
+          serverOnly: false)
+    ];
+
+    expect(
+      () => generator.generateSerializableEntitiesCode(
+        entities: entities,
+        config: config,
+      ),
+      throwsA(const TypeMatcher<Exception>().having((e) => e.toString(),
+          'message', equals('Exception: Unsupported protocol entity type.'))),
+    );
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_generator.dart/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_generator.dart/enum_field_test.dart
@@ -34,6 +34,11 @@ void main() {
           contains('enum Example with _i1.SerializableEntity {'));
     });
 
+    test('then generated enum imports server version of serverpod client', () {
+      expect(codeMap[expectedFileName],
+          contains("import 'package:serverpod/serverpod.dart' as"));
+    });
+
     test('then generated enum has static fromJson method', () {
       expect(codeMap[expectedFileName],
           contains('static Example? fromJson(int index)'));

--- a/tools/serverpod_cli/test/generator/dart/server_generator.dart/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_generator.dart/enum_field_test.dart
@@ -1,0 +1,104 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join('lib', 'src', 'generated', 'example.dart');
+  group('Given enum named Example when generating code', () {
+    var entities = [
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then generated enum name is Example', () {
+      expect(codeMap[expectedFileName], contains('enum Example'));
+    });
+
+    test('then generated enum inherits from SerializableEntity', () {
+      expect(codeMap[expectedFileName],
+          contains('enum Example with _i1.SerializableEntity {'));
+    });
+
+    test('then generated enum has static fromJson method', () {
+      expect(codeMap[expectedFileName],
+          contains('static Example? fromJson(int index)'));
+    });
+
+    test('then generated enum has toJson method', () {
+      expect(codeMap[expectedFileName], contains('int toJson() => index;'));
+    });
+  });
+
+  group('Given enum with documentation when generating code', () {
+    var documentation = [
+      '// This is an example documentation',
+      '// This is another example'
+    ];
+    var entities = [
+      EnumDefinitionBuilder()
+          .withFileName('example')
+          .withDocumentation(documentation)
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then documentation is included in code', () {
+      for (var comment in documentation) {
+        expect(codeMap[expectedFileName], contains(comment));
+      }
+    });
+  });
+
+  group('Given enum with two values with documentation when generating code',
+      () {
+    var entities = [
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .withValues([
+        ProtocolEnumValueDefinition(
+            'one', ['// This is a comment for the first value']),
+        ProtocolEnumValueDefinition(
+            'two', ['// This is a comment for the second value'])
+      ]).build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then generated enum includes first value', () {
+      expect(codeMap[expectedFileName], contains('one'));
+    });
+
+    test('then generated enum includes first value comment', () {
+      expect(codeMap[expectedFileName],
+          contains('// This is a comment for the first value'));
+    });
+
+    test('then generated enum includes second value', () {
+      expect(codeMap[expectedFileName],
+          contains('// This is a comment for the second value'));
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_generator.dart/expected_files_created_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_generator.dart/expected_files_created_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
 import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
 
@@ -32,6 +33,28 @@ void main() {
     });
   });
 
+  group('Given a single enum when generating the code', () {
+    var entities = [
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    test('then the server-side file is created', () {
+      expect(
+        codeMap.keys,
+        contains(path.join('lib', 'src', 'generated', 'example.dart')),
+        reason: 'Expected server-side file to be present, found none.',
+      );
+    });
+  });
+
   group('Given a multiple classes when generating the code', () {
     var entities = [
       ClassDefinitionBuilder()
@@ -41,7 +64,15 @@ void main() {
       ClassDefinitionBuilder()
           .withClassName('User')
           .withFileName('user')
-          .build()
+          .build(),
+      EnumDefinitionBuilder()
+          .withClassName('Animal')
+          .withFileName('animal')
+          .build(),
+      EnumDefinitionBuilder()
+          .withClassName('Color')
+          .withFileName('color')
+          .build(),
     ];
 
     var codeMap = generator.generateSerializableEntitiesCode(
@@ -61,6 +92,18 @@ void main() {
         contains(path.join('lib', 'src', 'generated', 'user.dart')),
         reason: 'Expected server-side file to be present, found none.',
       );
+
+      expect(
+        codeMap.keys,
+        contains(path.join('lib', 'src', 'generated', 'animal.dart')),
+        reason: 'Expected server-side file to be present, found none.',
+      );
+
+      expect(
+        codeMap.keys,
+        contains(path.join('lib', 'src', 'generated', 'color.dart')),
+        reason: 'Expected server-side file to be present, found none.',
+      );
     });
   });
 
@@ -69,6 +112,29 @@ void main() {
       () {
     var entities = [
       ClassDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .withServerOnly(true)
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    expect(
+      codeMap.keys,
+      contains(path.join('lib', 'src', 'generated', 'example.dart')),
+      reason: 'Expected server-side file to be present, found none.',
+    );
+  });
+
+  test(
+      'Given a server-side only enum when generating the code then the server-side file is created',
+      () {
+    var entities = [
+      EnumDefinitionBuilder()
           .withClassName('Example')
           .withFileName('example')
           .withServerOnly(true)

--- a/tools/serverpod_cli/test/generator/dart/server_generator.dart/static_comment_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_generator.dart/static_comment_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
 import 'package:test/test.dart';
 
 import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
@@ -15,6 +16,10 @@ void main() {
           .withClassName('Example')
           .withFileName('example')
           .withSimpleField('title', 'String')
+          .build(),
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
           .build()
     ];
 

--- a/tools/serverpod_cli/test/generator/dart/server_generator.dart/unsupported_entity_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_generator.dart/unsupported_entity_test.dart
@@ -1,0 +1,38 @@
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:test/test.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+class UnsupportedEntity extends SerializableEntityDefinition {
+  UnsupportedEntity(
+      {required super.fileName,
+      required super.sourceFileName,
+      required super.className,
+      required super.serverOnly});
+}
+
+void main() {
+  test('Given unsupported entity when generating code then exception is thrown',
+      () {
+    var entities = [
+      UnsupportedEntity(
+          fileName: 'example',
+          sourceFileName: 'example',
+          className: 'Example',
+          serverOnly: false)
+    ];
+
+    expect(
+      () => generator.generateSerializableEntitiesCode(
+        entities: entities,
+        config: config,
+      ),
+      throwsA(const TypeMatcher<Exception>().having((e) => e.toString(),
+          'message', equals('Exception: Unsupported protocol entity type.'))),
+    );
+  });
+}


### PR DESCRIPTION
issue: https://github.com/serverpod/serverpod/issues/1151

Adds tests for the enum dart code generator for the client and server code.

### Bonus:
Adds tests that validates that an exception is thrown if an unsupported entity type is passed in.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes