### PR TITLE
Make HTTP timeout configurable

### DIFF
--- a/examples/auth_example/auth_example_client/lib/src/protocol/client.dart
+++ b/examples/auth_example/auth_example_client/lib/src/protocol/client.dart
@@ -41,13 +41,15 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i4.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
-    Duration? timeout,
+    Duration? streamingConnectionTimeout,
+    Duration? connectionTimeout,
   }) : super(
           host,
           _i5.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
-          timeout: timeout,
+          streamingConnectionTimeout: streamingConnectionTimeout,
+          connectionTimeout: connectionTimeout,
         ) {
     example = EndpointExample(this);
     modules = _Modules(this);

--- a/examples/auth_example/auth_example_client/lib/src/protocol/client.dart
+++ b/examples/auth_example/auth_example_client/lib/src/protocol/client.dart
@@ -41,11 +41,13 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i4.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
+    Duration? timeout,
   }) : super(
           host,
           _i5.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
+          timeout: timeout,
         ) {
     example = EndpointExample(this);
     modules = _Modules(this);

--- a/examples/chat/chat_client/lib/src/protocol/client.dart
+++ b/examples/chat/chat_client/lib/src/protocol/client.dart
@@ -47,11 +47,13 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i6.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
+    Duration? timeout,
   }) : super(
           host,
           _i7.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
+          timeout: timeout,
         ) {
     channels = EndpointChannels(this);
     modules = _Modules(this);

--- a/examples/chat/chat_client/lib/src/protocol/client.dart
+++ b/examples/chat/chat_client/lib/src/protocol/client.dart
@@ -47,13 +47,15 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i6.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
-    Duration? timeout,
+    Duration? streamingConnectionTimeout,
+    Duration? connectionTimeout,
   }) : super(
           host,
           _i7.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
-          timeout: timeout,
+          streamingConnectionTimeout: streamingConnectionTimeout,
+          connectionTimeout: connectionTimeout,
         ) {
     channels = EndpointChannels(this);
     modules = _Modules(this);

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -21,9 +21,11 @@ abstract class ServerpodClient extends ServerpodClientShared {
   ServerpodClient(
     super.host,
     super.serializationManager, {
-    dynamic context,
+    super.context,
     super.authenticationKeyManager,
     super.logFailedCalls,
+    super.streamingConnectionTimeout,
+    super.connectionTimeout,
   }) {
     _httpClient = http.Client();
   }
@@ -43,10 +45,12 @@ abstract class ServerpodClient extends ServerpodClientShared {
           formatArgs(args, await authenticationKeyManager?.get(), method);
       var url = Uri.parse('$host$endpoint');
 
-      var response = await _httpClient.post(
-        url,
-        body: body,
-      );
+      var response = await _httpClient
+          .post(
+            url,
+            body: body,
+          )
+          .timeout(connectionTimeout);
 
       data = response.body;
 

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -15,7 +15,7 @@ import 'serverpod_client_shared_private.dart';
 /// (for Flutter native apps).
 abstract class ServerpodClient extends ServerpodClientShared {
   late HttpClient _httpClient;
-  final Duration timeout;
+  Duration timeout;
   bool _initialized = false;
 
   /// Creates a new ServerpodClient.

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -15,8 +15,8 @@ import 'serverpod_client_shared_private.dart';
 /// (for Flutter native apps).
 abstract class ServerpodClient extends ServerpodClientShared {
   late HttpClient _httpClient;
+  final Duration timeout;
   bool _initialized = false;
-  late Duration _timeout;
 
   /// Creates a new ServerpodClient.
   ServerpodClient(
@@ -27,13 +27,14 @@ abstract class ServerpodClient extends ServerpodClientShared {
     super.authenticationKeyManager,
     super.logFailedCalls,
     Duration? timeout,
-  }) {
+  })  : this.timeout = timeout ?? const Duration(seconds: 20) {
+
     assert(context == null || context is SecurityContext);
-    _timeout = timeout ?? const Duration(seconds: 20);
 
     // Setup client
     _httpClient = HttpClient(context: context);
-    _httpClient.connectionTimeout = _timeout;
+
+    _httpClient.connectionTimeout = this.timeout;
 
     // TODO: Generate working certificates
     _httpClient.badCertificateCallback =
@@ -77,10 +78,14 @@ abstract class ServerpodClient extends ServerpodClientShared {
       var response = await request
           .close() // done instead of close() ?
 <<<<<<< HEAD
+<<<<<<< HEAD
           .timeout(timeout);
 =======
           .timeout(_timeout);
 >>>>>>> c863eb72 (Make HTTP timeout configurable)
+=======
+          .timeout(timeout);
+>>>>>>> 5994be07 (Make requested changes)
       var data = await _readResponse(response);
 
       if (response.statusCode != HttpStatus.ok) {

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -14,8 +14,10 @@ import 'serverpod_client_shared_private.dart';
 /// This is the concrete implementation using the io library
 /// (for Flutter native apps).
 abstract class ServerpodClient extends ServerpodClientShared {
-  late HttpClient _httpClient;
+  /// Timeout time of requests, defaults to 20 seconds.
   Duration timeout;
+
+  late HttpClient _httpClient;
   bool _initialized = false;
 
   /// Creates a new ServerpodClient.
@@ -23,18 +25,15 @@ abstract class ServerpodClient extends ServerpodClientShared {
     super.host,
     super.serializationManager, {
     dynamic context,
-
     super.authenticationKeyManager,
     super.logFailedCalls,
     Duration? timeout,
-  })  : this.timeout = timeout ?? const Duration(seconds: 20) {
-
+  }) : timeout = timeout ?? const Duration(seconds: 20) {
     assert(context == null || context is SecurityContext);
 
     // Setup client
     _httpClient = HttpClient(context: context);
-
-    _httpClient.connectionTimeout = this.timeout;
+    _httpClient.connectionTimeout = timeout;
 
     // TODO: Generate working certificates
     _httpClient.badCertificateCallback =
@@ -75,17 +74,8 @@ abstract class ServerpodClient extends ServerpodClientShared {
 
       await request.flush();
 
-      var response = await request
-          .close() // done instead of close() ?
-<<<<<<< HEAD
-<<<<<<< HEAD
-          .timeout(timeout);
-=======
-          .timeout(_timeout);
->>>>>>> c863eb72 (Make HTTP timeout configurable)
-=======
-          .timeout(timeout);
->>>>>>> 5994be07 (Make requested changes)
+      var response = await request.close().timeout(timeout);
+
       var data = await _readResponse(response);
 
       if (response.statusCode != HttpStatus.ok) {

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -15,23 +15,26 @@ import 'serverpod_client_shared_private.dart';
 /// (for Flutter native apps).
 abstract class ServerpodClient extends ServerpodClientShared {
   late HttpClient _httpClient;
-  final Duration timeout;
   bool _initialized = false;
+  late Duration _timeout;
 
   /// Creates a new ServerpodClient.
   ServerpodClient(
     super.host,
     super.serializationManager, {
     dynamic context,
+
     super.authenticationKeyManager,
     super.logFailedCalls,
     Duration? timeout,
-  }) : timeout = timeout ?? const Duration(seconds: 20) {
+  }) {
     assert(context == null || context is SecurityContext);
+    _timeout = timeout ?? const Duration(seconds: 20);
 
     // Setup client
     _httpClient = HttpClient(context: context);
-    _httpClient.connectionTimeout = this.timeout;
+    _httpClient.connectionTimeout = _timeout;
+
     // TODO: Generate working certificates
     _httpClient.badCertificateCallback =
         ((X509Certificate cert, String host, int port) {
@@ -73,7 +76,11 @@ abstract class ServerpodClient extends ServerpodClientShared {
 
       var response = await request
           .close() // done instead of close() ?
+<<<<<<< HEAD
           .timeout(timeout);
+=======
+          .timeout(_timeout);
+>>>>>>> c863eb72 (Make HTTP timeout configurable)
       var data = await _readResponse(response);
 
       if (response.statusCode != HttpStatus.ok) {

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -15,8 +15,8 @@ import 'serverpod_client_shared_private.dart';
 /// (for Flutter native apps).
 abstract class ServerpodClient extends ServerpodClientShared {
   late HttpClient _httpClient;
+  final Duration timeout;
   bool _initialized = false;
-  late Duration _timeout;
 
   /// Creates a new ServerpodClient.
   ServerpodClient(
@@ -26,13 +26,12 @@ abstract class ServerpodClient extends ServerpodClientShared {
     super.authenticationKeyManager,
     super.logFailedCalls,
     Duration? timeout,
-  }) {
+  }) : timeout = timeout ?? const Duration(seconds: 20) {
     assert(context == null || context is SecurityContext);
-    _timeout = timeout ?? const Duration(seconds: 20);
 
     // Setup client
     _httpClient = HttpClient(context: context);
-    _httpClient.connectionTimeout = _timeout;
+    _httpClient.connectionTimeout = this.timeout;
     // TODO: Generate working certificates
     _httpClient.badCertificateCallback =
         ((X509Certificate cert, String host, int port) {
@@ -74,7 +73,7 @@ abstract class ServerpodClient extends ServerpodClientShared {
 
       var response = await request
           .close() // done instead of close() ?
-          .timeout(_timeout);
+          .timeout(timeout);
       var data = await _readResponse(response);
 
       if (response.statusCode != HttpStatus.ok) {

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -14,9 +14,6 @@ import 'serverpod_client_shared_private.dart';
 /// This is the concrete implementation using the io library
 /// (for Flutter native apps).
 abstract class ServerpodClient extends ServerpodClientShared {
-  /// Timeout time of requests, defaults to 20 seconds.
-  Duration timeout;
-
   late HttpClient _httpClient;
   bool _initialized = false;
 
@@ -27,13 +24,14 @@ abstract class ServerpodClient extends ServerpodClientShared {
     dynamic context,
     super.authenticationKeyManager,
     super.logFailedCalls,
-    Duration? timeout,
-  }) : timeout = timeout ?? const Duration(seconds: 20) {
+    super.streamingConnectionTimeout,
+    super.connectionTimeout,
+  }) {
     assert(context == null || context is SecurityContext);
 
     // Setup client
     _httpClient = HttpClient(context: context);
-    _httpClient.connectionTimeout = timeout;
+    _httpClient.connectionTimeout = connectionTimeout;
 
     // TODO: Generate working certificates
     _httpClient.badCertificateCallback =
@@ -74,7 +72,7 @@ abstract class ServerpodClient extends ServerpodClientShared {
 
       await request.flush();
 
-      var response = await request.close().timeout(timeout);
+      var response = await request.close().timeout(connectionTimeout);
 
       var data = await _readResponse(response);
 

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -94,6 +94,9 @@ abstract class ServerpodClientShared extends EndpointCaller {
   /// received within the timeout duration the socket will be closed.
   final Duration streamingConnectionTimeout;
 
+  /// Timeout when calling a server endpoint. If no response has been received, defaults to 20 seconds.
+  Duration connectionTimeout;
+
   bool _firstMessageReceived = false;
 
   ConnectivityMonitor? _connectivityMonitor;
@@ -121,10 +124,13 @@ abstract class ServerpodClientShared extends EndpointCaller {
     this.host,
     this.serializationManager, {
     dynamic context,
-    this.authenticationKeyManager,
+    required this.authenticationKeyManager,
     this.logFailedCalls = true,
-    this.streamingConnectionTimeout = const Duration(seconds: 5),
-  }) {
+    required Duration? streamingConnectionTimeout,
+    required Duration? connectionTimeout,
+  })  : connectionTimeout = connectionTimeout ?? const Duration(seconds: 20),
+        streamingConnectionTimeout =
+            streamingConnectionTimeout ?? const Duration(seconds: 5) {
     assert(host.endsWith('/'),
         'host must end with a slash, eg: https://example.com/');
     assert(host.startsWith('http://') || host.startsWith('https://'),

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -237,12 +237,14 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i14.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
+    Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
   }) : super(
           host,
           _i15.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
+          streamingConnectionTimeout: streamingConnectionTimeout,
           connectionTimeout: connectionTimeout,
         ) {
     insights = EndpointInsights(this);

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -237,13 +237,13 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i14.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
-    Duration? timeout,
+    Duration? connectionTimeout,
   }) : super(
           host,
           _i15.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
-          timeout: timeout,
+          connectionTimeout: connectionTimeout,
         ) {
     insights = EndpointInsights(this);
   }

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -237,11 +237,13 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i14.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
+    Duration? timeout,
   }) : super(
           host,
           _i15.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
+          timeout: timeout,
         ) {
     insights = EndpointInsights(this);
   }

--- a/templates/serverpod_templates/projectname_client/lib/src/protocol/client.dart
+++ b/templates/serverpod_templates/projectname_client/lib/src/protocol/client.dart
@@ -32,13 +32,15 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i3.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
-    Duration? timeout,
+    Duration? streamingConnectionTimeout,
+    Duration? connectionTimeout,
   }) : super(
           host,
           _i4.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
-          timeout: timeout,
+          streamingConnectionTimeout: streamingConnectionTimeout,
+          connectionTimeout: connectionTimeout,
         ) {
     example = EndpointExample(this);
   }

--- a/templates/serverpod_templates/projectname_client/lib/src/protocol/client.dart
+++ b/templates/serverpod_templates/projectname_client/lib/src/protocol/client.dart
@@ -32,11 +32,13 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i3.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
+    Duration? timeout,
   }) : super(
           host,
           _i4.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
+          timeout: timeout,
         ) {
     example = EndpointExample(this);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2721,13 +2721,15 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i31.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
-    Duration? timeout,
+    Duration? streamingConnectionTimeout,
+    Duration? connectionTimeout,
   }) : super(
           host,
           _i32.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
-          timeout: timeout,
+          streamingConnectionTimeout: streamingConnectionTimeout,
+          connectionTimeout: connectionTimeout,
         ) {
     asyncTasks = EndpointAsyncTasks(this);
     authentication = EndpointAuthentication(this);

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2721,11 +2721,13 @@ class Client extends _i1.ServerpodClient {
     String host, {
     _i31.SecurityContext? context,
     _i1.AuthenticationKeyManager? authenticationKeyManager,
+    Duration? timeout,
   }) : super(
           host,
           _i32.Protocol(),
           context: context,
           authenticationKeyManager: authenticationKeyManager,
+          timeout: timeout,
         ) {
     asyncTasks = EndpointAsyncTasks(this);
     authentication = EndpointAuthentication(this);

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -615,6 +615,13 @@ class LibraryGenerator {
                         ..symbol = 'AuthenticationKeyManager'
                         ..url = serverpodUrl(false)
                         ..isNullable = true)),
+                    Parameter((p) => p
+                      ..name = 'timeout'
+                      ..named = true
+                      ..type = TypeReference((t) => t
+                        ..symbol = 'Duration'
+                        ..url = 'dart:core'
+                        ..isNullable = true)),
                   ])
                   ..initializers.add(refer('super').call([
                     refer('host'),
@@ -623,6 +630,7 @@ class LibraryGenerator {
                     'context': refer('context'),
                     'authenticationKeyManager':
                         refer('authenticationKeyManager'),
+                    'timeout': refer('timeout'),
                   }).code);
               } else {
                 c

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -616,7 +616,14 @@ class LibraryGenerator {
                         ..url = serverpodUrl(false)
                         ..isNullable = true)),
                     Parameter((p) => p
-                      ..name = 'timeout'
+                      ..name = 'streamingConnectionTimeout'
+                      ..named = true
+                      ..type = TypeReference((t) => t
+                        ..symbol = 'Duration'
+                        ..url = 'dart:core'
+                        ..isNullable = true)),
+                    Parameter((p) => p
+                      ..name = 'connectionTimeout'
                       ..named = true
                       ..type = TypeReference((t) => t
                         ..symbol = 'Duration'
@@ -630,7 +637,9 @@ class LibraryGenerator {
                     'context': refer('context'),
                     'authenticationKeyManager':
                         refer('authenticationKeyManager'),
-                    'timeout': refer('timeout'),
+                    'streamingConnectionTimeout':
+                        refer('streamingConnectionTimeout'),
+                    'connectionTimeout': refer('connectionTimeout'),
                   }).code);
               } else {
                 c


### PR DESCRIPTION
Makes client timeout configurable.

Also adds timeout to `_httpClient.close()`, since this seems to be able to hang forever even if `_httpClient.connectionTimeout` is set.

Does this even need a test? It is a very minor change.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

