### PR TITLE
fix: Store table relations as a list of separate entries.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -252,10 +252,7 @@ class _ChannelImpl extends Channel {
 typedef ChannelExpressionBuilder = _i1.Expression Function(ChannelTable);
 
 class ChannelTable extends _i1.Table {
-  ChannelTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'channel') {
+  ChannelTable({super.tableRelation}) : super(tableName: 'channel') {
     name = _i1.ColumnString(
       'name',
       this,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -270,10 +270,8 @@ class _EmailAuthImpl extends EmailAuth {
 typedef EmailAuthExpressionBuilder = _i1.Expression Function(EmailAuthTable);
 
 class EmailAuthTable extends _i1.Table {
-  EmailAuthTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_email_auth') {
+  EmailAuthTable({super.tableRelation})
+      : super(tableName: 'serverpod_email_auth') {
     userId = _i1.ColumnInt(
       'userId',
       this,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -290,10 +290,8 @@ typedef EmailCreateAccountRequestExpressionBuilder = _i1.Expression Function(
     EmailCreateAccountRequestTable);
 
 class EmailCreateAccountRequestTable extends _i1.Table {
-  EmailCreateAccountRequestTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_email_create_request') {
+  EmailCreateAccountRequestTable({super.tableRelation})
+      : super(tableName: 'serverpod_email_create_request') {
     userName = _i1.ColumnString(
       'userName',
       this,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -273,10 +273,8 @@ typedef EmailFailedSignInExpressionBuilder = _i1.Expression Function(
     EmailFailedSignInTable);
 
 class EmailFailedSignInTable extends _i1.Table {
-  EmailFailedSignInTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_email_failed_sign_in') {
+  EmailFailedSignInTable({super.tableRelation})
+      : super(tableName: 'serverpod_email_failed_sign_in') {
     email = _i1.ColumnString(
       'email',
       this,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -271,10 +271,8 @@ class _EmailResetImpl extends EmailReset {
 typedef EmailResetExpressionBuilder = _i1.Expression Function(EmailResetTable);
 
 class EmailResetTable extends _i1.Table {
-  EmailResetTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_email_reset') {
+  EmailResetTable({super.tableRelation})
+      : super(tableName: 'serverpod_email_reset') {
     userId = _i1.ColumnInt(
       'userId',
       this,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -254,10 +254,8 @@ typedef GoogleRefreshTokenExpressionBuilder = _i1.Expression Function(
     GoogleRefreshTokenTable);
 
 class GoogleRefreshTokenTable extends _i1.Table {
-  GoogleRefreshTokenTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_google_refresh_token') {
+  GoogleRefreshTokenTable({super.tableRelation})
+      : super(tableName: 'serverpod_google_refresh_token') {
     userId = _i1.ColumnInt(
       'userId',
       this,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -270,10 +270,8 @@ class _UserImageImpl extends UserImage {
 typedef UserImageExpressionBuilder = _i1.Expression Function(UserImageTable);
 
 class UserImageTable extends _i1.Table {
-  UserImageTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_user_image') {
+  UserImageTable({super.tableRelation})
+      : super(tableName: 'serverpod_user_image') {
     userId = _i1.ColumnInt(
       'userId',
       this,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -366,10 +366,8 @@ class _UserInfoImpl extends UserInfo {
 typedef UserInfoExpressionBuilder = _i1.Expression Function(UserInfoTable);
 
 class UserInfoTable extends _i1.Table {
-  UserInfoTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_user_info') {
+  UserInfoTable({super.tableRelation})
+      : super(tableName: 'serverpod_user_info') {
     userIdentifier = _i1.ColumnString(
       'userIdentifier',
       this,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -375,10 +375,8 @@ typedef ChatMessageExpressionBuilder = _i1.Expression Function(
     ChatMessageTable);
 
 class ChatMessageTable extends _i1.Table {
-  ChatMessageTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_chat_message') {
+  ChatMessageTable({super.tableRelation})
+      : super(tableName: 'serverpod_chat_message') {
     channel = _i1.ColumnString(
       'channel',
       this,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -272,10 +272,8 @@ typedef ChatReadMessageExpressionBuilder = _i1.Expression Function(
     ChatReadMessageTable);
 
 class ChatReadMessageTable extends _i1.Table {
-  ChatReadMessageTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_chat_read_message') {
+  ChatReadMessageTable({super.tableRelation})
+      : super(tableName: 'serverpod_chat_read_message') {
     channel = _i1.ColumnString(
       'channel',
       this,

--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -181,7 +181,7 @@ T createRelationTable<T>({
   ) createTable,
 }) {
   var relationDefinition = TableRelationEntry(
-    relationFieldName: relationFieldName,
+    relationAlias: relationFieldName,
     field: field,
     foreignField: foreignField,
   );

--- a/packages/serverpod/lib/src/database/table_relation.dart
+++ b/packages/serverpod/lib/src/database/table_relation.dart
@@ -5,41 +5,97 @@ import 'package:serverpod/src/database/columns.dart';
 /// This is typically only used internally by the serverpod framework.
 @internal
 class TableRelation {
-  /// Name of table.
-  final String tableName;
-
-  /// Foreign table relation column.
-  final Column foreignTableColumn;
-
-  /// Relation column.
-  final String column;
-
-  /// Query prefix for the relation.
-  final String queryPrefix;
-
-  /// Retrieves the name of the table with the query prefix applied.
-  String get tableNameWithQueryPrefix => '$queryPrefix$tableName';
-
-  /// Creates a new [TableRelation] from the perspective of the foreign table.
-  factory TableRelation.foreign({
-    required String foreignTableName,
-    required Column column,
-    required String foreignColumnName,
-    required String relationQueryPrefix,
-  }) {
-    return TableRelation(
-      tableName: foreignTableName,
-      foreignTableColumn: column,
-      column: '$relationQueryPrefix$foreignTableName."$foreignColumnName"',
-      queryPrefix: relationQueryPrefix,
-    );
-  }
+  /// Records the relationship between multiple tables.
+  /// Order is important, as it determines the order of joins in the query.
+  final List<TableRelationEntry> _tableRelationEntries;
 
   /// Creates a new [TableRelation].
-  const TableRelation({
-    required this.tableName,
-    required this.foreignTableColumn,
-    required this.column,
-    required this.queryPrefix,
+  /// Throws [ArgumentError] if [tableRelationEntries] is empty.
+  TableRelation(this._tableRelationEntries) {
+    if (_tableRelationEntries.isEmpty) {
+      throw ArgumentError('TableRelation must have at least one entry.');
+    }
+  }
+
+  /// Builds all table relations required to join the tables.
+  List<TableRelation> get getRelations {
+    List<TableRelation> relations = [];
+    for (var i = 0; i < _tableRelationEntries.length; i++) {
+      relations.add(TableRelation(_tableRelationEntries.sublist(0, i + 1)));
+    }
+
+    return relations;
+  }
+
+  /// Name of the table to be joined.
+  String get lastForeignTableName {
+    return _tableRelationEntries.last.foreignField.table.tableName;
+  }
+
+  /// Name of the last field to be joined.
+  String get lastJoiningField {
+    return '${_fromRelationQueryAlias()}."${_tableRelationEntries.last.field.columnName}"';
+  }
+
+  /// Name of the last foreign field to be joined.
+  String get lastJoiningForeignField {
+    return '${_buildRelationQueryAlias()}."${_tableRelationEntries.last.foreignField.columnName}"';
+  }
+
+  /// Creates a new [TableRelation] from [this] and [relation].
+  TableRelation copyAndAppend(TableRelationEntry relation) {
+    return TableRelation([..._tableRelationEntries, relation]);
+  }
+
+  /// Retrieves the name of the table with the query prefix applied.
+  String get relationQueryAlias => _buildRelationQueryAlias();
+
+  /// Builds the relation query alias including [TableRelationEntries]
+  /// up until [end] index.
+  ///
+  /// If [end] is larger than the number of relations, all relations are used.
+  String _buildRelationQueryAlias([int? end]) {
+    if (end != null && end > _tableRelationEntries.length) {
+      end = _tableRelationEntries.length;
+    }
+
+    var prefix = '';
+    if (_tableRelationEntries.isEmpty) {
+      return prefix;
+    }
+
+    prefix = _tableRelationEntries.first.field.table.tableName;
+
+    for (var relation in _tableRelationEntries.sublist(0, end)) {
+      prefix +=
+          '_${relation.relationFieldName}_${relation.foreignField.table.tableName}';
+    }
+
+    return prefix;
+  }
+
+  String _fromRelationQueryAlias() {
+    return _buildRelationQueryAlias(_tableRelationEntries.length - 1);
+  }
+}
+
+/// Entry for recording a relation between two tables.
+/// This is typically only used internally by the serverpod framework.
+@internal
+class TableRelationEntry {
+  /// Name of relation field.
+  final String relationFieldName;
+
+  /// Column field to join on.
+  final Column field;
+
+  /// Foreign Column field to join to.
+  final Column foreignField;
+
+  /// Creates a new [TableRelationEntry].
+  TableRelationEntry({
+    required this.relationFieldName,
+    required this.field,
+    required this.foreignField,
   });
 }

--- a/packages/serverpod/lib/src/database/table_relation.dart
+++ b/packages/serverpod/lib/src/database/table_relation.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:serverpod/src/database/columns.dart';
 
@@ -19,12 +20,12 @@ class TableRelation {
 
   /// Builds all table relations required to join the tables.
   List<TableRelation> get getRelations {
-    List<TableRelation> relations = [];
-    for (var i = 0; i < _tableRelationEntries.length; i++) {
-      relations.add(TableRelation(_tableRelationEntries.sublist(0, i + 1)));
-    }
-
-    return relations;
+    return _tableRelationEntries
+        .mapIndexed(
+          (index, _) =>
+              TableRelation(_tableRelationEntries.sublist(0, index + 1)),
+        )
+        .toList();
   }
 
   /// Name of the table to be joined.
@@ -68,7 +69,7 @@ class TableRelation {
 
     for (var relation in _tableRelationEntries.sublist(0, end)) {
       prefix +=
-          '_${relation.relationFieldName}_${relation.foreignField.table.tableName}';
+          '_${relation.relationAlias}_${relation.foreignField.table.tableName}';
     }
 
     return prefix;
@@ -83,8 +84,8 @@ class TableRelation {
 /// This is typically only used internally by the serverpod framework.
 @internal
 class TableRelationEntry {
-  /// Name of relation field.
-  final String relationFieldName;
+  /// Alias for the relation.
+  final String relationAlias;
 
   /// Column field to join on.
   final Column field;
@@ -94,7 +95,7 @@ class TableRelationEntry {
 
   /// Creates a new [TableRelationEntry].
   TableRelationEntry({
-    required this.relationFieldName,
+    required this.relationAlias,
     required this.field,
     required this.foreignField,
   });

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -302,10 +302,7 @@ class _AuthKeyImpl extends AuthKey {
 typedef AuthKeyExpressionBuilder = _i1.Expression Function(AuthKeyTable);
 
 class AuthKeyTable extends _i1.Table {
-  AuthKeyTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_auth_key') {
+  AuthKeyTable({super.tableRelation}) : super(tableName: 'serverpod_auth_key') {
     userId = _i1.ColumnInt(
       'userId',
       this,

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -326,10 +326,8 @@ typedef CloudStorageEntryExpressionBuilder = _i1.Expression Function(
     CloudStorageEntryTable);
 
 class CloudStorageEntryTable extends _i1.Table {
-  CloudStorageEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_cloud_storage') {
+  CloudStorageEntryTable({super.tableRelation})
+      : super(tableName: 'serverpod_cloud_storage') {
     storageId = _i1.ColumnString(
       'storageId',
       this,

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -289,10 +289,8 @@ typedef CloudStorageDirectUploadEntryExpressionBuilder = _i1.Expression
     Function(CloudStorageDirectUploadEntryTable);
 
 class CloudStorageDirectUploadEntryTable extends _i1.Table {
-  CloudStorageDirectUploadEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_cloud_storage_direct_upload') {
+  CloudStorageDirectUploadEntryTable({super.tableRelation})
+      : super(tableName: 'serverpod_cloud_storage_direct_upload') {
     storageId = _i1.ColumnString(
       'storageId',
       this,

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -309,10 +309,8 @@ typedef FutureCallEntryExpressionBuilder = _i1.Expression Function(
     FutureCallEntryTable);
 
 class FutureCallEntryTable extends _i1.Table {
-  FutureCallEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_future_call') {
+  FutureCallEntryTable({super.tableRelation})
+      : super(tableName: 'serverpod_future_call') {
     name = _i1.ColumnString(
       'name',
       this,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -397,10 +397,7 @@ class _LogEntryImpl extends LogEntry {
 typedef LogEntryExpressionBuilder = _i1.Expression Function(LogEntryTable);
 
 class LogEntryTable extends _i1.Table {
-  LogEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_log') {
+  LogEntryTable({super.tableRelation}) : super(tableName: 'serverpod_log') {
     sessionLogId = _i1.ColumnInt(
       'sessionLogId',
       this,

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -398,10 +398,8 @@ typedef MessageLogEntryExpressionBuilder = _i1.Expression Function(
     MessageLogEntryTable);
 
 class MessageLogEntryTable extends _i1.Table {
-  MessageLogEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_message_log') {
+  MessageLogEntryTable({super.tableRelation})
+      : super(tableName: 'serverpod_message_log') {
     sessionLogId = _i1.ColumnInt(
       'sessionLogId',
       this,

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -253,10 +253,8 @@ class _MethodInfoImpl extends MethodInfo {
 typedef MethodInfoExpressionBuilder = _i1.Expression Function(MethodInfoTable);
 
 class MethodInfoTable extends _i1.Table {
-  MethodInfoTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_method') {
+  MethodInfoTable({super.tableRelation})
+      : super(tableName: 'serverpod_method') {
     endpoint = _i1.ColumnString(
       'endpoint',
       this,

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -398,10 +398,8 @@ typedef QueryLogEntryExpressionBuilder = _i1.Expression Function(
     QueryLogEntryTable);
 
 class QueryLogEntryTable extends _i1.Table {
-  QueryLogEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_query_log') {
+  QueryLogEntryTable({super.tableRelation})
+      : super(tableName: 'serverpod_query_log') {
     serverId = _i1.ColumnString(
       'serverId',
       this,

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -237,10 +237,8 @@ typedef ReadWriteTestEntryExpressionBuilder = _i1.Expression Function(
     ReadWriteTestEntryTable);
 
 class ReadWriteTestEntryTable extends _i1.Table {
-  ReadWriteTestEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_readwrite_test') {
+  ReadWriteTestEntryTable({super.tableRelation})
+      : super(tableName: 'serverpod_readwrite_test') {
     number = _i1.ColumnInt(
       'number',
       this,

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -293,10 +293,8 @@ typedef RuntimeSettingsExpressionBuilder = _i1.Expression Function(
     RuntimeSettingsTable);
 
 class RuntimeSettingsTable extends _i1.Table {
-  RuntimeSettingsTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_runtime_settings') {
+  RuntimeSettingsTable({super.tableRelation})
+      : super(tableName: 'serverpod_runtime_settings') {
     logSettings = _i1.ColumnSerializable(
       'logSettings',
       this,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -328,10 +328,8 @@ typedef ServerHealthConnectionInfoExpressionBuilder = _i1.Expression Function(
     ServerHealthConnectionInfoTable);
 
 class ServerHealthConnectionInfoTable extends _i1.Table {
-  ServerHealthConnectionInfoTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_health_connection_info') {
+  ServerHealthConnectionInfoTable({super.tableRelation})
+      : super(tableName: 'serverpod_health_connection_info') {
     serverId = _i1.ColumnString(
       'serverId',
       this,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -328,10 +328,8 @@ typedef ServerHealthMetricExpressionBuilder = _i1.Expression Function(
     ServerHealthMetricTable);
 
 class ServerHealthMetricTable extends _i1.Table {
-  ServerHealthMetricTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_health_metric') {
+  ServerHealthMetricTable({super.tableRelation})
+      : super(tableName: 'serverpod_health_metric') {
     name = _i1.ColumnString(
       'name',
       this,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -457,10 +457,8 @@ typedef SessionLogEntryExpressionBuilder = _i1.Expression Function(
     SessionLogEntryTable);
 
 class SessionLogEntryTable extends _i1.Table {
-  SessionLogEntryTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'serverpod_session_log') {
+  SessionLogEntryTable({super.tableRelation})
+      : super(tableName: 'serverpod_session_log') {
     serverId = _i1.ColumnString(
       'serverId',
       this,

--- a/packages/serverpod/test/database/database_query_test.dart
+++ b/packages/serverpod/test/database/database_query_test.dart
@@ -117,7 +117,7 @@ void main() {
         tableName: companyTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           )
@@ -139,12 +139,12 @@ void main() {
         tableName: citizenTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           ),
           TableRelationEntry(
-            relationFieldName: 'ceo',
+            relationAlias: 'ceo',
             field: ColumnInt('ceoId', companyTable),
             foreignField: ColumnInt('id', citizenTable),
           ),
@@ -168,7 +168,7 @@ void main() {
         tableName: companyTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           )
@@ -274,7 +274,7 @@ void main() {
         tableName: companyTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           )
@@ -299,12 +299,12 @@ void main() {
         tableName: citizenTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           ),
           TableRelationEntry(
-            relationFieldName: 'ceo',
+            relationAlias: 'ceo',
             field: ColumnInt('ceoId', companyTable),
             foreignField: ColumnInt('id', citizenTable),
           ),
@@ -329,7 +329,7 @@ void main() {
         tableName: companyTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           )
@@ -407,7 +407,7 @@ void main() {
         tableName: companyTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           )
@@ -429,12 +429,12 @@ void main() {
         tableName: citizenTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           ),
           TableRelationEntry(
-            relationFieldName: 'ceo',
+            relationAlias: 'ceo',
             field: ColumnInt('ceoId', companyTable),
             foreignField: ColumnInt('id', citizenTable),
           ),
@@ -456,7 +456,7 @@ void main() {
         tableName: companyTable.tableName,
         tableRelation: TableRelation([
           TableRelationEntry(
-            relationFieldName: 'company',
+            relationAlias: 'company',
             field: ColumnInt('companyId', citizenTable),
             foreignField: ColumnInt('id', companyTable),
           )

--- a/packages/serverpod/test/database/table_relation_test.dart
+++ b/packages/serverpod/test/database/table_relation_test.dart
@@ -1,0 +1,157 @@
+import 'package:serverpod/src/database/columns.dart';
+import 'package:serverpod/src/database/expressions.dart';
+import 'package:serverpod/src/database/table_relation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Given empty list when trying to construct TableRelation then throws',
+      () {
+    expect(
+        () => TableRelation([]),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.toString(),
+          'message',
+          equals(
+              'Invalid argument(s): TableRelation must have at least one entry.'),
+        )));
+  });
+
+  group('Given table relation with relation definition', () {
+    var table = Table(tableName: 'company');
+    var foreignTable = Table(tableName: 'citizen');
+    var tableRelationEntries = [
+      TableRelationEntry(
+        relationFieldName: 'ceo',
+        field: ColumnInt('ceoId', table),
+        foreignField: ColumnInt('id', foreignTable),
+      ),
+    ];
+    TableRelation tableRelation = TableRelation(tableRelationEntries);
+
+    test(
+        'when buildRelationQueryAlias is called then query prefix is built correctly.',
+        () {
+      expect(
+        tableRelation.relationQueryAlias,
+        'company_ceo_citizen',
+      );
+    });
+
+    group('when getRelations is called', () {
+      test('then returns list with one element.', () {
+        expect(tableRelation.getRelations.length, 1);
+      });
+
+      test(
+          'then last element builds same buildRelationQueryAlias as outer element.',
+          () {
+        expect(tableRelation.getRelations.last.relationQueryAlias,
+            tableRelation.relationQueryAlias);
+      });
+    });
+
+    test('when lastForeignTableName is called then last table is returned.',
+        () {
+      expect(tableRelation.lastForeignTableName, 'citizen');
+    });
+
+    test(
+        'when lastJoiningField is called then last joining field name is returned.',
+        () {
+      expect(tableRelation.lastJoiningField, 'company."ceoId"');
+    });
+
+    test('when lastJoiningForeignField is called then last foreign field name.',
+        () {
+      expect(tableRelation.lastJoiningForeignField, 'company_ceo_citizen."id"');
+    });
+
+    group('when using copyAndAppend to create new table relation ', () {
+      var table = Table(tableName: 'citizen');
+      var foreignTable = Table(tableName: 'restaurant');
+      var newTableRelation = tableRelation.copyAndAppend(
+        TableRelationEntry(
+          relationFieldName: 'favoriteRestaurant',
+          field: ColumnInt('favoriteRestaurantId', table),
+          foreignField: ColumnInt('id', foreignTable),
+        ),
+      );
+      test('then new table relation still starts with base table name.', () {
+        expect(
+          newTableRelation.relationQueryAlias,
+          startsWith('company'),
+        );
+      });
+
+      test('then new table relation builds query prefix correctly.', () {
+        expect(
+          newTableRelation.relationQueryAlias,
+          'company_ceo_citizen_favoriteRestaurant_restaurant',
+        );
+      });
+    });
+  });
+
+  group('Given table relation with multiple relation definitions', () {
+    var companyTable = Table(tableName: 'company');
+    var citizenTable = Table(tableName: 'citizen');
+    var restaurantTable = Table(tableName: 'restaurant');
+    var tableRelationEntries = [
+      TableRelationEntry(
+        relationFieldName: 'ceo',
+        field: ColumnInt('ceoId', companyTable),
+        foreignField: ColumnInt('id', citizenTable),
+      ),
+      TableRelationEntry(
+        relationFieldName: 'favoriteRestaurant',
+        field: ColumnInt('favoriteRestaurantId', citizenTable),
+        foreignField: ColumnInt('id', restaurantTable),
+      ),
+    ];
+    TableRelation tableRelation = TableRelation(tableRelationEntries);
+
+    test(
+        'when buildRelationQueryAlias is called then query prefix is built correctly.',
+        () {
+      expect(
+        tableRelation.relationQueryAlias,
+        'company_ceo_citizen_favoriteRestaurant_restaurant',
+      );
+    });
+
+    group('when getRelations is called', () {
+      test(
+          'then returns list with one entry for each table relation definition.',
+          () {
+        expect(
+          tableRelation.getRelations,
+          hasLength(tableRelationEntries.length),
+        );
+      });
+
+      test(
+          'then last element builds same buildRelationQueryAlias as outer element.',
+          () {
+        expect(tableRelation.getRelations.last.relationQueryAlias,
+            tableRelation.relationQueryAlias);
+      });
+    });
+    test('when lastForeignTableName is called then last table is returned.',
+        () {
+      expect(tableRelation.lastForeignTableName, 'restaurant');
+    });
+
+    test(
+        'when lastJoiningField is called then last joining field name is returned.',
+        () {
+      expect(tableRelation.lastJoiningField,
+          'company_ceo_citizen."favoriteRestaurantId"');
+    });
+
+    test('when lastJoiningForeignField is called then last foreign field name.',
+        () {
+      expect(tableRelation.lastJoiningForeignField,
+          'company_ceo_citizen_favoriteRestaurant_restaurant."id"');
+    });
+  });
+}

--- a/packages/serverpod/test/database/table_relation_test.dart
+++ b/packages/serverpod/test/database/table_relation_test.dart
@@ -21,7 +21,7 @@ void main() {
     var foreignTable = Table(tableName: 'citizen');
     var tableRelationEntries = [
       TableRelationEntry(
-        relationFieldName: 'ceo',
+        relationAlias: 'ceo',
         field: ColumnInt('ceoId', table),
         foreignField: ColumnInt('id', foreignTable),
       ),
@@ -71,7 +71,7 @@ void main() {
       var foreignTable = Table(tableName: 'restaurant');
       var newTableRelation = tableRelation.copyAndAppend(
         TableRelationEntry(
-          relationFieldName: 'favoriteRestaurant',
+          relationAlias: 'favoriteRestaurant',
           field: ColumnInt('favoriteRestaurantId', table),
           foreignField: ColumnInt('id', foreignTable),
         ),
@@ -98,12 +98,12 @@ void main() {
     var restaurantTable = Table(tableName: 'restaurant');
     var tableRelationEntries = [
       TableRelationEntry(
-        relationFieldName: 'ceo',
+        relationAlias: 'ceo',
         field: ColumnInt('ceoId', companyTable),
         foreignField: ColumnInt('id', citizenTable),
       ),
       TableRelationEntry(
-        relationFieldName: 'favoriteRestaurant',
+        relationAlias: 'favoriteRestaurant',
         field: ColumnInt('favoriteRestaurantId', citizenTable),
         foreignField: ColumnInt('id', restaurantTable),
       ),

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/address.dart
@@ -273,10 +273,7 @@ class _AddressImpl extends Address {
 typedef AddressExpressionBuilder = _i1.Expression Function(AddressTable);
 
 class AddressTable extends _i1.Table {
-  AddressTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'address') {
+  AddressTable({super.tableRelation}) : super(tableName: 'address') {
     street = _i1.ColumnString(
       'street',
       this,
@@ -296,22 +293,12 @@ class AddressTable extends _i1.Table {
   _i2.CitizenTable get inhabitant {
     if (_inhabitant != null) return _inhabitant!;
     _inhabitant = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'inhabitant',
-      foreignTableName: _i2.Citizen.t.tableName,
-      column: inhabitantId,
-      foreignColumnName: _i2.Citizen.t.id.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.CitizenTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'inhabitant',
+      field: Address.t.inhabitantId,
+      foreignField: _i2.Citizen.t.id,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.CitizenTable(tableRelation: foreignTableRelation),
     );
     return _inhabitant!;
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/citizen.dart
@@ -330,10 +330,7 @@ class _CitizenImpl extends Citizen {
 typedef CitizenExpressionBuilder = _i1.Expression Function(CitizenTable);
 
 class CitizenTable extends _i1.Table {
-  CitizenTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'citizen') {
+  CitizenTable({super.tableRelation}) : super(tableName: 'citizen') {
     name = _i1.ColumnString(
       'name',
       this,
@@ -369,22 +366,12 @@ class CitizenTable extends _i1.Table {
   _i2.AddressTable get address {
     if (_address != null) return _address!;
     _address = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'address',
-      foreignTableName: _i2.Address.t.tableName,
-      column: id,
-      foreignColumnName: _i2.Address.t.inhabitantId.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.AddressTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'address',
+      field: Citizen.t.id,
+      foreignField: _i2.Address.t.inhabitantId,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.AddressTable(tableRelation: foreignTableRelation),
     );
     return _address!;
   }
@@ -392,22 +379,12 @@ class CitizenTable extends _i1.Table {
   _i2.CompanyTable get company {
     if (_company != null) return _company!;
     _company = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'company',
-      foreignTableName: _i2.Company.t.tableName,
-      column: companyId,
-      foreignColumnName: _i2.Company.t.id.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.CompanyTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'company',
+      field: Citizen.t.companyId,
+      foreignField: _i2.Company.t.id,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.CompanyTable(tableRelation: foreignTableRelation),
     );
     return _company!;
   }
@@ -415,22 +392,12 @@ class CitizenTable extends _i1.Table {
   _i2.CompanyTable get oldCompany {
     if (_oldCompany != null) return _oldCompany!;
     _oldCompany = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'oldCompany',
-      foreignTableName: _i2.Company.t.tableName,
-      column: oldCompanyId,
-      foreignColumnName: _i2.Company.t.id.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.CompanyTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'oldCompany',
+      field: Citizen.t.oldCompanyId,
+      foreignField: _i2.Company.t.id,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.CompanyTable(tableRelation: foreignTableRelation),
     );
     return _oldCompany!;
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/company.dart
@@ -285,10 +285,7 @@ class _CompanyImpl extends Company {
 typedef CompanyExpressionBuilder = _i1.Expression Function(CompanyTable);
 
 class CompanyTable extends _i1.Table {
-  CompanyTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'company') {
+  CompanyTable({super.tableRelation}) : super(tableName: 'company') {
     name = _i1.ColumnString(
       'name',
       this,
@@ -308,22 +305,12 @@ class CompanyTable extends _i1.Table {
   _i2.TownTable get town {
     if (_town != null) return _town!;
     _town = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'town',
-      foreignTableName: _i2.Town.t.tableName,
-      column: townId,
-      foreignColumnName: _i2.Town.t.id.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.TownTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'town',
+      field: Company.t.townId,
+      foreignField: _i2.Town.t.id,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.TownTable(tableRelation: foreignTableRelation),
     );
     return _town!;
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/post.dart
@@ -291,10 +291,7 @@ class _PostImpl extends Post {
 typedef PostExpressionBuilder = _i1.Expression Function(PostTable);
 
 class PostTable extends _i1.Table {
-  PostTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'post') {
+  PostTable({super.tableRelation}) : super(tableName: 'post') {
     content = _i1.ColumnString(
       'content',
       this,
@@ -316,22 +313,12 @@ class PostTable extends _i1.Table {
   _i2.PostTable get previous {
     if (_previous != null) return _previous!;
     _previous = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'previous',
-      foreignTableName: _i2.Post.t.tableName,
-      column: id,
-      foreignColumnName: _i2.Post.t.nextId.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.PostTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'previous',
+      field: Post.t.id,
+      foreignField: _i2.Post.t.nextId,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.PostTable(tableRelation: foreignTableRelation),
     );
     return _previous!;
   }
@@ -339,22 +326,12 @@ class PostTable extends _i1.Table {
   _i2.PostTable get next {
     if (_next != null) return _next!;
     _next = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'next',
-      foreignTableName: _i2.Post.t.tableName,
-      column: nextId,
-      foreignColumnName: _i2.Post.t.id.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.PostTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'next',
+      field: Post.t.nextId,
+      foreignField: _i2.Post.t.id,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.PostTable(tableRelation: foreignTableRelation),
     );
     return _next!;
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/town.dart
@@ -271,10 +271,7 @@ class _TownImpl extends Town {
 typedef TownExpressionBuilder = _i1.Expression Function(TownTable);
 
 class TownTable extends _i1.Table {
-  TownTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'town') {
+  TownTable({super.tableRelation}) : super(tableName: 'town') {
     name = _i1.ColumnString(
       'name',
       this,
@@ -294,22 +291,12 @@ class TownTable extends _i1.Table {
   _i2.CitizenTable get mayor {
     if (_mayor != null) return _mayor!;
     _mayor = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'mayor',
-      foreignTableName: _i2.Citizen.t.tableName,
-      column: mayorId,
-      foreignColumnName: _i2.Citizen.t.id.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.CitizenTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'mayor',
+      field: Town.t.mayorId,
+      foreignField: _i2.Citizen.t.id,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.CitizenTable(tableRelation: foreignTableRelation),
     );
     return _mayor!;
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -262,10 +262,8 @@ typedef ObjectFieldScopesExpressionBuilder = _i1.Expression Function(
     ObjectFieldScopesTable);
 
 class ObjectFieldScopesTable extends _i1.Table {
-  ObjectFieldScopesTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_field_scopes') {
+  ObjectFieldScopesTable({super.tableRelation})
+      : super(tableName: 'object_field_scopes') {
     normal = _i1.ColumnString(
       'normal',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -235,10 +235,8 @@ typedef ObjectWithByteDataExpressionBuilder = _i1.Expression Function(
     ObjectWithByteDataTable);
 
 class ObjectWithByteDataTable extends _i1.Table {
-  ObjectWithByteDataTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_bytedata') {
+  ObjectWithByteDataTable({super.tableRelation})
+      : super(tableName: 'object_with_bytedata') {
     byteData = _i1.ColumnByteData(
       'byteData',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -234,10 +234,8 @@ typedef ObjectWithDurationExpressionBuilder = _i1.Expression Function(
     ObjectWithDurationTable);
 
 class ObjectWithDurationTable extends _i1.Table {
-  ObjectWithDurationTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_duration') {
+  ObjectWithDurationTable({super.tableRelation})
+      : super(tableName: 'object_with_duration') {
     duration = _i1.ColumnDuration(
       'duration',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -304,10 +304,8 @@ typedef ObjectWithEnumExpressionBuilder = _i1.Expression Function(
     ObjectWithEnumTable);
 
 class ObjectWithEnumTable extends _i1.Table {
-  ObjectWithEnumTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_enum') {
+  ObjectWithEnumTable({super.tableRelation})
+      : super(tableName: 'object_with_enum') {
     testEnum = _i1.ColumnEnum<_i2.TestEnum>(
       'testEnum',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -251,10 +251,8 @@ typedef ObjectWithIndexExpressionBuilder = _i1.Expression Function(
     ObjectWithIndexTable);
 
 class ObjectWithIndexTable extends _i1.Table {
-  ObjectWithIndexTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_index') {
+  ObjectWithIndexTable({super.tableRelation})
+      : super(tableName: 'object_with_index') {
     indexed = _i1.ColumnInt(
       'indexed',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -330,10 +330,8 @@ typedef ObjectWithObjectExpressionBuilder = _i1.Expression Function(
     ObjectWithObjectTable);
 
 class ObjectWithObjectTable extends _i1.Table {
-  ObjectWithObjectTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_object') {
+  ObjectWithObjectTable({super.tableRelation})
+      : super(tableName: 'object_with_object') {
     data = _i1.ColumnSerializable(
       'data',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -233,10 +233,8 @@ typedef ObjectWithParentExpressionBuilder = _i1.Expression Function(
     ObjectWithParentTable);
 
 class ObjectWithParentTable extends _i1.Table {
-  ObjectWithParentTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_parent') {
+  ObjectWithParentTable({super.tableRelation})
+      : super(tableName: 'object_with_parent') {
     other = _i1.ColumnInt(
       'other',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -233,10 +233,8 @@ typedef ObjectWithSelfParentExpressionBuilder = _i1.Expression Function(
     ObjectWithSelfParentTable);
 
 class ObjectWithSelfParentTable extends _i1.Table {
-  ObjectWithSelfParentTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_self_parent') {
+  ObjectWithSelfParentTable({super.tableRelation})
+      : super(tableName: 'object_with_self_parent') {
     other = _i1.ColumnInt(
       'other',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -252,10 +252,8 @@ typedef ObjectWithUuidExpressionBuilder = _i1.Expression Function(
     ObjectWithUuidTable);
 
 class ObjectWithUuidTable extends _i1.Table {
-  ObjectWithUuidTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'object_with_uuid') {
+  ObjectWithUuidTable({super.tableRelation})
+      : super(tableName: 'object_with_uuid') {
     uuid = _i1.ColumnUuid(
       'uuid',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -275,10 +275,8 @@ typedef RelatedUniqueDataExpressionBuilder = _i1.Expression Function(
     RelatedUniqueDataTable);
 
 class RelatedUniqueDataTable extends _i1.Table {
-  RelatedUniqueDataTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'related_unique_data') {
+  RelatedUniqueDataTable({super.tableRelation})
+      : super(tableName: 'related_unique_data') {
     uniqueDataId = _i1.ColumnInt(
       'uniqueDataId',
       this,
@@ -298,22 +296,12 @@ class RelatedUniqueDataTable extends _i1.Table {
   _i2.UniqueDataTable get uniqueData {
     if (_uniqueData != null) return _uniqueData!;
     _uniqueData = _i1.createRelationTable(
-      queryPrefix: queryPrefix,
-      fieldName: 'uniqueData',
-      foreignTableName: _i2.UniqueData.t.tableName,
-      column: uniqueDataId,
-      foreignColumnName: _i2.UniqueData.t.id.columnName,
-      createTable: (
-        relationQueryPrefix,
-        foreignTableRelation,
-      ) =>
-          _i2.UniqueDataTable(
-        queryPrefix: relationQueryPrefix,
-        tableRelations: [
-          ...?tableRelations,
-          foreignTableRelation,
-        ],
-      ),
+      relationFieldName: 'uniqueData',
+      field: RelatedUniqueData.t.uniqueDataId,
+      foreignField: _i2.UniqueData.t.id,
+      tableRelation: tableRelation,
+      createTable: (foreignTableRelation) =>
+          _i2.UniqueDataTable(tableRelation: foreignTableRelation),
     );
     return _uniqueData!;
   }

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -236,10 +236,7 @@ class _SimpleDataImpl extends SimpleData {
 typedef SimpleDataExpressionBuilder = _i1.Expression Function(SimpleDataTable);
 
 class SimpleDataTable extends _i1.Table {
-  SimpleDataTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'simple_data') {
+  SimpleDataTable({super.tableRelation}) : super(tableName: 'simple_data') {
     num = _i1.ColumnInt(
       'num',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -236,10 +236,8 @@ typedef SimpleDateTimeExpressionBuilder = _i1.Expression Function(
     SimpleDateTimeTable);
 
 class SimpleDateTimeTable extends _i1.Table {
-  SimpleDateTimeTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'simple_date_time') {
+  SimpleDateTimeTable({super.tableRelation})
+      : super(tableName: 'simple_date_time') {
     dateTime = _i1.ColumnDateTime(
       'dateTime',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -371,10 +371,7 @@ class _TypesImpl extends Types {
 typedef TypesExpressionBuilder = _i1.Expression Function(TypesTable);
 
 class TypesTable extends _i1.Table {
-  TypesTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'types') {
+  TypesTable({super.tableRelation}) : super(tableName: 'types') {
     anInt = _i1.ColumnInt(
       'anInt',
       this,

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -250,10 +250,7 @@ class _UniqueDataImpl extends UniqueData {
 typedef UniqueDataExpressionBuilder = _i1.Expression Function(UniqueDataTable);
 
 class UniqueDataTable extends _i1.Table {
-  UniqueDataTable({
-    super.queryPrefix,
-    super.tableRelations,
-  }) : super(tableName: 'unique_data') {
+  UniqueDataTable({super.tableRelation}) : super(tableName: 'unique_data') {
     number = _i1.ColumnInt(
       'number',
       this,

--- a/tests/serverpod_test_server/test/database_operations/entity_relations/table_test.dart
+++ b/tests/serverpod_test_server/test/database_operations/entity_relations/table_test.dart
@@ -21,7 +21,7 @@ void main() {
       test('then each column expression has table relation.', () {
         var columns = expression.columns;
         var columnWithTableRelations =
-            columns.where((element) => element.table.tableRelations != null);
+            columns.where((element) => element.table.tableRelation != null);
 
         expect(columnWithTableRelations.length, 2,
             reason:
@@ -38,12 +38,12 @@ void main() {
       });
 
       test('then table relations exists.', () {
-        expect(nestedRelationAccess.table.tableRelations, isNotNull);
+        expect(nestedRelationAccess.table.tableRelation, isNotNull);
       });
 
       test('then an table relation is build for each table relation reference.',
           () {
-        expect(nestedRelationAccess.table.tableRelations?.length, 3,
+        expect(nestedRelationAccess.table.tableRelation?.getRelations.length, 3,
             reason:
                 'A table relation for each relation field traversal should be built, Citizen -> Company -> Town.');
       });
@@ -51,63 +51,69 @@ void main() {
       test(
           'then first table relation describes relation for citizen oldCompany field.',
           () {
-        var firstTableRelation = nestedRelationAccess.table.tableRelations![0];
+        var firstTableRelation =
+            nestedRelationAccess.table.tableRelation?.getRelations[0];
 
         expectTableRelationWith(
-          actualTable: firstTableRelation,
-          expectedTableName: 'company',
-          expectedQueryPrefix: 'citizen_oldCompany_',
-          expectedForeignTableColumn: 'citizen."oldCompanyId"',
-          expectedColumn: 'citizen_oldCompany_company."id"',
+          actualTableRelation: firstTableRelation,
+          expectedLastForeignTableName: 'company',
+          expectedRelationQueryAlias: 'citizen_oldCompany_company',
+          expectedLastJoiningField: 'citizen."oldCompanyId"',
+          expectedLastJoiningForeignField: 'citizen_oldCompany_company."id"',
         );
-      }, skip: nestedRelationAccess.table.tableRelations == null);
+      }, skip: nestedRelationAccess.table.tableRelation == null);
 
       test(
           'then second table relation describes relation for company town field.',
           () {
-        var secondTableRelation = nestedRelationAccess.table.tableRelations![1];
+        var secondTableRelation =
+            nestedRelationAccess.table.tableRelation?.getRelations[1];
 
         expectTableRelationWith(
-          actualTable: secondTableRelation,
-          expectedTableName: 'town',
-          expectedQueryPrefix: 'citizen_oldCompany_company_town_',
-          expectedForeignTableColumn: 'citizen_oldCompany_company."townId"',
-          expectedColumn: 'citizen_oldCompany_company_town_town."id"',
+          actualTableRelation: secondTableRelation,
+          expectedLastForeignTableName: 'town',
+          expectedRelationQueryAlias: 'citizen_oldCompany_company_town_town',
+          expectedLastJoiningField: 'citizen_oldCompany_company."townId"',
+          expectedLastJoiningForeignField:
+              'citizen_oldCompany_company_town_town."id"',
         );
-      }, skip: nestedRelationAccess.table.tableRelations == null);
+      }, skip: nestedRelationAccess.table.tableRelation == null);
 
       test('then third table relation describes relation for town mayor field.',
           () {
-        var thirdTableRelation = nestedRelationAccess.table.tableRelations![2];
+        var thirdTableRelation =
+            nestedRelationAccess.table.tableRelation?.getRelations[2];
 
         expectTableRelationWith(
-          actualTable: thirdTableRelation,
-          expectedTableName: 'citizen',
-          expectedQueryPrefix: 'citizen_oldCompany_company_town_town_mayor_',
-          expectedForeignTableColumn:
+          actualTableRelation: thirdTableRelation,
+          expectedLastForeignTableName: 'citizen',
+          expectedRelationQueryAlias:
+              'citizen_oldCompany_company_town_town_mayor_citizen',
+          expectedLastJoiningField:
               'citizen_oldCompany_company_town_town."mayorId"',
-          expectedColumn:
+          expectedLastJoiningForeignField:
               'citizen_oldCompany_company_town_town_mayor_citizen."id"',
         );
-      }, skip: nestedRelationAccess.table.tableRelations == null);
+      }, skip: nestedRelationAccess.table.tableRelation == null);
     });
   });
 }
 
 void expectTableRelationWith({
   required dynamic
-      actualTable /* Dynamic is used since we don't want to expose the TableRelation class */,
-  required String expectedTableName,
-  required String expectedQueryPrefix,
-  required String expectedForeignTableColumn,
-  required String expectedColumn,
+      actualTableRelation /* Dynamic is used since we don't want to expose the TableRelation class */,
+  required String expectedLastForeignTableName,
+  required String expectedRelationQueryAlias,
+  required String expectedLastJoiningField,
+  required String expectedLastJoiningForeignField,
 }) {
-  expect(actualTable.tableName, expectedTableName,
-      reason: 'Table name is wrong.');
-  expect(actualTable.queryPrefix, expectedQueryPrefix,
-      reason: 'Query prefix is wrong.');
-  expect(actualTable.foreignTableColumn.toString(), expectedForeignTableColumn,
-      reason: 'Foreign table column is wrong.');
-  expect(actualTable.column.toString(), expectedColumn,
-      reason: 'Column is wrong.');
+  expect(actualTableRelation.relationQueryAlias, expectedRelationQueryAlias,
+      reason: 'Relation query alias is wrong.');
+  expect(actualTableRelation.lastForeignTableName, expectedLastForeignTableName,
+      reason: 'Last foreign table name is wrong.');
+  expect(actualTableRelation.lastJoiningField, expectedLastJoiningField,
+      reason: 'Last joining field is wrong.');
+  expect(actualTableRelation.lastJoiningForeignField,
+      expectedLastJoiningForeignField,
+      reason: 'Last joining foreign field is wrong.');
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
@@ -1309,9 +1309,11 @@ class SerializableEntityLibraryGenerator {
                 .assign(refer('createRelationTable',
                         'package:serverpod/serverpod.dart')
                     .call([], {
-                  'queryPrefix': refer('queryPrefix'),
-                  'fieldName': literalString(field.name),
-                  'foreignTableName': field.type
+                  'relationFieldName': literalString(field.name),
+                  'field': refer(classDefinition.className)
+                      .property('t')
+                      .property(objectRelation.fieldName),
+                  'foreignField': field.type
                       .reference(
                         serverCode,
                         subDirParts: classDefinition.subDirParts,
@@ -1319,21 +1321,10 @@ class SerializableEntityLibraryGenerator {
                         nullable: false,
                       )
                       .property('t')
-                      .property('tableName'),
-                  'column': refer(objectRelation.fieldName),
-                  'foreignColumnName': field.type
-                      .reference(
-                        serverCode,
-                        subDirParts: classDefinition.subDirParts,
-                        config: config,
-                        nullable: false,
-                      )
-                      .property('t')
-                      .property(objectRelation.foreignFieldName)
-                      .property('columnName'),
+                      .property(objectRelation.foreignFieldName),
+                  'tableRelation': refer('tableRelation'),
                   'createTable': Method((m) => m
                     ..requiredParameters.addAll([
-                      Parameter((p) => p..name = 'relationQueryPrefix'),
                       Parameter((p) => p..name = 'foreignTableRelation'),
                     ])
                     ..lambda = true
@@ -1346,11 +1337,7 @@ class SerializableEntityLibraryGenerator {
                       typeSuffix: 'Table',
                     )
                         .call([], {
-                      'queryPrefix': refer('relationQueryPrefix'),
-                      'tableRelations': literalList([
-                        refer('tableRelations').nullSafeSpread,
-                        refer('foreignTableRelation'),
-                      ]),
+                      'tableRelation': refer('foreignTableRelation'),
                     }).code).closure
                 }))
                 .statement,
@@ -1368,15 +1355,7 @@ class SerializableEntityLibraryGenerator {
       constructorBuilder.optionalParameters.add(
         Parameter(
           (p) => p
-            ..name = 'queryPrefix'
-            ..toSuper = true
-            ..named = true,
-        ),
-      );
-      constructorBuilder.optionalParameters.add(
-        Parameter(
-          (p) => p
-            ..name = 'tableRelations'
+            ..name = 'tableRelation'
             ..toSuper = true
             ..named = true,
         ),

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/table_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/table_class_test.dart
@@ -59,13 +59,13 @@ void main() {
       });
 
       test(
-          'has constructor taking query prefix and table relations and passes table name to super.',
+          'has constructor taking table relation and passes table name to super.',
           () {
         expect(
             CompilationUnitHelpers.hasConstructorDeclaration(
               maybeClassNamedExampleTable!,
               name: null,
-              parameters: ['super.queryPrefix', 'super.tableRelations'],
+              parameters: ['super.tableRelation'],
               superArguments: ['tableName: \'$tableName\''],
             ),
             isTrue,


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod/issues/1407

### Change
- Stores each join as a separate entry.
- Move logic to build the query alias into the table relation.


### Benefits
- This enables the table relations to be split at any part so that we can form subqueries starting from any place in the relation chain.
- Simpler interface when creating relations between tables.
- Thanks to columns storing the table we can now always access the table the column belongs to.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Nothing that has been released.
