### PR TITLE
feat: Add nullability information in internal protocol definitions.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -226,7 +226,12 @@ abstract class RelationDefinition {
 
 /// Internal representation of an unresolved [ListRelationDefinition].
 class UnresolvedListRelationDefinition extends RelationDefinition {
-  UnresolvedListRelationDefinition({String? name}) : super(name, false);
+  final bool nullableRelation;
+
+  UnresolvedListRelationDefinition({
+    String? name,
+    required this.nullableRelation,
+  }) : super(name, false);
 }
 
 /// Used for relations for fields of type [List] that has a reference pointer
@@ -235,9 +240,12 @@ class ListRelationDefinition extends RelationDefinition {
   /// References the field in the other object holding the id of this object.
   String foreignFieldName;
 
+  final bool nullableRelation;
+
   ListRelationDefinition({
     String? name,
     required this.foreignFieldName,
+    required this.nullableRelation,
   }) : super(name, false);
 }
 
@@ -256,12 +264,15 @@ class ObjectRelationDefinition extends RelationDefinition {
   /// References the column in the unresolved [parentTable] that this field should be joined on.
   String foreignFieldName;
 
+  final bool nullableRelation;
+
   ObjectRelationDefinition({
     String? name,
     required this.parentTable,
     required this.fieldName,
     required this.foreignFieldName,
     required bool isForeignKeyOrigin,
+    required this.nullableRelation,
   }) : super(name, isForeignKeyOrigin);
 }
 
@@ -276,7 +287,7 @@ class UnresolvedObjectRelationDefinition extends RelationDefinition {
   final ForeignKeyAction onUpdate;
 
   /// Only used for implicit relations, toggles if the relation id is nullable.
-  bool optionalRelation;
+  final bool nullableRelation;
 
   UnresolvedObjectRelationDefinition({
     String? name,
@@ -284,7 +295,7 @@ class UnresolvedObjectRelationDefinition extends RelationDefinition {
     required this.onDelete,
     required this.onUpdate,
     required bool isForeignKeyOrigin,
-    this.optionalRelation = false,
+    this.nullableRelation = false,
   }) : super(name, isForeignKeyOrigin);
 }
 

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
@@ -125,11 +125,13 @@ class EntityDependencyResolver {
     if (foreignFieldName == null) return;
 
     fieldDefinition.relation = ObjectRelationDefinition(
-        name: relation.name,
-        parentTable: tableName,
-        fieldName: defaultPrimaryKeyName,
-        foreignFieldName: foreignFieldName,
-        isForeignKeyOrigin: relation.isForeignKeyOrigin);
+      name: relation.name,
+      parentTable: tableName,
+      fieldName: defaultPrimaryKeyName,
+      foreignFieldName: foreignFieldName,
+      isForeignKeyOrigin: relation.isForeignKeyOrigin,
+      nullableRelation: relation.nullableRelation,
+    );
   }
 
   static void _resolveImplicitDefinedRelation(
@@ -138,7 +140,7 @@ class EntityDependencyResolver {
     UnresolvedObjectRelationDefinition relation,
     String tableName,
   ) {
-    var relationFieldType = relation.optionalRelation
+    var relationFieldType = relation.nullableRelation
         ? TypeDefinition.int.asNullable
         : TypeDefinition.int;
 
@@ -163,10 +165,12 @@ class EntityDependencyResolver {
     );
 
     fieldDefinition.relation = ObjectRelationDefinition(
-        parentTable: tableName,
-        fieldName: '${fieldDefinition.name}Id',
-        foreignFieldName: defaultPrimaryKeyName,
-        isForeignKeyOrigin: true);
+      parentTable: tableName,
+      fieldName: '${fieldDefinition.name}Id',
+      foreignFieldName: defaultPrimaryKeyName,
+      isForeignKeyOrigin: true,
+      nullableRelation: relation.nullableRelation,
+    );
   }
 
   static void _resolveManualDefinedRelation(
@@ -188,10 +192,12 @@ class EntityDependencyResolver {
     );
 
     fieldDefinition.relation = ObjectRelationDefinition(
-        parentTable: tableName,
-        fieldName: relationFieldName,
-        foreignFieldName: defaultPrimaryKeyName,
-        isForeignKeyOrigin: true);
+      parentTable: tableName,
+      fieldName: relationFieldName,
+      foreignFieldName: defaultPrimaryKeyName,
+      isForeignKeyOrigin: true,
+      nullableRelation: relation.nullableRelation,
+    );
   }
 
   static SerializableEntityFieldDefinition? _findForeignFieldByRelationName(
@@ -272,9 +278,9 @@ class EntityDependencyResolver {
       );
 
       fieldDefinition.relation = ListRelationDefinition(
-        name: autoRelationName,
-        foreignFieldName: foreignFieldName,
-      );
+          name: autoRelationName,
+          foreignFieldName: foreignFieldName,
+          nullableRelation: true);
     } else {
       var foreignFields = referenceClass.fields.where((field) {
         var fieldRelation = field.relation;
@@ -288,6 +294,7 @@ class EntityDependencyResolver {
         fieldDefinition.relation = ListRelationDefinition(
           name: relation.name,
           foreignFieldName: foreignFields.first.name,
+          nullableRelation: foreignFields.first.type.nullable,
         );
       }
     }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -212,7 +212,10 @@ class EntityParser {
     var optionalRelation = _isOptionalRelation(node);
 
     if (typeResult.type.isListType) {
-      return UnresolvedListRelationDefinition(name: relationName);
+      return UnresolvedListRelationDefinition(
+        name: relationName,
+        nullableRelation: optionalRelation,
+      );
     } else if (typeResult.type.isIdType && parentTable != null) {
       return ForeignRelationDefinition(
         name: relationName,
@@ -228,7 +231,7 @@ class EntityParser {
         onUpdate: onUpdate,
         onDelete: onDelete,
         isForeignKeyOrigin: relationFieldName != null,
-        optionalRelation: optionalRelation,
+        nullableRelation: optionalRelation,
       );
     } else {
       return null;

--- a/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
@@ -112,10 +112,12 @@ class ClassDefinitionBuilder {
           .withTypeDefinition(className, true)
           .withShouldPersist(false)
           .withRelation(ObjectRelationDefinition(
-              parentTable: parentTable,
-              fieldName: '${fieldName}Id',
-              foreignFieldName: 'id',
-              isForeignKeyOrigin: true))
+            parentTable: parentTable,
+            fieldName: '${fieldName}Id',
+            foreignFieldName: 'id',
+            isForeignKeyOrigin: true,
+            nullableRelation: false,
+          ))
           .build(),
       FieldDefinitionBuilder()
           .withName('${fieldName}Id')

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_keyword_test.dart
@@ -47,6 +47,13 @@ void main() {
       );
     });
 
+    test('has the nullableRelation set to false', () {
+      var parent = classDefinition.findField('parent');
+      var relation = parent?.relation;
+
+      expect((relation as ObjectRelationDefinition).nullableRelation, false);
+    });
+
     var parentId = classDefinition.findField('parentId');
 
     test('then the class has a relation field for the id.', () {
@@ -137,6 +144,13 @@ void main() {
         reason: 'Expected to be nullable.',
       );
     });
+
+    test('has the nullableRelation set to true', () {
+      var parent = classDefinition.findField('parent');
+      var relation = parent?.relation;
+
+      expect((relation as ObjectRelationDefinition).nullableRelation, true);
+    });
   });
 
   group(
@@ -170,6 +184,13 @@ void main() {
         isFalse,
         reason: 'Expected to not be nullable.',
       );
+    });
+
+    test('has the nullableRelation set to false', () {
+      var parent = classDefinition.findField('parent');
+      var relation = parent?.relation;
+
+      expect((relation as ObjectRelationDefinition).nullableRelation, false);
     });
   });
 

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
@@ -49,9 +49,8 @@ void main() {
       );
     }, skip: errors.isNotEmpty);
 
+    var relation = classDefinition.findField('employees')?.relation;
     test('then the reference field is set on the list relation.', () {
-      var relation = classDefinition.findField('employees')?.relation;
-
       expect(relation.runtimeType, ListRelationDefinition);
       expect(
         (relation as ListRelationDefinition).foreignFieldName,
@@ -59,6 +58,10 @@ void main() {
         reason: 'Expected the reference field to be set to "companyId".',
       );
     }, skip: errors.isNotEmpty);
+
+    test('has the nullableRelation set to false', () {
+      expect((relation as ListRelationDefinition).nullableRelation, false);
+    }, skip: relation is! ListRelationDefinition);
   });
 
   group(
@@ -345,9 +348,8 @@ void main() {
       expect(collector.errors, isEmpty);
     });
 
+    var relation = companyDefinition.findField('employees')?.relation;
     test('then the reference field is set on the list relation.', () {
-      var relation = companyDefinition.findField('employees')?.relation;
-
       expect(relation.runtimeType, ListRelationDefinition);
       expect(
         (relation as ListRelationDefinition).foreignFieldName,
@@ -355,6 +357,10 @@ void main() {
         reason: 'Expected the reference field to be set.',
       );
     });
+
+    test('has the nullableRelation set to true', () {
+      expect((relation as ListRelationDefinition).nullableRelation, true);
+    }, skip: relation is! ListRelationDefinition);
 
     test('then the relation field is created on the employee side.', () {
       var field = employeeDefinition.findField('_company_employees_companyId');

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_one_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_one_test.dart
@@ -57,12 +57,17 @@ void main() {
       test('has the relation name set', () {
         expect(relation?.name, 'user_address');
       });
+
       test('is an ObjectRelationDefinition', () {
         expect(
           relation.runtimeType,
           ObjectRelationDefinition,
           reason: 'Expected the relation to be an ObjectRelationDefinition.',
         );
+      });
+
+      test('has the nullableRelation set to false', () {
+        expect((relation as ObjectRelationDefinition).nullableRelation, false);
       });
 
       test('has the parent table is set', () {
@@ -140,6 +145,10 @@ void main() {
           ObjectRelationDefinition,
         );
       });
+
+      test('has the nullableRelation set to false', () {
+        expect((relation as ObjectRelationDefinition).nullableRelation, false);
+      }, skip: relation is! ObjectRelationDefinition);
 
       test('without a name for the relation', () {
         expect(relation?.name, isNull);


### PR DESCRIPTION
# Changes

Adds nullability check for class definition relations from the analyzer. This feature is required for the code generation of relational operations.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
