### PR TITLE
feat: Introduce scope "none".

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -154,6 +154,7 @@ class SerializableEntityFieldDefinition {
 enum EntityFieldScopeDefinition {
   all,
   serverOnly,
+  none,
 }
 
 /// The definition of an index for a file, that is also stored in the database.

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -123,8 +123,8 @@ class SerializableEntityFieldDefinition {
   /// - [shouldSerializeField]
   /// - [shouldSerializeFieldForDatabase]
   bool shouldIncludeField(bool serverCode) {
-    if (serverCode) return true;
-    return scope == EntityFieldScopeDefinition.all;
+    return scope == EntityFieldScopeDefinition.all ||
+        (serverCode && scope == EntityFieldScopeDefinition.serverOnly);
   }
 
   /// Returns true, if this field should be added to the serialization.

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/field_scope_test.dart
@@ -433,6 +433,7 @@ void main() {
       fields:
         name: String, scope=serverOnly
         example: String, scope=all
+        town: String, scope=none
       ''',
       Uri(path: 'lib/src/protocol/example.yaml'),
       [],
@@ -456,15 +457,22 @@ void main() {
 
     test('then the generated entity has the scope.', () {
       expect(
-        definition.fields.first.scope,
+        definition.fields[0].scope,
         EntityFieldScopeDefinition.serverOnly,
       );
     });
 
     test('then the generated entity has the scope.', () {
       expect(
-        definition.fields.last.scope,
+        definition.fields[1].scope,
         EntityFieldScopeDefinition.all,
+      );
+    });
+
+    test('then the generated entity has the scope.', () {
+      expect(
+        definition.fields[2].scope,
+        EntityFieldScopeDefinition.none,
       );
     });
   });
@@ -503,7 +511,7 @@ void main() {
 
     expect(
       collector.errors.first.message,
-      '"" is not a valid property. Valid properties are (all, serverOnly).',
+      '"" is not a valid property. Valid properties are (all, serverOnly, none).',
     );
   });
 
@@ -541,7 +549,7 @@ void main() {
 
     expect(
       collector.errors.first.message,
-      '"InvalidScope" is not a valid property. Valid properties are (all, serverOnly).',
+      '"InvalidScope" is not a valid property. Valid properties are (all, serverOnly, none).',
     );
   });
 

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/class_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/class_field_test.dart
@@ -273,7 +273,7 @@ void main() {
   });
 
   group(
-      'Given a class with a non persistent all scoped field when generating code',
+      'Given a class with a non persistent field with scope all when generating code',
       () {
     var entities = [
       ClassDefinitionBuilder()
@@ -317,7 +317,7 @@ void main() {
   });
 
   group(
-      'Given a class with a non persistent a server only scoped field when generating code',
+      'Given a class with a non persistent field with scope server only when generating code',
       () {
     var entities = [
       ClassDefinitionBuilder()
@@ -362,7 +362,7 @@ void main() {
   });
 
   group(
-      'Given a class with a non persistent a none scoped field when generating code',
+      'Given a class with a non persistent field with scope none when generating code',
       () {
     var entities = [
       ClassDefinitionBuilder()

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/class_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/class_field_test.dart
@@ -317,7 +317,7 @@ void main() {
   });
 
   group(
-      'Given a class with non persistent a server only scoped field when generating code',
+      'Given a class with a non persistent a server only scoped field when generating code',
       () {
     var entities = [
       ClassDefinitionBuilder()
@@ -352,6 +352,46 @@ void main() {
               name: 'title',
               type: 'String?',
             ),
+            isFalse,
+            reason: 'Field title should not be generated.');
+      },
+      skip: maybeClassNamedExample == null
+          ? 'Could not run test because $testClassName class was not found.'
+          : false,
+    );
+  });
+
+  group(
+      'Given a class with a non persistent a none scoped field when generating code',
+      () {
+    var entities = [
+      ClassDefinitionBuilder()
+          .withFileName(testClassFileName)
+          .withField(
+            SerializableEntityFieldDefinition(
+                name: 'title',
+                type: TypeDefinition(className: 'String', nullable: true),
+                scope: EntityFieldScopeDefinition.none,
+                shouldPersist: false),
+          )
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    var compilationUnit = parseString(content: codeMap[expectedFileName]!).unit;
+    var maybeClassNamedExample = CompilationUnitHelpers.tryFindClassDeclaration(
+        compilationUnit,
+        name: testClassName);
+    test(
+      'then class is NOT generated with that class variable.',
+      () {
+        expect(
+            CompilationUnitHelpers.hasFieldDeclaration(maybeClassNamedExample!,
+                name: 'title', type: 'String?'),
             isFalse,
             reason: 'Field title should not be generated.');
       },

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/class_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/class_field_test.dart
@@ -609,7 +609,7 @@ void main() {
   });
 
   group(
-      'Given a class with a non persistent all scoped field when generating code',
+      'Given a class with a non persistent field with scope all when generating code',
       () {
     var entities = [
       ClassDefinitionBuilder()
@@ -654,7 +654,7 @@ void main() {
   });
 
   group(
-      'Given a class with a non persistent serverOnly scoped field when generating code',
+      'Given a class with a non persistent field with scope serverOnly when generating code',
       () {
     var entities = [
       ClassDefinitionBuilder()
@@ -699,7 +699,7 @@ void main() {
   });
 
   group(
-      'Given a class with a non persistent none scoped field when generating code',
+      'Given a class with a non persistent field with scope none when generating code',
       () {
     var entities = [
       ClassDefinitionBuilder()

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/class_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/class_field_test.dart
@@ -608,7 +608,9 @@ void main() {
             : false);
   });
 
-  group('Given a class with an all scoped field when generating code', () {
+  group(
+      'Given a class with a non persistent all scoped field when generating code',
+      () {
     var entities = [
       ClassDefinitionBuilder()
           .withClassName(testClassName)
@@ -651,7 +653,9 @@ void main() {
     );
   });
 
-  group('Given a class with a database scoped field when generating code', () {
+  group(
+      'Given a class with a non persistent serverOnly scoped field when generating code',
+      () {
     var entities = [
       ClassDefinitionBuilder()
           .withClassName(testClassName)
@@ -687,6 +691,48 @@ void main() {
             ),
             isTrue,
             reason: 'Missing declaration for title field.');
+      },
+      skip: maybeClassNamedExample == null
+          ? 'Could not run test because $testClassName class was not found.'
+          : false,
+    );
+  });
+
+  group(
+      'Given a class with a non persistent none scoped field when generating code',
+      () {
+    var entities = [
+      ClassDefinitionBuilder()
+          .withClassName(testClassName)
+          .withFileName(testClassFileName)
+          .withField(
+            SerializableEntityFieldDefinition(
+              name: 'title',
+              type: TypeDefinition(className: 'String', nullable: true),
+              scope: EntityFieldScopeDefinition.none,
+              shouldPersist: false,
+            ),
+          )
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableEntitiesCode(
+      entities: entities,
+      config: config,
+    );
+
+    var compilationUnit = parseString(content: codeMap[expectedFilePath]!).unit;
+    var maybeClassNamedExample = CompilationUnitHelpers.tryFindClassDeclaration(
+        compilationUnit,
+        name: testClassName);
+    test(
+      'then a class is NOT generated with that class variable.',
+      () {
+        expect(
+            CompilationUnitHelpers.hasFieldDeclaration(maybeClassNamedExample!,
+                name: 'title', type: 'String?'),
+            isFalse,
+            reason: 'Found declaration for field that should not exist.');
       },
       skip: maybeClassNamedExample == null
           ? 'Could not run test because $testClassName class was not found.'


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod/issues/1281

Introduces scope "none" a long side "all" and "serverOnly".

The scope makes a field not available on the server or the client.
This will be used to create implicit fields in one to many relationships: https://github.com/serverpod/serverpod/issues/1239

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
