### PR TITLE
fix: Deep check of DateTime and Uint8Lists during deserialization.

### DIFF
--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -180,7 +180,7 @@ class DatabaseConnection {
           include: include,
         );
 
-        list.add(_formatTableRow<T>(tableName, rawTableRow));
+        list.add(poolManager.serializationManager.deserialize<T>(rawTableRow));
       }
     } catch (e, trace) {
       _logQuery(session, query, startTime, exception: e, trace: trace);
@@ -219,31 +219,6 @@ class DatabaseConnection {
     } else {
       return result[0];
     }
-  }
-
-  //TODO: is this still needed?
-  T? _formatTableRow<T extends TableRow>(
-      String tableName, Map<String, dynamic>? rawRow) {
-    var data = <String, dynamic>{};
-
-    for (var columnName in rawRow!.keys) {
-      var value = rawRow[columnName];
-
-      if (value is DateTime) {
-        data[columnName] = value.toIso8601String();
-      } else if (value is Uint8List) {
-        var byteData = ByteData.view(
-          value.buffer,
-          value.offsetInBytes,
-          value.length,
-        );
-        data[columnName] = byteData.base64encodedString();
-      } else {
-        data[columnName] = value;
-      }
-    }
-
-    return poolManager.serializationManager.deserialize<T>(data);
   }
 
   /// For most cases use the corresponding method in [Database] instead.
@@ -460,7 +435,8 @@ class DatabaseConnection {
         substitutionValues: {},
       );
       for (var rawRow in result) {
-        list.add(_formatTableRow<T>(tableName, rawRow[tableName]));
+        list.add(
+            poolManager.serializationManager.deserialize<T>(rawRow[tableName]));
       }
     } catch (e, trace) {
       _logQuery(session, query, startTime, exception: e, trace: trace);


### PR DESCRIPTION
# Changes

Moves `DateTime` and `Uint8List` management from our database layer into the deserialization logic making it work for any deeply nested objects.

Related: https://github.com/serverpod/serverpod/issues/1339

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
