### PR TITLE
fix: Deserialization of datetime handles null explicitly.

### DIFF
--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -65,7 +65,8 @@ abstract class SerializationManager {
       return data;
     } else if (_isNullableType<DateTime>(t)) {
       if (data is DateTime) return data as T;
-      return DateTime.tryParse(data ?? '')?.toUtc() as T;
+      if (data == null) return null as T;
+      return DateTime.tryParse(data)?.toUtc() as T;
     } else if (_isNullableType<ByteData>(t)) {
       if (data is Uint8List) {
         var byteData = ByteData.view(


### PR DESCRIPTION
Explicitly null check DateTime on deserialization this will stop us from unnecessarily throwing exceptions.

Closes: #1469

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.
