### PR TITLE
fix: Remove redundant Table variable and Query builder takes table as param.

### DIFF
--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -55,8 +55,7 @@ class DatabaseConnection {
       orderByList = [Order(column: orderBy, orderDescending: orderDescending)];
     }
 
-    var tableName = table.tableName;
-    var query = SelectQueryBuilder(table: tableName)
+    var query = SelectQueryBuilder(table: table)
         .withSelectFields(table.columns)
         .withWhere(where)
         .withOrderBy(orderByList)
@@ -284,7 +283,7 @@ class DatabaseConnection {
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'deleteWhere');
 
-    var query = DeleteQueryBuilder(table: table.tableName)
+    var query = DeleteQueryBuilder(table: table)
         .withReturn(Returning.id)
         .withWhere(where)
         .build();
@@ -303,7 +302,7 @@ class DatabaseConnection {
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'count');
 
-    var query = CountQueryBuilder(table: table.tableName)
+    var query = CountQueryBuilder(table: table)
         .withCountAlias('c')
         .withWhere(where)
         .withLimit(limit)

--- a/packages/serverpod/lib/src/database/database_connection_legacy.dart
+++ b/packages/serverpod/lib/src/database/database_connection_legacy.dart
@@ -169,8 +169,7 @@ class DatabaseConnectionLegacy {
 
     var startTime = DateTime.now();
 
-    var tableName = table.tableName;
-    var query = DeleteQueryBuilder(table: tableName)
+    var query = DeleteQueryBuilder(table: table)
         .withWhere(where)
         .withReturn(Returning.all)
         .build();
@@ -187,6 +186,7 @@ class DatabaseConnectionLegacy {
         timeoutInSeconds: 60,
         substitutionValues: {},
       );
+      var tableName = table.tableName;
       for (var rawRow in result) {
         list.add(_poolManager.serializationManager
             .deserialize<T>(rawRow[tableName]));
@@ -208,7 +208,7 @@ class DatabaseConnectionLegacy {
   }) async {
     var startTime = DateTime.now();
 
-    var query = DeleteQueryBuilder(table: row.table.tableName)
+    var query = DeleteQueryBuilder(table: row.table)
         .withWhere(Expression('id = ${row.id}'))
         .build();
 

--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -11,7 +11,7 @@ import 'package:serverpod/src/database/table_relation.dart';
 /// where expressions and includes for table relations.
 @internal
 class SelectQueryBuilder {
-  final String _table;
+  final Table _table;
   List<Column>? _fields;
   List<Order>? _orderBy;
   int? _limit;
@@ -20,17 +20,21 @@ class SelectQueryBuilder {
   Include? _include;
 
   /// Creates a new [SelectQueryBuilder].
-  SelectQueryBuilder({required String table}) : _table = table;
+  SelectQueryBuilder({required Table table}) : _table = table;
 
   /// Builds the SQL query.
   String build() {
-    _validateTableReferences(_table, orderBy: _orderBy, where: _where);
+    _validateTableReferences(
+      _table.tableName,
+      orderBy: _orderBy,
+      where: _where,
+    );
 
     var join =
         _buildJoinQuery(where: _where, orderBy: _orderBy, include: _include);
 
     var query = _buildSelectQuery(_fields, _include);
-    query += ' FROM "$_table"';
+    query += ' FROM "${_table.tableName}"';
     if (join != null) query += ' $join';
     if (_where != null) query += ' WHERE $_where';
     if (_orderBy != null) {
@@ -94,14 +98,14 @@ class SelectQueryBuilder {
 /// for table relations.
 @internal
 class CountQueryBuilder {
-  final String _table;
+  final Table _table;
   String? _alias;
   String _field;
   int? _limit;
   Expression? _where;
 
   /// Creates a new [CountQueryBuilder].
-  CountQueryBuilder({required String table})
+  CountQueryBuilder({required Table table})
       : _table = table,
         _field = '*';
 
@@ -134,13 +138,13 @@ class CountQueryBuilder {
 
   /// Builds the SQL query.
   String build() {
-    _validateTableReferences(_table, where: _where);
+    _validateTableReferences(_table.tableName, where: _where);
 
     var join = _buildJoinQuery(where: _where);
 
     var query = 'SELECT COUNT($_field)';
     if (_alias != null) query += ' AS $_alias';
-    query += ' FROM "$_table"';
+    query += ' FROM "${_table.tableName}"';
     if (join != null) query += ' $join';
     if (_where != null) query += ' WHERE $_where';
     if (_limit != null) query += ' LIMIT $_limit';
@@ -171,12 +175,12 @@ enum Returning {
 /// Builds a SQL query for a delete statement.
 @internal
 class DeleteQueryBuilder {
-  final String _table;
+  final Table _table;
   String? _returningStatement;
   Expression? _where;
 
   /// Creates a new [DeleteQueryBuilder].
-  DeleteQueryBuilder({required String table})
+  DeleteQueryBuilder({required Table table})
       : _table = table,
         _returningStatement = null;
 
@@ -187,7 +191,7 @@ class DeleteQueryBuilder {
         _returningStatement = ' RETURNING *';
         break;
       case Returning.id:
-        _returningStatement = ' RETURNING "$_table".id';
+        _returningStatement = ' RETURNING "${_table.tableName}".id';
         break;
       case Returning.none:
         _returningStatement = null;
@@ -207,11 +211,11 @@ class DeleteQueryBuilder {
 
   /// Builds the SQL query.
   String build() {
-    _validateTableReferences(_table, where: _where);
+    _validateTableReferences(_table.tableName, where: _where);
 
     var using = _buildUsingQuery(where: _where);
 
-    var query = 'DELETE FROM "$_table"';
+    var query = 'DELETE FROM "${_table.tableName}"';
     if (using != null) query += ' USING ${using.using}';
     if (_where != null) query += ' WHERE $_where';
     if (using != null) query += ' AND ${using.where}';

--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -12,7 +12,7 @@ import 'package:serverpod/src/database/table_relation.dart';
 @internal
 class SelectQueryBuilder {
   final Table _table;
-  late List<Column> _fields;
+  List<Column> _fields;
   List<Order>? _orderBy;
   int? _limit;
   int? _offset;
@@ -21,18 +21,16 @@ class SelectQueryBuilder {
 
   /// Creates a new [SelectQueryBuilder].
   /// Throws an [ArgumentError] if the table has no columns.
-  SelectQueryBuilder({required Table table}) : _table = table {
-    var columns = table.columns;
-
-    if (columns.isEmpty) {
+  SelectQueryBuilder({required Table table})
+      : _table = table,
+        _fields = table.columns {
+    if (_fields.isEmpty) {
       throw ArgumentError.value(
         table,
         'table',
         'Must have at least one column',
       );
     }
-
-    _fields = table.columns;
   }
 
   /// Builds the SQL query.

--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -120,10 +120,8 @@ class Table {
   /// The database id.
   late final ColumnInt id;
 
-  late List<Column>? _columns;
-
   /// List of [Column] used by the table.
-  List<Column> get columns => _columns!;
+  List<Column> get columns => [id];
 
   /// Query prefix for [Column]s of the table.
   String get queryPrefix {
@@ -136,10 +134,8 @@ class Table {
   /// Creates a new [Table]. Typically, this is done only by generated code.
   Table({
     required this.tableName,
-    List<Column>? columns,
     this.tableRelation,
   }) {
-    _columns = columns;
     id = ColumnInt(
       'id',
       this,

--- a/packages/serverpod/test/database/database_query_test.dart
+++ b/packages/serverpod/test/database/database_query_test.dart
@@ -9,20 +9,19 @@ void main() {
 
   group('Given SelectQueryBuilder', () {
     test('when default initialized then build outputs a valid SQL query.', () {
-      var query = SelectQueryBuilder(table: 'citizen').build();
+      var query = SelectQueryBuilder(table: citizenTable).build();
 
       expect(query, 'SELECT * FROM "citizen"');
     });
 
     test('when query with specific fields is built then output selects fields.',
         () {
-      var table = Table(tableName: 'citizen');
       var fields = [
-        ColumnString('id', table),
-        ColumnString('name', table),
-        ColumnString('age', table),
+        ColumnString('id', citizenTable),
+        ColumnString('name', citizenTable),
+        ColumnString('age', citizenTable),
       ];
-      var query = SelectQueryBuilder(table: table.tableName)
+      var query = SelectQueryBuilder(table: citizenTable)
           .withSelectFields(fields)
           .build();
 
@@ -33,7 +32,7 @@ void main() {
     test(
         'when query with simple where expression is built then output is a WHERE query.',
         () {
-      var query = SelectQueryBuilder(table: 'citizen')
+      var query = SelectQueryBuilder(table: citizenTable)
           .withWhere(const Expression('"test"=@test'))
           .build();
 
@@ -47,7 +46,7 @@ void main() {
       var expression2 = const Expression('FALSE = FALSE');
       var combinedExpression = expression1 & expression2;
 
-      var query = SelectQueryBuilder(table: 'citizen')
+      var query = SelectQueryBuilder(table: citizenTable)
           .withWhere(combinedExpression)
           .build();
 
@@ -58,14 +57,13 @@ void main() {
     test(
         'when query with single order by is built then output is single order by query.',
         () {
-      var table = Table(tableName: 'citizen');
       Order order = Order(
-        column: ColumnString('id', table),
+        column: ColumnString('id', citizenTable),
         orderDescending: false,
       );
 
-      var query = SelectQueryBuilder(table: table.tableName)
-          .withOrderBy([order]).build();
+      var query =
+          SelectQueryBuilder(table: citizenTable).withOrderBy([order]).build();
 
       expect(query, 'SELECT * FROM "citizen" ORDER BY citizen."id"');
     });
@@ -73,39 +71,38 @@ void main() {
     test(
         'when query with multiple order by is built then output is query with multiple order by requirements.',
         () {
-      var table = Table(tableName: 'citizen');
       var orders = [
         Order(
-          column: ColumnString('id', table),
+          column: ColumnString('id', citizenTable),
           orderDescending: false,
         ),
         Order(
-          column: ColumnString('name', table),
+          column: ColumnString('name', citizenTable),
           orderDescending: true,
         ),
         Order(
-          column: ColumnString('age', table),
+          column: ColumnString('age', citizenTable),
           orderDescending: false,
         )
       ];
 
-      var query = SelectQueryBuilder(table: table.tableName)
-          .withOrderBy(orders)
-          .build();
+      var query =
+          SelectQueryBuilder(table: citizenTable).withOrderBy(orders).build();
 
       expect(query,
           'SELECT * FROM "citizen" ORDER BY citizen."id", citizen."name" DESC, citizen."age"');
     });
 
     test('when query with limit is built then output is query with limit.', () {
-      var query = SelectQueryBuilder(table: 'citizen').withLimit(10).build();
+      var query = SelectQueryBuilder(table: citizenTable).withLimit(10).build();
 
       expect(query, 'SELECT * FROM "citizen" LIMIT 10');
     });
 
     test('when query with offset is built then output is query with offset.',
         () {
-      var query = SelectQueryBuilder(table: 'citizen').withOffset(10).build();
+      var query =
+          SelectQueryBuilder(table: citizenTable).withOffset(10).build();
 
       expect(query, 'SELECT * FROM "citizen" OFFSET 10');
     });
@@ -124,7 +121,7 @@ void main() {
         ]),
       );
 
-      var query = SelectQueryBuilder(table: citizenTable.tableName)
+      var query = SelectQueryBuilder(table: citizenTable)
           .withWhere(ColumnString('name', relationTable).equals('Serverpod'))
           .build();
 
@@ -151,7 +148,7 @@ void main() {
         ]),
       );
 
-      var query = SelectQueryBuilder(table: citizenTable.tableName)
+      var query = SelectQueryBuilder(table: citizenTable)
           .withWhere(ColumnString(
             'name',
             nestedRelationTable,
@@ -175,7 +172,7 @@ void main() {
         ]),
       );
 
-      var query = SelectQueryBuilder(table: citizenTable.tableName)
+      var query = SelectQueryBuilder(table: citizenTable)
           .withSelectFields([
             ColumnString('id', citizenTable),
             ColumnString('name', citizenTable),
@@ -200,7 +197,7 @@ void main() {
     test(
         'when column where expression has different table as base then exception is thrown.',
         () {
-      var queryBuilder = SelectQueryBuilder(table: citizenTable.tableName)
+      var queryBuilder = SelectQueryBuilder(table: citizenTable)
           .withWhere(ColumnString('name', companyTable).equals('Serverpod'));
 
       expect(
@@ -215,7 +212,7 @@ void main() {
 
     test('when order by has different table as base then exception is thrown.',
         () {
-      var queryBuilder = SelectQueryBuilder(table: citizenTable.tableName)
+      var queryBuilder = SelectQueryBuilder(table: citizenTable)
           .withOrderBy([Order(column: ColumnString('name', companyTable))]);
 
       expect(
@@ -231,21 +228,22 @@ void main() {
 
   group('Given CountQueryBuilder', () {
     test('when default initialized then build outputs a valid SQL query.', () {
-      var query = CountQueryBuilder(table: 'citizen').build();
+      var query = CountQueryBuilder(table: citizenTable).build();
 
       expect(query, 'SELECT COUNT(*) FROM "citizen"');
     });
     test('when query with alias is built then count result has defined alias.',
         () {
       var query =
-          CountQueryBuilder(table: 'citizen').withCountAlias('c').build();
+          CountQueryBuilder(table: citizenTable).withCountAlias('c').build();
 
       expect(query, 'SELECT COUNT(*) AS c FROM "citizen"');
     });
 
     test('when query with field is built then count is based on that field.',
         () {
-      var query = CountQueryBuilder(table: 'citizen').withField('age').build();
+      var query =
+          CountQueryBuilder(table: citizenTable).withField('age').build();
 
       expect(query, 'SELECT COUNT(age) FROM "citizen"');
     });
@@ -253,7 +251,7 @@ void main() {
     test(
         'when query with where expression is built then output is a WHERE query.',
         () {
-      var query = CountQueryBuilder(table: 'citizen')
+      var query = CountQueryBuilder(table: citizenTable)
           .withWhere(const Expression('"test"=@test'))
           .build();
 
@@ -262,7 +260,7 @@ void main() {
 
     test('when query with limit is built then output is a query with limit.',
         () {
-      var query = CountQueryBuilder(table: 'citizen').withLimit(10).build();
+      var query = CountQueryBuilder(table: citizenTable).withLimit(10).build();
 
       expect(query, 'SELECT COUNT(*) FROM "citizen" LIMIT 10');
     });
@@ -281,7 +279,7 @@ void main() {
         ]),
       );
 
-      var query = CountQueryBuilder(table: citizenTable.tableName)
+      var query = CountQueryBuilder(table: citizenTable)
           .withWhere(ColumnString(
             'name',
             relationTable,
@@ -311,7 +309,7 @@ void main() {
         ]),
       );
 
-      var query = CountQueryBuilder(table: citizenTable.tableName)
+      var query = CountQueryBuilder(table: citizenTable)
           .withWhere(ColumnString(
             'name',
             nestedRelationTable,
@@ -336,7 +334,7 @@ void main() {
         ]),
       );
 
-      var query = CountQueryBuilder(table: citizenTable.tableName)
+      var query = CountQueryBuilder(table: citizenTable)
           .withCountAlias('c')
           .withField('age')
           .withWhere(
@@ -352,7 +350,7 @@ void main() {
     test(
         'when column where expression has different table as base then exception is thrown.',
         () {
-      var queryBuilder = CountQueryBuilder(table: citizenTable.tableName)
+      var queryBuilder = CountQueryBuilder(table: citizenTable)
           .withWhere(ColumnString('name', companyTable).equals('Serverpod'));
 
       expect(
@@ -368,7 +366,7 @@ void main() {
 
   group('Given DeleteQueryBuilder', () {
     test('when default initialized then build outputs a valid SQL query.', () {
-      var query = DeleteQueryBuilder(table: 'citizen').build();
+      var query = DeleteQueryBuilder(table: citizenTable).build();
 
       expect(query, 'DELETE FROM "citizen"');
     });
@@ -376,7 +374,7 @@ void main() {
     test(
         'when query with where expression is built then output is a WHERE query.',
         () {
-      var query = DeleteQueryBuilder(table: 'citizen')
+      var query = DeleteQueryBuilder(table: citizenTable)
           .withWhere(const Expression('"test"=@test'))
           .build();
 
@@ -385,7 +383,7 @@ void main() {
 
     test('when query returning all is built then output is a return all query.',
         () {
-      var query = DeleteQueryBuilder(table: 'citizen')
+      var query = DeleteQueryBuilder(table: citizenTable)
           .withReturn(Returning.all)
           .build();
 
@@ -394,8 +392,9 @@ void main() {
 
     test('when query return id is build then the output is a return id query.',
         () {
-      var query =
-          DeleteQueryBuilder(table: 'citizen').withReturn(Returning.id).build();
+      var query = DeleteQueryBuilder(table: citizenTable)
+          .withReturn(Returning.id)
+          .build();
 
       expect(query, 'DELETE FROM "citizen" RETURNING "citizen".id');
     });
@@ -414,7 +413,7 @@ void main() {
         ]),
       );
 
-      var query = DeleteQueryBuilder(table: citizenTable.tableName)
+      var query = DeleteQueryBuilder(table: citizenTable)
           .withWhere(ColumnString('name', relationTable).equals('Serverpod'))
           .build();
 
@@ -441,7 +440,7 @@ void main() {
         ]),
       );
 
-      var query = DeleteQueryBuilder(table: citizenTable.tableName)
+      var query = DeleteQueryBuilder(table: citizenTable)
           .withWhere(ColumnString('name', nestedRelationTable).equals('Alex'))
           .build();
 
@@ -463,7 +462,7 @@ void main() {
         ]),
       );
 
-      var query = DeleteQueryBuilder(table: citizenTable.tableName)
+      var query = DeleteQueryBuilder(table: citizenTable)
           .withWhere(ColumnString('name', relationTable).equals('Serverpod'))
           .withReturn(Returning.all)
           .build();
@@ -475,7 +474,7 @@ void main() {
     test(
         'when column where expression has different table as base then exception is thrown.',
         () {
-      var queryBuilder = DeleteQueryBuilder(table: citizenTable.tableName)
+      var queryBuilder = DeleteQueryBuilder(table: citizenTable)
           .withWhere(ColumnString('name', companyTable).equals('Serverpod'));
 
       expect(

--- a/tests/serverpod_test_server/test/database_operations/entity_relations/sql_query_test.dart
+++ b/tests/serverpod_test_server/test/database_operations/entity_relations/sql_query_test.dart
@@ -5,7 +5,7 @@ import '../../../../../packages/serverpod/lib/src/database/database_query.dart';
 void main() {
   group('Given nested relations when building shallow include sql query', () {
     test('then query only joins what is included.', () {
-      var query = SelectQueryBuilder(table: Citizen.t.tableName)
+      var query = SelectQueryBuilder(table: Citizen.t)
           .withSelectFields(Citizen.t.columns)
           .withInclude(
             Citizen.include(


### PR DESCRIPTION
Mixed improvements to QueryBuilder and one cleanup if Table.

### Changes
- Remove `columns` parameter in table to remove dangerous dereference.
- QueryBuilder now takes in Table instead of table name.
- QueryBuilder now always selects explicit fields (removes use of `*`).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
