### PR TITLE
refactor: Rename internal relation representation.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -90,15 +90,16 @@ class SerializableEntityFieldDefinition {
   final SerializableEntityFieldScope scope;
 
   /// If set the field is a relation to another table. The type of the relation
-  /// [IdRelationDefinition], [ObjectRelationDefinition] or [ListRelationDefinition]
+  /// [ForeignRelationDefinition], [ObjectRelationDefinition] or [ListRelationDefinition]
   /// determines where and how the relation is stored.
   RelationDefinition? relation;
 
-  /// Returns true, if this field has a relation pointer, meaning that there is
-  /// another field in the database that references this field or that this
-  /// field is a reference to another field.
-  bool get hasRelationPointer =>
-      relation != null && relation is! IdRelationDefinition;
+  /// Returns true, if this field has a relation pointer to/from another field
+  /// with relation type [ForeignRelationDefinition]. This means that this field
+  /// relation does not propagate to the database, but instead is managed by
+  /// the other field.
+  bool get isSymbolicRelation =>
+      relation != null && relation is! ForeignRelationDefinition;
 
   /// The documentation of this field, line by line.
   final List<String>? documentation;
@@ -257,18 +258,18 @@ class ObjectRelationDefinition extends RelationDefinition {
   });
 }
 
-/// Internal representation of an unresolved [IdRelationDefinition].
-class UnresolvedIdRelationDefinition extends RelationDefinition {
+/// Internal representation of an unresolved [ForeignRelationDefinition].
+class UnresolvedForeignRelationDefinition extends RelationDefinition {
   /// References the column in the unresolved [parentTable] that this field should be joined on.
   String referenceFieldName;
 
-  UnresolvedIdRelationDefinition({
+  UnresolvedForeignRelationDefinition({
     required this.referenceFieldName,
   });
 }
 
 /// Used for relations for fields that stores the id of another object.
-class IdRelationDefinition extends RelationDefinition {
+class ForeignRelationDefinition extends RelationDefinition {
   /// If this column should have a foreign key,
   /// then [parentTable] contains the referenced table.
   /// For now, the foreign key only references the id column of the
@@ -278,7 +279,7 @@ class IdRelationDefinition extends RelationDefinition {
   /// References the column in the [parentTable] that this field should be joined on.
   String referenceFieldName;
 
-  IdRelationDefinition({
+  ForeignRelationDefinition({
     required this.parentTable,
     required this.referenceFieldName,
   });

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -313,9 +313,9 @@ class SerializableEntityAnalyzer {
 
     var scalarRelation = scalarField?.relation;
     if (scalarField == null) return;
-    if (scalarRelation is! UnresolvedIdRelationDefinition) return;
+    if (scalarRelation is! UnresolvedForeignRelationDefinition) return;
 
-    scalarField.relation = IdRelationDefinition(
+    scalarField.relation = ForeignRelationDefinition(
       parentTable: tableName,
       referenceFieldName: scalarRelation.referenceFieldName,
     );
@@ -341,7 +341,7 @@ class SerializableEntityAnalyzer {
 
     var referenceFields = referenceClass.fields.where((field) {
       var relation = field.relation;
-      if (relation is! IdRelationDefinition) return false;
+      if (relation is! ForeignRelationDefinition) return false;
       return relation.parentTable == classDefinition.tableName;
     });
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -171,7 +171,7 @@ class EntityParser {
     RelationDefinition? relation;
 
     if (parentTable != null) {
-      relation = IdRelationDefinition(
+      relation = ForeignRelationDefinition(
         parentTable: parentTable,
         referenceFieldName: 'id',
       );
@@ -185,7 +185,7 @@ class EntityParser {
       if (scalarFieldName != null)
         SerializableEntityFieldDefinition(
           name: scalarFieldName,
-          relation: UnresolvedIdRelationDefinition(
+          relation: UnresolvedForeignRelationDefinition(
             referenceFieldName: 'id',
           ),
           scope: SerializableEntityFieldScope.all,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -342,7 +342,7 @@ class Restrictions {
     if (localEntityRelations == null) return errors;
 
     var referenceClassExists = localEntityRelations.classNameExists(parsedType);
-    if (field.hasRelationPointer && !referenceClassExists) {
+    if (field.isSymbolicRelation && !referenceClassExists) {
       errors.add(SourceSpanSeverityException(
         'The class "$parsedType" was not found in any protocol.',
         span,
@@ -352,7 +352,7 @@ class Restrictions {
 
     var referenceClasses = localEntityRelations.classNames[parsedType];
     var referenceClass = referenceClasses?.first;
-    if (referenceClass is! ClassDefinition && field.hasRelationPointer) {
+    if (referenceClass is! ClassDefinition && field.isSymbolicRelation) {
       errors.add(SourceSpanSeverityException(
         'Only classes can be used in relations, "$parsedType" is not a class.',
         span,
@@ -360,7 +360,7 @@ class Restrictions {
     }
     if (referenceClass is! ClassDefinition) return errors;
 
-    if (field.hasRelationPointer && !_hasTableDefined(referenceClasses)) {
+    if (!_hasTableDefined(referenceClasses)) {
       errors.add(SourceSpanSeverityException(
         'The class "$parsedType" must have a "table" property defined to be used in a relation.',
         span,
@@ -371,7 +371,7 @@ class Restrictions {
 
     var referenceFields = referenceClass.fields.where((field) {
       var relation = field.relation;
-      if (relation is! IdRelationDefinition) return false;
+      if (relation is! ForeignRelationDefinition) return false;
       return relation.parentTable == def.tableName;
     });
 

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -67,13 +67,13 @@ DatabaseDefinition createDatabaseDefinitionFromEntities(
 
 List<ForeignKeyDefinition> _createForeignKeys(ClassDefinition classDefinition) {
   var fields = classDefinition.fields
-      .where((field) => field.relation is IdRelationDefinition)
+      .where((field) => field.relation is ForeignRelationDefinition)
       .toList();
 
   List<ForeignKeyDefinition> foreignKeys = [];
   for (var i = 0; i < fields.length; i++) {
     var field = fields[i];
-    var relation = field.relation as IdRelationDefinition;
+    var relation = field.relation as ForeignRelationDefinition;
     foreignKeys.add(ForeignKeyDefinition(
       constraintName: '${classDefinition.tableName!}_fk_$i',
       columns: [field.name],

--- a/tools/serverpod_cli/lib/src/generator/psql/legacy_pgsql_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/psql/legacy_pgsql_generator.dart
@@ -61,7 +61,7 @@ class LegacyPgsqlCodeGenerator extends CodeGenerator {
         for (var field in tableInfo.fields) {
           // Check if a parent is not above the current table and not self-referencing
           var relation = field.relation;
-          if (relation is IdRelationDefinition &&
+          if (relation is ForeignRelationDefinition &&
               relation.parentTable != tableInfo.tableName &&
               !visitedTableNames.contains(relation.parentTable)) {
             var tableToMove = tableInfo;
@@ -138,7 +138,7 @@ class LegacyPgsqlCodeGenerator extends CodeGenerator {
     var fkIdx = 0;
     for (var field in classInfo.fields) {
       var relation = field.relation;
-      if (relation is IdRelationDefinition) {
+      if (relation is ForeignRelationDefinition) {
         out += 'ALTER TABLE ONLY "${classInfo.tableName}"\n';
         out += '  ADD CONSTRAINT ${classInfo.tableName}_fk_$fkIdx\n';
         out += '    FOREIGN KEY("${field.name}")\n';

--- a/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
@@ -45,7 +45,7 @@ class FieldDefinitionBuilder {
     String parentTable,
     String referenceFieldName,
   ) {
-    _relation = IdRelationDefinition(
+    _relation = ForeignRelationDefinition(
       parentTable: parentTable,
       referenceFieldName: referenceFieldName,
     );

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -1114,8 +1114,8 @@ fields:
 
         var relation = definition.fields.last.relation;
 
-        expect(relation.runtimeType, IdRelationDefinition);
-        expect((relation as IdRelationDefinition).parentTable, 'example');
+        expect(relation.runtimeType, ForeignRelationDefinition);
+        expect((relation as ForeignRelationDefinition).parentTable, 'example');
       },
     );
 
@@ -1149,8 +1149,8 @@ fields:
 
         var relation = definition.fields.last.relation;
 
-        expect(relation.runtimeType, IdRelationDefinition);
-        expect((relation as IdRelationDefinition).parentTable, 'example');
+        expect(relation.runtimeType, ForeignRelationDefinition);
+        expect((relation as ForeignRelationDefinition).parentTable, 'example');
       },
     );
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -86,8 +86,8 @@ fields:
       var parent = classDefinition.findField('parentId');
       var relation = parent?.relation;
 
-      expect(relation.runtimeType, IdRelationDefinition);
-      expect((relation as IdRelationDefinition).parentTable, 'example');
+      expect(relation.runtimeType, ForeignRelationDefinition);
+      expect((relation as ForeignRelationDefinition).parentTable, 'example');
     });
 
     test(
@@ -96,8 +96,8 @@ fields:
       var parent = classDefinition.findField('parentId');
       var relation = parent?.relation;
 
-      expect(relation.runtimeType, IdRelationDefinition);
-      expect((relation as IdRelationDefinition).referenceFieldName, 'id');
+      expect(relation.runtimeType, ForeignRelationDefinition);
+      expect((relation as ForeignRelationDefinition).referenceFieldName, 'id');
     });
   });
 
@@ -275,14 +275,14 @@ fields:
     });
     test('then the relation is set with the parent table.', () {
       var relation = classDefinition.fields.last.relation;
-      expect(relation.runtimeType, IdRelationDefinition);
-      expect((relation as IdRelationDefinition).parentTable, 'example');
+      expect(relation.runtimeType, ForeignRelationDefinition);
+      expect((relation as ForeignRelationDefinition).parentTable, 'example');
     });
 
     test('then the relation is set with the reference to the id.', () {
       var relation = classDefinition.fields.last.relation;
-      expect(relation.runtimeType, IdRelationDefinition);
-      expect((relation as IdRelationDefinition).referenceFieldName, 'id');
+      expect(relation.runtimeType, ForeignRelationDefinition);
+      expect((relation as ForeignRelationDefinition).referenceFieldName, 'id');
     });
 
     test('then no scalar field is added', () {
@@ -682,16 +682,16 @@ fields:
         () {
       var relation = classDefinition.findField('parentId')?.relation;
 
-      expect(relation.runtimeType, IdRelationDefinition);
-      expect((relation as IdRelationDefinition).parentTable, 'example_parent');
+      expect(relation.runtimeType, ForeignRelationDefinition);
+      expect((relation as ForeignRelationDefinition).parentTable, 'example_parent');
     });
 
     test('then a relation with the reference id is set on the scalar field.',
         () {
       var relation = classDefinition.findField('parentId')?.relation;
 
-      expect(relation.runtimeType, IdRelationDefinition);
-      expect((relation as IdRelationDefinition).referenceFieldName, 'id');
+      expect(relation.runtimeType, ForeignRelationDefinition);
+      expect((relation as ForeignRelationDefinition).referenceFieldName, 'id');
     });
   });
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -683,7 +683,8 @@ fields:
       var relation = classDefinition.findField('parentId')?.relation;
 
       expect(relation.runtimeType, ForeignRelationDefinition);
-      expect((relation as ForeignRelationDefinition).parentTable, 'example_parent');
+      expect((relation as ForeignRelationDefinition).parentTable,
+          'example_parent');
     });
 
     test('then a relation with the reference id is set on the scalar field.',


### PR DESCRIPTION
# Refactor

Renaming relation object and pointer reference variable in our entity definitions.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
