### PR TITLE
refactor: Remove redundant `_JoinContext`.

### DIFF
--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -464,20 +464,6 @@ List<Table> _gatherIncludeTables(Include? include, Table table) {
   return tables;
 }
 
-class _JoinContext {
-  // TODO: Remove class once we have full support for many relations
-  // Only the join statement should matter at that point.
-  final TableRelation tableRelation;
-  final bool subQuery;
-  final String? joinStatement;
-
-  _JoinContext(
-    this.tableRelation,
-    this.subQuery, {
-    this.joinStatement,
-  });
-}
-
 String? _buildJoinQuery({
   Expression? where,
   ColumnExpression? having,
@@ -487,40 +473,38 @@ String? _buildJoinQuery({
   TableRelation? countTableRelation,
   joinOneLevelManyRelations = false,
 }) {
-  LinkedHashMap<String, _JoinContext> tableRelations = LinkedHashMap();
+  // Linked hash map to preserve order and remove duplicates.
+  // Key is the query alias and value is the join statement.
+  LinkedHashMap<String, String> joins = LinkedHashMap();
   if (where != null) {
-    tableRelations.addAll(_gatherWhereJoinContexts(
+    joins.addAll(_gatherWhereJoins(
       where.columns,
       joinOneLevelManyRelations: joinOneLevelManyRelations,
     ));
   }
 
   if (orderBy != null) {
-    tableRelations
-        .addAll(_gatherOrderByJoinContexts(orderBy, subQueries: subQueries));
+    joins.addAll(_gatherOrderByJoins(orderBy, subQueries: subQueries));
   }
 
   if (include != null) {
-    tableRelations.addAll(_gatherIncludeJoinContexts(include));
+    joins.addAll(_gatherIncludeJoins(include));
   }
 
   if (countTableRelation != null) {
-    tableRelations[countTableRelation.relationQueryAlias] = _JoinContext(
-      countTableRelation,
-      false,
-      joinStatement: _buildJoinStatement(tableRelation: countTableRelation),
-    );
+    joins[countTableRelation.relationQueryAlias] =
+        _buildJoinStatement(tableRelation: countTableRelation);
   }
 
   if (having != null) {
-    tableRelations.addEntries([_gatherHavingJoinContext(having)]);
+    joins.addEntries([_buildHavingJoin(having)]);
   }
 
-  if (tableRelations.isEmpty) {
+  if (joins.isEmpty) {
     return null;
   }
 
-  return _joinStatementFromJoinContexts(tableRelations);
+  return joins.values.join(' ');
 }
 
 String? _buildGroupByQuery(
@@ -776,11 +760,12 @@ String _formatOrderByCount(
   return str;
 }
 
-LinkedHashMap<String, _JoinContext> _gatherOrderByJoinContexts(
+LinkedHashMap<String, String> _gatherOrderByJoins(
   List<Order> orderBy, {
   _SubQueries? subQueries,
 }) {
-  LinkedHashMap<String, _JoinContext> joins = LinkedHashMap();
+  // Linked hash map to preserve order and remove duplicates.
+  LinkedHashMap<String, String> joins = LinkedHashMap();
   var orderByQueries = subQueries?._orderByQueries;
   orderBy.forEachIndexed((orderIndex, order) {
     var column = order.column;
@@ -807,19 +792,13 @@ LinkedHashMap<String, _JoinContext> _gatherOrderByJoinContexts(
               'Missing query alias for order by sub query with index $index.');
         }
 
-        joins[queryAlias] = _JoinContext(
-          subTableRelation,
-          true,
-          joinStatement: _buildSubQueryJoinStatement(
-            tableRelation: tableRelation,
-            queryAlias: queryAlias,
-          ),
+        joins[queryAlias] = _buildSubQueryJoinStatement(
+          tableRelation: tableRelation,
+          queryAlias: queryAlias,
         );
       } else {
-        joins[subTableRelation.relationQueryAlias] = _JoinContext(
-          subTableRelation,
-          false,
-          joinStatement: _buildJoinStatement(tableRelation: subTableRelation),
+        joins[subTableRelation.relationQueryAlias] = _buildJoinStatement(
+          tableRelation: subTableRelation,
         );
       }
     });
@@ -843,12 +822,12 @@ String _buildJoinStatement({required TableRelation tableRelation}) {
       '${tableRelation.foreignFieldNameWithJoins}';
 }
 
-LinkedHashMap<String, _JoinContext> _gatherWhereJoinContexts(
+LinkedHashMap<String, String> _gatherWhereJoins(
   List<Column> columns, {
   joinOneLevelManyRelations = false,
 }) {
-  // Linked hash map to preserve order
-  LinkedHashMap<String, _JoinContext> joins = LinkedHashMap();
+  // Linked hash map to preserve order and remove duplicates.
+  LinkedHashMap<String, String> joins = LinkedHashMap();
   var columnsWithTableRelations =
       columns.where((column) => column.table.tableRelation != null);
   for (var column in columnsWithTableRelations) {
@@ -858,8 +837,6 @@ LinkedHashMap<String, _JoinContext> _gatherWhereJoinContexts(
     }
 
     var manyRelationColumn = column is ColumnCount;
-    var hasSubQuery = manyRelationColumn && column.innerWhere != null;
-
     var subTableRelations = tableRelation.getRelations;
 
     bool oneLevelManyRelation =
@@ -873,11 +850,8 @@ LinkedHashMap<String, _JoinContext> _gatherWhereJoinContexts(
         return;
       }
 
-      joins[subTableRelation.relationQueryAlias] = _JoinContext(
-        subTableRelation,
-        lastEntry ? hasSubQuery : false,
-        joinStatement: _buildJoinStatement(tableRelation: subTableRelation),
-      );
+      joins[subTableRelation.relationQueryAlias] =
+          _buildJoinStatement(tableRelation: subTableRelation);
     });
   }
 
@@ -906,7 +880,7 @@ List<TableRelation> _gatherTableRelationsFromWhereWithoutSubQueries(
   return joins.values.toList();
 }
 
-MapEntry<String, _JoinContext> _gatherHavingJoinContext(
+MapEntry<String, String> _buildHavingJoin(
   ColumnExpression having,
 ) {
   var column = having.column;
@@ -918,18 +892,15 @@ MapEntry<String, _JoinContext> _gatherHavingJoinContext(
 
   return MapEntry(
     lastRelation.relationQueryAlias,
-    _JoinContext(
-      lastRelation,
-      false,
-      joinStatement: _buildJoinStatement(tableRelation: lastRelation),
-    ),
+    _buildJoinStatement(tableRelation: lastRelation),
   );
 }
 
-LinkedHashMap<String, _JoinContext> _gatherIncludeJoinContexts(
+LinkedHashMap<String, String> _gatherIncludeJoins(
   Include include,
 ) {
-  LinkedHashMap<String, _JoinContext> tableRelations = LinkedHashMap();
+  // Linked hash map to preserve order and remove duplicates.
+  LinkedHashMap<String, String> joins = LinkedHashMap();
   var includeTables = _gatherIncludeTables(include, include.table);
   var tablesWithTableRelations =
       includeTables.where((table) => table.tableRelation != null);
@@ -937,42 +908,13 @@ LinkedHashMap<String, _JoinContext> _gatherIncludeJoinContexts(
     var tableRelation = table.tableRelation;
 
     for (var subTableRelation in tableRelation?.getRelations ?? []) {
-      tableRelations[subTableRelation.relationQueryAlias] =
-          _JoinContext(subTableRelation, false);
+      joins[subTableRelation.relationQueryAlias] = _buildJoinStatement(
+        tableRelation: subTableRelation,
+      );
     }
   }
 
-  return tableRelations;
-}
-
-String _joinStatementFromJoinContexts(
-    LinkedHashMap<String, _JoinContext> joinContexts) {
-  List<String> joinStatements = [];
-  for (var joinContext in joinContexts.values) {
-    var joinStatement = joinContext.joinStatement;
-    if (joinStatement != null) {
-      joinStatements.add(joinStatement);
-      continue;
-    }
-
-    var tableRelation = joinContext.tableRelation;
-    joinStatement = 'LEFT JOIN';
-    if (!joinContext.subQuery) {
-      joinStatement += ' "${tableRelation.foreignTableName}" AS';
-    }
-
-    joinStatement += ' "${tableRelation.relationQueryAlias}" '
-        'ON ${tableRelation.fieldNameWithJoins} ';
-
-    if (!joinContext.subQuery) {
-      joinStatement += '= ${tableRelation.foreignFieldNameWithJoins}';
-    } else {
-      joinStatement += '= ${tableRelation.foreignFieldQueryAliasWithJoins}';
-    }
-
-    joinStatements.add(joinStatement);
-  }
-  return joinStatements.join(' ');
+  return joins;
 }
 
 _UsingQuery _usingQueryFromTableRelations(List<TableRelation> tableRelations) {

--- a/packages/serverpod/test/database/database_query_test.dart
+++ b/packages/serverpod/test/database/database_query_test.dart
@@ -741,16 +741,15 @@ void main() {
         'when count column is used in where expression then exception is thrown.',
         () {
       var countColumn = ColumnCount(citizenTable.id.equals(5), citizenTable.id);
-      var queryBuilder = DeleteQueryBuilder(table: citizenTable)
-          .withWhere(countColumn.equals(5));
 
       expect(
-          () => queryBuilder.build(),
-          throwsA(isA<FormatException>().having(
+          () => DeleteQueryBuilder(table: citizenTable)
+              .withWhere(countColumn.equals(5)),
+          throwsA(isA<UnimplementedError>().having(
             (e) => e.toString(),
             'message',
             equals(
-                'FormatException: Count columns are not supported in where expressions.'),
+                'UnimplementedError: Count columns are not supported in delete where expressions.'),
           )));
     });
   });


### PR DESCRIPTION
### Changes
- Small code cleanup to remove the now redundant `_JoinContext` class.
- Move and improve error message for if unsupported count columns are used in delete queries.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.