### PR TITLE
fix: Resolve list relation regardless of order of protocol files.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
@@ -149,7 +149,7 @@ class EntityDependencyResolver {
         : TypeDefinition.int;
 
     var foreignRelationField = SerializableEntityFieldDefinition(
-      name: _createImplicitForeignFieldName(fieldDefinition.name),
+      name: _createImplicitForeignIdFieldName(fieldDefinition.name),
       relation: ForeignRelationDefinition(
         name: relation.name,
         parentTable: tableName,
@@ -307,7 +307,7 @@ class EntityDependencyResolver {
         foreignFieldName = foreignField.name;
       } else if (foreignRelation is UnresolvedObjectRelationDefinition) {
         foreignFieldName = foreignRelation.fieldName ??
-            _createImplicitForeignFieldName(foreignField.name);
+            _createImplicitForeignIdFieldName(foreignField.name);
       }
 
       if (foreignFieldName == null) return;
@@ -321,7 +321,7 @@ class EntityDependencyResolver {
     }
   }
 
-  static String _createImplicitForeignFieldName(String fieldName) {
+  static String _createImplicitForeignIdFieldName(String fieldName) {
     return '${fieldName}Id';
   }
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
@@ -149,7 +149,7 @@ class EntityDependencyResolver {
         : TypeDefinition.int;
 
     var foreignRelationField = SerializableEntityFieldDefinition(
-      name: '${fieldDefinition.name}Id',
+      name: _createImplicitForeignFieldName(fieldDefinition.name),
       relation: ForeignRelationDefinition(
         name: relation.name,
         parentTable: tableName,
@@ -291,19 +291,37 @@ class EntityDependencyResolver {
     } else {
       var foreignFields = referenceClass.fields.where((field) {
         var fieldRelation = field.relation;
-        if (fieldRelation is! ForeignRelationDefinition) return false;
-        return fieldRelation.parentTable == classDefinition.tableName &&
-            fieldRelation.name == relation.name;
+        if (!(fieldRelation is UnresolvedObjectRelationDefinition ||
+            fieldRelation is ForeignRelationDefinition)) return false;
+        return fieldRelation?.name == relation.name;
       });
 
-      if (foreignFields.isNotEmpty) {
-        fieldDefinition.relation = ListRelationDefinition(
-          name: relation.name,
-          fieldName: 'id',
-          foreignFieldName: foreignFields.first.name,
-          nullableRelation: foreignFields.first.type.nullable,
-        );
+      if (foreignFields.isEmpty) return;
+
+      var foreignField = foreignFields.first;
+
+      String? foreignFieldName;
+
+      var foreignRelation = foreignField.relation;
+      if (foreignRelation is ForeignRelationDefinition) {
+        foreignFieldName = foreignField.name;
+      } else if (foreignRelation is UnresolvedObjectRelationDefinition) {
+        foreignFieldName = foreignRelation.fieldName ??
+            _createImplicitForeignFieldName(foreignField.name);
       }
+
+      if (foreignFieldName == null) return;
+
+      fieldDefinition.relation = ListRelationDefinition(
+        name: relation.name,
+        fieldName: 'id',
+        foreignFieldName: foreignFieldName,
+        nullableRelation: foreignFields.first.type.nullable,
+      );
     }
+  }
+
+  static String _createImplicitForeignFieldName(String fieldName) {
+    return '${fieldName}Id';
   }
 }

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
@@ -493,7 +493,7 @@ void main() {
         fields:
           description: String
           customerId: int
-          company: Customer?, relation(name=customer_order, field=customerId)
+          customer: Customer?, relation(name=customer_order, field=customerId)
         ''',
       ).build(),
     ];
@@ -544,7 +544,7 @@ void main() {
         fields:
           description: String
           customerId: int
-          company: Customer?, relation(field=customerId)
+          customer: Customer?, relation(field=customerId)
         ''',
       ).build(),
     ];

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
@@ -578,7 +578,7 @@ void main() {
       var relation = classDefinition.findField('orders')?.relation
           as ListRelationDefinition;
 
-      expect(relation.foreignFieldName, isNot('companyId'));
+      expect(relation.foreignFieldName, isNot('customerId'));
     });
   });
 }

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
@@ -574,7 +574,7 @@ void main() {
           ListRelationDefinition);
     });
 
-    test('then the list relation is NOT linked with the companyId field', () {
+    test('then the list relation is NOT linked with the customerId field', () {
       var relation = classDefinition.findField('orders')?.relation
           as ListRelationDefinition;
 

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_many_test.dart
@@ -472,4 +472,113 @@ void main() {
       expect(field, isNotNull);
     });
   });
+
+  group(
+      'Given a named list relation protocol ordered before the primary key protocol, when parsing the protocols',
+      () {
+    var protocols = [
+      ProtocolSourceBuilder().withFileName('customer').withYaml(
+        '''
+        class: Customer
+        table: customer
+        fields:
+          name: String
+          orders: List<Order>?, relation(name=customer_order)
+        ''',
+      ).build(),
+      ProtocolSourceBuilder().withFileName('order').withYaml(
+        '''
+        class: Order
+        table: order
+        fields:
+          description: String
+          customerId: int
+          company: Customer?, relation(name=customer_order, field=customerId)
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      protocols,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+    var classDefinition = definitions
+        .whereType<ClassDefinition>()
+        .firstWhere((d) => d.className == 'Customer');
+
+    var errors = collector.errors;
+
+    test('then no errors are collected.', () {
+      expect(errors, isEmpty);
+    });
+
+    test('then customer has list orders field', () {
+      expect(classDefinition.findField('orders'), isNotNull);
+    });
+
+    test('then orders is list relation', () {
+      expect(classDefinition.findField('orders')?.relation.runtimeType,
+          ListRelationDefinition);
+    });
+  });
+
+  group(
+      'Given an unnamed list relation protocol linked to another protocol with an unname object relation, when parsing the protocols',
+      () {
+    var protocols = [
+      ProtocolSourceBuilder().withFileName('customer').withYaml(
+        '''
+        class: Customer
+        table: customer
+        fields:
+          name: String
+          orders: List<Order>?, relation
+        ''',
+      ).build(),
+      ProtocolSourceBuilder().withFileName('order').withYaml(
+        '''
+        class: Order
+        table: order
+        fields:
+          description: String
+          customerId: int
+          company: Customer?, relation(field=customerId)
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      protocols,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+    var classDefinition = definitions
+        .whereType<ClassDefinition>()
+        .firstWhere((d) => d.className == 'Customer');
+
+    var errors = collector.errors;
+
+    test('then no errors are collected.', () {
+      expect(errors, isEmpty);
+    });
+
+    test('then customer has list orders field', () {
+      expect(classDefinition.findField('orders'), isNotNull);
+    });
+
+    test('then orders is list relation', () {
+      expect(classDefinition.findField('orders')?.relation.runtimeType,
+          ListRelationDefinition);
+    });
+
+    test('then the list relation is NOT linked with the companyId field', () {
+      var relation = classDefinition.findField('orders')?.relation
+          as ListRelationDefinition;
+
+      expect(relation.foreignFieldName, isNot('companyId'));
+    });
+  });
 }


### PR DESCRIPTION
# Fix

Fixes a bug where the ordered of the protocol files mattered when resolving list relations.

Closes: https://github.com/serverpod/serverpod/issues/1397

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
