### PR TITLE
fix: throw UnimplementedError when ordering by multiple many relations.

### DIFF
--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -85,14 +85,29 @@ class SelectQueryBuilder {
   /// If order by includes columns from a relation, the relation will be joined
   /// in the query.
   /// Throws an [ArgumentError] if the same column is included multiple times.
+  /// Throws an [UnimplementedError] if multiple many relation columns are
+  /// included.
   SelectQueryBuilder withOrderBy(List<Order>? orderBy) {
     Set<String> columns = {};
+    bool hasCountColumn = false;
     for (var order in orderBy ?? []) {
       if (columns.contains(order.column.queryAlias)) {
         throw ArgumentError(
           'Ordering by same column multiple times: ${order.column.queryAlias}',
         );
       }
+
+      if (order.column is ColumnCount) {
+        if (hasCountColumn) {
+          throw UnimplementedError(
+            'Ordering by multiple many relation columns is not supported. '
+            'Please file an issue at '
+            'https://github.com/serverpod/serverpod/issues if you need this.',
+          );
+        }
+        hasCountColumn = true;
+      }
+
       columns.add(order.column.queryAlias);
     }
 

--- a/packages/serverpod/test/database/database_query_test.dart
+++ b/packages/serverpod/test/database/database_query_test.dart
@@ -451,6 +451,40 @@ void main() {
                 'FormatException: Count columns are not supported in where expressions.'),
           )));
     });
+
+    test('when ordering by multiple many relations then exception is thrown.',
+        () {
+      var friendsRelationTable = _TableWithManyRelation(
+        tableName: citizenTable.tableName,
+        relationAlias: 'friends',
+      );
+      var enemiesRelationTable = _TableWithManyRelation(
+        tableName: citizenTable.tableName,
+        relationAlias: 'enemies',
+      );
+
+      List<Order> orderByList = [
+        Order(
+          column: friendsRelationTable.manyRelation.count(),
+          orderDescending: false,
+        ),
+        Order(
+          column: enemiesRelationTable.manyRelation.count(),
+          orderDescending: false,
+        )
+      ];
+
+      expect(
+          () =>
+              SelectQueryBuilder(table: citizenTable).withOrderBy(orderByList),
+          throwsA(isA<UnimplementedError>().having(
+            (e) => e.toString(),
+            'message',
+            equals(
+              'UnimplementedError: Ordering by multiple many relation columns is not supported. Please file an issue at https://github.com/serverpod/serverpod/issues if you need this.',
+            ),
+          )));
+    });
   });
 
   group('Given CountQueryBuilder', () {


### PR DESCRIPTION
Stops developers from including multiple many relation orderings when querying database.

The reason is that we right now do a common join and then group for any many relation count ordering. This does not work when multiple many relation counts are included.

For that to work we probably need to implement subqueries that can then be used to order on.

Closes: 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
