### PR TITLE
feat: Add scope and persist keywords to protocol.

### DIFF
--- a/tools/serverpod_cli/lib/analyzer.dart
+++ b/tools/serverpod_cli/lib/analyzer.dart
@@ -14,7 +14,7 @@ export 'src/analyzer/entities/definitions.dart'
         SerializableEntityDefinition,
         ClassDefinition,
         SerializableEntityFieldDefinition,
-        SerializableEntityFieldScope,
+        EntityFieldScopeDefinition,
         SerializableEntityIndexDefinition,
         EnumDefinition;
 export 'src/generator/types.dart' show TypeDefinition;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -8,6 +8,17 @@ List<String> convertIndexList(String stringifiedFields) {
   return stringifiedFields.split(',').map((field) => field.trim()).toList();
 }
 
+T convertToEnum<T extends Enum>({
+  required String value,
+  required T enumDefault,
+  required List<T> enumValues,
+}) {
+  return enumValues.firstWhere(
+    (v) => v.name.toLowerCase() == value.toLowerCase(),
+    orElse: () => enumDefault,
+  );
+}
+
 typedef DeepNestedNodeHandler = YamlMap Function(
     String? content, SourceSpan span);
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -50,6 +50,7 @@ YamlMap convertStringifiedNestedNodesToYamlMap(
         nestedContent,
         nestedSpan,
         onDuplicateKey: onDuplicateKey,
+        onNegatedKeyWithValue: onNegatedKeyWithValue,
       );
     },
   );

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -86,7 +86,7 @@ class SerializableEntityFieldDefinition {
   /// in a certain context.
   ///
   /// See also:
-  /// - [SerializableEntityFieldScope]
+  /// - [EntityFieldScopeDefinition]
   final EntityFieldScopeDefinition scope;
 
   final bool shouldPersist;
@@ -150,6 +150,7 @@ class SerializableEntityFieldDefinition {
   }
 }
 
+/// The scope of a field.
 enum EntityFieldScopeDefinition {
   all,
   serverOnly,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -87,7 +87,9 @@ class SerializableEntityFieldDefinition {
   ///
   /// See also:
   /// - [SerializableEntityFieldScope]
-  final SerializableEntityFieldScope scope;
+  final EntityFieldScopeDefinition scope;
+
+  final bool shouldPersist;
 
   /// If set the field is a relation to another table. The type of the relation
   /// [ForeignRelationDefinition], [ObjectRelationDefinition] or [ListRelationDefinition]
@@ -109,6 +111,7 @@ class SerializableEntityFieldDefinition {
     required this.name,
     required this.type,
     required this.scope,
+    required this.shouldPersist,
     this.relation,
     this.documentation,
   });
@@ -121,11 +124,7 @@ class SerializableEntityFieldDefinition {
   /// - [shouldSerializeFieldForDatabase]
   bool shouldIncludeField(bool serverCode) {
     if (serverCode) return true;
-    if (scope == SerializableEntityFieldScope.all ||
-        scope == SerializableEntityFieldScope.api) {
-      return true;
-    }
-    return false;
+    return scope == EntityFieldScopeDefinition.all;
   }
 
   /// Returns true, if this field should be added to the serialization.
@@ -135,11 +134,7 @@ class SerializableEntityFieldDefinition {
   /// - [shouldIncludeField]
   /// - [shouldSerializeFieldForDatabase]
   bool shouldSerializeField(bool serverCode) {
-    if (scope == SerializableEntityFieldScope.all ||
-        scope == SerializableEntityFieldScope.api) {
-      return true;
-    }
-    return false;
+    return scope == EntityFieldScopeDefinition.all;
   }
 
   /// Returns true, if this field should be added to the serialization for the
@@ -151,25 +146,13 @@ class SerializableEntityFieldDefinition {
   /// - [shouldIncludeField]
   /// - [shouldSerializeField]
   bool shouldSerializeFieldForDatabase(bool serverCode) {
-    assert(serverCode);
-    if (scope == SerializableEntityFieldScope.all ||
-        scope == SerializableEntityFieldScope.database) {
-      return true;
-    }
-    return false;
+    return shouldPersist;
   }
 }
 
-/// The scope where a field should be present.
-enum SerializableEntityFieldScope {
-  /// Only include the associated field in the database.
-  database,
-
-  /// Only include the associated field in the api.
-  api,
-
-  /// Include the associated field everywhere.
+enum EntityFieldScopeDefinition {
   all,
+  serverOnly,
 }
 
 /// The definition of an index for a file, that is also stored in the database.

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -228,16 +228,21 @@ class EntityParser {
     return documentContents.containsKey(Keyword.relation);
   }
 
-  static bool _parseShouldPersist(YamlMap documentContents) {
-    var isApiDefined = documentContents.containsKey(Keyword.api);
-    if (isApiDefined) return false;
+  static bool _parseShouldPersist(YamlMap node) {
+    var isApi = _parseBooleanKey(node, Keyword.api);
+    if (isApi) return false;
+    if (!node.containsKey(Keyword.persist)) return true;
 
-    var persistValue = documentContents.nodes[Keyword.persist]?.value;
+    return _parseBooleanKey(node, Keyword.persist);
+  }
 
-    var persist = _parseBool(persistValue);
-    if (persist != null) return persist;
+  static bool _parseBooleanKey(YamlMap node, String key) {
+    var value = node.nodes[key]?.value;
+    var boolValue = _parseBool(value);
+    if (boolValue != null) return boolValue;
 
-    return true;
+    var containsKey = node.containsKey(key);
+    return containsKey;
   }
 
   static bool? _parseBool(dynamic value) {
@@ -249,22 +254,17 @@ class EntityParser {
     return null;
   }
 
-  static bool _isOptionalRelation(YamlMap documentContents) {
-    var relation = documentContents.nodes[Keyword.relation];
-
+  static bool _isOptionalRelation(YamlMap node) {
+    var relation = node.nodes[Keyword.relation];
     if (relation is! YamlMap) return false;
 
-    var optional = relation.containsKey(Keyword.optional);
-
-    if (optional) return true;
-
-    return false;
+    return _parseBooleanKey(relation, Keyword.optional);
   }
 
   static EntityFieldScopeDefinition _parseClassFieldScope(
     YamlMap documentContents,
   ) {
-    var database = documentContents.containsKey(Keyword.database);
+    var database = _parseBooleanKey(documentContents, Keyword.database);
     if (database) return EntityFieldScopeDefinition.serverOnly;
 
     var scope = documentContents.nodes[Keyword.scope]?.value;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -230,7 +230,23 @@ class EntityParser {
 
   static bool _parseShouldPersist(YamlMap documentContents) {
     var isApiDefined = documentContents.containsKey(Keyword.api);
-    return !isApiDefined;
+    if (isApiDefined) return false;
+
+    var persistValue = documentContents.nodes[Keyword.persist]?.value;
+
+    var persist = _parseBool(persistValue);
+    if (persist != null) return persist;
+
+    return true;
+  }
+
+  static bool? _parseBool(dynamic value) {
+    if (value is String) {
+      if (value.toLowerCase() == 'true') return true;
+      if (value.toLowerCase() == 'false') return false;
+    }
+
+    return null;
   }
 
   static bool _isOptionalRelation(YamlMap documentContents) {
@@ -250,7 +266,16 @@ class EntityParser {
   ) {
     var database = documentContents.containsKey(Keyword.database);
     if (database) return EntityFieldScopeDefinition.serverOnly;
-    return EntityFieldScopeDefinition.all;
+
+    var scope = documentContents.nodes[Keyword.scope]?.value;
+
+    if (scope is! String) return EntityFieldScopeDefinition.all;
+
+    return convertToEnum(
+      value: scope,
+      enumDefault: EntityFieldScopeDefinition.all,
+      enumValues: EntityFieldScopeDefinition.values,
+    );
   }
 
   static String? _parseParentTable(YamlMap documentContents) {

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
@@ -16,6 +16,8 @@ class Keyword {
   static const String api = 'api';
   static const String database = 'database';
   static const String optional = 'optional';
+  static const String scope = 'scope';
+  static const String persist = 'persist';
 
   /// Special keyword to allow keys to be any string.
   static const String any = 'any';

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/protocol_validator.dart
@@ -135,9 +135,11 @@ void _collectInvalidKeyErrors(
         'Key must be of type String.',
         keyNode.span,
       ));
+      continue;
     }
 
-    if (!(validKeys.contains(Keyword.any) || validKeys.contains(key))) {
+    var parsedKey = key.startsWith('!') ? key.substring(1) : key;
+    if (!(validKeys.contains(Keyword.any) || validKeys.contains(parsedKey))) {
       collector.addError(SourceSpanSeverityException(
         'The "$key" property is not allowed for $documentType type. Valid keys are $validKeys.',
         keyNode.span,
@@ -337,6 +339,12 @@ dynamic _extractNodeValue(
       onDuplicateKey: (key, span) {
         collector.addError(SourceSpanSeverityException(
           'The field option "$key" is defined more than once.',
+          span,
+        ));
+      },
+      onNegatedKeyWithValue: (key, span) {
+        collector.addError(SourceSpanSeverityException(
+          'Negating a key with a value is not allowed.',
           span,
         ));
       },

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -643,3 +643,25 @@ class EnumValue<T extends Enum> {
     return [];
   }
 }
+
+class BooleanValue {
+  List<SourceSpanSeverityException> validateNullable(
+    String parentNodeName,
+    dynamic value,
+    SourceSpan? span,
+  ) {
+    if (value is! String) return [];
+
+    var boolValue = value.toLowerCase();
+    if (!(boolValue == 'true' || boolValue == 'false')) {
+      return [
+        SourceSpanSeverityException(
+          'The value must be a boolean (true, false).',
+          span,
+        )
+      ];
+    }
+
+    return [];
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -635,6 +635,8 @@ class BooleanValueRestriction {
     dynamic value,
     SourceSpan? span,
   ) {
+    if (value is bool) return [];
+
     var errors = [
       SourceSpanSeverityException(
         'The value must be a boolean.',

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -412,7 +412,7 @@ class Restrictions {
     var indexFields = convertIndexList(content);
 
     var validDatabaseFieldNames = fields
-        .where((field) => field.scope != SerializableEntityFieldScope.api)
+        .where((field) => field.shouldPersist)
         .fold(<String>{}, (output, field) => output..add(field.name));
 
     var missingFieldErrors = indexFields

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -105,21 +105,6 @@ class Restrictions {
     return [];
   }
 
-  List<SourceSpanSeverityException> validateBoolType(
-    String parentNodeName,
-    dynamic content,
-    SourceSpan? span,
-  ) {
-    if (content is bool) return [];
-
-    return [
-      SourceSpanSeverityException(
-        'The property value must be a bool.',
-        span,
-      )
-    ];
-  }
-
   List<SourceSpanSeverityException> validateParentKey(
     String parentNodeName,
     String _,
@@ -645,21 +630,23 @@ class EnumValue<T extends Enum> {
 }
 
 class BooleanValue {
-  List<SourceSpanSeverityException> validateNullable(
+  List<SourceSpanSeverityException> validate(
     String parentNodeName,
     dynamic value,
     SourceSpan? span,
   ) {
-    if (value is! String) return [];
+    var errors = [
+      SourceSpanSeverityException(
+        'The value must be a boolean.',
+        span,
+      )
+    ];
+
+    if (value is! String) return errors;
 
     var boolValue = value.toLowerCase();
     if (!(boolValue == 'true' || boolValue == 'false')) {
-      return [
-        SourceSpanSeverityException(
-          'The value must be a boolean.',
-          span,
-        )
-      ];
+      return errors;
     }
 
     return [];

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -596,10 +596,10 @@ class Restrictions {
   }
 }
 
-class EnumValue<T extends Enum> {
+class EnumValueRestriction<T extends Enum> {
   List<T> enums;
 
-  EnumValue({
+  EnumValueRestriction({
     required this.enums,
   });
 
@@ -629,7 +629,7 @@ class EnumValue<T extends Enum> {
   }
 }
 
-class BooleanValue {
+class BooleanValueRestriction {
   List<SourceSpanSeverityException> validate(
     String parentNodeName,
     dynamic value,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -656,7 +656,7 @@ class BooleanValue {
     if (!(boolValue == 'true' || boolValue == 'false')) {
       return [
         SourceSpanSeverityException(
-          'The value must be a boolean (true, false).',
+          'The value must be a boolean.',
           span,
         )
       ];

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -593,3 +593,36 @@ class Restrictions {
     return hasTable;
   }
 }
+
+class EnumValue<T extends Enum> {
+  List<T> enums;
+
+  EnumValue({
+    required this.enums,
+  });
+
+  List<SourceSpanSeverityException> validate(
+    String parentNodeName,
+    dynamic enumValue,
+    SourceSpan? span,
+  ) {
+    var options = enums.map((v) => v.name);
+
+    var errors = <SourceSpanSeverityException>[
+      SourceSpanSeverityException(
+        '"$enumValue" is not a valid property. Valid properties are $options.',
+        span,
+      )
+    ];
+
+    if (enumValue is! String) return errors;
+
+    var isEnumValue = enums.any(
+      (e) => e.name.toLowerCase() == enumValue.toLowerCase(),
+    );
+
+    if (!isEnumValue) return errors;
+
+    return [];
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -471,6 +471,23 @@ class Restrictions {
     return [];
   }
 
+  List<SourceSpanSeverityException> validatePersistKey(
+    String parentNodeName,
+    String relation,
+    SourceSpan? span,
+  ) {
+    var definition = documentDefinition;
+    if (definition is ClassDefinition && definition.tableName == null) {
+      return [
+        SourceSpanSeverityException(
+          'The "persist" property requires a table to be set on the class.',
+          span,
+        )
+      ];
+    }
+    return [];
+  }
+
   List<SourceSpanSeverityException> validateEnumValues(
     String parentNodeName,
     dynamic content,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -26,7 +26,7 @@ class ClassYamlDefinition {
       ),
       ValidateNode(
         Keyword.serverOnly,
-        valueRestriction: BooleanValue().validate,
+        valueRestriction: BooleanValueRestriction().validate,
       ),
       ValidateNode(
         Keyword.fields,
@@ -70,26 +70,26 @@ class ClassYamlDefinition {
                   ValidateNode(
                     Keyword.optional,
                     keyRestriction: restrictions.validateOptionalKey,
-                    valueRestriction: BooleanValue().validate,
+                    valueRestriction: BooleanValueRestriction().validate,
                   ),
                 },
               ),
               ValidateNode(
                 Keyword.scope,
                 mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
-                valueRestriction: EnumValue(
+                valueRestriction: EnumValueRestriction(
                   enums: EntityFieldScopeDefinition.values,
                 ).validate,
               ),
               ValidateNode(
                 Keyword.persist,
                 keyRestriction: restrictions.validatePersistKey,
-                valueRestriction: BooleanValue().validate,
+                valueRestriction: BooleanValueRestriction().validate,
                 mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
               ),
               ValidateNode(
                 Keyword.database,
-                valueRestriction: BooleanValue().validate,
+                valueRestriction: BooleanValueRestriction().validate,
                 mutuallyExclusiveKeys: {
                   Keyword.api,
                   Keyword.scope,
@@ -98,7 +98,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.api,
-                valueRestriction: BooleanValue().validate,
+                valueRestriction: BooleanValueRestriction().validate,
                 mutuallyExclusiveKeys: {
                   Keyword.database,
                   Keyword.scope,
@@ -128,7 +128,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.unique,
-                valueRestriction: BooleanValue().validate,
+                valueRestriction: BooleanValueRestriction().validate,
               ),
             },
           )

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -83,6 +83,7 @@ class ClassYamlDefinition {
               ValidateNode(
                 Keyword.persist,
                 keyRestriction: restrictions.validatePersistKey,
+                valueRestriction: BooleanValue().validateNullable,
                 mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
               ),
               ValidateNode(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -26,7 +26,7 @@ class ClassYamlDefinition {
       ),
       ValidateNode(
         Keyword.serverOnly,
-        valueRestriction: restrictions.validateBoolType,
+        valueRestriction: BooleanValue().validate,
       ),
       ValidateNode(
         Keyword.fields,
@@ -70,7 +70,7 @@ class ClassYamlDefinition {
                   ValidateNode(
                     Keyword.optional,
                     keyRestriction: restrictions.validateOptionalKey,
-                    valueRestriction: BooleanValue().validateNullable,
+                    valueRestriction: BooleanValue().validate,
                   ),
                 },
               ),
@@ -84,12 +84,12 @@ class ClassYamlDefinition {
               ValidateNode(
                 Keyword.persist,
                 keyRestriction: restrictions.validatePersistKey,
-                valueRestriction: BooleanValue().validateNullable,
+                valueRestriction: BooleanValue().validate,
                 mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
               ),
               ValidateNode(
                 Keyword.database,
-                valueRestriction: BooleanValue().validateNullable,
+                valueRestriction: BooleanValue().validate,
                 mutuallyExclusiveKeys: {
                   Keyword.api,
                   Keyword.scope,
@@ -98,7 +98,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.api,
-                valueRestriction: BooleanValue().validateNullable,
+                valueRestriction: BooleanValue().validate,
                 mutuallyExclusiveKeys: {
                   Keyword.database,
                   Keyword.scope,
@@ -128,7 +128,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.unique,
-                valueRestriction: restrictions.validateBoolType,
+                valueRestriction: BooleanValue().validate,
               ),
             },
           )

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -82,17 +82,23 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.persist,
+                mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
               ),
               ValidateNode(
                 Keyword.database,
-                mutuallyExclusiveKeys: {Keyword.api, Keyword.scope},
+                mutuallyExclusiveKeys: {
+                  Keyword.api,
+                  Keyword.scope,
+                  Keyword.persist
+                },
               ),
               ValidateNode(
                 Keyword.api,
                 mutuallyExclusiveKeys: {
                   Keyword.database,
                   Keyword.scope,
-                  Keyword.parent
+                  Keyword.parent,
+                  Keyword.persist,
                 },
               ),
             },

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -82,6 +82,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.persist,
+                keyRestriction: restrictions.validatePersistKey,
                 mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
               ),
               ValidateNode(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -70,6 +70,7 @@ class ClassYamlDefinition {
                   ValidateNode(
                     Keyword.optional,
                     keyRestriction: restrictions.validateOptionalKey,
+                    valueRestriction: BooleanValue().validateNullable,
                   ),
                 },
               ),
@@ -88,6 +89,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.database,
+                valueRestriction: BooleanValue().validateNullable,
                 mutuallyExclusiveKeys: {
                   Keyword.api,
                   Keyword.scope,
@@ -96,6 +98,7 @@ class ClassYamlDefinition {
               ),
               ValidateNode(
                 Keyword.api,
+                valueRestriction: BooleanValue().validateNullable,
                 mutuallyExclusiveKeys: {
                   Keyword.database,
                   Keyword.scope,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
@@ -73,12 +74,26 @@ class ClassYamlDefinition {
                 },
               ),
               ValidateNode(
+                Keyword.scope,
+                mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
+                valueRestriction: EnumValue(
+                  enums: EntityFieldScopeDefinition.values,
+                ).validate,
+              ),
+              ValidateNode(
+                Keyword.persist,
+              ),
+              ValidateNode(
                 Keyword.database,
-                mutuallyExclusiveKeys: {Keyword.api},
+                mutuallyExclusiveKeys: {Keyword.api, Keyword.scope},
               ),
               ValidateNode(
                 Keyword.api,
-                mutuallyExclusiveKeys: {Keyword.database, Keyword.parent},
+                mutuallyExclusiveKeys: {
+                  Keyword.database,
+                  Keyword.scope,
+                  Keyword.parent
+                },
               ),
             },
           ),

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
@@ -14,7 +14,7 @@ class EnumYamlDefinition {
       ),
       ValidateNode(
         Keyword.serverOnly,
-        valueRestriction: restrictions.validateBoolType,
+        valueRestriction: BooleanValue().validate,
       ),
       ValidateNode(
         Keyword.values,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart
@@ -14,7 +14,7 @@ class EnumYamlDefinition {
       ),
       ValidateNode(
         Keyword.serverOnly,
-        valueRestriction: BooleanValue().validate,
+        valueRestriction: BooleanValueRestriction().validate,
       ),
       ValidateNode(
         Keyword.values,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
@@ -21,7 +21,7 @@ class ExceptionYamlDefinition {
       ),
       ValidateNode(
         Keyword.serverOnly,
-        valueRestriction: BooleanValue().validate,
+        valueRestriction: BooleanValueRestriction().validate,
       ),
       ValidateNode(
         Keyword.fields,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart
@@ -21,7 +21,7 @@ class ExceptionYamlDefinition {
       ),
       ValidateNode(
         Keyword.serverOnly,
-        valueRestriction: restrictions.validateBoolType,
+        valueRestriction: BooleanValue().validate,
       ),
       ValidateNode(
         Keyword.fields,

--- a/tools/serverpod_cli/lib/src/generator/psql/legacy_pgsql_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/psql/legacy_pgsql_generator.dart
@@ -107,8 +107,8 @@ class LegacyPgsqlCodeGenerator extends CodeGenerator {
       // Skip id field as it is already added
       if (field.name == 'id') continue;
 
-      // Skip fields that are API only
-      if (field.scope == SerializableEntityFieldScope.api) continue;
+      // Skip fields that should not be persisted
+      if (!field.shouldPersist) continue;
 
       var nullable = field.type.nullable ? '' : ' NOT NULL';
       out += ',\n  "${field.name}" ${field.type.databaseType}$nullable';

--- a/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
@@ -31,7 +31,8 @@ class ClassDefinitionBuilder {
         FieldDefinitionBuilder()
             .withName('id')
             .withType(TypeDefinition.int.asNullable)
-            .withScope(SerializableEntityFieldScope.all)
+            .withScope(EntityFieldScopeDefinition.all)
+            .withShouldPersist(true)
             .build(),
       );
     }

--- a/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
@@ -4,8 +4,9 @@ import 'package:serverpod_cli/src/generator/types.dart';
 class FieldDefinitionBuilder {
   String _name;
   TypeDefinition _type;
-  SerializableEntityFieldScope _scope;
+  EntityFieldScopeDefinition _scope;
   RelationDefinition? _relation;
+  bool _shouldPersist;
   List<String>? _documentation;
 
   FieldDefinitionBuilder()
@@ -14,7 +15,8 @@ class FieldDefinitionBuilder {
           className: 'String',
           nullable: true,
         ),
-        _scope = SerializableEntityFieldScope.all;
+        _scope = EntityFieldScopeDefinition.all,
+        _shouldPersist = true;
 
   FieldDefinitionBuilder withName(String name) {
     _name = name;
@@ -35,9 +37,16 @@ class FieldDefinitionBuilder {
   }
 
   FieldDefinitionBuilder withScope(
-    SerializableEntityFieldScope scope,
+    EntityFieldScopeDefinition scope,
   ) {
     _scope = scope;
+    return this;
+  }
+
+  FieldDefinitionBuilder withShouldPersist(
+    bool shouldPersist,
+  ) {
+    _shouldPersist = shouldPersist;
     return this;
   }
 
@@ -65,6 +74,7 @@ class FieldDefinitionBuilder {
       type: _type,
       scope: _scope,
       relation: _relation,
+      shouldPersist: _shouldPersist,
       documentation: _documentation,
     );
   }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/extra_properties_test.dart
@@ -129,7 +129,7 @@ fields:
 
       var error = collector.errors.first;
 
-      expect(error.message, 'The property value must be a bool.');
+      expect(error.message, 'The value must be a boolean.');
     });
 
     test(
@@ -163,7 +163,7 @@ fields:
 
       var error = collector.errors.first;
 
-      expect(error.message, 'The property value must be a bool.');
+      expect(error.message, 'The value must be a boolean.');
     });
   });
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -211,6 +211,39 @@ void main() {
   );
 
   test(
+    'Given a class with a field with persist negated',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          parent: Example?, relation(!optional=true)
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(error.message, 'Negating a key with a value is not allowed.');
+    },
+  );
+
+  test(
     'Given a class with a field with both the persist and api keywords, then collect an error that only one of them is allowed.',
     () {
       var collector = CodeGenerationCollector();

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -36,4 +36,106 @@ void main() {
       );
     },
   );
+
+  group(
+    'Given a class with a field with persist set.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String, persist
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      test('then no errors are collected', () {
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then the generated entity should be persisted', () {
+        expect(
+          (definition as ClassDefinition).fields.last.shouldPersist,
+          isTrue,
+        );
+      });
+    },
+  );
+
+  test(
+    'Given a class with a field with persist set to true, then the generated entity should be persisted.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String, persist=true
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        (definition as ClassDefinition).fields.last.shouldPersist,
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'Given a class with a field with persist set to false, then the generated entity should not be persisted.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String, persist=false
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        (definition as ClassDefinition).fields.last.shouldPersist,
+        isFalse,
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -1,0 +1,39 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'Given a class with a field with no persist set but has a table, then the generated entity should be persisted.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(
+        (definition as ClassDefinition).fields.last.shouldPersist,
+        isTrue,
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -277,6 +277,39 @@ void main() {
   );
 
   test(
+    'Given a class with a field with the persist key set to a none boolean value, then collect a warning that the value must be a bool.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String, persist=INVALID
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(error.message, 'The value must be a boolean (true, false).');
+    },
+  );
+
+  test(
     'Given a class with a field with both the persist and api keywords, then collect an error that only one of them is allowed.',
     () {
       var collector = CodeGenerationCollector();

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -178,7 +178,7 @@ void main() {
   );
 
   test(
-    'Given a class with a field with persist negated',
+    'Given a class with a field with a negated key and a value set, then collect an error that the negation operator cannot be used together with a value.',
     () {
       var collector = CodeGenerationCollector();
       var protocol = ProtocolSource(
@@ -211,7 +211,7 @@ void main() {
   );
 
   test(
-    'Given a class with a field with persist negated',
+    'Given a class with a field with a nested negated key and a value set, then collect an error that the negation operator cannot be used together with a value.',
     () {
       var collector = CodeGenerationCollector();
       var protocol = ProtocolSource(
@@ -244,12 +244,46 @@ void main() {
   );
 
   test(
+    'Given a class without a table but with a field with persist set, then collect an error that the field cannot be persisted without setting table.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        fields:
+          name: String, persist
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(error.message,
+          'The "persist" property requires a table to be set on the class.');
+    },
+  );
+
+  test(
     'Given a class with a field with both the persist and api keywords, then collect an error that only one of them is allowed.',
     () {
       var collector = CodeGenerationCollector();
       var protocol = ProtocolSource(
         '''
         class: Example
+        table: example
         fields:
           name: String, persist, api
         ''',
@@ -290,6 +324,7 @@ void main() {
       var protocol = ProtocolSource(
         '''
         class: Example
+        table: example
         fields:
           name: String, persist, database
         ''',

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -244,6 +244,39 @@ void main() {
   );
 
   test(
+    'Given a class with a field with the optional key set to an invalid value, then collect an error that value must be a boolean.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          parent: Example?, relation(optional=INVALID)
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(error.message, 'The value must be a boolean.');
+    },
+  );
+
+  test(
     'Given a class without a table but with a field with persist set, then collect an error that the field cannot be persisted without setting table.',
     () {
       var collector = CodeGenerationCollector();
@@ -305,7 +338,7 @@ void main() {
 
       var error = collector.errors.first;
 
-      expect(error.message, 'The value must be a boolean (true, false).');
+      expect(error.message, 'The value must be a boolean.');
     },
   );
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -138,4 +138,155 @@ void main() {
       );
     },
   );
+
+  group(
+    'Given a class with a field with persist negated',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String, !persist
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      test('then no errors are collected.', () {
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then the generated entity should not be persisted.', () {
+        expect(
+          (definition as ClassDefinition).fields.last.shouldPersist,
+          isFalse,
+        );
+      });
+    },
+  );
+
+  test(
+    'Given a class with a field with persist negated',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String, !persist=true
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(0));
+
+      var error = collector.errors.first;
+
+      expect(error.message, 'Negating a key with a value is not allowed.');
+    },
+  );
+
+  test(
+    'Given a class with a field with both the persist and api keywords, then collect an error that only one of them is allowed.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        fields:
+          name: String, persist, api
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(1));
+
+      var error1 = collector.errors[0];
+      var error2 = collector.errors[1];
+
+      expect(
+        error1.message,
+        'The "persist" property is mutually exclusive with the "api" property.',
+      );
+      expect(
+        error2.message,
+        'The "api" property is mutually exclusive with the "persist" property.',
+      );
+    },
+  );
+
+  test(
+    'Given a class with a field with both the persist and database keywords, then collect an error that only one of them is allowed.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        fields:
+          name: String, persist, database
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
+
+      expect(collector.errors.length, greaterThan(1));
+
+      var error1 = collector.errors[0];
+      var error2 = collector.errors[1];
+
+      expect(
+        error1.message,
+        'The "persist" property is mutually exclusive with the "database" property.',
+      );
+      expect(
+        error2.message,
+        'The "database" property is mutually exclusive with the "persist" property.',
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
@@ -1,0 +1,255 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Database and api keyword tests', () {
+    test(
+      'Given a class with a field with two database keywords, then collect an error that only one database is allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, database, database
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(error.message,
+            'The field option "database" is defined more than once.');
+      },
+    );
+
+    test(
+      'Given a class with a field with two api keywords, then collect an error that only one api is allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, api, api
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(
+            error.message, 'The field option "api" is defined more than once.');
+      },
+    );
+
+    test(
+      'Given a class with a field with both the api and database keywords, then collect an error that only one of them is allowed.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, api, database
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(1));
+
+        var error1 = collector.errors[0];
+        var error2 = collector.errors[1];
+
+        expect(error1.message,
+            'The "database" property is mutually exclusive with the "api" property.');
+        expect(error2.message,
+            'The "api" property is mutually exclusive with the "database" property.');
+      },
+    );
+
+    test(
+      'Given a class with a field with no scope set, then the generated entity has the all scope.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          name: String
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect((definition as ClassDefinition).fields.last.scope,
+            SerializableEntityFieldScope.all);
+      },
+    );
+
+    group(
+      'Given a class with a field with the scope set to database',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        table: example
+        fields:
+          name: String, database
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+                as ClassDefinition;
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition],
+        );
+
+        test('then the generated entity has the database scope.', () {
+          expect(
+            definition.fields.last.scope,
+            SerializableEntityFieldScope.database,
+          );
+        });
+      },
+    );
+
+    group(
+      'Given a class with a field with the scope set to api',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+      class: Example
+      table: example
+      fields:
+        name: String, api
+      ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+                as ClassDefinition;
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition],
+        );
+
+        /*test('then a deprecated info is collected.', () {
+          expect(collector.errors.length, greaterThan(0));
+          var error = collector.errors.first;
+
+          expect(error.message, 'Api is deprecated, use "!persist" instead');
+        });*/
+
+        test('then the generated entity has the api scope.', () {
+          expect(
+            definition.fields.last.scope,
+            SerializableEntityFieldScope.api,
+          );
+        });
+      },
+    );
+
+    test(
+      'Given a class with a field with the scope set to api and a parent table, then report an error that the parent keyword and api scope is not valid together.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+      class: Example
+      table: example
+      fields:
+        nextId: int, parent=example, api
+      ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(
+          collector.errors.length,
+          greaterThan(0),
+          reason: 'Expected an error, none was found.',
+        );
+        expect(
+          collector.errors.last.message,
+          'The "api" property is mutually exclusive with the "parent" property.',
+        );
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
@@ -250,6 +250,70 @@ void main() {
     );
 
     test(
+      'Given a class with a field with database set to an invalid value, then collect an error that the value must be a bool.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, database=INVALID
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(error.message, 'The value must be a boolean.');
+      },
+    );
+
+    test(
+      'Given a class with a field with api set to an invalid value, then collect an error that the value must be a bool.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, api=INVALID
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition!],
+        );
+
+        expect(collector.errors.length, greaterThan(0));
+
+        var error = collector.errors.first;
+
+        expect(error.message, 'The value must be a boolean.');
+      },
+    );
+
+    test(
       'Given a class with a field with the scope set to api and a parent table, then report an error that the parent keyword and api scope is not valid together.',
       () {
         var collector = CodeGenerationCollector();

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
@@ -73,6 +73,70 @@ void main() {
     );
 
     test(
+      'Given a class with a field with a negated api keyword, then the generated entity should be persisted.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, !api
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+                as ClassDefinition;
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition],
+        );
+
+        expect(
+          definition.fields.last.shouldPersist,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'Given a class with a field with a negated database keyword, then the generated entity has the scope all.',
+      () {
+        var collector = CodeGenerationCollector();
+        var protocol = ProtocolSource(
+          '''
+        class: Example
+        fields:
+          name: String, !database
+        ''',
+          Uri(path: 'lib/src/protocol/example.yaml'),
+          [],
+        );
+
+        var definition =
+            SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+                as ClassDefinition;
+        SerializableEntityAnalyzer.validateYamlDefinition(
+          protocol.yaml,
+          protocol.yamlSourceUri.path,
+          collector,
+          definition,
+          [definition],
+        );
+
+        expect(
+          definition.fields.last.scope,
+          EntityFieldScopeDefinition.all,
+        );
+      },
+    );
+
+    test(
       'Given a class with a field with both the api and database keywords, then collect an error that only one of them is allowed.',
       () {
         var collector = CodeGenerationCollector();
@@ -179,7 +243,7 @@ void main() {
         test('then the generated entity should not be persisted.', () {
           expect(
             definition.fields.last.shouldPersist,
-            false,
+            isFalse,
           );
         });
       },

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
@@ -398,8 +398,6 @@ void main() {
         [definition!],
       );
 
-      expect(collector.errors.length, greaterThan(0));
-
       expect(collector.errors.length, greaterThan(1));
 
       var error1 = collector.errors[0];
@@ -435,8 +433,6 @@ void main() {
         definition,
         [definition!],
       );
-
-      expect(collector.errors.length, greaterThan(0));
 
       expect(collector.errors.length, greaterThan(1));
 

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
@@ -134,7 +134,7 @@ void main() {
         );
 
         expect((definition as ClassDefinition).fields.last.scope,
-            SerializableEntityFieldScope.all);
+            EntityFieldScopeDefinition.all);
       },
     );
 
@@ -164,10 +164,10 @@ void main() {
           [definition],
         );
 
-        test('then the generated entity has the database scope.', () {
+        test('then the generated entity has the serverOnly scope.', () {
           expect(
             definition.fields.last.scope,
-            SerializableEntityFieldScope.database,
+            EntityFieldScopeDefinition.serverOnly,
           );
         });
       },
@@ -206,10 +206,10 @@ void main() {
           expect(error.message, 'Api is deprecated, use "!persist" instead');
         });*/
 
-        test('then the generated entity has the api scope.', () {
+        test('then the generated entity should not be persisted.', () {
           expect(
-            definition.fields.last.scope,
-            SerializableEntityFieldScope.api,
+            definition.fields.last.shouldPersist,
+            false,
           );
         });
       },

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
@@ -233,13 +233,6 @@ void main() {
           [definition],
         );
 
-        /*test('then a deprecated info is collected.', () {
-          expect(collector.errors.length, greaterThan(0));
-          var error = collector.errors.first;
-
-          expect(error.message, 'Api is deprecated, use "!persist" instead');
-        });*/
-
         test('then the generated entity should not be persisted.', () {
           expect(
             definition.fields.last.shouldPersist,

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_validation_test.dart
@@ -16,7 +16,7 @@ void main() {
 class: Example
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -40,7 +40,7 @@ class: Example
 exception: Example
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -65,7 +65,7 @@ class: Example
 fields:
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -91,7 +91,7 @@ exception: Example
 fields:
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -117,7 +117,7 @@ class: Example
 fields: int
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -143,7 +143,7 @@ enum: Example
 fields:
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -172,7 +172,7 @@ fields:
   1: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -198,7 +198,7 @@ fields:
   Invalid-Field-Name: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -227,7 +227,7 @@ fields:
   UPPERCASE: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -256,7 +256,7 @@ fields:
   PascalCase: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -285,7 +285,7 @@ fields:
   snake_case: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -314,7 +314,7 @@ fields:
   name: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -340,7 +340,7 @@ fields:
   name:
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -374,7 +374,7 @@ fields:
   name:
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -408,7 +408,7 @@ fields:
   name: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -436,7 +436,7 @@ fields:
   name: String
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -469,7 +469,7 @@ fields:
   name: int
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -502,7 +502,7 @@ fields:
   name: bool
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -535,7 +535,7 @@ fields:
   name: double
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -568,7 +568,7 @@ fields:
   name: DateTime
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -601,7 +601,7 @@ fields:
   name: Uuid
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -634,7 +634,7 @@ fields:
   name: ByteData
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -667,7 +667,7 @@ fields:
   name: String?
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -705,7 +705,7 @@ fields:
   name: List<String>?
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -743,7 +743,7 @@ fields:
   name: List<String?>?
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -781,7 +781,7 @@ fields:
   name: ???
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -819,7 +819,7 @@ fields:
   name: String???
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -857,7 +857,7 @@ fields:
   name: List<String>
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -890,7 +890,7 @@ fields:
   name: Map<String, String>
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -923,7 +923,7 @@ fields:
   name: List<List<Map<String, int>>>
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -956,7 +956,7 @@ fields:
   name: module:auth:UserInfo
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -989,7 +989,7 @@ fields:
   name: invalid-type
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -1061,7 +1061,7 @@ fields:
   nameId: int, parent=
 ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =
@@ -1096,7 +1096,7 @@ fields:
           parentId: int, parent=example
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1131,7 +1131,7 @@ fields:
           parentId: int, parent = example
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1166,7 +1166,7 @@ fields:
           parentId: int, parent=example
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1202,7 +1202,7 @@ fields:
           name: int, parent=unknown_table
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1236,7 +1236,7 @@ fields:
           parentId: int, parent=example, parent=example
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1269,7 +1269,7 @@ fields:
           parentId: int, parent=example
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1294,265 +1294,34 @@ fields:
     );
   });
 
-  group('Field scope tests', () {
-    test(
-      'Given a class with a field with two database keywords, then collect an error that only one database is allowed.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
-        class: Example
-        fields:
-          name: String, database, database
-        ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
-
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
-
-        expect(collector.errors.length, greaterThan(0));
-
-        var error = collector.errors.first;
-
-        expect(error.message,
-            'The field option "database" is defined more than once.');
-      },
-    );
-
-    test(
-      'Given a class with a field with two api keywords, then collect an error that only one api is allowed.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
-        class: Example
-        fields:
-          name: String, api, api
-        ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
-
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
-
-        expect(collector.errors.length, greaterThan(0));
-
-        var error = collector.errors.first;
-
-        expect(
-            error.message, 'The field option "api" is defined more than once.');
-      },
-    );
-
-    test(
-      'Given a class with a field with both the api and database keywords, then collect an error that only one of them is allowed.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
-        class: Example
-        fields:
-          name: String, api, database
-        ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
-
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
-
-        expect(collector.errors.length, greaterThan(1));
-
-        var error1 = collector.errors[0];
-        var error2 = collector.errors[1];
-
-        expect(error1.message,
-            'The "database" property is mutually exclusive with the "api" property.');
-        expect(error2.message,
-            'The "api" property is mutually exclusive with the "database" property.');
-      },
-    );
-
-    test(
-      'Given a class with a field with a complex datatype, then generate an entity with that datatype.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
+  test(
+    'Given a class with a field with a complex datatype, then generate an entity with that datatype.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
         class: Example
         fields:
           name: Map<String, String>
         ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
 
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
+      var definition =
+          SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        definition,
+        [definition!],
+      );
 
-        expect(
-            (definition as ClassDefinition).fields.first.type.className, 'Map');
-      },
-    );
-
-    test(
-      'Given a class with a field with no scope set, then the generated entity has the all scope.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
-        class: Example
-        table: example
-        fields:
-          name: String
-        ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
-
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
-
-        expect((definition as ClassDefinition).fields.last.scope,
-            SerializableEntityFieldScope.all);
-      },
-    );
-
-    test(
-      'Given a class with a field with the scope set to database, then the generated entity has the database scope.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
-        class: Example
-        table: example
-        fields:
-          name: String, database
-        ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
-
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
-
-        expect((definition as ClassDefinition).fields.last.scope,
-            SerializableEntityFieldScope.database);
-      },
-    );
-
-    test(
-      'Given a class with a field with the scope set to api, then the generated entity has the api scope.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
-      class: Example
-      table: example
-      fields:
-        name: String, api
-      ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
-
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
-
-        expect((definition as ClassDefinition).fields.last.scope,
-            SerializableEntityFieldScope.api);
-      },
-    );
-
-    test(
-      'Given a class with a field with the scope set to api and a parent table, then report an error that the parent keyword and api scope is not valid together.',
-      () {
-        var collector = CodeGenerationCollector();
-        var protocol = ProtocolSource(
-          '''
-      class: Example
-      table: example
-      fields:
-        nextId: int, parent=example, api
-      ''',
-          Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
-        );
-
-        var definition =
-            SerializableEntityAnalyzer.extractEntityDefinition(protocol);
-        SerializableEntityAnalyzer.validateYamlDefinition(
-          protocol.yaml,
-          protocol.yamlSourceUri.path,
-          collector,
-          definition,
-          [definition!],
-        );
-
-        expect(
-          collector.errors.length,
-          greaterThan(0),
-          reason: 'Expected an error, none was found.',
-        );
-        expect(
-          collector.errors.last.message,
-          'The "api" property is mutually exclusive with the "parent" property.',
-        );
-      },
-    );
-  });
+      expect(
+          (definition as ClassDefinition).fields.first.type.className, 'Map');
+    },
+  );
 
   group('Test id field.', () {
     test(
@@ -1567,7 +1336,7 @@ fields:
           id: int
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1601,7 +1370,7 @@ fields:
           name: String
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1631,7 +1400,7 @@ fields:
           name: String
         ''',
           Uri(path: 'lib/src/protocol/example.yaml'),
-          ['lib', 'src', 'protocol'],
+          [],
         );
 
         var definition =
@@ -1661,7 +1430,7 @@ fields:
         customField: Map<String, CustomClass>
       ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
-        ['lib', 'src', 'protocol'],
+        [],
       );
 
       var definition =

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/indexes_properties_test.dart
@@ -510,7 +510,7 @@ indexes:
 
     expect(collector.errors.length, greaterThan(0));
     var error = collector.errors.first;
-    expect(error.message, 'The property value must be a bool.');
+    expect(error.message, 'The value must be a boolean.');
   });
 
   test(

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -39,9 +39,9 @@ fields:
       expect(collector.errors, isEmpty);
     });
 
-    test('then the scope is set to api on the relation field.', () {
+    test('then the field should not persisted.', () {
       var parent = classDefinition.findField('parent');
-      expect(parent?.scope, SerializableEntityFieldScope.api);
+      expect(parent?.shouldPersist, isFalse);
     });
 
     test(
@@ -68,7 +68,12 @@ fields:
 
     test('then the scalar field has the global scope.', () {
       var parent = classDefinition.findField('parentId');
-      expect(parent?.scope, SerializableEntityFieldScope.all);
+      expect(parent?.scope, EntityFieldScopeDefinition.all);
+    });
+
+    test('then the scalar field should be persisted.', () {
+      var parent = classDefinition.findField('parentId');
+      expect(parent?.shouldPersist, isTrue);
     });
 
     test('then the scalar field type defaults to none nullable.', () {

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -56,54 +56,53 @@ fields:
       );
     });
 
+    var parentId = classDefinition.findField('parentId');
     test('then the class has a scalar field for the id.', () {
-      var parentIdField = classDefinition.findField('parentId');
-
       expect(
-        parentIdField,
+        parentId,
         isNotNull,
         reason: 'Expected to find a field named parentId.',
       );
     });
 
-    test('then the scalar field has the global scope.', () {
-      var parent = classDefinition.findField('parentId');
-      expect(parent?.scope, EntityFieldScopeDefinition.all);
-    });
+    group('', () {
+      test('then the scalar field has the global scope.', () {
+        expect(parentId?.scope, EntityFieldScopeDefinition.all);
+      });
 
-    test('then the scalar field should be persisted.', () {
-      var parent = classDefinition.findField('parentId');
-      expect(parent?.shouldPersist, isTrue);
-    });
+      test('then the scalar field should be persisted.', () {
+        expect(parentId?.shouldPersist, isTrue);
+      });
 
-    test('then the scalar field type defaults to none nullable.', () {
-      var parent = classDefinition.findField('parentId');
-      expect(
-        parent?.type.nullable,
-        isFalse,
-        reason: 'Expected to be non-nullable.',
-      );
-    });
+      test('then the scalar field type defaults to none nullable.', () {
+        expect(
+          parentId?.type.nullable,
+          isFalse,
+          reason: 'Expected to be non-nullable.',
+        );
+      });
 
-    test(
-        'then the scalar field has the parent table set from the object reference.',
-        () {
-      var parent = classDefinition.findField('parentId');
-      var relation = parent?.relation;
+      test(
+          'then the scalar field has the parent table set from the object reference.',
+          () {
+        var parent = classDefinition.findField('parentId');
+        var relation = parent?.relation;
 
-      expect(relation.runtimeType, ForeignRelationDefinition);
-      expect((relation as ForeignRelationDefinition).parentTable, 'example');
-    });
+        expect(relation.runtimeType, ForeignRelationDefinition);
+        expect((relation as ForeignRelationDefinition).parentTable, 'example');
+      });
 
-    test(
-        'then the scalar field has the reference field set to the relation id field.',
-        () {
-      var parent = classDefinition.findField('parentId');
-      var relation = parent?.relation;
+      test(
+          'then the scalar field has the reference field set to the relation id field.',
+          () {
+        var parent = classDefinition.findField('parentId');
+        var relation = parent?.relation;
 
-      expect(relation.runtimeType, ForeignRelationDefinition);
-      expect((relation as ForeignRelationDefinition).referenceFieldName, 'id');
-    });
+        expect(relation.runtimeType, ForeignRelationDefinition);
+        expect(
+            (relation as ForeignRelationDefinition).referenceFieldName, 'id');
+      });
+    }, skip: parentId == null);
   });
 
   group(

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -139,9 +139,52 @@ fields:
     test('then no errors are collected.', () {
       expect(collector.errors, isEmpty);
     });
+
     test('then scalar field is nullable.', () {
       var parent = classDefinition.findField('parentId');
       expect(parent?.type.nullable, isTrue, reason: 'Expected to be nullable.');
+    });
+  });
+
+  group(
+      'Given a class with a self relation on a field with the class datatype where the relation is not optional',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  parent: Example?, relation(!optional)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var definition = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    );
+    SerializableEntityAnalyzer.resolveEntityDependencies([definition!]);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      definition,
+      [definition],
+    );
+
+    var classDefinition = definition as ClassDefinition;
+
+    test('then no errors are collected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then scalar field is not nullable.', () {
+      var parent = classDefinition.findField('parentId');
+      expect(parent?.type.nullable, isFalse,
+          reason: 'Expected to not be nullable.');
     });
   });
 

--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -77,14 +77,6 @@
           "include": "#basic_value_types"
         },
         {
-          "name": "entity.name.tag.yaml",
-          "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*=)"
-        },
-        {
-          "name": "entity.name.tag.yaml",
-          "match": "\\b(?<=\\(|,\\s*)([a-zA-Z0-9_-]+)(?=[,=]|\\s|\\))"
-        },
-        {
           "name": "string.quoted.double.yaml",
           "match": "\\b(?<==)([a-zA-Z0-9_-]+)(?=,|\\))"
         },
@@ -98,7 +90,11 @@
         },
         {
           "name": "entity.name.tag.yaml",
-          "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
+          "match": "\\b(!?[a-zA-Z0-9_-]+)(?=\\s*[:=]|$)"
+        },
+        {
+          "name": "entity.name.tag.yaml",
+          "match": "\\b(!?[a-zA-Z0-9_-]+)(?=\\s*[,\\)]|$)"
         },
         {
           "begin": "(:\\s*)([^\\s<]*)(<)",
@@ -127,7 +123,7 @@
           ]
         },
         {
-          "match": "(:\\s*)([^<\\s?]+)",
+          "match": "(:\\s*)([^,<\\s?]+)",
           "captures": {
             "1": {
               "name": "punctuation.separator.mapping.key-value.yaml"


### PR DESCRIPTION
# Changes

- New keyword `scope` can have value of `all` or `serverOnly` (case-insensitive), defaults to `all`
- New keyword `persist` can have value of true or false, default is true if a table is defined, false otherwise (invalid use if table is not defined).
- New support for operator `!` in field keys in the protocol, can be used on keys without a value to inverse the implicit boolean value. 
- Old keyword `api` mapped to `!persist`
- Old keyword `database` mapped to `scope=serverOnly`
- VScode plugin to support highlighting of inverted keywords e.g. `!persist`
- Internal models consistently built from the new data.

Closes: https://github.com/serverpod/serverpod/issues/1142

## Not implemented

- Code generator is only retrofitted to previous functionality, new combination such as `scope=serverOnly, !persist` is not handled and still has to be implemented.
- `api` and `database` shall be deprecated.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
