### PR TITLE
refactor: Update and Insert based on column structure instead of json.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -43,7 +43,7 @@ abstract class Channel extends _i1.TableRow {
   String channel;
 
   @override
-  String get tableName => 'channel';
+  _i1.Table get table => t;
   Channel copyWith({
     int? id,
     String? name,
@@ -59,6 +59,7 @@ abstract class Channel extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -50,7 +50,7 @@ abstract class EmailAuth extends _i1.TableRow {
   String hash;
 
   @override
-  String get tableName => 'serverpod_email_auth';
+  _i1.Table get table => t;
   EmailAuth copyWith({
     int? id,
     int? userId,
@@ -68,6 +68,7 @@ abstract class EmailAuth extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -58,7 +58,7 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow {
   String verificationCode;
 
   @override
-  String get tableName => 'serverpod_email_create_request';
+  _i1.Table get table => t;
   EmailCreateAccountRequest copyWith({
     int? id,
     String? userName,
@@ -78,6 +78,7 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -52,7 +52,7 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
   String ipAddress;
 
   @override
-  String get tableName => 'serverpod_email_failed_sign_in';
+  _i1.Table get table => t;
   EmailFailedSignIn copyWith({
     int? id,
     String? email,
@@ -70,6 +70,7 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -51,7 +51,7 @@ abstract class EmailReset extends _i1.TableRow {
   DateTime expiration;
 
   @override
-  String get tableName => 'serverpod_email_reset';
+  _i1.Table get table => t;
   EmailReset copyWith({
     int? id,
     int? userId,
@@ -69,6 +69,7 @@ abstract class EmailReset extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -44,7 +44,7 @@ abstract class GoogleRefreshToken extends _i1.TableRow {
   String refreshToken;
 
   @override
-  String get tableName => 'serverpod_google_refresh_token';
+  _i1.Table get table => t;
   GoogleRefreshToken copyWith({
     int? id,
     int? userId,
@@ -60,6 +60,7 @@ abstract class GoogleRefreshToken extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -50,7 +50,7 @@ abstract class UserImage extends _i1.TableRow {
   String url;
 
   @override
-  String get tableName => 'serverpod_user_image';
+  _i1.Table get table => t;
   UserImage copyWith({
     int? id,
     int? userId,
@@ -68,6 +68,7 @@ abstract class UserImage extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -91,7 +91,7 @@ abstract class UserInfo extends _i1.TableRow {
   bool blocked;
 
   @override
-  String get tableName => 'serverpod_user_info';
+  _i1.Table get table => t;
   UserInfo copyWith({
     int? id,
     String? userIdentifier,
@@ -119,6 +119,7 @@ abstract class UserInfo extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -95,7 +95,7 @@ abstract class ChatMessage extends _i1.TableRow {
   List<_i3.ChatMessageAttachment>? attachments;
 
   @override
-  String get tableName => 'serverpod_chat_message';
+  _i1.Table get table => t;
   ChatMessage copyWith({
     int? id,
     String? channel,
@@ -125,6 +125,7 @@ abstract class ChatMessage extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -51,7 +51,7 @@ abstract class ChatReadMessage extends _i1.TableRow {
   int lastReadMessageId;
 
   @override
-  String get tableName => 'serverpod_chat_read_message';
+  _i1.Table get table => t;
   ChatReadMessage copyWith({
     int? id,
     String? channel,
@@ -69,6 +69,7 @@ abstract class ChatReadMessage extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -464,7 +464,7 @@ class DatabaseConnection {
   }) async {
     var startTime = DateTime.now();
 
-    var query = DeleteQueryBuilder(table: row.tableName)
+    var query = DeleteQueryBuilder(table: row.table.tableName)
         .withWhere(Expression('id = ${row.id}'))
         .build();
 

--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -299,7 +299,13 @@ class DatabaseConnection {
     Map data = row.allToJson();
 
     for (var column in selectedColumns) {
-      assert(data.containsKey(column.columnName));
+      if (!data.containsKey(column.columnName)) {
+        throw ArgumentError.value(
+          column,
+          column.columnName,
+          'does not exist in row',
+        );
+      }
     }
 
     var updates = selectedColumns
@@ -338,7 +344,13 @@ class DatabaseConnection {
     Map data = row.allToJson();
 
     for (var column in row.table.columns) {
-      assert(data.containsKey(column.columnName));
+      if (!data.containsKey(column.columnName)) {
+        throw ArgumentError.value(
+          column,
+          column.columnName,
+          'does not exist in row',
+        );
+      }
     }
 
     var selectedColumns = row.table.columns.where((column) {

--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -298,6 +298,11 @@ class DatabaseConnection {
     var selectedColumns = columns ?? row.table.columns;
     Map data = row.allToJson();
 
+    int? id = data['id'];
+    if (id == null) {
+      throw ArgumentError.notNull('row.id');
+    }
+
     for (var column in selectedColumns) {
       if (!data.containsKey(column.columnName)) {
         throw ArgumentError.value(
@@ -314,8 +319,6 @@ class DatabaseConnection {
       var value = DatabasePoolManager.encoder.convert(data[column.columnName]);
       return '"${column.columnName}" = $value';
     }).join(', ');
-
-    int? id = data['id'];
 
     var query = 'UPDATE ${row.table.tableName} SET $updates WHERE id = $id';
 

--- a/packages/serverpod/lib/src/database/table.dart
+++ b/packages/serverpod/lib/src/database/table.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/database.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Holds data corresponding to a row in the database. Concrete classes are
@@ -11,12 +12,16 @@ abstract class TableRow extends SerializableEntity {
   /// the database.
   int? id;
 
+  /// The table that this row belongs to.
+  Table get table;
+
   /// The name of the table that contains this row.
-  String get tableName;
+  @Deprecated('Use: table.tableName instead, will be removed in 2.0.0.')
+  String get tableName => table.tableName;
 
   /// Will create a serialization of with the fields that are stored in the
   /// database only.
-  //TODO: better name
+  @Deprecated('Will be removed in 2.0.0.')
   Map<String, dynamic> toJsonForDatabase();
 
   /// Sets the value of a column by its name. Used in communication with the

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -64,7 +64,7 @@ abstract class AuthKey extends _i1.TableRow {
   String method;
 
   @override
-  String get tableName => 'serverpod_auth_key';
+  _i1.Table get table => t;
   AuthKey copyWith({
     int? id,
     int? userId,
@@ -86,6 +86,7 @@ abstract class AuthKey extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -72,7 +72,7 @@ abstract class CloudStorageEntry extends _i1.TableRow {
   bool verified;
 
   @override
-  String get tableName => 'serverpod_cloud_storage';
+  _i1.Table get table => t;
   CloudStorageEntry copyWith({
     int? id,
     String? storageId,
@@ -96,6 +96,7 @@ abstract class CloudStorageEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -57,7 +57,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
   String authKey;
 
   @override
-  String get tableName => 'serverpod_cloud_storage_direct_upload';
+  _i1.Table get table => t;
   CloudStorageDirectUploadEntry copyWith({
     int? id,
     String? storageId,
@@ -77,6 +77,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -64,7 +64,7 @@ abstract class FutureCallEntry extends _i1.TableRow {
   String? identifier;
 
   @override
-  String get tableName => 'serverpod_future_call';
+  _i1.Table get table => t;
   FutureCallEntry copyWith({
     int? id,
     String? name,
@@ -86,6 +86,7 @@ abstract class FutureCallEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -100,7 +100,7 @@ abstract class LogEntry extends _i1.TableRow {
   int order;
 
   @override
-  String get tableName => 'serverpod_log';
+  _i1.Table get table => t;
   LogEntry copyWith({
     int? id,
     int? sessionLogId,
@@ -132,6 +132,7 @@ abstract class LogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -100,7 +100,7 @@ abstract class MessageLogEntry extends _i1.TableRow {
   int order;
 
   @override
-  String get tableName => 'serverpod_message_log';
+  _i1.Table get table => t;
   MessageLogEntry copyWith({
     int? id,
     int? sessionLogId,
@@ -132,6 +132,7 @@ abstract class MessageLogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -44,7 +44,7 @@ abstract class MethodInfo extends _i1.TableRow {
   String method;
 
   @override
-  String get tableName => 'serverpod_method';
+  _i1.Table get table => t;
   MethodInfo copyWith({
     int? id,
     String? endpoint,
@@ -60,6 +60,7 @@ abstract class MethodInfo extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -100,7 +100,7 @@ abstract class QueryLogEntry extends _i1.TableRow {
   int order;
 
   @override
-  String get tableName => 'serverpod_query_log';
+  _i1.Table get table => t;
   QueryLogEntry copyWith({
     int? id,
     String? serverId,
@@ -132,6 +132,7 @@ abstract class QueryLogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -39,12 +39,10 @@ abstract class ReadWriteTestEntry extends _i1.TableRow {
 
   @override
   _i1.Table get table => t;
-
   ReadWriteTestEntry copyWith({
     int? id,
     int? number,
   });
-
   @override
   Map<String, dynamic> toJson() {
     return {

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -38,11 +38,13 @@ abstract class ReadWriteTestEntry extends _i1.TableRow {
   int number;
 
   @override
-  String get tableName => 'serverpod_readwrite_test';
+  _i1.Table get table => t;
+
   ReadWriteTestEntry copyWith({
     int? id,
     int? number,
   });
+
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -52,6 +54,7 @@ abstract class ReadWriteTestEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -60,7 +60,7 @@ abstract class RuntimeSettings extends _i1.TableRow {
   bool logMalformedCalls;
 
   @override
-  String get tableName => 'serverpod_runtime_settings';
+  _i1.Table get table => t;
   RuntimeSettings copyWith({
     int? id,
     _i2.LogSettings? logSettings,
@@ -80,6 +80,7 @@ abstract class RuntimeSettings extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -74,7 +74,7 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
   int granularity;
 
   @override
-  String get tableName => 'serverpod_health_connection_info';
+  _i1.Table get table => t;
   ServerHealthConnectionInfo copyWith({
     int? id,
     String? serverId,
@@ -98,6 +98,7 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -74,7 +74,7 @@ abstract class ServerHealthMetric extends _i1.TableRow {
   int granularity;
 
   @override
-  String get tableName => 'serverpod_health_metric';
+  _i1.Table get table => t;
   ServerHealthMetric copyWith({
     int? id,
     String? name,
@@ -98,6 +98,7 @@ abstract class ServerHealthMetric extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -124,7 +124,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
   DateTime touched;
 
   @override
-  String get tableName => 'serverpod_session_log';
+  _i1.Table get table => t;
   SessionLogEntry copyWith({
     int? id,
     String? serverId,
@@ -162,6 +162,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/address.dart
@@ -50,7 +50,7 @@ abstract class Address extends _i1.TableRow {
   _i2.Citizen? inhabitant;
 
   @override
-  String get tableName => 'address';
+  _i1.Table get table => t;
   Address copyWith({
     int? id,
     String? street,
@@ -68,6 +68,7 @@ abstract class Address extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/citizen.dart
@@ -67,7 +67,7 @@ abstract class Citizen extends _i1.TableRow {
   _i2.Company? oldCompany;
 
   @override
-  String get tableName => 'citizen';
+  _i1.Table get table => t;
   Citizen copyWith({
     int? id,
     String? name,
@@ -91,6 +91,7 @@ abstract class Citizen extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/company.dart
@@ -49,7 +49,7 @@ abstract class Company extends _i1.TableRow {
   _i2.Town? town;
 
   @override
-  String get tableName => 'company';
+  _i1.Table get table => t;
   Company copyWith({
     int? id,
     String? name,
@@ -67,6 +67,7 @@ abstract class Company extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/post.dart
@@ -56,7 +56,7 @@ abstract class Post extends _i1.TableRow {
   _i2.Post? next;
 
   @override
-  String get tableName => 'post';
+  _i1.Table get table => t;
   Post copyWith({
     int? id,
     String? content,
@@ -76,6 +76,7 @@ abstract class Post extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/town.dart
@@ -49,7 +49,7 @@ abstract class Town extends _i1.TableRow {
   _i2.Citizen? mayor;
 
   @override
-  String get tableName => 'town';
+  _i1.Table get table => t;
   Town copyWith({
     int? id,
     String? name,
@@ -67,6 +67,7 @@ abstract class Town extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -46,7 +46,7 @@ abstract class ObjectFieldScopes extends _i1.TableRow {
   String? database;
 
   @override
-  String get tableName => 'object_field_scopes';
+  _i1.Table get table => t;
   ObjectFieldScopes copyWith({
     int? id,
     String? normal,
@@ -63,6 +63,7 @@ abstract class ObjectFieldScopes extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -36,7 +36,7 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   _i2.ByteData byteData;
 
   @override
-  String get tableName => 'object_with_bytedata';
+  _i1.Table get table => t;
   ObjectWithByteData copyWith({
     int? id,
     _i2.ByteData? byteData,
@@ -50,6 +50,7 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -35,7 +35,7 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   Duration duration;
 
   @override
-  String get tableName => 'object_with_duration';
+  _i1.Table get table => t;
   ObjectWithDuration copyWith({
     int? id,
     Duration? duration,
@@ -49,6 +49,7 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -60,7 +60,7 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   List<List<_i2.TestEnum>> enumListList;
 
   @override
-  String get tableName => 'object_with_enum';
+  _i1.Table get table => t;
   ObjectWithEnum copyWith({
     int? id,
     _i2.TestEnum? testEnum,
@@ -82,6 +82,7 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -41,7 +41,7 @@ abstract class ObjectWithIndex extends _i1.TableRow {
   int indexed2;
 
   @override
-  String get tableName => 'object_with_index';
+  _i1.Table get table => t;
   ObjectWithIndex copyWith({
     int? id,
     int? indexed,
@@ -57,6 +57,7 @@ abstract class ObjectWithIndex extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -68,7 +68,7 @@ abstract class ObjectWithObject extends _i1.TableRow {
   List<_i2.SimpleData?>? nullableListWithNullableData;
 
   @override
-  String get tableName => 'object_with_object';
+  _i1.Table get table => t;
   ObjectWithObject copyWith({
     int? id,
     _i2.SimpleData? data,
@@ -92,6 +92,7 @@ abstract class ObjectWithObject extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -34,7 +34,7 @@ abstract class ObjectWithParent extends _i1.TableRow {
   int other;
 
   @override
-  String get tableName => 'object_with_parent';
+  _i1.Table get table => t;
   ObjectWithParent copyWith({
     int? id,
     int? other,
@@ -48,6 +48,7 @@ abstract class ObjectWithParent extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -34,7 +34,7 @@ abstract class ObjectWithSelfParent extends _i1.TableRow {
   int? other;
 
   @override
-  String get tableName => 'object_with_self_parent';
+  _i1.Table get table => t;
   ObjectWithSelfParent copyWith({
     int? id,
     int? other,
@@ -48,6 +48,7 @@ abstract class ObjectWithSelfParent extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -41,7 +41,7 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   _i1.UuidValue? uuidNullable;
 
   @override
-  String get tableName => 'object_with_uuid';
+  _i1.Table get table => t;
   ObjectWithUuid copyWith({
     int? id,
     _i1.UuidValue? uuid,
@@ -57,6 +57,7 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -38,7 +38,7 @@ abstract class SimpleData extends _i1.TableRow {
   int num;
 
   @override
-  String get tableName => 'simple_data';
+  _i1.Table get table => t;
   SimpleData copyWith({
     int? id,
     int? num,
@@ -52,6 +52,7 @@ abstract class SimpleData extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -37,7 +37,7 @@ abstract class SimpleDateTime extends _i1.TableRow {
   DateTime dateTime;
 
   @override
-  String get tableName => 'simple_date_time';
+  _i1.Table get table => t;
   SimpleDateTime copyWith({
     int? id,
     DateTime? dateTime,
@@ -51,6 +51,7 @@ abstract class SimpleDateTime extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -84,7 +84,7 @@ abstract class Types extends _i1.TableRow {
   _i3.TestEnum? anEnum;
 
   @override
-  String get tableName => 'types';
+  _i1.Table get table => t;
   Types copyWith({
     int? id,
     int? anInt,
@@ -114,6 +114,7 @@ abstract class Types extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
       'id': id,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -94,6 +94,7 @@ const _databaseEntityReservedFieldNames = [
   'tableName',
   'include',
   'db',
+  'table',
 ];
 
 class Restrictions {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
@@ -131,8 +131,7 @@ class SerializableEntityLibraryGenerator {
           classBuilder.fields.add(_buildEntityClassDBField(className));
         }
 
-        // add tableName getter
-        classBuilder.methods.add(_buildEntityClassTableNameGetter(tableName));
+        classBuilder.methods.add(_buildEntityClassTableGetter());
       } else {
         classBuilder.extend =
             refer('SerializableEntity', serverpodUrl(serverCode));
@@ -345,15 +344,15 @@ class SerializableEntityLibraryGenerator {
     }
   }
 
-  Method _buildEntityClassTableNameGetter(String tableName) {
+  Method _buildEntityClassTableGetter() {
     return Method(
       (m) => m
-        ..name = 'tableName'
+        ..name = 'table'
         ..annotations.add(refer('override'))
         ..type = MethodType.getter
-        ..returns = refer('String')
+        ..returns = refer('Table', serverpodUrl(serverCode))
         ..lambda = true
-        ..body = Code('\'$tableName\''),
+        ..body = const Code('t'),
     );
   }
 
@@ -911,9 +910,11 @@ class SerializableEntityLibraryGenerator {
     return Method(
       (m) {
         m.returns = refer('Map<String,dynamic>');
-        // TODO: better name
         m.name = 'toJsonForDatabase';
-        m.annotations.add(refer('override'));
+        m.annotations.addAll([
+          refer('override'),
+          refer("Deprecated('Will be removed in 2.0.0')")
+        ]);
 
         m.body = literalMap(
           {

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_restricted_names_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_restricted_names_test.dart
@@ -97,6 +97,7 @@ void main() {
     'tableName',
     'include',
     'db',
+    'table',
   ];
 
   group('Classes with table', () {

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/class_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/class_field_test.dart
@@ -193,14 +193,14 @@ void main() {
             reason: 'Missing declaration for ${testClassName}Table singleton.');
       });
 
-      test('has a tableName method.', () {
+      test('has a table getter.', () {
         expect(
             CompilationUnitHelpers.hasMethodDeclaration(
               maybeClassNamedExample!,
-              name: 'tableName',
+              name: 'table',
             ),
             isTrue,
-            reason: 'Missing declaration for tableName method.');
+            reason: 'Missing declaration for table method.');
       });
 
       test('is NOT generated with id field.', () {


### PR DESCRIPTION
# Changes

Refactors the logic of how we update and insert data into the database. Bases the logic on the column structure rather than the JSON blob. This will help us keep the logic in sync and enable future modifications managing columns that are not represented in the dart world.

Deprecate `toJsonForDatabase` and the getter `tableName` in generated protocols / `TableRow`.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
