### PR TITLE
fix: Restrict persist key from being use on relations.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -462,15 +462,28 @@ class Restrictions {
     SourceSpan? span,
   ) {
     var definition = documentDefinition;
-    if (definition is ClassDefinition && definition.tableName == null) {
-      return [
-        SourceSpanSeverityException(
-          'The "persist" property requires a table to be set on the class.',
-          span,
-        )
-      ];
+    if (definition is! ClassDefinition) return [];
+
+    var errors = <SourceSpanSeverityException>[];
+
+    if (definition.tableName == null) {
+      errors.add(SourceSpanSeverityException(
+        'The "persist" property requires a table to be set on the class.',
+        span,
+      ));
     }
-    return [];
+
+    var field = definition.findField(parentNodeName);
+    if (definition.tableName != null && field?.shouldPersist != false) {
+      errors.add(SourceSpanSeverityException(
+        'Fields are persisted by default, the property can be removed.',
+        span,
+        severity: SourceSpanSeverity.hint,
+        tags: [SourceSpanTag.unnecessary],
+      ));
+    }
+
+    return errors;
   }
 
   List<SourceSpanSeverityException> validateEnumValues(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -49,7 +49,9 @@ class ClassYamlDefinition {
               ValidateNode(
                 Keyword.parent,
                 isDeprecated: true,
-                mutuallyExclusiveKeys: {Keyword.relation},
+                mutuallyExclusiveKeys: {
+                  Keyword.relation,
+                },
                 alternativeUsageMessage:
                     'Use the relation keyword instead. E.g. relation(parent=parent_table)',
                 valueRestriction: restrictions.validateParentName,
@@ -85,7 +87,12 @@ class ClassYamlDefinition {
                 Keyword.persist,
                 keyRestriction: restrictions.validatePersistKey,
                 valueRestriction: BooleanValueRestriction().validate,
-                mutuallyExclusiveKeys: {Keyword.database, Keyword.api},
+                mutuallyExclusiveKeys: {
+                  Keyword.database,
+                  Keyword.api,
+                  Keyword.relation,
+                  Keyword.parent,
+                },
               ),
               ValidateNode(
                 Keyword.database,

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
@@ -62,9 +63,9 @@ void main() {
         [definition!],
       );
 
-      test('then no errors are collected', () {
+      /*test('then no errors are collected', () {
         expect(collector.errors, isEmpty);
-      });
+      });*/
 
       test('then the generated entity should be persisted', () {
         expect(
@@ -174,6 +175,117 @@ void main() {
           isFalse,
         );
       });
+    },
+  );
+
+  test(
+    'Given a class with a field with persist negated and a relation defined, then collect an error that the keys are mutually exclusive.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          parent: Example?, !persist, relation
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.resolveEntityDependencies([entity!]);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        entity,
+        [entity],
+      );
+
+      expect(collector.errors, isNotEmpty);
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The "persist" property is mutually exclusive with the "relation" property.',
+      );
+    },
+  );
+
+  test(
+    'Given a class with a field with persist negated and a relation defined, then collect an error that the keys are mutually exclusive.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          parent: int?, !persist, parent=example
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.resolveEntityDependencies([entity!]);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        entity,
+        [entity],
+      );
+
+      expect(collector.errors, isNotEmpty);
+
+      var error = collector.errors.last;
+
+      expect(
+        error.message,
+        'The "persist" property is mutually exclusive with the "parent" property.',
+      );
+    },
+  );
+
+  test(
+    'Given a class with a field with a persist key set to true, then collect an info that the keyword is unnecessary.',
+    () {
+      var collector = CodeGenerationCollector();
+      var protocol = ProtocolSource(
+        '''
+        class: Example
+        table: example
+        fields:
+          parent: Example?, persist
+        ''',
+        Uri(path: 'lib/src/protocol/example.yaml'),
+        [],
+      );
+
+      var entity = SerializableEntityAnalyzer.extractEntityDefinition(protocol);
+      SerializableEntityAnalyzer.resolveEntityDependencies([entity!]);
+      SerializableEntityAnalyzer.validateYamlDefinition(
+        protocol.yaml,
+        protocol.yamlSourceUri.path,
+        collector,
+        entity,
+        [entity],
+      );
+
+      expect(collector.errors, isNotEmpty);
+
+      var error = collector.errors.first as SourceSpanSeverityException;
+
+      expect(
+        error.message,
+        'Fields are persisted by default, the property can be removed.',
+      );
+
+      expect(error.severity, SourceSpanSeverity.hint);
+      expect(error.tags?.first, SourceSpanTag.unnecessary);
     },
   );
 
@@ -336,7 +448,7 @@ void main() {
 
       expect(collector.errors.length, greaterThan(0));
 
-      var error = collector.errors.first;
+      var error = collector.errors.last;
 
       expect(error.message, 'The value must be a boolean.');
     },
@@ -392,7 +504,7 @@ void main() {
         class: Example
         table: example
         fields:
-          name: String, persist, database
+          name: String, !persist, database
         ''',
         Uri(path: 'lib/src/protocol/example.yaml'),
         [],

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_persist_test.dart
@@ -63,10 +63,6 @@ void main() {
         [definition!],
       );
 
-      /*test('then no errors are collected', () {
-        expect(collector.errors, isEmpty);
-      });*/
-
       test('then the generated entity should be persisted', () {
         expect(
           (definition as ClassDefinition).fields.last.shouldPersist,


### PR DESCRIPTION
# Changes

Make the `persist` key mutually exclusive with `relation` and `parent` keywords. Gives a hint that `persist` key is redundant to set to true on fields (on a class with a table).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
