### PR TITLE
Fix typo in `CreateCommand`'s CLI help text

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -20,7 +20,7 @@ class CreateCommand extends ServerpodCommand {
       'force',
       abbr: 'f',
       negatable: false,
-      help: 'Create the project even if there are issues that prevents if from '
+      help: 'Create the project even if there are issues that prevent it from '
           'running out of the box.',
     );
     argParser.addOption(


### PR DESCRIPTION
Specific issue was an incorrect plural combined with `if` instead of `it` in the help for the `--force` flag.

Fixes #1394.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

No breaking changes
