### PR TITLE
feat: Add onDelete and onUpdate bindings in protocol.

### DIFF
--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -733,7 +733,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'serverpod_session_log',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )
@@ -849,7 +849,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'serverpod_session_log',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )
@@ -1013,7 +1013,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'serverpod_session_log',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -412,7 +412,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'object_field_scopes',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )
@@ -462,7 +462,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'object_with_self_parent',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )

--- a/tests/serverpod_test_server/test/service_protocol_test.dart
+++ b/tests/serverpod_test_server/test/service_protocol_test.dart
@@ -365,7 +365,8 @@ void main() {
         expect(
             table.foreignKeys.first.constraintName, 'object_with_parent_fk_0');
         expect(table.foreignKeys.first.referenceTable, 'object_field_scopes');
-        expect(table.foreignKeys.first.onUpdate, isNull);
+        expect(table.foreignKeys.first.onUpdate,
+            service.ForeignKeyAction.noAction);
         expect(
             table.foreignKeys.first.onDelete, service.ForeignKeyAction.cascade);
         expect(table.foreignKeys.first.matchType, isNull);

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -248,8 +248,14 @@ class UnresolvedForeignRelationDefinition extends RelationDefinition {
   /// References the column in the unresolved [parentTable] that this field should be joined on.
   String referenceFieldName;
 
+  //final ForeignKeyAction onDelete;
+
+  final ForeignKeyAction onUpdate;
+
   UnresolvedForeignRelationDefinition({
     required this.referenceFieldName,
+    //required this.onDelete,
+    required this.onUpdate,
   });
 }
 
@@ -272,6 +278,6 @@ class ForeignRelationDefinition extends RelationDefinition {
     required this.parentTable,
     required this.referenceFieldName,
     this.onDelete = ForeignKeyAction.cascade,
-    this.onUpdate = ForeignKeyAction.noAction,
+    required this.onUpdate,
   });
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -281,3 +281,7 @@ class ForeignRelationDefinition extends RelationDefinition {
     required this.onUpdate,
   });
 }
+
+const ForeignKeyAction onDeleteDefault = ForeignKeyAction.cascade;
+
+const ForeignKeyAction onUpdateDefault = ForeignKeyAction.noAction;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -248,13 +248,13 @@ class UnresolvedForeignRelationDefinition extends RelationDefinition {
   /// References the column in the unresolved [parentTable] that this field should be joined on.
   String referenceFieldName;
 
-  //final ForeignKeyAction onDelete;
+  final ForeignKeyAction onDelete;
 
   final ForeignKeyAction onUpdate;
 
   UnresolvedForeignRelationDefinition({
     required this.referenceFieldName,
-    //required this.onDelete,
+    required this.onDelete,
     required this.onUpdate,
   });
 }
@@ -277,7 +277,7 @@ class ForeignRelationDefinition extends RelationDefinition {
   ForeignRelationDefinition({
     required this.parentTable,
     required this.referenceFieldName,
-    this.onDelete = ForeignKeyAction.cascade,
+    required this.onDelete,
     required this.onUpdate,
   });
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -1,6 +1,7 @@
 import 'package:path/path.dart' as p;
 
 import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
 
 /// An abstract representation of a yaml file in the
 /// protocol directory.
@@ -263,8 +264,14 @@ class ForeignRelationDefinition extends RelationDefinition {
   /// References the column in the [parentTable] that this field should be joined on.
   String referenceFieldName;
 
+  final ForeignKeyAction onDelete;
+
+  final ForeignKeyAction onUpdate;
+
   ForeignRelationDefinition({
     required this.parentTable,
     required this.referenceFieldName,
+    this.onDelete = ForeignKeyAction.cascade,
+    this.onUpdate = ForeignKeyAction.noAction,
   });
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -319,6 +319,7 @@ class SerializableEntityAnalyzer {
       parentTable: tableName,
       referenceFieldName: scalarRelation.referenceFieldName,
       onUpdate: scalarRelation.onUpdate,
+      onDelete: scalarRelation.onDelete,
     );
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -318,6 +318,7 @@ class SerializableEntityAnalyzer {
     scalarField.relation = ForeignRelationDefinition(
       parentTable: tableName,
       referenceFieldName: scalarRelation.referenceFieldName,
+      onUpdate: scalarRelation.onUpdate,
     );
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -174,13 +174,23 @@ class EntityParser {
     var isEnum = _parseIsEnumField(value);
 
     RelationDefinition? relation;
-    var onUpdate = _parseOnUpdate(value);
+    var onDelete = _parseDatabaseAction(
+      Keyword.onDelete,
+      ForeignKeyAction.cascade,
+      value,
+    );
+    var onUpdate = _parseDatabaseAction(
+      Keyword.onUpdate,
+      ForeignKeyAction.noAction,
+      value,
+    );
 
     if (parentTable != null) {
       relation = ForeignRelationDefinition(
         parentTable: parentTable,
         referenceFieldName: 'id',
         onUpdate: onUpdate,
+        onDelete: onDelete,
       );
     } else if (scalarFieldName != null) {
       relation = ObjectRelationDefinition(scalarFieldName: scalarFieldName);
@@ -195,6 +205,7 @@ class EntityParser {
           relation: UnresolvedForeignRelationDefinition(
             referenceFieldName: 'id',
             onUpdate: onUpdate,
+            onDelete: onDelete,
           ),
           shouldPersist: true,
           scope: scope,
@@ -229,14 +240,17 @@ class EntityParser {
     return '${fieldName}Id';
   }
 
-  static ForeignKeyAction _parseOnUpdate(YamlMap value) {
-    var onUpdateDefault = ForeignKeyAction.noAction;
-    var onUpdate = _parseRelationNode(value, Keyword.onUpdate)?.value;
-    if (onUpdate is! String) return onUpdateDefault;
+  static ForeignKeyAction _parseDatabaseAction(
+    String key,
+    ForeignKeyAction defaultValue,
+    YamlMap node,
+  ) {
+    var action = _parseRelationNode(node, key)?.value;
+    if (action is! String) return defaultValue;
 
     return convertToEnum(
-      value: onUpdate,
-      enumDefault: onUpdateDefault,
+      value: action,
+      enumDefault: defaultValue,
       enumValues: ForeignKeyAction.values,
     );
   }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -220,7 +220,7 @@ class EntityParser {
   }
 
   static String? _parseScalarField(YamlMap value, String fieldName) {
-    if (!value.containsKey(Keyword.relation)) return null;
+    if (!_isRelation(value)) return null;
     var type = value.nodes[Keyword.type]?.value;
     if (type is! String) return null;
     if (AnalyzeChecker.isIdType(type)) return null;
@@ -305,18 +305,10 @@ class EntityParser {
     var parent = documentContents.nodes[Keyword.parent]?.value;
     if (parent is String) return parent;
 
-    var relationMap = documentContents.nodes[Keyword.relation];
-
-    if (relationMap is! YamlMap) return null;
-    parent = relationMap.nodes[Keyword.parent]?.value;
-
+    parent = _parseRelationNode(documentContents, Keyword.parent)?.value;
     if (parent is String) return parent;
 
-    var type = documentContents.nodes[Keyword.type]?.value;
-    if (AnalyzeChecker.isIdType(type)) return null;
-    if (type is! String) return null;
-
-    return parent;
+    return null;
   }
 
   static bool _parseIsEnumField(YamlMap documentContents) {

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
@@ -13,6 +13,7 @@ class Keyword {
   static const String unique = 'unique';
   static const String parent = 'parent';
   static const String relation = 'relation';
+  static const String onUpdate = 'onUpdate';
   static const String api = 'api';
   static const String database = 'database';
   static const String optional = 'optional';
@@ -20,5 +21,5 @@ class Keyword {
   static const String persist = 'persist';
 
   /// Special keyword to allow keys to be any string.
-  static const String any = 'any';
+  static const String any = '#any';
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
@@ -14,6 +14,7 @@ class Keyword {
   static const String parent = 'parent';
   static const String relation = 'relation';
   static const String onUpdate = 'onUpdate';
+  static const String onDelete = 'onDelete';
   static const String api = 'api';
   static const String database = 'database';
   static const String optional = 'optional';

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -77,6 +77,12 @@ class ClassYamlDefinition {
                     ).validate,
                   ),
                   ValidateNode(
+                    Keyword.onDelete,
+                    valueRestriction: EnumValueRestriction(
+                      enums: ForeignKeyAction.values,
+                    ).validate,
+                  ),
+                  ValidateNode(
                     Keyword.optional,
                     keyRestriction: restrictions.validateOptionalKey,
                     valueRestriction: BooleanValueRestriction().validate,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -2,6 +2,7 @@ import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/keywords.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/validate_node.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
 
 class ClassYamlDefinition {
   late Set<ValidateNode> documentStructure;
@@ -68,6 +69,12 @@ class ClassYamlDefinition {
                     Keyword.parent,
                     keyRestriction: restrictions.validateParentKey,
                     valueRestriction: restrictions.validateParentName,
+                  ),
+                  ValidateNode(
+                    Keyword.onUpdate,
+                    valueRestriction: EnumValueRestriction(
+                      enums: ForeignKeyAction.values,
+                    ).validate,
                   ),
                   ValidateNode(
                     Keyword.optional,

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -81,6 +81,8 @@ List<ForeignKeyDefinition> _createForeignKeys(ClassDefinition classDefinition) {
       referenceTableSchema: 'public',
       referenceColumns: ['id'],
       onDelete: ForeignKeyAction.cascade,
+      //onDelete: field.relation?.onDelete,
+      //onUpdate: field.relation?.onUpdate,
     ));
   }
 

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -79,7 +79,7 @@ List<ForeignKeyDefinition> _createForeignKeys(ClassDefinition classDefinition) {
       columns: [field.name],
       referenceTable: relation.parentTable,
       referenceTableSchema: 'public',
-      referenceColumns: [relation.referenceFieldName],
+      referenceColumns: ['id'],
       onDelete: relation.onDelete,
       onUpdate: relation.onUpdate,
     ));

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -79,10 +79,9 @@ List<ForeignKeyDefinition> _createForeignKeys(ClassDefinition classDefinition) {
       columns: [field.name],
       referenceTable: relation.parentTable,
       referenceTableSchema: 'public',
-      referenceColumns: ['id'],
-      onDelete: ForeignKeyAction.cascade,
-      //onDelete: field.relation?.onDelete,
-      //onUpdate: field.relation?.onUpdate,
+      referenceColumns: [relation.referenceFieldName],
+      onDelete: relation.onDelete,
+      onUpdate: relation.onUpdate,
     ));
   }
 

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -374,15 +374,21 @@ extension ForeignKeyDefinitionPgSqlGeneration on ForeignKeyDefinition {
 
     var refColumsFmt = referenceColumns.map((e) => '"$e"');
 
-    var delete = onDelete != null ? onDelete?.toPgSqlAction() : 'CASCADE';
-    var update = onUpdate != null ? onUpdate?.toPgSqlAction() : 'NO ACTION';
+    String? delete = onDelete?.toPgSqlAction();
+    String? update = onUpdate?.toPgSqlAction();
 
     out += 'ALTER TABLE ONLY "$tableName"\n';
     out += '    ADD CONSTRAINT "$constraintName"\n';
     out += '    FOREIGN KEY("${columns.join(', ')}")\n';
     out += '    REFERENCES "$referenceTable"(${refColumsFmt.join(', ')})\n';
-    out += '    ON DELETE $delete;\n';
-    out += '    ON UPDATE $update;\n';
+
+    if (delete != null) {
+      out += '    ON DELETE $delete;\n';
+    }
+
+    if (update != null) {
+      out += '    ON UPDATE $update;\n';
+    }
 
     return out;
   }

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -374,13 +374,34 @@ extension ForeignKeyDefinitionPgSqlGeneration on ForeignKeyDefinition {
 
     var refColumsFmt = referenceColumns.map((e) => '"$e"');
 
+    var delete = onDelete != null ? onDelete?.toPgSqlAction() : 'CASCADE';
+    var update = onUpdate != null ? onUpdate?.toPgSqlAction() : 'NO ACTION';
+
     out += 'ALTER TABLE ONLY "$tableName"\n';
     out += '    ADD CONSTRAINT "$constraintName"\n';
     out += '    FOREIGN KEY("${columns.join(', ')}")\n';
     out += '    REFERENCES "$referenceTable"(${refColumsFmt.join(', ')})\n';
-    out += '    ON DELETE CASCADE;\n';
+    out += '    ON DELETE $delete;\n';
+    out += '    ON UPDATE $update;\n';
 
     return out;
+  }
+}
+
+extension on ForeignKeyAction {
+  String toPgSqlAction() {
+    switch (this) {
+      case ForeignKeyAction.noAction:
+        return 'NO ACTION';
+      case ForeignKeyAction.restrict:
+        return 'RESTRICT';
+      case ForeignKeyAction.cascade:
+        return 'CASCADE';
+      case ForeignKeyAction.setNull:
+        return 'SET NULL';
+      case ForeignKeyAction.setDefault:
+        return 'SET DEFAULT';
+    }
   }
 }
 

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -374,21 +374,24 @@ extension ForeignKeyDefinitionPgSqlGeneration on ForeignKeyDefinition {
 
     var refColumsFmt = referenceColumns.map((e) => '"$e"');
 
-    String? delete = onDelete?.toPgSqlAction();
-    String? update = onUpdate?.toPgSqlAction();
-
     out += 'ALTER TABLE ONLY "$tableName"\n';
     out += '    ADD CONSTRAINT "$constraintName"\n';
     out += '    FOREIGN KEY("${columns.join(', ')}")\n';
-    out += '    REFERENCES "$referenceTable"(${refColumsFmt.join(', ')})\n';
+    out += '    REFERENCES "$referenceTable"(${refColumsFmt.join(', ')})';
 
+    String? delete = onDelete?.toPgSqlAction();
     if (delete != null) {
-      out += '    ON DELETE $delete;\n';
+      out += '\n';
+      out += '    ON DELETE $delete';
     }
 
+    String? update = onUpdate?.toPgSqlAction();
     if (update != null) {
-      out += '    ON UPDATE $update;\n';
+      out += '\n';
+      out += '    ON UPDATE $update';
     }
+
+    out += ';\n';
 
     return out;
   }

--- a/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:serverpod_cli/src/test_util/builders/foreign_relation_definition_builder.dart';
 
 import 'serializable_entity_field_definition_builder.dart';
 
@@ -103,20 +104,23 @@ class ClassDefinitionBuilder {
   ClassDefinitionBuilder withObjectRelationField(
       String fieldName, String className, String parentTable) {
     _fields.addAll([
-      SerializableEntityFieldDefinition(
-          name: fieldName,
-          type: TypeDefinition(className: className, nullable: true),
-          scope: EntityFieldScopeDefinition.all,
-          shouldPersist: false,
-          relation:
-              ObjectRelationDefinition(scalarFieldName: '${fieldName}Id')),
-      SerializableEntityFieldDefinition(
-          name: '${fieldName}Id',
-          type: TypeDefinition.int,
-          scope: EntityFieldScopeDefinition.all,
-          shouldPersist: true,
-          relation: ForeignRelationDefinition(
-              parentTable: parentTable, referenceFieldName: 'id')),
+      FieldDefinitionBuilder()
+          .withName(fieldName)
+          .withTypeDefinition(className, true)
+          .withShouldPersist(false)
+          .withRelation(ObjectRelationDefinition(
+            scalarFieldName: '${fieldName}Id',
+          ))
+          .build(),
+      FieldDefinitionBuilder()
+          .withName('${fieldName}Id')
+          .withIdType()
+          .withShouldPersist(true)
+          .withRelation(ForeignRelationDefinitionBuilder()
+              .withParentTable(parentTable)
+              .withReferenceFieldName('id')
+              .build())
+          .build(),
     ]);
     return this;
   }

--- a/tools/serverpod_cli/lib/src/test_util/builders/foreign_relation_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/foreign_relation_definition_builder.dart
@@ -1,0 +1,39 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+
+class ForeignRelationDefinitionBuilder {
+  String parentTable = 'parent_table';
+  String referenceFieldName = 'id';
+  ForeignKeyAction onDelete = ForeignKeyAction.cascade;
+  ForeignKeyAction onUpdate = ForeignKeyAction.noAction;
+
+  ForeignRelationDefinitionBuilder withParentTable(String parentTable) {
+    this.parentTable = parentTable;
+    return this;
+  }
+
+  ForeignRelationDefinitionBuilder withReferenceFieldName(
+      String referenceFieldName) {
+    this.referenceFieldName = referenceFieldName;
+    return this;
+  }
+
+  ForeignRelationDefinitionBuilder withOnDelete(ForeignKeyAction onDelete) {
+    this.onDelete = onDelete;
+    return this;
+  }
+
+  ForeignRelationDefinitionBuilder withOnUpdate(ForeignKeyAction onUpdate) {
+    this.onUpdate = onUpdate;
+    return this;
+  }
+
+  ForeignRelationDefinition build() {
+    return ForeignRelationDefinition(
+      parentTable: parentTable,
+      referenceFieldName: referenceFieldName,
+      onDelete: onDelete,
+      onUpdate: onUpdate,
+    );
+  }
+}

--- a/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
 
 class FieldDefinitionBuilder {
   String _name;
@@ -50,6 +51,13 @@ class FieldDefinitionBuilder {
     return this;
   }
 
+  FieldDefinitionBuilder withRelation(
+    RelationDefinition relation,
+  ) {
+    _relation = relation;
+    return this;
+  }
+
   FieldDefinitionBuilder withRelationTo(
     String parentTable,
     String referenceFieldName,
@@ -57,6 +65,7 @@ class FieldDefinitionBuilder {
     _relation = ForeignRelationDefinition(
       parentTable: parentTable,
       referenceFieldName: referenceFieldName,
+      onUpdate: ForeignKeyAction.noAction,
     );
     return this;
   }

--- a/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
@@ -1,6 +1,6 @@
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
-import 'package:serverpod_service_client/serverpod_service_client.dart';
+import 'package:serverpod_cli/src/test_util/builders/foreign_relation_definition_builder.dart';
 
 class FieldDefinitionBuilder {
   String _name;
@@ -24,11 +24,26 @@ class FieldDefinitionBuilder {
     return this;
   }
 
+  FieldDefinitionBuilder withPrimaryKey() {
+    _name = 'id';
+    _type = TypeDefinition.int;
+
+    return this;
+  }
+
   FieldDefinitionBuilder withTypeDefinition(
     String className, [
     bool nullable = false,
   ]) {
     _type = TypeDefinition(className: className, nullable: nullable);
+    return this;
+  }
+
+  FieldDefinitionBuilder withIdType([bool isNullable = false]) {
+    _type = TypeDefinition.int;
+    if (isNullable) {
+      _type = _type.asNullable;
+    }
     return this;
   }
 
@@ -62,12 +77,10 @@ class FieldDefinitionBuilder {
     String parentTable,
     String referenceFieldName,
   ) {
-    _relation = ForeignRelationDefinition(
-      parentTable: parentTable,
-      referenceFieldName: referenceFieldName,
-      onUpdate: ForeignKeyAction.noAction,
-      onDelete: ForeignKeyAction.cascade,
-    );
+    _relation = ForeignRelationDefinitionBuilder()
+        .withParentTable(parentTable)
+        .withReferenceFieldName(referenceFieldName)
+        .build();
     return this;
   }
 

--- a/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/serializable_entity_field_definition_builder.dart
@@ -66,6 +66,7 @@ class FieldDefinitionBuilder {
       parentTable: parentTable,
       referenceFieldName: referenceFieldName,
       onUpdate: ForeignKeyAction.noAction,
+      onDelete: ForeignKeyAction.cascade,
     );
     return this;
   }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
@@ -49,4 +49,208 @@ void main() {
       expect(relation.onDelete, ForeignKeyAction.cascade);
     }, skip: failedPrecondition);
   });
+
+  group('Given a class with onUpdate database action explicitly set to Cascade',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+      class: Example
+      table: example
+      fields:
+        example: Example?, relation(onUpdate=Cascade)
+      ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    ) as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onUpdate is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onUpdate, ForeignKeyAction.cascade);
+    }, skip: failedPrecondition);
+  });
+
+  group(
+      'Given a class with onUpdate database action explicitly set to NoAction',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+      class: Example
+      table: example
+      fields:
+        example: Example?, relation(onUpdate=NoAction)
+      ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    ) as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onUpdate is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+
+      expect(relation.onUpdate, ForeignKeyAction.noAction);
+    }, skip: failedPrecondition);
+  });
+
+  group(
+      'Given a class with onUpdate database action explicitly set to Restrict',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+      class: Example
+      table: example
+      fields:
+        example: Example?, relation(onUpdate=Restrict)
+      ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    ) as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onUpdate is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onUpdate, ForeignKeyAction.restrict);
+    }, skip: failedPrecondition);
+  });
+
+  group('Given a class with onUpdate database action explicitly set to SetNull',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+      class: Example
+      table: example
+      fields:
+        example: Example?, relation(onUpdate=SetNull)
+      ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    ) as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onUpdate is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onUpdate, ForeignKeyAction.setNull);
+    }, skip: failedPrecondition);
+  });
+
+  group(
+      'Given a class with onUpdate database action explicitly set to SetDefault',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+      class: Example
+      table: example
+      fields:
+        example: Example?, relation(onUpdate=SetDefault)
+      ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    ) as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onUpdate is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onUpdate, ForeignKeyAction.setDefault);
+    }, skip: failedPrecondition);
+  });
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
@@ -1,0 +1,47 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a class with no database action explicitly set', () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  example: Example?, relation
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    ) as ClassDefinition;
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then onUpdate is set to default.', () {
+      var field = entity.fields.last;
+      expect(field.relation?.onUpdate, ForeignKeyAction.noAction);
+    });
+
+    test('then onDelete is set to default.', () {
+      var field = entity.fields.last;
+      expect(field.relation?.onUpdate, ForeignKeyAction.cascade);
+    });
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
@@ -253,4 +253,276 @@ void main() {
       expect(relation.onUpdate, ForeignKeyAction.setDefault);
     }, skip: failedPrecondition);
   });
+
+  test(
+      'Given a class with onUpdate database action set to an invalid value, then collect an error.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+      class: Example
+      table: example
+      fields:
+        example: Example?, relation(onUpdate=Invalid)
+      ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol,
+    ) as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    expect(collector.errors, isNotEmpty);
+
+    var error = collector.errors.first;
+
+    expect(
+      error.message,
+      '"Invalid" is not a valid property. Valid properties are (setNull, setDefault, restrict, noAction, cascade).',
+    );
+  });
+
+  group('Given a class with onDelete database action explicitly set to Cascade',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+    class: Example
+    table: example
+    fields:
+      example: Example?, relation(onDelete=Cascade)
+    ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onDelete is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onDelete, ForeignKeyAction.cascade);
+    }, skip: failedPrecondition);
+  });
+
+  group(
+      'Given a class with onDelete database action explicitly set to NoAction',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+    class: Example
+    table: example
+    fields:
+      example: Example?, relation(onDelete=NoAction)
+    ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onDelete is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+
+      expect(relation.onDelete, ForeignKeyAction.noAction);
+    }, skip: failedPrecondition);
+  });
+
+  group(
+      'Given a class with onDelete database action explicitly set to Restrict',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+    class: Example
+    table: example
+    fields:
+      example: Example?, relation(onDelete=Restrict)
+    ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onDelete is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onDelete, ForeignKeyAction.restrict);
+    }, skip: failedPrecondition);
+  });
+
+  group('Given a class with onDelete database action explicitly set to SetNull',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+    class: Example
+    table: example
+    fields:
+      example: Example?, relation(onDelete=SetNull)
+    ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onDelete is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onDelete, ForeignKeyAction.setNull);
+    }, skip: failedPrecondition);
+  });
+
+  group(
+      'Given a class with onDelete database action explicitly set to SetDefault',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+    class: Example
+    table: example
+    fields:
+      example: Example?, relation(onDelete=SetDefault)
+    ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    test('then no errors are detected.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    var field = entity.findField('exampleId');
+
+    var failedPrecondition =
+        field == null || field.relation is! ForeignRelationDefinition;
+    test('then onDelete is set.', () {
+      var relation = field?.relation as ForeignRelationDefinition;
+      expect(relation.onDelete, ForeignKeyAction.setDefault);
+    }, skip: failedPrecondition);
+  });
+
+  test(
+      'Given a class with onDelete database action set to an invalid value, then collect an error.',
+      () {
+    var collector = CodeGenerationCollector();
+    var protocol = ProtocolSource(
+      '''
+    class: Example
+    table: example
+    fields:
+      example: Example?, relation(onDelete=Invalid)
+    ''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      ['lib', 'src', 'protocol'],
+    );
+
+    var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol)
+        as ClassDefinition;
+    SerializableEntityAnalyzer.resolveEntityDependencies([entity]);
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol.yaml,
+      protocol.yamlSourceUri.path,
+      collector,
+      entity,
+      [entity],
+    );
+
+    expect(collector.errors, isNotEmpty);
+
+    var error = collector.errors.first;
+
+    expect(
+      error.message,
+      '"Invalid" is not a valid property. Valid properties are (setNull, setDefault, restrict, noAction, cascade).',
+    );
+  });
 }

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
@@ -37,17 +37,17 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onUpdate is set to default.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.noAction);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
 
     test('then onDelete is set to default.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.cascade);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group('Given a class with onUpdate database action explicitly set to Cascade',
@@ -82,12 +82,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onUpdate is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.cascade);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group(
@@ -123,13 +123,13 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onUpdate is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
 
       expect(relation.onUpdate, ForeignKeyAction.noAction);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group(
@@ -165,12 +165,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onUpdate is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.restrict);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group('Given a class with onUpdate database action explicitly set to SetNull',
@@ -205,12 +205,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onUpdate is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.setNull);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group(
@@ -246,12 +246,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onUpdate is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.setDefault);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   test(
@@ -322,12 +322,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onDelete is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.cascade);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group(
@@ -362,13 +362,13 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onDelete is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
 
       expect(relation.onDelete, ForeignKeyAction.noAction);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group(
@@ -403,12 +403,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onDelete is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.restrict);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group('Given a class with onDelete database action explicitly set to SetNull',
@@ -442,12 +442,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onDelete is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.setNull);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   group(
@@ -482,12 +482,12 @@ void main() {
 
     var field = entity.findField('exampleId');
 
-    var failedPrecondition =
+    var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
     test('then onDelete is set.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.setDefault);
-    }, skip: failedPrecondition);
+    }, skip: noneFieldRelation);
   });
 
   test(

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_database_action_test.dart
@@ -39,14 +39,14 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onUpdate is set to default.', () {
+    test('then onUpdate is set to the default.', () {
       var relation = field?.relation as ForeignRelationDefinition;
-      expect(relation.onUpdate, ForeignKeyAction.noAction);
+      expect(relation.onUpdate, onUpdateDefault);
     }, skip: noneFieldRelation);
 
-    test('then onDelete is set to default.', () {
+    test('then onDelete is set to the default.', () {
       var relation = field?.relation as ForeignRelationDefinition;
-      expect(relation.onDelete, ForeignKeyAction.cascade);
+      expect(relation.onDelete, onDeleteDefault);
     }, skip: noneFieldRelation);
   });
 
@@ -84,7 +84,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onUpdate is set.', () {
+    test('then onUpdate is set to cascade.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.cascade);
     }, skip: noneFieldRelation);
@@ -125,7 +125,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onUpdate is set.', () {
+    test('then onUpdate is set to no action.', () {
       var relation = field?.relation as ForeignRelationDefinition;
 
       expect(relation.onUpdate, ForeignKeyAction.noAction);
@@ -167,7 +167,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onUpdate is set.', () {
+    test('then onUpdate is set to restrict.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.restrict);
     }, skip: noneFieldRelation);
@@ -207,7 +207,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onUpdate is set.', () {
+    test('then onUpdate is set to set null.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.setNull);
     }, skip: noneFieldRelation);
@@ -248,7 +248,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onUpdate is set.', () {
+    test('then onUpdate is set to set default.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onUpdate, ForeignKeyAction.setDefault);
     }, skip: noneFieldRelation);
@@ -324,7 +324,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onDelete is set.', () {
+    test('then onDelete is set to cascade.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.cascade);
     }, skip: noneFieldRelation);
@@ -364,7 +364,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onDelete is set.', () {
+    test('then onDelete is set to no action.', () {
       var relation = field?.relation as ForeignRelationDefinition;
 
       expect(relation.onDelete, ForeignKeyAction.noAction);
@@ -405,7 +405,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onDelete is set.', () {
+    test('then onDelete is set to restrict.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.restrict);
     }, skip: noneFieldRelation);
@@ -444,7 +444,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onDelete is set.', () {
+    test('then onDelete is set to set null.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.setNull);
     }, skip: noneFieldRelation);
@@ -484,7 +484,7 @@ void main() {
 
     var noneFieldRelation =
         field == null || field.relation is! ForeignRelationDefinition;
-    test('then onDelete is set.', () {
+    test('then onDelete is set to set default.', () {
       var relation = field?.relation as ForeignRelationDefinition;
       expect(relation.onDelete, ForeignKeyAction.setDefault);
     }, skip: noneFieldRelation);

--- a/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
@@ -97,11 +97,11 @@ void main() {
       );
 
       test('then on delete is set to set null.', () {
-        expect(sql.contains('ON DELETE SET NULL;'), isTrue);
+        expect(sql.contains('ON DELETE SET NULL'), isTrue);
       });
 
       test('then on update is set to set null.', () {
-        expect(sql.contains('ON UPDATE SET NULL;'), isTrue);
+        expect(sql.contains('ON UPDATE SET NULL'), isTrue);
       });
     });
   });

--- a/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
@@ -44,7 +44,7 @@ void main() {
 
     var databaseDefinition = createDatabaseDefinitionFromEntities([entity]);
 
-    var failedPrecondition = databaseDefinition.tables.isEmpty;
+    var tablesDoNotExist = databaseDefinition.tables.isEmpty;
     test('then a foreign relation exists.', () {
       var table = databaseDefinition.tables.first;
       expect(
@@ -52,12 +52,12 @@ void main() {
         isNotEmpty,
         reason: 'Expected a foreign relation to exists.',
       );
-    }, skip: failedPrecondition);
+    }, skip: tablesDoNotExist);
 
     group(' ', () {
       var table = databaseDefinition.tables.first;
 
-      var failedPrecondition =
+      var foreignKeyDoNotExist =
           databaseDefinition.tables.first.foreignKeys.isEmpty;
 
       test('then the foreign key references is a self reference.', () {
@@ -68,7 +68,7 @@ void main() {
 
         var referenceColumn = foreignKey.referenceColumns.first;
         expect(referenceColumn, 'id');
-      }, skip: failedPrecondition);
+      }, skip: foreignKeyDoNotExist);
 
       test(
           'then generate a database definition with onDelete set on the foreign key.',
@@ -76,15 +76,15 @@ void main() {
         var foreignKey = table.foreignKeys.first;
 
         expect(foreignKey.onDelete, ForeignKeyAction.setNull);
-      }, skip: failedPrecondition);
+      }, skip: foreignKeyDoNotExist);
 
       test(
           'then generate a database definition with onUpdate set on the foreign key.',
           () {
         var foreignKey = table.foreignKeys.first;
         expect(foreignKey.onUpdate, ForeignKeyAction.setNull);
-      }, skip: failedPrecondition);
-    }, skip: failedPrecondition);
+      }, skip: foreignKeyDoNotExist);
+    }, skip: tablesDoNotExist);
 
     group('when generating sql code', () {
       // TODO: fix this, not sure what this does or why it is not set in the

--- a/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
@@ -96,11 +96,11 @@ void main() {
         module: 'mock',
       );
 
-      test('then on delete is set.', () {
+      test('then on delete is set to set null.', () {
         expect(sql.contains('ON DELETE SET NULL;'), isTrue);
       });
 
-      test('then on update is set.', () {
+      test('then on update is set to set null.', () {
         expect(sql.contains('ON UPDATE SET NULL;'), isTrue);
       });
     });

--- a/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
@@ -1,0 +1,88 @@
+import 'package:serverpod_cli/src/database/create_definition.dart';
+import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/foreign_relation_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/serializable_entity_field_definition_builder.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given a class definition with a table, then generate a table with that name.',
+      () {
+    var field = FieldDefinitionBuilder().withPrimaryKey().build();
+    var entity = ClassDefinitionBuilder()
+        .withTableName('example')
+        .withField(field)
+        .build();
+
+    var databaseDefinition = createDatabaseDefinitionFromEntities([entity]);
+
+    expect(databaseDefinition.tables, hasLength(1));
+    expect(databaseDefinition.tables.first.name, 'example');
+  });
+  group(
+      'Given a class definition with a foreign relation with onDelete and onUpdate set to "SetNull"',
+      () {
+    var relation = ForeignRelationDefinitionBuilder()
+        .withParentTable('example')
+        .withReferenceFieldName('id')
+        .withOnDelete(ForeignKeyAction.setNull)
+        .withOnUpdate(ForeignKeyAction.setNull)
+        .build();
+
+    var field = FieldDefinitionBuilder()
+        .withName('parentId')
+        .withIdType(true)
+        .withRelation(relation)
+        .build();
+
+    var entity = ClassDefinitionBuilder()
+        .withTableName('example')
+        .withField(field)
+        .build();
+
+    var databaseDefinition = createDatabaseDefinitionFromEntities([entity]);
+
+    var failedPrecondition = databaseDefinition.tables.isEmpty;
+    test('then a foreign relation exists.', () {
+      var table = databaseDefinition.tables.first;
+      expect(
+        table.foreignKeys,
+        isNotEmpty,
+        reason: 'Expected a foreign relation to exists.',
+      );
+    }, skip: failedPrecondition);
+
+    group(' ', () {
+      var table = databaseDefinition.tables.first;
+
+      var failedPrecondition =
+          databaseDefinition.tables.first.foreignKeys.isEmpty;
+
+      test('then the foreign key references is a self reference.', () {
+        var foreignKey = table.foreignKeys.first;
+
+        var referenceDatabase = foreignKey.referenceTable;
+        expect(referenceDatabase, 'example');
+
+        var referenceColumn = foreignKey.referenceColumns.first;
+        expect(referenceColumn, 'id');
+      }, skip: failedPrecondition);
+
+      test(
+          'then generate a database definition with onDelete set on the foreign key.',
+          () {
+        var foreignKey = table.foreignKeys.first;
+
+        expect(foreignKey.onDelete, ForeignKeyAction.setNull);
+      }, skip: failedPrecondition);
+
+      test(
+          'then generate a database definition with onUpdate set on the foreign key.',
+          () {
+        var foreignKey = table.foreignKeys.first;
+        expect(foreignKey.onUpdate, ForeignKeyAction.setNull);
+      }, skip: failedPrecondition);
+    }, skip: failedPrecondition);
+  });
+}

--- a/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/database/create_definition.dart';
 import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/foreign_relation_definition_builder.dart';
@@ -84,5 +85,24 @@ void main() {
         expect(foreignKey.onUpdate, ForeignKeyAction.setNull);
       }, skip: failedPrecondition);
     }, skip: failedPrecondition);
+
+    group('when generating sql code', () {
+      // TODO: fix this, not sure what this does or why it is not set in the
+      // definition creator ?! But code generator crashes without it.
+      databaseDefinition.priority = 1;
+
+      var sql = databaseDefinition.toPgSql(
+        version: 'version',
+        module: 'mock',
+      );
+
+      test('then on delete is set.', () {
+        expect(sql.contains('ON DELETE SET NULL;'), isTrue);
+      });
+
+      test('then on update is set.', () {
+        expect(sql.contains('ON UPDATE SET NULL;'), isTrue);
+      });
+    });
   });
 }

--- a/tools/serverpod_cli/test/database/extentions/pgsql_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/pgsql_code_generation_test.dart
@@ -55,9 +55,11 @@ ALTER TABLE ONLY "citizen"
     ADD CONSTRAINT "citizen_fk_0"
     FOREIGN KEY("companyId")
     REFERENCES "company"("id")
-    ON DELETE CASCADE;
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 ''');
 
+        expect(createCompanyIndex, isNot(-1));
         expect(createCompanyIndex, lessThan(createForeignKeyForCitizenIndex));
       });
 
@@ -69,9 +71,11 @@ ALTER TABLE ONLY "company"
     ADD CONSTRAINT "company_fk_0"
     FOREIGN KEY("townId")
     REFERENCES "town"("id")
-    ON DELETE CASCADE;
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 ''');
 
+        expect(createCompanyIndex, isNot(-1));
         expect(createCompanyIndex, lessThan(createForeignKeyForCitizenIndex));
       });
 
@@ -83,9 +87,11 @@ ALTER TABLE ONLY "town"
     ADD CONSTRAINT "town_fk_0"
     FOREIGN KEY("mayorId")
     REFERENCES "citizen"("id")
-    ON DELETE CASCADE;
+    ON DELETE CASCADE
+    ON UPDATE NO ACTION;
 ''');
 
+        expect(createCompanyIndex, isNot(-1));
         expect(createCompanyIndex, lessThan(createForeignKeyForCitizenIndex));
       });
     },

--- a/tools/serverpod_cli/test/generator/dart/server_generator.dart/generateProtocol/circular_relation_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_generator.dart/generateProtocol/circular_relation_test.dart
@@ -132,7 +132,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'company',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )
@@ -187,7 +187,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'town',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )
@@ -242,7 +242,7 @@ class Protocol extends _i1.SerializationManagerServer {
           referenceTable: 'citizen',
           referenceTableSchema: 'public',
           referenceColumns: ['id'],
-          onUpdate: null,
+          onUpdate: _i2.ForeignKeyAction.noAction,
           onDelete: _i2.ForeignKeyAction.cascade,
           matchType: null,
         )


### PR DESCRIPTION
# Changes

- New keyword `onDelete` in protocol, can have values `SetNull`, `SetDefault`, `Cascade`, `NoAction`, `Restrict`. Default to `Cascade` (previous behavior).
- New keyword `onUpdate` in protocol, can have values `SetNull`, `SetDefault`, `Cascade`, `NoAction`, `Restrict`. Default to `NoAction` (previous behavior).

Example:
```yaml
class: Example
table: example
fields:
  parent: Example, relation(onUpdate=Cascade, onDelete=SetNull)
```

Closes: https://github.com/serverpod/serverpod/issues/1148

## Tests

I set up the initial test structure for the database code generation, but there was some strange things regarding variables that we will have to take a look at. We should probably extract this code  into distinct modules to make it easier to test.

## Limitation

Since we do not support a default value yet `SetDefault` has limited use, but has the following default behavior in postgresql: 

PostgreSQL will try to replace the value with NULL (since NULL is the default value when no default value is specified). If the column is also set as NOT NULL, it would cause a constraint violation error because you're trying to set a NOT NULL column to NULL.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
