### PR TITLE
refactor: Break out entities library generator into functions.

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
@@ -35,768 +35,762 @@ class SerializableEntityLibraryGenerator {
     var objectRelationFields =
         fields.where((field) => field.relation is ObjectRelationDefinition);
 
-    var library = Library(
-      (library) {
-        library.body.add(Class((classBuilder) {
-          classBuilder
-            ..name = className
-            ..docs.addAll(classDefinition.documentation ?? []);
-          if (classDefinition.isException) {
-            classBuilder.implements = ListBuilder(
-                [refer('SerializableException', serverpodUrl(serverCode))]);
-          }
+    return Library(
+      (libraryBuilder) {
+        libraryBuilder.body.add(_buildEntityClass(
+          className,
+          classDefinition,
+          tableName,
+          fields,
+          objectRelationFields,
+        ));
 
-          if (serverCode && tableName != null) {
-            classBuilder.extend =
-                refer('TableRow', 'package:serverpod/serverpod.dart');
+        if (serverCode && tableName != null) {
+          libraryBuilder.body.addAll([
+            _buildExpressionBuilderTypeDef(
+              className,
+            ),
+            _buildEntityTableClass(
+              className,
+              tableName,
+              fields,
+              classDefinition,
+            ),
+            _buildDeprecatedStaticTableInstance(
+              className,
+            ),
+            _buildEntityIncludeClass(
+              className,
+              fields,
+              classDefinition,
+            ),
+          ]);
+        }
+      },
+    );
+  }
 
-            classBuilder.fields.add(Field((f) => f
-              ..static = true
-              ..modifier = FieldModifier.final$
-              ..name = 't'
-              ..assignment = refer('${className}Table').call([]).code));
+  Class _buildEntityClass(
+    String className,
+    ClassDefinition classDefinition,
+    String? tableName,
+    List<SerializableEntityFieldDefinition> fields,
+    Iterable<SerializableEntityFieldDefinition> objectRelationFields,
+  ) {
+    return Class((classBuilder) {
+      classBuilder
+        ..name = className
+        ..docs.addAll(classDefinition.documentation ?? []);
 
-            // add tableName getter
-            classBuilder.methods.add(Method(
-              (m) => m
-                ..name = 'tableName'
-                ..annotations.add(refer('override'))
-                ..type = MethodType.getter
-                ..returns = refer('String')
-                ..lambda = true
-                ..body = Code('\'$tableName\''),
-            ));
-          } else {
-            classBuilder.extend =
-                refer('SerializableEntity', serverpodUrl(serverCode));
-          }
+      if (classDefinition.isException) {
+        classBuilder.implements = ListBuilder(
+            [refer('SerializableException', serverpodUrl(serverCode))]);
+      }
 
-          // Fields
-          for (var field in fields) {
-            if (field.shouldIncludeField(serverCode) &&
-                !(field.name == 'id' && serverCode && tableName != null)) {
-              classBuilder.fields.add(Field((f) {
-                f.type = field.type.reference(serverCode,
-                    subDirParts: classDefinition.subDirParts, config: config);
-                f
-                  ..name = field.name
-                  ..docs.addAll(field.documentation ?? []);
+      if (serverCode && tableName != null) {
+        classBuilder.extend =
+            refer('TableRow', 'package:serverpod/serverpod.dart');
+
+        classBuilder.fields.add(Field((f) => f
+          ..static = true
+          ..modifier = FieldModifier.final$
+          ..name = 't'
+          ..assignment = refer('${className}Table').call([]).code));
+
+        // add tableName getter
+        classBuilder.methods.add(Method(
+          (m) => m
+            ..name = 'tableName'
+            ..annotations.add(refer('override'))
+            ..type = MethodType.getter
+            ..returns = refer('String')
+            ..lambda = true
+            ..body = Code('\'$tableName\''),
+        ));
+      } else {
+        classBuilder.extend =
+            refer('SerializableEntity', serverpodUrl(serverCode));
+      }
+
+      // Fields
+      for (var field in fields) {
+        if (field.shouldIncludeField(serverCode) &&
+            !(field.name == 'id' && serverCode && tableName != null)) {
+          classBuilder.fields.add(Field((f) {
+            f.type = field.type.reference(serverCode,
+                subDirParts: classDefinition.subDirParts, config: config);
+            f
+              ..name = field.name
+              ..docs.addAll(field.documentation ?? []);
+          }));
+        }
+      }
+
+      // Default constructor
+      classBuilder.constructors.add(Constructor((c) {
+        for (var field in fields) {
+          if (field.shouldIncludeField(serverCode)) {
+            if (field.name == 'id' && serverCode && tableName != null) {
+              c.optionalParameters.add(Parameter((p) {
+                p.named = true;
+                p.name = 'id';
+                p.type = TypeReference(
+                  (t) => t
+                    ..symbol = 'int'
+                    ..isNullable = true,
+                );
+              }));
+            } else {
+              c.optionalParameters.add(Parameter((p) {
+                p.named = true;
+                p.required = !field.type.nullable;
+                p.toThis = true;
+                p.name = field.name;
               }));
             }
           }
+        }
+        if (serverCode && tableName != null) {
+          c.initializers.add(refer('super').call([refer('id')]).code);
+        }
+      }));
 
-          // Default constructor
-          classBuilder.constructors.add(Constructor((c) {
-            for (var field in fields) {
-              if (field.shouldIncludeField(serverCode)) {
-                if (field.name == 'id' && serverCode && tableName != null) {
-                  c.optionalParameters.add(Parameter((p) {
-                    p.named = true;
-                    p.name = 'id';
-                    p.type = TypeReference(
-                      (t) => t
-                        ..symbol = 'int'
-                        ..isNullable = true,
-                    );
-                  }));
-                } else {
-                  c.optionalParameters.add(Parameter((p) {
-                    p.named = true;
-                    p.required = !field.type.nullable;
-                    p.toThis = true;
-                    p.name = field.name;
-                  }));
-                }
-              }
-            }
-            if (serverCode && tableName != null) {
-              c.initializers.add(refer('super').call([refer('id')]).code);
-            }
-          }));
+      // Deserialization
+      classBuilder.constructors.add(Constructor((c) {
+        c.factory = true;
+        c.name = 'fromJson';
+        c.requiredParameters.addAll([
+          Parameter((p) {
+            p.name = 'jsonSerialization';
+            p.type = refer('Map<String,dynamic>');
+          }),
+          Parameter((p) {
+            p.name = 'serializationManager';
+            p.type = refer('SerializationManager', serverpodUrl(serverCode));
+          }),
+        ]);
+        c.body = refer(className)
+            .call([], {
+              for (var field in fields)
+                if (field.shouldIncludeField(serverCode))
+                  field.name: refer('serializationManager')
+                      .property('deserialize')
+                      .call([
+                    refer('jsonSerialization').index(literalString(field.name))
+                  ], {}, [
+                    field.type.reference(serverCode,
+                        subDirParts: classDefinition.subDirParts,
+                        config: config)
+                  ])
+            })
+            .returned
+            .statement;
+      }));
 
-          // Deserialization
-          classBuilder.constructors.add(Constructor((c) {
-            c.factory = true;
-            c.name = 'fromJson';
-            c.requiredParameters.addAll([
-              Parameter((p) {
-                p.name = 'jsonSerialization';
-                p.type = refer('Map<String,dynamic>');
-              }),
-              Parameter((p) {
-                p.name = 'serializationManager';
-                p.type =
-                    refer('SerializationManager', serverpodUrl(serverCode));
-              }),
-            ]);
-            c.body = refer(className)
-                .call([], {
-                  for (var field in fields)
-                    if (field.shouldIncludeField(serverCode))
-                      field.name: refer('serializationManager')
-                          .property('deserialize')
-                          .call([
-                        refer('jsonSerialization')
-                            .index(literalString(field.name))
-                      ], {}, [
-                        field.type.reference(serverCode,
-                            subDirParts: classDefinition.subDirParts,
-                            config: config)
-                      ])
-                })
-                .returned
-                .statement;
-          }));
+      // Serialization
+      classBuilder.methods.add(Method(
+        (m) {
+          m.returns = refer('Map<String,dynamic>');
+          m.name = 'toJson';
+          m.annotations.add(refer('override'));
 
-          // Serialization
+          m.body = literalMap(
+            {
+              for (var field in fields)
+                if (field.shouldSerializeField(serverCode))
+                  literalString(field.name): refer(field.name)
+            },
+          ).returned.statement;
+        },
+      ));
+
+      // Serialization for database and everything
+      if (serverCode) {
+        if (tableName != null) {
           classBuilder.methods.add(Method(
             (m) {
               m.returns = refer('Map<String,dynamic>');
-              m.name = 'toJson';
+              // TODO: better name
+              m.name = 'toJsonForDatabase';
               m.annotations.add(refer('override'));
 
               m.body = literalMap(
                 {
                   for (var field in fields)
-                    if (field.shouldSerializeField(serverCode))
+                    if (field.shouldSerializeFieldForDatabase(serverCode))
                       literalString(field.name): refer(field.name)
                 },
               ).returned.statement;
             },
           ));
+        }
 
-          // Serialization for database and everything
-          if (serverCode) {
-            if (tableName != null) {
-              classBuilder.methods.add(Method(
-                (m) {
-                  m.returns = refer('Map<String,dynamic>');
-                  // TODO: better name
-                  m.name = 'toJsonForDatabase';
-                  m.annotations.add(refer('override'));
+        classBuilder.methods.add(Method(
+          (m) {
+            m.returns = refer('Map<String,dynamic>');
+            m.name = 'allToJson';
+            m.annotations.add(refer('override'));
 
-                  m.body = literalMap(
-                    {
-                      for (var field in fields)
-                        if (field.shouldSerializeFieldForDatabase(serverCode))
-                          literalString(field.name): refer(field.name)
-                    },
-                  ).returned.statement;
-                },
-              ));
-            }
-
-            classBuilder.methods.add(Method(
-              (m) {
-                m.returns = refer('Map<String,dynamic>');
-                m.name = 'allToJson';
-                m.annotations.add(refer('override'));
-
-                m.body = literalMap(
-                  {
-                    for (var field in fields)
-                      literalString(field.name): refer(field.name)
-                  },
-                  //  refer('String'), refer('dynamic')
-                ).returned.statement;
+            m.body = literalMap(
+              {
+                for (var field in fields)
+                  literalString(field.name): refer(field.name)
               },
-            ));
+              //  refer('String'), refer('dynamic')
+            ).returned.statement;
+          },
+        ));
 
-            if (tableName != null) {
-              // Column setter
-              classBuilder.methods.add(Method((m) => m
-                ..annotations.add(refer('override'))
-                ..name = 'setColumn'
-                ..returns = refer('void')
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..name = 'columnName'
-                    ..type = refer('String')),
-                  Parameter((p) => p..name = 'value'),
-                ])
-                ..body = Block.of([
-                  const Code('switch(columnName){'),
-                  for (var field in fields)
-                    if (field.shouldSerializeFieldForDatabase(serverCode))
-                      Block.of([
-                        Code('case \'${field.name}\':'),
-                        refer(field.name).assign(refer('value')).statement,
-                        refer('').returned.statement,
-                      ]),
-                  const Code('default:'),
-                  refer('UnimplementedError').call([]).thrown.statement,
-                  const Code('}'),
-                ])));
+        if (tableName != null) {
+          // Column setter
+          classBuilder.methods.add(Method((m) => m
+            ..annotations.add(refer('override'))
+            ..name = 'setColumn'
+            ..returns = refer('void')
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..name = 'columnName'
+                ..type = refer('String')),
+              Parameter((p) => p..name = 'value'),
+            ])
+            ..body = Block.of([
+              const Code('switch(columnName){'),
+              for (var field in fields)
+                if (field.shouldSerializeFieldForDatabase(serverCode))
+                  Block.of([
+                    Code('case \'${field.name}\':'),
+                    refer(field.name).assign(refer('value')).statement,
+                    refer('').returned.statement,
+                  ]),
+              const Code('default:'),
+              refer('UnimplementedError').call([]).thrown.statement,
+              const Code('}'),
+            ])));
 
-              // find
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'find'
-                ..returns = TypeReference(
+          // find
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'find'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(TypeReference(
                   (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(TypeReference(
-                      (r) => r
-                        ..symbol = 'List'
-                        ..types.add(
-                          TypeReference(
-                            (r) => r..symbol = className,
-                          ),
-                        ),
-                    )),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                ])
-                ..optionalParameters.addAll([
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = '${className}ExpressionBuilder')
-                    ..name = 'where'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'int')
-                    ..name = 'limit'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'int')
-                    ..name = 'offset'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Column'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'orderBy'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((t) => t
-                      ..symbol = 'List'
-                      ..isNullable = true
-                      ..types.add(
-                          refer('Order', 'package:serverpod/serverpod.dart')))
-                    ..name = 'orderByList'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = refer('bool')
-                    ..name = 'orderDescending'
-                    ..defaultTo = const Code('false')
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = refer('bool')
-                    ..name = 'useCache'
-                    ..defaultTo = const Code('true')
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Transaction'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'transaction'
-                    ..named = true),
-                  if (objectRelationFields.isNotEmpty)
-                    Parameter((p) => p
-                      ..type = TypeReference((b) => b
-                        ..isNullable = true
-                        ..symbol = '${className}Include')
-                      ..name = 'include'
-                      ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('find')
-                    .call([], {
-                      'where': refer('where')
-                          .notEqualTo(refer('null'))
-                          .conditional(
-                              refer('where')
-                                  .call([refer(className).property('t')]),
-                              refer('null')),
-                      'limit': refer('limit'),
-                      'offset': refer('offset'),
-                      'orderBy': refer('orderBy'),
-                      'orderByList': refer('orderByList'),
-                      'orderDescending': refer('orderDescending'),
-                      'useCache': refer('useCache'),
-                      'transaction': refer('transaction'),
-                      if (objectRelationFields.isNotEmpty)
-                        'include': refer('include'),
-                    }, [
-                      refer(className)
-                    ])
-                    .returned
-                    .statement));
-
-              // find single row
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'findSingleRow'
-                ..returns = TypeReference(
-                  (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(TypeReference(
-                      (r) => r
-                        ..symbol = className
-                        ..isNullable = true,
-                    )),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                ])
-                ..optionalParameters.addAll([
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = '${className}ExpressionBuilder')
-                    ..name = 'where'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'int')
-                    ..name = 'offset'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Column'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'orderBy'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = refer('bool')
-                    ..name = 'orderDescending'
-                    ..defaultTo = const Code('false')
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = refer('bool')
-                    ..name = 'useCache'
-                    ..defaultTo = const Code('true')
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Transaction'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'transaction'
-                    ..named = true),
-                  if (objectRelationFields.isNotEmpty)
-                    Parameter((p) => p
-                      ..type = TypeReference((b) => b
-                        ..isNullable = true
-                        ..symbol = '${className}Include')
-                      ..name = 'include'
-                      ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('findSingleRow')
-                    .call([], {
-                      'where': refer('where')
-                          .notEqualTo(refer('null'))
-                          .conditional(
-                              refer('where')
-                                  .call([refer(className).property('t')]),
-                              refer('null')),
-                      'offset': refer('offset'),
-                      'orderBy': refer('orderBy'),
-                      'orderDescending': refer('orderDescending'),
-                      'useCache': refer('useCache'),
-                      'transaction': refer('transaction'),
-                      if (objectRelationFields.isNotEmpty)
-                        'include': refer('include'),
-                    }, [
-                      refer(className)
-                    ])
-                    .returned
-                    .statement));
-
-              // findById
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'findById'
-                ..returns = TypeReference(
-                  (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(TypeReference(
-                      (r) => r
-                        ..symbol = className
-                        ..isNullable = true,
-                    )),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                  Parameter((p) => p
-                    ..type = refer('int')
-                    ..name = 'id'),
-                ])
-                ..optionalParameters.addAll([
-                  if (objectRelationFields.isNotEmpty)
-                    Parameter((p) => p
-                      ..type = TypeReference((b) => b
-                        ..isNullable = true
-                        ..symbol = '${className}Include')
-                      ..name = 'include'
-                      ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('findById')
-                    .call(
-                      [refer('id')],
-                      {
-                        if (objectRelationFields.isNotEmpty)
-                          'include': refer('include'),
-                      },
-                      [refer(className)],
-                    )
-                    .returned
-                    .statement));
-
-              // delete
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'delete'
-                ..returns = TypeReference(
-                  (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(refer('int')),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                ])
-                ..optionalParameters.addAll([
-                  Parameter((p) => p
-                    ..required = true
-                    ..type = refer('${className}ExpressionBuilder')
-                    ..name = 'where'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Transaction'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'transaction'
-                    ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('delete')
-                    .call([], {
-                      'where':
-                          refer('where').call([refer(className).property('t')]),
-                      'transaction': refer('transaction'),
-                    }, [
-                      refer(className)
-                    ])
-                    .returned
-                    .statement));
-
-              // deleteRow
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'deleteRow'
-                ..returns = TypeReference(
-                  (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(refer('bool')),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                  Parameter((p) => p
-                    ..type = refer(className)
-                    ..name = 'row'),
-                ])
-                ..optionalParameters.addAll([
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Transaction'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'transaction'
-                    ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('deleteRow')
-                    .call([
-                      refer('row')
-                    ], {
-                      'transaction': refer('transaction'),
-                    })
-                    .returned
-                    .statement));
-
-              // update
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'update'
-                ..returns = TypeReference(
-                  (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(refer('bool')),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                  Parameter((p) => p
-                    ..type = refer(className)
-                    ..name = 'row'),
-                ])
-                ..optionalParameters.addAll([
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Transaction'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'transaction'
-                    ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('update')
-                    .call([
-                      refer('row')
-                    ], {
-                      'transaction': refer('transaction'),
-                    })
-                    .returned
-                    .statement));
-
-              // insert
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'insert'
-                ..returns = TypeReference(
-                  (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(refer('void')),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                  Parameter((p) => p
-                    ..type = refer(className)
-                    ..name = 'row'),
-                ])
-                ..optionalParameters.addAll([
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Transaction'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'transaction'
-                    ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('insert')
-                    .call([
-                      refer('row')
-                    ], {
-                      'transaction': refer('transaction'),
-                    })
-                    .returned
-                    .statement));
-
-              // count
-              classBuilder.methods.add(Method((m) => m
-                ..static = true
-                ..name = 'count'
-                ..returns = TypeReference(
-                  (r) => r
-                    ..symbol = 'Future'
-                    ..types.add(refer('int')),
-                )
-                ..requiredParameters.addAll([
-                  Parameter((p) => p
-                    ..type =
-                        refer('Session', 'package:serverpod/serverpod.dart')
-                    ..name = 'session'),
-                ])
-                ..optionalParameters.addAll([
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = '${className}ExpressionBuilder')
-                    ..name = 'where'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'int')
-                    ..name = 'limit'
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = refer('bool')
-                    ..name = 'useCache'
-                    ..defaultTo = const Code('true')
-                    ..named = true),
-                  Parameter((p) => p
-                    ..type = TypeReference((b) => b
-                      ..isNullable = true
-                      ..symbol = 'Transaction'
-                      ..url = 'package:serverpod/serverpod.dart')
-                    ..name = 'transaction'
-                    ..named = true),
-                ])
-                ..modifier = MethodModifier.async
-                ..body = refer('session')
-                    .property('db')
-                    .property('count')
-                    .call([], {
-                      'where': refer('where')
-                          .notEqualTo(refer('null'))
-                          .conditional(
-                              refer('where')
-                                  .call([refer(className).property('t')]),
-                              refer('null')),
-                      'limit': refer('limit'),
-                      'useCache': refer('useCache'),
-                      'transaction': refer('transaction'),
-                    }, [
-                      refer(className)
-                    ])
-                    .returned
-                    .statement));
-
-              // include
-              classBuilder.methods.add(Method(
-                (m) => m
-                  ..static = true
-                  ..name = 'include'
-                  ..returns =
-                      TypeReference((r) => r..symbol = '${className}Include')
-                  ..optionalParameters.addAll([
-                    for (var field in objectRelationFields)
-                      Parameter(
-                        (p) => p
-                          ..type = field.type.reference(
-                            serverCode,
-                            subDirParts: classDefinition.subDirParts,
-                            config: config,
-                            typeSuffix: 'Include',
-                          )
-                          ..name = field.name
-                          ..named = true,
+                    ..symbol = 'List'
+                    ..types.add(
+                      TypeReference(
+                        (r) => r..symbol = className,
                       ),
-                  ])
-                  ..body = refer('${className}Include')
-                      .property('_')
-                      .call([], {
-                        for (var field in objectRelationFields)
-                          field.name: refer(field.name),
-                      })
-                      .returned
-                      .statement,
-              ));
-            }
-          }
-        }));
+                    ),
+                )),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+            ])
+            ..optionalParameters.addAll([
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = '${className}ExpressionBuilder')
+                ..name = 'where'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'int')
+                ..name = 'limit'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'int')
+                ..name = 'offset'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Column'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'orderBy'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((t) => t
+                  ..symbol = 'List'
+                  ..isNullable = true
+                  ..types
+                      .add(refer('Order', 'package:serverpod/serverpod.dart')))
+                ..name = 'orderByList'
+                ..named = true),
+              Parameter((p) => p
+                ..type = refer('bool')
+                ..name = 'orderDescending'
+                ..defaultTo = const Code('false')
+                ..named = true),
+              Parameter((p) => p
+                ..type = refer('bool')
+                ..name = 'useCache'
+                ..defaultTo = const Code('true')
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Transaction'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'transaction'
+                ..named = true),
+              if (objectRelationFields.isNotEmpty)
+                Parameter((p) => p
+                  ..type = TypeReference((b) => b
+                    ..isNullable = true
+                    ..symbol = '${className}Include')
+                  ..name = 'include'
+                  ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('find')
+                .call([], {
+                  'where': refer('where').notEqualTo(refer('null')).conditional(
+                      refer('where').call([refer(className).property('t')]),
+                      refer('null')),
+                  'limit': refer('limit'),
+                  'offset': refer('offset'),
+                  'orderBy': refer('orderBy'),
+                  'orderByList': refer('orderByList'),
+                  'orderDescending': refer('orderDescending'),
+                  'useCache': refer('useCache'),
+                  'transaction': refer('transaction'),
+                  if (objectRelationFields.isNotEmpty)
+                    'include': refer('include'),
+                }, [
+                  refer(className)
+                ])
+                .returned
+                .statement));
 
-        if (serverCode && tableName != null) {
-          // Expression builder
-          library.body.add(FunctionType(
-            (f) {
-              f.returnType = refer('Expression', serverpodUrl(serverCode));
-              f.requiredParameters.add(refer('${className}Table'));
-            },
-          ).toTypeDef('${className}ExpressionBuilder'));
+          // find single row
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'findSingleRow'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(TypeReference(
+                  (r) => r
+                    ..symbol = className
+                    ..isNullable = true,
+                )),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+            ])
+            ..optionalParameters.addAll([
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = '${className}ExpressionBuilder')
+                ..name = 'where'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'int')
+                ..name = 'offset'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Column'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'orderBy'
+                ..named = true),
+              Parameter((p) => p
+                ..type = refer('bool')
+                ..name = 'orderDescending'
+                ..defaultTo = const Code('false')
+                ..named = true),
+              Parameter((p) => p
+                ..type = refer('bool')
+                ..name = 'useCache'
+                ..defaultTo = const Code('true')
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Transaction'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'transaction'
+                ..named = true),
+              if (objectRelationFields.isNotEmpty)
+                Parameter((p) => p
+                  ..type = TypeReference((b) => b
+                    ..isNullable = true
+                    ..symbol = '${className}Include')
+                  ..name = 'include'
+                  ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('findSingleRow')
+                .call([], {
+                  'where': refer('where').notEqualTo(refer('null')).conditional(
+                      refer('where').call([refer(className).property('t')]),
+                      refer('null')),
+                  'offset': refer('offset'),
+                  'orderBy': refer('orderBy'),
+                  'orderDescending': refer('orderDescending'),
+                  'useCache': refer('useCache'),
+                  'transaction': refer('transaction'),
+                  if (objectRelationFields.isNotEmpty)
+                    'include': refer('include'),
+                }, [
+                  refer(className)
+                ])
+                .returned
+                .statement));
 
-          // Table class definition
-          library.body.add(Class((c) {
-            c.name = '${className}Table';
-            c.extend = refer('Table', serverpodUrl(serverCode));
-            c.constructors.add(Constructor((constructor) {
-              constructor.optionalParameters.add(
-                Parameter(
-                  (p) => p
-                    ..name = 'queryPrefix'
-                    ..toSuper = true
-                    ..named = true,
-                ),
-              );
-              constructor.optionalParameters.add(
-                Parameter(
-                  (p) => p
-                    ..name = 'tableRelations'
-                    ..toSuper = true
-                    ..named = true,
-                ),
-              );
-              constructor.initializers.add(refer('super')
-                  .call([], {'tableName': literalString(tableName)}).code);
+          // findById
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'findById'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(TypeReference(
+                  (r) => r
+                    ..symbol = className
+                    ..isNullable = true,
+                )),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+              Parameter((p) => p
+                ..type = refer('int')
+                ..name = 'id'),
+            ])
+            ..optionalParameters.addAll([
+              if (objectRelationFields.isNotEmpty)
+                Parameter((p) => p
+                  ..type = TypeReference((b) => b
+                    ..isNullable = true
+                    ..symbol = '${className}Include')
+                  ..name = 'include'
+                  ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('findById')
+                .call(
+                  [refer('id')],
+                  {
+                    if (objectRelationFields.isNotEmpty)
+                      'include': refer('include'),
+                  },
+                  [refer(className)],
+                )
+                .returned
+                .statement));
 
-              constructor.body = Block.of([
-                for (var field in fields.where((field) =>
-                    field.shouldSerializeFieldForDatabase(serverCode)))
-                  if (!(field.name == 'id' && serverCode))
-                    refer(field.name)
-                        .assign(TypeReference((t) => t
-                          ..symbol = field.type.columnType
-                          ..url = 'package:serverpod/serverpod.dart'
-                          ..types.addAll(field.type.isEnum
-                              ? [
-                                  field.type.reference(
-                                    serverCode,
-                                    nullable: false,
-                                    subDirParts: classDefinition.subDirParts,
-                                    config: config,
-                                  )
-                                ]
-                              : [])).call([
-                          literalString(field.name)
-                        ], {
-                          'queryPrefix': refer('super').property('queryPrefix'),
-                          'tableRelations':
-                              refer('super').property('tableRelations')
-                        }))
-                        .statement,
-              ]);
-            }));
+          // delete
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'delete'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(refer('int')),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+            ])
+            ..optionalParameters.addAll([
+              Parameter((p) => p
+                ..required = true
+                ..type = refer('${className}ExpressionBuilder')
+                ..name = 'where'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Transaction'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'transaction'
+                ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('delete')
+                .call([], {
+                  'where':
+                      refer('where').call([refer(className).property('t')]),
+                  'transaction': refer('transaction'),
+                }, [
+                  refer(className)
+                ])
+                .returned
+                .statement));
 
-            // Column fields
-            for (var field in fields) {
-              // Simple column field
-              if (field.shouldSerializeFieldForDatabase(serverCode) &&
-                  !(field.name == 'id' && serverCode)) {
-                c.fields.add(Field((f) => f
-                  ..late = true
-                  ..modifier = FieldModifier.final$
-                  ..name = field.name
-                  ..docs.addAll(field.documentation ?? [])
-                  ..type = TypeReference((t) => t
+          // deleteRow
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'deleteRow'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(refer('bool')),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+              Parameter((p) => p
+                ..type = refer(className)
+                ..name = 'row'),
+            ])
+            ..optionalParameters.addAll([
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Transaction'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'transaction'
+                ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('deleteRow')
+                .call([
+                  refer('row')
+                ], {
+                  'transaction': refer('transaction'),
+                })
+                .returned
+                .statement));
+
+          // update
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'update'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(refer('bool')),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+              Parameter((p) => p
+                ..type = refer(className)
+                ..name = 'row'),
+            ])
+            ..optionalParameters.addAll([
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Transaction'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'transaction'
+                ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('update')
+                .call([
+                  refer('row')
+                ], {
+                  'transaction': refer('transaction'),
+                })
+                .returned
+                .statement));
+
+          // insert
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'insert'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(refer('void')),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+              Parameter((p) => p
+                ..type = refer(className)
+                ..name = 'row'),
+            ])
+            ..optionalParameters.addAll([
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Transaction'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'transaction'
+                ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('insert')
+                .call([
+                  refer('row')
+                ], {
+                  'transaction': refer('transaction'),
+                })
+                .returned
+                .statement));
+
+          // count
+          classBuilder.methods.add(Method((m) => m
+            ..static = true
+            ..name = 'count'
+            ..returns = TypeReference(
+              (r) => r
+                ..symbol = 'Future'
+                ..types.add(refer('int')),
+            )
+            ..requiredParameters.addAll([
+              Parameter((p) => p
+                ..type = refer('Session', 'package:serverpod/serverpod.dart')
+                ..name = 'session'),
+            ])
+            ..optionalParameters.addAll([
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = '${className}ExpressionBuilder')
+                ..name = 'where'
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'int')
+                ..name = 'limit'
+                ..named = true),
+              Parameter((p) => p
+                ..type = refer('bool')
+                ..name = 'useCache'
+                ..defaultTo = const Code('true')
+                ..named = true),
+              Parameter((p) => p
+                ..type = TypeReference((b) => b
+                  ..isNullable = true
+                  ..symbol = 'Transaction'
+                  ..url = 'package:serverpod/serverpod.dart')
+                ..name = 'transaction'
+                ..named = true),
+            ])
+            ..modifier = MethodModifier.async
+            ..body = refer('session')
+                .property('db')
+                .property('count')
+                .call([], {
+                  'where': refer('where').notEqualTo(refer('null')).conditional(
+                      refer('where').call([refer(className).property('t')]),
+                      refer('null')),
+                  'limit': refer('limit'),
+                  'useCache': refer('useCache'),
+                  'transaction': refer('transaction'),
+                }, [
+                  refer(className)
+                ])
+                .returned
+                .statement));
+
+          // include
+          classBuilder.methods.add(Method(
+            (m) => m
+              ..static = true
+              ..name = 'include'
+              ..returns =
+                  TypeReference((r) => r..symbol = '${className}Include')
+              ..optionalParameters.addAll([
+                for (var field in objectRelationFields)
+                  Parameter(
+                    (p) => p
+                      ..type = field.type.reference(
+                        serverCode,
+                        subDirParts: classDefinition.subDirParts,
+                        config: config,
+                        typeSuffix: 'Include',
+                      )
+                      ..name = field.name
+                      ..named = true,
+                  ),
+              ])
+              ..body = refer('${className}Include')
+                  .property('_')
+                  .call([], {
+                    for (var field in objectRelationFields)
+                      field.name: refer(field.name),
+                  })
+                  .returned
+                  .statement,
+          ));
+        }
+      }
+    });
+  }
+
+  Code _buildExpressionBuilderTypeDef(String className) {
+    return FunctionType(
+      (f) {
+        f.returnType = refer('Expression', serverpodUrl(serverCode));
+        f.requiredParameters.add(refer('${className}Table'));
+      },
+    ).toTypeDef('${className}ExpressionBuilder');
+  }
+
+  Class _buildEntityTableClass(
+      String className,
+      String tableName,
+      List<SerializableEntityFieldDefinition> fields,
+      ClassDefinition classDefinition) {
+    return Class((c) {
+      c.name = '${className}Table';
+      c.extend = refer('Table', serverpodUrl(serverCode));
+      c.constructors.add(Constructor((constructor) {
+        constructor.optionalParameters.add(
+          Parameter(
+            (p) => p
+              ..name = 'queryPrefix'
+              ..toSuper = true
+              ..named = true,
+          ),
+        );
+        constructor.optionalParameters.add(
+          Parameter(
+            (p) => p
+              ..name = 'tableRelations'
+              ..toSuper = true
+              ..named = true,
+          ),
+        );
+        constructor.initializers.add(refer('super')
+            .call([], {'tableName': literalString(tableName)}).code);
+
+        constructor.body = Block.of([
+          for (var field in fields.where(
+              (field) => field.shouldSerializeFieldForDatabase(serverCode)))
+            if (!(field.name == 'id' && serverCode))
+              refer(field.name)
+                  .assign(TypeReference((t) => t
                     ..symbol = field.type.columnType
                     ..url = 'package:serverpod/serverpod.dart'
                     ..types.addAll(field.type.isEnum
@@ -808,226 +802,255 @@ class SerializableEntityLibraryGenerator {
                               config: config,
                             )
                           ]
-                        : []))));
-              } else if (field.relation is ObjectRelationDefinition) {
-                // Complex relation fields
-                var objectRelation = field.relation as ObjectRelationDefinition;
+                        : [])).call([
+                    literalString(field.name)
+                  ], {
+                    'queryPrefix': refer('super').property('queryPrefix'),
+                    'tableRelations': refer('super').property('tableRelations')
+                  }))
+                  .statement,
+        ]);
+      }));
 
-                // Add internal nullable table field
-                c.fields.add(Field((f) => f
-                  ..name = '_${field.name}'
-                  ..docs.addAll(field.documentation ?? [])
-                  ..type = field.type.reference(
-                    serverCode,
-                    subDirParts: classDefinition.subDirParts,
-                    config: config,
-                    nullable: true,
-                    typeSuffix: 'Table',
-                  )));
+      // Column fields
+      for (var field in fields) {
+        // Simple column field
+        if (field.shouldSerializeFieldForDatabase(serverCode) &&
+            !(field.name == 'id' && serverCode)) {
+          c.fields.add(Field((f) => f
+            ..late = true
+            ..modifier = FieldModifier.final$
+            ..name = field.name
+            ..docs.addAll(field.documentation ?? [])
+            ..type = TypeReference((t) => t
+              ..symbol = field.type.columnType
+              ..url = 'package:serverpod/serverpod.dart'
+              ..types.addAll(field.type.isEnum
+                  ? [
+                      field.type.reference(
+                        serverCode,
+                        nullable: false,
+                        subDirParts: classDefinition.subDirParts,
+                        config: config,
+                      )
+                    ]
+                  : []))));
+        } else if (field.relation is ObjectRelationDefinition) {
+          // Complex relation fields
+          var objectRelation = field.relation as ObjectRelationDefinition;
 
-                // Add getter method for relation table that creates the table
-                c.methods.add(Method((m) => m
-                  ..name = field.name
-                  ..type = MethodType.getter
-                  ..returns = field.type.reference(
-                    serverCode,
-                    subDirParts: classDefinition.subDirParts,
-                    config: config,
-                    nullable: false,
-                    typeSuffix: 'Table',
-                  )
-                  ..body = Block.of([
-                    Code('if (_${field.name} != null) return _${field.name}!;'),
-                    refer('_${field.name}')
-                        .assign(refer('createRelationTable',
-                                'package:serverpod/serverpod.dart')
-                            .call([], {
-                          'queryPrefix': refer('queryPrefix'),
-                          'fieldName': literalString(field.name),
-                          'foreignTableName': field.type
-                              .reference(
-                                serverCode,
-                                subDirParts: classDefinition.subDirParts,
-                                config: config,
-                                nullable: false,
-                              )
-                              .property('t')
-                              .property('tableName'),
-                          'column': refer(objectRelation.fieldName),
-                          'foreignColumnName': field.type
-                              .reference(
-                                serverCode,
-                                subDirParts: classDefinition.subDirParts,
-                                config: config,
-                                nullable: false,
-                              )
-                              .property('t')
-                              .property(objectRelation.foreignFieldName)
-                              .property('columnName'),
-                          'createTable': Method((m) => m
-                            ..requiredParameters.addAll([
-                              Parameter((p) => p..name = 'relationQueryPrefix'),
-                              Parameter(
-                                  (p) => p..name = 'foreignTableRelation'),
-                            ])
-                            ..lambda = true
-                            ..body = field.type
-                                .reference(
-                              serverCode,
-                              subDirParts: classDefinition.subDirParts,
-                              config: config,
-                              nullable: false,
-                              typeSuffix: 'Table',
-                            )
-                                .call([], {
-                              'queryPrefix': refer('relationQueryPrefix'),
-                              'tableRelations': literalList([
-                                refer('tableRelations').nullSafeSpread,
-                                refer('foreignTableRelation'),
-                              ]),
-                            }).code).closure
-                        }))
-                        .statement,
-                    Code('return _${field.name}!;'),
-                  ])));
-              }
-            }
+          // Add internal nullable table field
+          c.fields.add(Field((f) => f
+            ..name = '_${field.name}'
+            ..docs.addAll(field.documentation ?? [])
+            ..type = field.type.reference(
+              serverCode,
+              subDirParts: classDefinition.subDirParts,
+              config: config,
+              nullable: true,
+              typeSuffix: 'Table',
+            )));
 
-            // List of column values
-            c.methods.add(Method(
-              (m) => m
-                ..annotations.add(refer('override'))
-                ..returns = TypeReference((t) => t
-                  ..symbol = 'List'
-                  ..types
-                      .add(refer('Column', 'package:serverpod/serverpod.dart')))
-                ..name = 'columns'
-                ..lambda = true
-                ..type = MethodType.getter
-                ..body = literalList([
-                  for (var field in fields)
-                    if (field.shouldSerializeFieldForDatabase(serverCode))
-                      refer(field.name)
-                ]).code,
-            ));
-
-            // getRelation method if we have relation fields
-            var objectRelationFields =
-                fields.where((f) => f.relation is ObjectRelationDefinition);
-            if (objectRelationFields.isNotEmpty) {
-              c.methods.add(Method(
-                (m) => m
-                  ..annotations.add(refer('override'))
-                  ..returns = TypeReference((t) => t
-                    ..symbol = 'Table'
-                    ..isNullable = true
-                    ..url = 'package:serverpod/serverpod.dart')
-                  ..name = 'getRelationTable'
-                  ..requiredParameters.add(
-                    Parameter(
-                      (p) => p
-                        ..type = refer('String')
-                        ..name = 'relationField',
-                    ),
-                  )
-                  ..body = (BlockBuilder()
-                        ..statements.addAll([
-                          for (var objectRelationField in objectRelationFields)
-                            Block.of([
-                              Code(
-                                  'if (relationField == ${literalString(objectRelationField.name)}) {'),
-                              lazyCode(() {
-                                return refer(objectRelationField.name)
-                                    .returned
-                                    .statement;
-                              }),
-                              const Code('}'),
-                            ]),
-                          const Code('return null;'),
-                        ]))
-                      .build(),
-              ));
-            }
-          }));
-
-          // Create instance of table
-          library.body.add(Field((f) => f
-            ..annotations.add(refer('Deprecated')
-                .call([literalString('Use ${className}Table.t instead.')]))
-            ..name = 't$className'
-            ..type = refer('${className}Table')
-            ..assignment = refer('${className}Table').call([]).code));
-
-          // Includes class definition
-          library.body.add(Class(((c) {
-            c.extend = refer('Include', 'package:serverpod/serverpod.dart');
-            c.name = '${className}Include';
-            var objectRelationFields = fields
-                .where((f) => f.relation is ObjectRelationDefinition)
-                .toList();
-
-            // Add constructor
-            c.constructors.add(Constructor((constructor) {
-              constructor.name = '_';
-              for (var field in objectRelationFields) {
-                constructor.optionalParameters.add(Parameter(
-                  (p) => p
-                    ..name = field.name
-                    ..named = true
-                    ..toThis = true,
-                ));
-              }
-            }));
-
-            // Add field declarations
-            for (var field in objectRelationFields) {
-              c.fields.add(Field((f) => f
-                ..name = field.name
-                ..type = field.type.reference(
-                  serverCode,
-                  subDirParts: classDefinition.subDirParts,
-                  config: config,
-                  typeSuffix: 'Include',
-                )));
-            }
-
-            // Add includes getter
-            c.methods.add(Method(
-              (m) => m
-                ..annotations.add(refer('override'))
-                ..returns = TypeReference((t) => t
-                  ..symbol = 'Map'
-                  ..types.addAll([
-                    refer('String'),
-                    refer('Include?', 'package:serverpod/serverpod.dart'),
-                  ]))
-                ..name = 'includes'
-                ..lambda = true
-                ..type = MethodType.getter
-                ..body = literalMap({
-                  for (var field in objectRelationFields)
-                    literalString(field.name): refer(field.name)
-                }).code,
-            ));
-
-            // Add table getter
-            c.methods.add(Method(
-              (m) => m
-                ..annotations.add(refer('override'))
-                ..returns = TypeReference((t) => t
-                  ..symbol = 'Table'
-                  ..url = serverpodUrl(serverCode))
-                ..name = 'table'
-                ..lambda = true
-                ..type = MethodType.getter
-                ..body = refer('$className.t').code,
-            ));
-          })));
+          // Add getter method for relation table that creates the table
+          c.methods.add(Method((m) => m
+            ..name = field.name
+            ..type = MethodType.getter
+            ..returns = field.type.reference(
+              serverCode,
+              subDirParts: classDefinition.subDirParts,
+              config: config,
+              nullable: false,
+              typeSuffix: 'Table',
+            )
+            ..body = Block.of([
+              Code('if (_${field.name} != null) return _${field.name}!;'),
+              refer('_${field.name}')
+                  .assign(refer('createRelationTable',
+                          'package:serverpod/serverpod.dart')
+                      .call([], {
+                    'queryPrefix': refer('queryPrefix'),
+                    'fieldName': literalString(field.name),
+                    'foreignTableName': field.type
+                        .reference(
+                          serverCode,
+                          subDirParts: classDefinition.subDirParts,
+                          config: config,
+                          nullable: false,
+                        )
+                        .property('t')
+                        .property('tableName'),
+                    'column': refer(objectRelation.fieldName),
+                    'foreignColumnName': field.type
+                        .reference(
+                          serverCode,
+                          subDirParts: classDefinition.subDirParts,
+                          config: config,
+                          nullable: false,
+                        )
+                        .property('t')
+                        .property(objectRelation.foreignFieldName)
+                        .property('columnName'),
+                    'createTable': Method((m) => m
+                      ..requiredParameters.addAll([
+                        Parameter((p) => p..name = 'relationQueryPrefix'),
+                        Parameter((p) => p..name = 'foreignTableRelation'),
+                      ])
+                      ..lambda = true
+                      ..body = field.type
+                          .reference(
+                        serverCode,
+                        subDirParts: classDefinition.subDirParts,
+                        config: config,
+                        nullable: false,
+                        typeSuffix: 'Table',
+                      )
+                          .call([], {
+                        'queryPrefix': refer('relationQueryPrefix'),
+                        'tableRelations': literalList([
+                          refer('tableRelations').nullSafeSpread,
+                          refer('foreignTableRelation'),
+                        ]),
+                      }).code).closure
+                  }))
+                  .statement,
+              Code('return _${field.name}!;'),
+            ])));
         }
-      },
-    );
+      }
 
-    return library;
+      // List of column values
+      c.methods.add(Method(
+        (m) => m
+          ..annotations.add(refer('override'))
+          ..returns = TypeReference((t) => t
+            ..symbol = 'List'
+            ..types.add(refer('Column', 'package:serverpod/serverpod.dart')))
+          ..name = 'columns'
+          ..lambda = true
+          ..type = MethodType.getter
+          ..body = literalList([
+            for (var field in fields)
+              if (field.shouldSerializeFieldForDatabase(serverCode))
+                refer(field.name)
+          ]).code,
+      ));
+
+      // getRelation method if we have relation fields
+      var objectRelationFields =
+          fields.where((f) => f.relation is ObjectRelationDefinition);
+      if (objectRelationFields.isNotEmpty) {
+        c.methods.add(Method(
+          (m) => m
+            ..annotations.add(refer('override'))
+            ..returns = TypeReference((t) => t
+              ..symbol = 'Table'
+              ..isNullable = true
+              ..url = 'package:serverpod/serverpod.dart')
+            ..name = 'getRelationTable'
+            ..requiredParameters.add(
+              Parameter(
+                (p) => p
+                  ..type = refer('String')
+                  ..name = 'relationField',
+              ),
+            )
+            ..body = (BlockBuilder()
+                  ..statements.addAll([
+                    for (var objectRelationField in objectRelationFields)
+                      Block.of([
+                        Code(
+                            'if (relationField == ${literalString(objectRelationField.name)}) {'),
+                        lazyCode(() {
+                          return refer(objectRelationField.name)
+                              .returned
+                              .statement;
+                        }),
+                        const Code('}'),
+                      ]),
+                    const Code('return null;'),
+                  ]))
+                .build(),
+        ));
+      }
+    });
+  }
+
+  Field _buildDeprecatedStaticTableInstance(String className) {
+    return Field((f) => f
+      ..annotations.add(refer('Deprecated')
+          .call([literalString('Use ${className}Table.t instead.')]))
+      ..name = 't$className'
+      ..type = refer('${className}Table')
+      ..assignment = refer('${className}Table').call([]).code);
+  }
+
+  Class _buildEntityIncludeClass(
+      String className,
+      List<SerializableEntityFieldDefinition> fields,
+      ClassDefinition classDefinition) {
+    return Class(((c) {
+      c.extend = refer('Include', 'package:serverpod/serverpod.dart');
+      c.name = '${className}Include';
+      var objectRelationFields =
+          fields.where((f) => f.relation is ObjectRelationDefinition).toList();
+
+      // Add constructor
+      c.constructors.add(Constructor((constructor) {
+        constructor.name = '_';
+        for (var field in objectRelationFields) {
+          constructor.optionalParameters.add(Parameter(
+            (p) => p
+              ..name = field.name
+              ..named = true
+              ..toThis = true,
+          ));
+        }
+      }));
+
+      // Add field declarations
+      for (var field in objectRelationFields) {
+        c.fields.add(Field((f) => f
+          ..name = field.name
+          ..type = field.type.reference(
+            serverCode,
+            subDirParts: classDefinition.subDirParts,
+            config: config,
+            typeSuffix: 'Include',
+          )));
+      }
+
+      // Add includes getter
+      c.methods.add(Method(
+        (m) => m
+          ..annotations.add(refer('override'))
+          ..returns = TypeReference((t) => t
+            ..symbol = 'Map'
+            ..types.addAll([
+              refer('String'),
+              refer('Include?', 'package:serverpod/serverpod.dart'),
+            ]))
+          ..name = 'includes'
+          ..lambda = true
+          ..type = MethodType.getter
+          ..body = literalMap({
+            for (var field in objectRelationFields)
+              literalString(field.name): refer(field.name)
+          }).code,
+      ));
+
+      // Add table getter
+      c.methods.add(Method(
+        (m) => m
+          ..annotations.add(refer('override'))
+          ..returns = TypeReference((t) => t
+            ..symbol = 'Table'
+            ..url = serverpodUrl(serverCode))
+          ..name = 'table'
+          ..lambda = true
+          ..type = MethodType.getter
+          ..body = refer('$className.t').code,
+      ));
+    }));
   }
 
   /// Handle enums for [generateEntityLibrary]


### PR DESCRIPTION
Break out the entities library generator into functions that each is responsible for one thing.

This PR does not change the behavior of the class.

Further refactoring will be done later on but this helps understanding what parts are responsible for what in the generated classes.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
