### PR TITLE
Add short-circuit evaluation to `&` and `|` in queries

### DIFF
--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -24,7 +24,28 @@ class Expression<T> {
   /// Database AND operator.
   Expression operator &(dynamic other) {
     if (other is bool) {
-      return other ? this : Constant(other);
+      other = Constant(other);
+    }
+    bool? thisBoolValue = this is! Constant
+        ? null
+        : this._expression == 'TRUE'
+            ? true
+            : this._expression == 'FALSE'
+                ? false
+                : null;
+    bool? otherBoolValue = other is! Constant
+        ? null
+        : other._expression == 'TRUE'
+            ? true
+            : this._expression == 'FALSE'
+                ? false
+                : null;
+    if (thisBoolValue == false || otherBoolValue == false) {
+      return Constant(false);
+    } else if (thisBoolValue == true) {
+      return other;
+    } else if (otherBoolValue == true) {
+      return this;
     } else if (other is Expression) {
       return _AndExpression(this, other);
     }
@@ -35,7 +56,28 @@ class Expression<T> {
   /// Database OR operator.
   Expression operator |(dynamic other) {
     if (other is bool) {
-      return other ? Constant(other) : this;
+      other = Constant(other);
+    }
+    bool? thisBoolValue = this is! Constant
+        ? null
+        : this._expression == 'TRUE'
+            ? true
+            : this._expression == 'FALSE'
+                ? false
+                : null;
+    bool? otherBoolValue = other is! Constant
+        ? null
+        : other._expression == 'TRUE'
+            ? true
+            : this._expression == 'FALSE'
+                ? false
+                : null;
+    if (thisBoolValue == true || otherBoolValue == true) {
+      return Constant(true);
+    } else if (thisBoolValue == false) {
+      return other;
+    } else if (otherBoolValue == false) {
+      return this;
     } else if (other is Expression) {
       return _OrExpression(this, other);
     }

--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -23,7 +23,9 @@ class Expression<T> {
 
   /// Database AND operator.
   Expression operator &(dynamic other) {
-    if (other is Expression) {
+    if (other is bool) {
+      return other ? this : Constant(other);
+    } else if (other is Expression) {
       return _AndExpression(this, other);
     }
 
@@ -32,7 +34,9 @@ class Expression<T> {
 
   /// Database OR operator.
   Expression operator |(dynamic other) {
-    if (other is Expression) {
+    if (other is bool) {
+      return other ? Constant(other) : this;
+    } else if (other is Expression) {
       return _OrExpression(this, other);
     }
 


### PR DESCRIPTION
This PR:
1. allows the user to use `bool` values directly in expressions (they get wrapped with `Constant(bool)`);
2. adds basic short-circuit evaluation, to simplify queries (presumably Postgres also does this, but why not)

(I didn't write any tests... sorry, I really don't have time to do so right now...)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).
