### PR TITLE
feat: Add ability to specify the relation field holding the id for object relations.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -225,37 +225,40 @@ class UnresolvedListRelationDefinition extends RelationDefinition {}
 /// to another Objects field name that holds the id of this object.
 class ListRelationDefinition extends RelationDefinition {
   /// References the field in the other object holding the id of this object.
-  String referenceFieldName;
+  String foreignFieldName;
 
   ListRelationDefinition({
-    required this.referenceFieldName,
+    required this.foreignFieldName,
   });
 }
 
 /// Used for relations for fields that point to another field that holds the id
 /// of another object.
 class ObjectRelationDefinition extends RelationDefinition {
-  /// If this field is a complex datatype with a parent relation in the database,
-  /// then [scalarFieldName] contains the name of the field with the foreign key.
-  final String scalarFieldName;
+  /// References the field in the current object that points to the foreign table.
+  final String fieldName;
 
   ObjectRelationDefinition({
-    required this.scalarFieldName,
+    required this.fieldName,
   });
 }
 
 class UnresolvedObjectRelationDefinition extends RelationDefinition {
-  final String scalarFieldName;
+  /// References the field in the current object that points to the foreign table.
+  final String fieldName;
 
-  final String referenceFieldName;
+  /// References the column in the unresolved [parentTable] that this field should be joined on.
+  final String foreignFieldName;
 
+  /// On delete behavior in the database.
   final ForeignKeyAction onDelete;
 
+  /// On update behavior in the database.
   final ForeignKeyAction onUpdate;
 
   UnresolvedObjectRelationDefinition({
-    required this.scalarFieldName,
-    required this.referenceFieldName,
+    required this.fieldName,
+    required this.foreignFieldName,
     required this.onDelete,
     required this.onUpdate,
   });
@@ -266,8 +269,10 @@ class UnresolvedForeignRelationDefinition extends RelationDefinition {
   /// References the column in the unresolved [parentTable] that this field should be joined on.
   String referenceFieldName;
 
+  /// On delete behavior in the database.
   final ForeignKeyAction onDelete;
 
+  /// On update behavior in the database.
   final ForeignKeyAction onUpdate;
 
   UnresolvedForeignRelationDefinition({
@@ -286,15 +291,17 @@ class ForeignRelationDefinition extends RelationDefinition {
   String parentTable;
 
   /// References the column in the [parentTable] that this field should be joined on.
-  String referenceFieldName;
+  String foreignFieldName;
 
+  /// On delete behavior in the database.
   final ForeignKeyAction onDelete;
 
+  /// On update behavior in the database.
   final ForeignKeyAction onUpdate;
 
   ForeignRelationDefinition({
     required this.parentTable,
-    required this.referenceFieldName,
+    required this.foreignFieldName,
     required this.onDelete,
     required this.onUpdate,
   });

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -244,6 +244,23 @@ class ObjectRelationDefinition extends RelationDefinition {
   });
 }
 
+class UnresolvedObjectRelationDefinition extends RelationDefinition {
+  final String scalarFieldName;
+
+  final String referenceFieldName;
+
+  final ForeignKeyAction onDelete;
+
+  final ForeignKeyAction onUpdate;
+
+  UnresolvedObjectRelationDefinition({
+    required this.scalarFieldName,
+    required this.referenceFieldName,
+    required this.onDelete,
+    required this.onUpdate,
+  });
+}
+
 /// Internal representation of an unresolved [ForeignRelationDefinition].
 class UnresolvedForeignRelationDefinition extends RelationDefinition {
   /// References the column in the unresolved [parentTable] that this field should be joined on.

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -321,14 +321,14 @@ class SerializableEntityAnalyzer {
     if (relation is! UnresolvedObjectRelationDefinition) return;
 
     fieldDefinition.relation = ObjectRelationDefinition(
-      scalarFieldName: relation.scalarFieldName,
+      fieldName: relation.fieldName,
     );
 
-    var field = classDefinition.findField(relation.scalarFieldName);
+    var field = classDefinition.findField(relation.fieldName);
     if (field == null) return;
 
     field.relation = UnresolvedForeignRelationDefinition(
-      referenceFieldName: relation.referenceFieldName,
+      referenceFieldName: relation.foreignFieldName,
       onUpdate: relation.onUpdate,
       onDelete: relation.onDelete,
     );
@@ -353,19 +353,19 @@ class SerializableEntityAnalyzer {
     var tableName = referenceClass.tableName;
     if (tableName is! String) return;
 
-    var scalarField = classDefinition.findField(
-      relation.scalarFieldName,
+    var relationField = classDefinition.findField(
+      relation.fieldName,
     );
 
-    var scalarRelation = scalarField?.relation;
-    if (scalarField == null) return;
-    if (scalarRelation is! UnresolvedForeignRelationDefinition) return;
+    var fieldRelation = relationField?.relation;
+    if (relationField == null) return;
+    if (fieldRelation is! UnresolvedForeignRelationDefinition) return;
 
-    scalarField.relation = ForeignRelationDefinition(
+    relationField.relation = ForeignRelationDefinition(
       parentTable: tableName,
-      referenceFieldName: scalarRelation.referenceFieldName,
-      onUpdate: scalarRelation.onUpdate,
-      onDelete: scalarRelation.onDelete,
+      foreignFieldName: fieldRelation.referenceFieldName,
+      onUpdate: fieldRelation.onUpdate,
+      onDelete: fieldRelation.onDelete,
     );
   }
 
@@ -387,17 +387,17 @@ class SerializableEntityAnalyzer {
 
     if (referenceClass is! ClassDefinition) return;
 
-    var referenceFields = referenceClass.fields.where((field) {
+    var foreignFields = referenceClass.fields.where((field) {
       var relation = field.relation;
       if (relation is! ForeignRelationDefinition) return false;
       return relation.parentTable == classDefinition.tableName;
     });
 
-    if (referenceFields.isEmpty) return;
+    if (foreignFields.isEmpty) return;
 
     // TODO: Handle multiple references.
     fieldDefinition.relation = ListRelationDefinition(
-      referenceFieldName: referenceFields.first.name,
+      foreignFieldName: foreignFields.first.name,
     );
   }
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -305,7 +305,7 @@ class SerializableEntityAnalyzer {
       fieldDefinition,
       entityDefinitions,
     );
-    _resolveIdRelationTable(
+    _resolveForeignRelationDefinition(
       classDefinition,
       fieldDefinition,
       entityDefinitions,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -169,54 +169,24 @@ class EntityParser {
 
     var scope = _parseClassFieldScope(value);
     var shouldPersist = _parseShouldPersist(value);
-    var isEnum = _parseIsEnumField(value);
-
-    var parentTable = _parseParentTable(value);
-    var relationFieldName = _parseRelationField(value, fieldName);
-    var manualRelationField = _parseManualRelationFieldPointer(value);
-
-    var onDelete = _parseDatabaseAction(
-      Keyword.onDelete,
-      onDeleteDefault,
-      value,
-    );
-    var onUpdate = _parseDatabaseAction(
-      Keyword.onUpdate,
-      onUpdateDefault,
-      value,
-    );
 
     var referenceFieldName = 'id';
+    String relationName = _parseFieldRelationName(value, fieldName);
 
-    RelationDefinition? relation;
-    if (parentTable != null) {
-      relation = ForeignRelationDefinition(
-        parentTable: parentTable,
-        foreignFieldName: referenceFieldName,
-        onUpdate: onUpdate,
-        onDelete: onDelete,
-      );
-    } else if (relationFieldName != null) {
-      relation = ObjectRelationDefinition(fieldName: relationFieldName);
-    } else if (typeResult.type.isList && _isRelation(value)) {
-      relation = UnresolvedListRelationDefinition();
-    } else if (manualRelationField != null) {
-      relation = UnresolvedObjectRelationDefinition(
-        fieldName: manualRelationField,
-        foreignFieldName: referenceFieldName,
-        onUpdate: onUpdate,
-        onDelete: onDelete,
-      );
-    }
+    RelationDefinition? relation = _parseRelation(
+      fieldName,
+      referenceFieldName,
+      typeResult,
+      value,
+    );
 
     return [
-      if (relationFieldName != null)
+      if (_shouldCreateRelationField(relation))
         SerializableEntityFieldDefinition(
-          name: relationFieldName,
-          relation: UnresolvedForeignRelationDefinition(
-            referenceFieldName: referenceFieldName,
-            onUpdate: onUpdate,
-            onDelete: onDelete,
+          name: relationName,
+          relation: _createUnresolvedForeignRelationDefinition(
+            value,
+            referenceFieldName,
           ),
           shouldPersist: true,
           scope: scope,
@@ -225,14 +195,99 @@ class EntityParser {
       SerializableEntityFieldDefinition(
         name: fieldName,
         relation: relation,
-        shouldPersist: relationFieldName != null || manualRelationField != null
-            ? false
-            : shouldPersist,
+        shouldPersist: _shouldNeverPersist(relation) ? false : shouldPersist,
         scope: scope,
-        type: typeResult.type..isEnum = isEnum,
+        type: typeResult.type,
         documentation: fieldDocumentation,
       )
     ];
+  }
+
+  static UnresolvedForeignRelationDefinition
+      _createUnresolvedForeignRelationDefinition(
+    YamlMap node,
+    String referenceFieldName,
+  ) {
+    var onDelete = _parseOnDelete(node);
+    var onUpdate = _parseOnUpdate(node);
+
+    return UnresolvedForeignRelationDefinition(
+      referenceFieldName: referenceFieldName,
+      onUpdate: onUpdate,
+      onDelete: onDelete,
+    );
+  }
+
+  static bool _shouldNeverPersist(RelationDefinition? relation) {
+    if (relation is ObjectRelationDefinition) return true;
+    if (relation is UnresolvedListRelationDefinition) return true;
+    if (relation is UnresolvedObjectRelationDefinition) return true;
+    return false;
+  }
+
+  static bool _shouldCreateRelationField(
+    RelationDefinition? relation,
+  ) {
+    return relation is ObjectRelationDefinition;
+  }
+
+  static RelationDefinition? _parseRelation(
+    String fieldName,
+    String referenceFieldName,
+    TypeParseResult typeResult,
+    YamlMap node,
+  ) {
+    if (!_isRelation(node)) return null;
+
+    if (typeResult.type.isList) {
+      return UnresolvedListRelationDefinition();
+    }
+
+    var parentTable = _parseParentTable(node);
+
+    var onDelete = _parseOnDelete(node);
+    var onUpdate = _parseOnUpdate(node);
+
+    if (parentTable != null) {
+      return ForeignRelationDefinition(
+        parentTable: parentTable,
+        foreignFieldName: referenceFieldName,
+        onUpdate: onUpdate,
+        onDelete: onDelete,
+      );
+    }
+
+    var relationFieldName = _parseFieldRelationName(node, fieldName);
+
+    if (_containsRelationKey(node, Keyword.field)) {
+      return UnresolvedObjectRelationDefinition(
+        fieldName: relationFieldName,
+        foreignFieldName: referenceFieldName,
+        onUpdate: onUpdate,
+        onDelete: onDelete,
+      );
+    }
+
+    if (!_isIdType(node)) {
+      return ObjectRelationDefinition(fieldName: relationFieldName);
+    }
+
+    return null;
+  }
+
+  static bool _containsRelationKey(YamlMap value, String key) {
+    var relationNode = value.nodes[Keyword.relation]?.value;
+    if (relationNode is! YamlMap) return false;
+    return relationNode.containsKey(key);
+  }
+
+  static String _parseFieldRelationName(YamlMap value, String fieldName) {
+    var relationFieldNode = _parseRelationNode(value, Keyword.field);
+    var relationField = relationFieldNode?.value;
+
+    if (relationField is String) return relationField;
+
+    return '${fieldName}Id';
   }
 
   static TypeDefinition _createRelationFieldType(YamlMap value) {
@@ -243,39 +298,26 @@ class EntityParser {
     }
   }
 
-  static bool _isListType(YamlMap value) {
-    var type = value.nodes[Keyword.type]?.value;
-    if (type is! String) return false;
-    return type.startsWith('List');
-  }
-
   static bool _isIdType(YamlMap value) {
     var type = value.nodes[Keyword.type]?.value;
     if (type is! String) return false;
     return AnalyzeChecker.isIdType(type);
   }
 
-  static String? _parseManualRelationFieldPointer(YamlMap value) {
-    if (!_isRelation(value)) return null;
-    if (_isIdType(value)) return null;
-    if (_isListType(value)) return null;
-
-    var relationFieldNode = _parseRelationNode(value, Keyword.field);
-    var relationField = relationFieldNode?.value;
-
-    if (relationField is! String) return null;
-    return relationField;
+  static ForeignKeyAction _parseOnUpdate(YamlMap node) {
+    return _parseDatabaseAction(
+      Keyword.onUpdate,
+      onUpdateDefault,
+      node,
+    );
   }
 
-  static String? _parseRelationField(YamlMap value, String fieldName) {
-    if (!_isRelation(value)) return null;
-    if (_isIdType(value)) return null;
-    if (_isListType(value)) return null;
-
-    var field = _parseRelationNode(value, Keyword.field);
-    if (field != null) return null;
-
-    return '${fieldName}Id';
+  static ForeignKeyAction _parseOnDelete(YamlMap node) {
+    return _parseDatabaseAction(
+      Keyword.onDelete,
+      onDeleteDefault,
+      node,
+    );
   }
 
   static ForeignKeyAction _parseDatabaseAction(
@@ -300,6 +342,7 @@ class EntityParser {
   }
 
   static bool _isRelation(YamlMap documentContents) {
+    if (documentContents.containsKey(Keyword.parent)) return true;
     return documentContents.containsKey(Keyword.relation);
   }
 
@@ -361,10 +404,6 @@ class EntityParser {
     if (parent is String) return parent;
 
     return null;
-  }
-
-  static bool _parseIsEnumField(YamlMap documentContents) {
-    return documentContents.containsKey(Keyword.enumType);
   }
 
   static List<SerializableEntityIndexDefinition>? _parseIndexes(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/keywords.dart
@@ -13,6 +13,7 @@ class Keyword {
   static const String unique = 'unique';
   static const String parent = 'parent';
   static const String relation = 'relation';
+  static const String field = 'field';
   static const String onUpdate = 'onUpdate';
   static const String onDelete = 'onDelete';
   static const String api = 'api';

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -291,12 +291,12 @@ class Restrictions {
     var parentClass = parentClasses.first;
     if (parentClass is! ClassDefinition) return [];
 
-    var referenceField = parentClass.findField(relation.foriegnFieldName);
+    var referenceField = parentClass.findField(relation.foreignFieldName);
 
     if (field.type.className != referenceField?.type.className) {
       return [
         SourceSpanSeverityException(
-          'The field "$fieldName" is of type "${field.type.className}" but reference field "${relation.foriegnFieldName}" is of type "${referenceField?.type.className}".',
+          'The field "$fieldName" is of type "${field.type.className}" but reference field "${relation.foreignFieldName}" is of type "${referenceField?.type.className}".',
           span,
         )
       ];

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -291,12 +291,12 @@ class Restrictions {
     var parentClass = parentClasses.first;
     if (parentClass is! ClassDefinition) return [];
 
-    var referenceField = parentClass.findField(relation.referenceFieldName);
+    var referenceField = parentClass.findField(relation.foriegnFieldName);
 
     if (field.type.className != referenceField?.type.className) {
       return [
         SourceSpanSeverityException(
-          'The field "$fieldName" is of type "${field.type.className}" but reference field "${relation.referenceFieldName}" is of type "${referenceField?.type.className}".',
+          'The field "$fieldName" is of type "${field.type.className}" but reference field "${relation.foriegnFieldName}" is of type "${referenceField?.type.className}".',
           span,
         )
       ];

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -272,6 +272,15 @@ class Restrictions {
       ];
     }
 
+    if (!field.shouldPersist) {
+      return [
+        SourceSpanSeverityException(
+          'The field "$fieldName" is not persisted and cannot be used in a relation.',
+          span,
+        )
+      ];
+    }
+
     var relation = field.relation;
     if (relation is! ForeignRelationDefinition) return [];
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -71,6 +71,11 @@ class ClassYamlDefinition {
                     valueRestriction: restrictions.validateParentName,
                   ),
                   ValidateNode(
+                    Keyword.field,
+                    keyRestriction: restrictions.validateRelationFieldKey,
+                    valueRestriction: restrictions.validateRelationFieldName,
+                  ),
+                  ValidateNode(
                     Keyword.onUpdate,
                     valueRestriction: EnumValueRestriction(
                       enums: ForeignKeyAction.values,

--- a/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
@@ -109,7 +109,7 @@ class ClassDefinitionBuilder {
           .withTypeDefinition(className, true)
           .withShouldPersist(false)
           .withRelation(ObjectRelationDefinition(
-            scalarFieldName: '${fieldName}Id',
+            fieldName: '${fieldName}Id',
           ))
           .build(),
       FieldDefinitionBuilder()

--- a/tools/serverpod_cli/lib/src/test_util/builders/foreign_relation_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/foreign_relation_definition_builder.dart
@@ -31,7 +31,7 @@ class ForeignRelationDefinitionBuilder {
   ForeignRelationDefinition build() {
     return ForeignRelationDefinition(
       parentTable: parentTable,
-      foriegnFieldName: referenceFieldName,
+      foreignFieldName: referenceFieldName,
       onDelete: onDelete,
       onUpdate: onUpdate,
     );

--- a/tools/serverpod_cli/lib/src/test_util/builders/foreign_relation_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/foreign_relation_definition_builder.dart
@@ -31,7 +31,7 @@ class ForeignRelationDefinitionBuilder {
   ForeignRelationDefinition build() {
     return ForeignRelationDefinition(
       parentTable: parentTable,
-      referenceFieldName: referenceFieldName,
+      foriegnFieldName: referenceFieldName,
       onDelete: onDelete,
       onUpdate: onUpdate,
     );

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -45,19 +45,19 @@ fields:
     });
 
     test(
-        'then a scalar field with the same name appended with Id is set on the relation field.',
+        'then a relation field with the same name appended with Id is set on the relation field.',
         () {
       var parent = classDefinition.findField('parent');
       var relation = parent?.relation;
       expect(relation.runtimeType, ObjectRelationDefinition);
       expect(
-        (relation as ObjectRelationDefinition).scalarFieldName,
+        (relation as ObjectRelationDefinition).fieldName,
         'parentId',
       );
     });
 
     var parentId = classDefinition.findField('parentId');
-    test('then the class has a scalar field for the id.', () {
+    test('then the class has a relation field for the id.', () {
       expect(
         parentId,
         isNotNull,
@@ -66,15 +66,15 @@ fields:
     });
 
     group('', () {
-      test('then the scalar field has the global scope.', () {
+      test('then the relation field has the global scope.', () {
         expect(parentId?.scope, EntityFieldScopeDefinition.all);
       });
 
-      test('then the scalar field should be persisted.', () {
+      test('then the relation field should be persisted.', () {
         expect(parentId?.shouldPersist, isTrue);
       });
 
-      test('then the scalar field type defaults to none nullable.', () {
+      test('then the relation field type defaults to none nullable.', () {
         expect(
           parentId?.type.nullable,
           isFalse,
@@ -83,7 +83,7 @@ fields:
       });
 
       test(
-          'then the scalar field has the parent table set from the object reference.',
+          'then the relation field has the parent table set from the object reference.',
           () {
         var parent = classDefinition.findField('parentId');
         var relation = parent?.relation;
@@ -93,14 +93,14 @@ fields:
       });
 
       test(
-          'then the scalar field has the reference field set to the relation id field.',
+          'then the relation field has the reference field set to the relation id field.',
           () {
         var parent = classDefinition.findField('parentId');
         var relation = parent?.relation;
 
         expect(relation.runtimeType, ForeignRelationDefinition);
         expect(
-            (relation as ForeignRelationDefinition).referenceFieldName, 'id');
+            (relation as ForeignRelationDefinition).foreignFieldName, 'id');
       });
     }, skip: parentId == null);
   });
@@ -140,7 +140,7 @@ fields:
       expect(collector.errors, isEmpty);
     });
 
-    test('then scalar field is nullable.', () {
+    test('then relation field is nullable.', () {
       var parent = classDefinition.findField('parentId');
       expect(parent?.type.nullable, isTrue, reason: 'Expected to be nullable.');
     });
@@ -181,7 +181,7 @@ fields:
       expect(collector.errors, isEmpty);
     });
 
-    test('then scalar field is not nullable.', () {
+    test('then relation field is not nullable.', () {
       var parent = classDefinition.findField('parentId');
       expect(parent?.type.nullable, isFalse,
           reason: 'Expected to not be nullable.');
@@ -329,10 +329,10 @@ fields:
     test('then the relation is set with the reference to the id.', () {
       var relation = classDefinition.fields.last.relation;
       expect(relation.runtimeType, ForeignRelationDefinition);
-      expect((relation as ForeignRelationDefinition).referenceFieldName, 'id');
+      expect((relation as ForeignRelationDefinition).foreignFieldName, 'id');
     });
 
-    test('then no scalar field is added', () {
+    test('then no relation field is added', () {
       expect(classDefinition.findField('parentIdId'), isNull);
     });
   });
@@ -725,7 +725,7 @@ fields:
       expect(collector.errors, isEmpty);
     });
 
-    test('then a relation with the parent table is set on the scalar field.',
+    test('then a relation with the parent table is set on the relation field.',
         () {
       var relation = classDefinition.findField('parentId')?.relation;
 
@@ -734,12 +734,12 @@ fields:
           'example_parent');
     });
 
-    test('then a relation with the reference id is set on the scalar field.',
+    test('then a relation with the reference id is set on the relation field.',
         () {
       var relation = classDefinition.findField('parentId')?.relation;
 
       expect(relation.runtimeType, ForeignRelationDefinition);
-      expect((relation as ForeignRelationDefinition).referenceFieldName, 'id');
+      expect((relation as ForeignRelationDefinition).foreignFieldName, 'id');
     });
   });
 
@@ -791,7 +791,7 @@ fields:
       expect(collector.errors, isEmpty);
     });
 
-    test('then no scalar field is created.', () {
+    test('then no relation field is created.', () {
       var parentField = classDefinition.findField('parentId');
 
       expect(parentField, isNull);
@@ -852,7 +852,7 @@ fields:
       expect(collector.errors, isEmpty);
     });
 
-    test('then no scalar field is created.', () {
+    test('then no relation field is created.', () {
       var parentField = classDefinition.findField('parentId');
 
       expect(parentField, isNull);

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_keyword_test.dart
@@ -99,8 +99,7 @@ fields:
         var relation = parent?.relation;
 
         expect(relation.runtimeType, ForeignRelationDefinition);
-        expect(
-            (relation as ForeignRelationDefinition).foreignFieldName, 'id');
+        expect((relation as ForeignRelationDefinition).foreignFieldName, 'id');
       });
     }, skip: parentId == null);
   });

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_manual_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_manual_field_test.dart
@@ -261,7 +261,7 @@ fields:
     });
 
     test(
-        'then the error message reports that the field keyword cannot be used on a List relation.',
+        'then the error message reports that the field keyword cannot be used on an id relation.',
         () {
       var error = collector.errors.first;
       expect(

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_manual_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_manual_field_test.dart
@@ -1,0 +1,342 @@
+import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/entities/entity_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(
+      'Given a class with a relation with a defined field name that holds the relation',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol1 = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  myParentId: int
+  parent: ExampleParent?, relation(field=myParentId)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var protocol2 = ProtocolSource(
+      '''
+class: ExampleParent
+table: example_parent
+fields:
+  name: String
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var definition1 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol1,
+    );
+
+    var definition2 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol2,
+    );
+
+    var entities = [definition1!, definition2!];
+    SerializableEntityAnalyzer.resolveEntityDependencies(entities);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol1.yaml,
+      protocol1.yamlSourceUri.path,
+      collector,
+      definition1,
+      entities,
+    );
+
+    var exampleClass = definition1 as ClassDefinition;
+
+    test('then no errors were collected', () {
+      expect(
+        collector.errors,
+        isEmpty,
+      );
+    });
+
+    test('then the implicit parentId field is NOT created', () {
+      var field = exampleClass.findField('parentId');
+      expect(field, isNull);
+    });
+
+    test('then the relation field pointer is set on the object relation.', () {
+      var relation = exampleClass.findField('parent')?.relation;
+      expect(relation.runtimeType, ObjectRelationDefinition);
+      expect(
+        (relation as ObjectRelationDefinition).scalarFieldName,
+        'myParentId',
+      );
+    });
+
+    test('then the parent field is set to NOT persist.', () {
+      var field = exampleClass.findField('parent');
+      expect(field?.shouldPersist, isFalse);
+    });
+  });
+
+  group('Given a class with a relation pointing to a field that does not exist',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol1 = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  parent: Example?, relation(field=myParentId)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var definition1 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol1,
+    );
+
+    var entities = [definition1!];
+    SerializableEntityAnalyzer.resolveEntityDependencies(entities);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol1.yaml,
+      protocol1.yamlSourceUri.path,
+      collector,
+      definition1,
+      entities,
+    );
+
+    var errors = collector.errors;
+
+    test('then an error was collected.', () {
+      expect(errors, isNotEmpty);
+    });
+
+    test('then the error message reports that the field is missing.', () {
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The field "myParentId" was not found in the class.',
+      );
+    }, skip: errors.isEmpty);
+
+    test('then the error is reported at the field value location.', () {
+      var span = collector.errors.first.span;
+
+      expect(span?.start.line, 3);
+      expect(span?.start.column, 35);
+
+      expect(span?.end.line, 3);
+      expect(span?.end.column, 35 + 'myParentId'.length);
+    }, skip: errors.isEmpty);
+  });
+
+  group('Given a class with a List relation with a field pointer defined', () {
+    var collector = CodeGenerationCollector();
+
+    var protocol1 = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  myChildId: int
+  child: List<ExampleChild>?, relation(field=myChildId)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var protocol2 = ProtocolSource(
+      '''
+class: ExampleChild
+table: example_child
+fields:
+  name: String
+  exampleId: int, relation(parent=example)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var definition1 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol1,
+    );
+
+    var definition2 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol2,
+    );
+
+    var entities = [definition1!, definition2!];
+    SerializableEntityAnalyzer.resolveEntityDependencies(entities);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol1.yaml,
+      protocol1.yamlSourceUri.path,
+      collector,
+      definition1,
+      entities,
+    );
+
+    var errors = collector.errors;
+
+    test('then an error was collected.', () {
+      expect(errors, isNotEmpty);
+    });
+
+    test(
+        'then the error message reports that the field keyword cannot be used on a List relation.',
+        () {
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The "field" property can only be used on an object relation.',
+      );
+    }, skip: errors.isEmpty);
+
+    test('then the error is reported at the field key location.', () {
+      var span = collector.errors.first.span;
+
+      expect(span?.start.line, 4);
+      expect(span?.start.column, 39);
+
+      expect(span?.end.line, 4);
+      expect(span?.end.column, 39 + 'field'.length);
+    }, skip: errors.isEmpty);
+  });
+
+  group('Given a class with an id relation with a field pointer defined', () {
+    var collector = CodeGenerationCollector();
+
+    var protocol1 = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  otherId: int
+  exampleChildId: int, relation(parent=example_child, field=otherId)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var protocol2 = ProtocolSource(
+      '''
+class: ExampleChild
+table: example_child
+fields:
+  name: String
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var definition1 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol1,
+    );
+
+    var definition2 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol2,
+    );
+
+    var entities = [definition1!, definition2!];
+    SerializableEntityAnalyzer.resolveEntityDependencies(entities);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol1.yaml,
+      protocol1.yamlSourceUri.path,
+      collector,
+      definition1,
+      entities,
+    );
+
+    var errors = collector.errors;
+
+    test('then an error was collected.', () {
+      expect(errors, isNotEmpty);
+    });
+
+    test(
+        'then the error message reports that the field keyword cannot be used on a List relation.',
+        () {
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The "field" property can only be used on an object relation.',
+      );
+    }, skip: errors.isEmpty);
+
+    test('then the error is reported at the field key location.', () {
+      var span = collector.errors.first.span;
+
+      expect(span?.start.line, 4);
+      expect(span?.start.column, 54);
+
+      expect(span?.end.line, 4);
+      expect(span?.end.column, 54 + 'field'.length);
+    }, skip: errors.isEmpty);
+  });
+
+  group(
+      'Given a class with a relation pointing to a field with a mismatching type to the reference',
+      () {
+    var collector = CodeGenerationCollector();
+
+    var protocol1 = ProtocolSource(
+      '''
+class: Example
+table: example
+fields:
+  myParentId: String
+  parent: Example?, relation(field=myParentId)
+''',
+      Uri(path: 'lib/src/protocol/example.yaml'),
+      [],
+    );
+
+    var definition1 = SerializableEntityAnalyzer.extractEntityDefinition(
+      protocol1,
+    );
+
+    var entities = [definition1!];
+    SerializableEntityAnalyzer.resolveEntityDependencies(entities);
+
+    SerializableEntityAnalyzer.validateYamlDefinition(
+      protocol1.yaml,
+      protocol1.yamlSourceUri.path,
+      collector,
+      definition1,
+      entities,
+    );
+
+    var errors = collector.errors;
+
+    test('then an error was collected.', () {
+      expect(errors, isNotEmpty);
+    });
+
+    test(
+        'then the error message reports that the field has a mismatching type to the reference.',
+        () {
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The field "myParentId" is of type "String" but reference field "id" is of type "int".',
+      );
+    }, skip: errors.isEmpty);
+
+    test('then the error is reported at the field key location.', () {
+      var span = collector.errors.first.span;
+
+      expect(span?.start.line, 4);
+      expect(span?.start.column, 35);
+
+      expect(span?.end.line, 4);
+      expect(span?.end.column, 35 + 'myParentId'.length);
+    }, skip: errors.isEmpty);
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_manual_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_manual_field_test.dart
@@ -70,7 +70,7 @@ fields:
       var relation = exampleClass.findField('parent')?.relation;
       expect(relation.runtimeType, ObjectRelationDefinition);
       expect(
-        (relation as ObjectRelationDefinition).scalarFieldName,
+        (relation as ObjectRelationDefinition).fieldName,
         'myParentId',
       );
     });

--- a/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/entity_analyzer/relation_one_to_many_test.dart
@@ -76,7 +76,7 @@ fields:
 
       expect(relation.runtimeType, ListRelationDefinition);
       expect(
-        (relation as ListRelationDefinition).referenceFieldName,
+        (relation as ListRelationDefinition).foreignFieldName,
         'companyId',
         reason: 'Expected the reference field to be set to "companyId".',
       );


### PR DESCRIPTION
# Changes

- Adds the `field` keyword to be used on relations.
- `field` keyword cannot be used on list relations or id relations.
- The named field must exist in the class
- The field type must match the reference field type (I.E. be an int).

Closes: https://github.com/serverpod/serverpod/issues/1150

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

