### PR TITLE
fix: Only report duplicated and invalid negations once.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -110,7 +110,13 @@ Iterable<Map<YamlScalar, YamlNode>> _extractKeyValuePairs(
 }) {
   if (content == null) return [];
 
-  var fieldPairs = fieldOptions.map((stringifiedKeyValuePair) {
+  List<Map<YamlScalar, YamlNode>> fieldPairs = [];
+
+  // This must be a for loop and can never be converted to a map.
+  // There seems to be some type of bug (in dart?) that causes the loop
+  // to run several times if done with a map. There is also different behaviors
+  // between debug and normal runtime.
+  for (var stringifiedKeyValuePair in fieldOptions) {
     var keyValueSpan = _extractSubSpan(content, span, stringifiedKeyValuePair);
 
     if (_hasNestedStringifiedValues(stringifiedKeyValuePair)) {
@@ -121,16 +127,18 @@ Iterable<Map<YamlScalar, YamlNode>> _extractKeyValuePairs(
       var stringifiedContent = nestedComponents.last;
 
       if (stringifiedContent == '') {
-        return _createdYamlScalarNode(
+        fieldPairs.add(_createdYamlScalarNode(
           key,
           null,
           keyValueSpan,
-        );
+        ));
+        continue;
       } else {
         var nestedSpan = _extractSubSpan(content, span, stringifiedContent);
         var nodeMap = handleDeepNestedNodes(stringifiedContent, nestedSpan);
 
-        return _createYamlMapNode(key, nodeMap, keyValueSpan);
+        fieldPairs.add(_createYamlMapNode(key, nodeMap, keyValueSpan));
+        continue;
       }
     }
 
@@ -155,12 +163,13 @@ Iterable<Map<YamlScalar, YamlNode>> _extractKeyValuePairs(
       }
     }
 
-    return _createdYamlScalarNode(
+    fieldPairs.add(_createdYamlScalarNode(
       key,
       value,
       keyValueSpan,
-    );
-  });
+    ));
+    continue;
+  }
 
   return fieldPairs;
 }


### PR DESCRIPTION
# Changes

Fixes a bug where we reported duplicated keys and negated keys with a value more than once.

The previous implementation should logically be the same as this one, the difference is we now use a for loop instead of a map. The map caused the callbacks to trigger more times than items in the list we iterated over. I'm still not exactly sure why this is the case, this is a very strange situation and I have not been able to isolate the issue. But it does seem like the compiler does something clever with the map implementation and optimizes things in a way that cause the behavior difference. For now this solves the problem ill see if I can figure this out later.

Closes: https://github.com/serverpod/serverpod/issues/1284

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

