### PR TITLE
fix: Support Order by count in nested relation

### DIFF
--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:serverpod/database.dart';
 import 'package:serverpod/src/database/table_relation.dart';
@@ -371,7 +372,7 @@ String? _buildGroupByQuery(
     return null;
   }
 
-  return selectFields.map((column) => '"${column.queryAlias}"').join(', ');
+  return selectFields.map((column) => '$column').join(', ');
 }
 
 String? _buildWhereQuery({Expression? where}) {
@@ -480,10 +481,13 @@ LinkedHashMap<String, _JoinContext> _gatherJoinContexts(List<Column> columns) {
 
     var subQuery = column is ColumnCount && column.innerWhere != null;
 
-    for (var subTableRelation in tableRelation.getRelations) {
+    var subTableRelations = tableRelation.getRelations;
+
+    subTableRelations.forEachIndexed((index, subTableRelation) {
+      bool lastEntry = index == subTableRelations.length - 1;
       joins[subTableRelation.relationQueryAlias] =
-          _JoinContext(subTableRelation, subQuery);
-    }
+          _JoinContext(subTableRelation, lastEntry ? subQuery : false);
+    });
   }
 
   return joins;

--- a/packages/serverpod/test/database/database_query_test.dart
+++ b/packages/serverpod/test/database/database_query_test.dart
@@ -183,7 +183,7 @@ void main() {
 
       expect(
         query,
-        'SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "citizen" AS "citizen_friends_citizen" ON "citizen"."id" = "citizen_friends_citizen"."id" GROUP BY "citizen.id" ORDER BY COUNT("citizen_friends_citizen"."id")',
+        'SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "citizen" AS "citizen_friends_citizen" ON "citizen"."id" = "citizen_friends_citizen"."id" GROUP BY "citizen"."id" ORDER BY COUNT("citizen_friends_citizen"."id")',
       );
     });
 
@@ -203,7 +203,7 @@ void main() {
           SelectQueryBuilder(table: citizenTable).withOrderBy([order]).build();
 
       expect(query,
-          'WITH "citizen_friends_citizen" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" WHERE "citizen"."id" = 5) SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "citizen_friends_citizen" ON "citizen"."id" = "citizen_friends_citizen"."citizen.id" GROUP BY "citizen.id" ORDER BY COUNT("citizen_friends_citizen"."citizen.id")');
+          'WITH "citizen_friends_citizen" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" WHERE "citizen"."id" = 5) SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "citizen_friends_citizen" ON "citizen"."id" = "citizen_friends_citizen"."citizen.id" GROUP BY "citizen"."id" ORDER BY COUNT("citizen_friends_citizen"."citizen.id")');
     });
 
     test('when query with limit is built then output is query with limit.', () {
@@ -326,7 +326,7 @@ void main() {
           .build();
 
       expect(query,
-          'WITH "citizen_companiesOwned_company" AS (SELECT "company"."id" AS "company.id" FROM "company" WHERE "company"."id" = 5) SELECT "citizen"."id" AS "citizen.id", "citizen"."name" AS "citizen.name", "citizen"."age" AS "citizen.age" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."companyId" = "citizen_company_company"."id" LEFT JOIN "citizen_companiesOwned_company" ON "citizen"."id" = "citizen_companiesOwned_company"."company.id" WHERE "citizen_company_company"."name" = \'Serverpod\' GROUP BY "citizen.id", "citizen.name", "citizen.age" ORDER BY "citizen"."id" DESC, COUNT("citizen_companiesOwned_company"."company.id") LIMIT 10 OFFSET 5');
+          'WITH "citizen_companiesOwned_company" AS (SELECT "company"."id" AS "company.id" FROM "company" WHERE "company"."id" = 5) SELECT "citizen"."id" AS "citizen.id", "citizen"."name" AS "citizen.name", "citizen"."age" AS "citizen.age" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."companyId" = "citizen_company_company"."id" LEFT JOIN "citizen_companiesOwned_company" ON "citizen"."id" = "citizen_companiesOwned_company"."company.id" WHERE "citizen_company_company"."name" = \'Serverpod\' GROUP BY "citizen"."id", "citizen"."name", "citizen"."age" ORDER BY "citizen"."id" DESC, COUNT("citizen_companiesOwned_company"."company.id") LIMIT 10 OFFSET 5');
     });
 
     test(

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/order_by_test.dart
@@ -1,0 +1,73 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod/server.dart';
+import 'package:test/test.dart';
+
+Future<void> _createTestDatabase(Session session) async {
+  var otherEmployees = await Person.db.insert(session, [
+    Person(name: 'Tom'),
+    Person(name: 'John'),
+    Person(name: 'Jane'),
+  ]);
+
+  var otherOrganization = await Organization.db.insertRow(
+    session,
+    Organization(name: 'Other'),
+  );
+
+  await Organization.db.attach
+      .people(session, otherOrganization, otherEmployees);
+
+  var serverpodEmployees = await Person.db.insert(session, [
+    Person(name: 'Alex'),
+    Person(name: 'Isak'),
+    Person(name: 'Viktor'),
+  ]);
+
+  var serverpod = await Organization.db.insertRow(
+    session,
+    Organization(name: 'Serverpod'),
+  );
+
+  await Organization.db.attach.people(session, serverpod, serverpodEmployees);
+}
+
+Future<void> _clearTestDatabase(Session session) async {
+  await Person.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+  await Organization.db
+      .deleteWhere(session, where: (_) => db.Constant.bool(true));
+}
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  setUpAll(() async => await _createTestDatabase(session));
+  tearDownAll(() async => await _clearTestDatabase(session));
+
+  group('Given ordered find query', () {
+    test(
+        'when ordering on filtered count of nested many relation then result is as expected.',
+        () async {
+      var customers = await Person.db.find(
+        session,
+        // Order people by number of people in their organization with a name
+        // starting with 'a' and then their name in descending order.
+        orderByList: [
+          db.Order(
+            column:
+                Person.t.organization.people.count((p) => p.name.ilike('a%')),
+            orderDescending: true,
+          ),
+          db.Order(
+            column: Person.t.name,
+            orderDescending: true,
+          )
+        ],
+      );
+
+      var customerNames = customers.map((e) => e.name);
+      expect(customerNames, ['Viktor', 'Isak', 'Alex', 'Tom', 'John', 'Jane']);
+    });
+  });
+}


### PR DESCRIPTION
Given these entities: 

``` yaml
class: Person
table: person
fields:
  name: String
  organization: Organization?, relation(name=org_person, optional)

```

``` yaml
class: Organization
table: organization
fields:
  name: String
  people: List<Person>?, relation(name=org_person)
```

There was an issue when ordering by nested count queries like so:

``` dart
Person.db.find(
    session,
    // Order people by number of people in their organization with a name
    // starting with 'a'
    orderBy: Person.t.organization.people.count((p) => p.name.ilike('a%')),
    orderDescending: true,
);
```

An issue occurred that named both the grouping and the joins incorrectly.

This PR fixes that issue.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Affects only unreleased new features.
