### PR TITLE
feat: Add support for any filter on 1:n relations.

### DIFF
--- a/packages/serverpod/lib/src/database/columns.dart
+++ b/packages/serverpod/lib/src/database/columns.dart
@@ -405,6 +405,26 @@ class NoneExpression<T> extends _IsNotNullExpression<T> {
   }
 }
 
+/// A database expression that returns all rows where any of the related rows
+/// match the filtering criteria.
+class AnyExpression<T> extends _IsNotNullExpression<T> {
+  /// Creates a new [AnyExpression].
+  AnyExpression(super.column);
+
+  @override
+  String _formatColumnName(ColumnCount columnCount) {
+    var tableRelation = columnCount.table.tableRelation;
+    if (tableRelation == null) {
+      throw StateError('Table relation is null for ColumnCount.');
+    }
+
+    // When ColumnCount appears in a NoneExpression it is always expressed as a
+    // sub query. Therefore, we reference the column from the last table in
+    // the relation without any query alias.
+    return tableRelation.lastRelation.foreignFieldNameWithJoins;
+  }
+}
+
 class _IsNotNullExpression<T> extends ColumnExpression<T> {
   _IsNotNullExpression(super.column);
 

--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -665,6 +665,7 @@ class _SubQueries {
   static const String orderByPrefix = 'order_by';
   static const String whereCountPrefix = 'where_count';
   static const String whereNonePrefix = 'where_none';
+  static const String whereAnyPrefix = 'where_any';
   final Map<int, _SubQuery> _orderByQueries = {};
   final Map<int, _SubQuery> _whereCountQueries = {};
 
@@ -755,6 +756,14 @@ class _SubQueries {
           column,
           expression,
         );
+      } else if (expression is AnyExpression) {
+        subQueries[index] = _buildWhereAnySubQuery(
+          relationQueryAlias,
+          index,
+          tableRelation,
+          column,
+          expression,
+        );
       } else {
         subQueries[index] = _buildWhereCountSubQuery(
           relationQueryAlias,
@@ -796,6 +805,26 @@ class _SubQueries {
       ColumnExpression<dynamic> expression) {
     var uniqueRelationQueryAlias =
         buildUniqueQueryAlias(whereNonePrefix, relationQueryAlias, index);
+
+    var subQuery = SelectQueryBuilder(table: tableRelation.fieldTable)
+        .withWhere(column.innerWhere)
+        .withManyRelationWhereAddition(expression)
+        .withSelectFields([tableRelation.fieldColumn])
+        .enableOneLevelWhereExpressionJoins()
+        .forceGroupBy()
+        .build();
+
+    return _SubQuery(subQuery, uniqueRelationQueryAlias);
+  }
+
+  static _SubQuery _buildWhereAnySubQuery(
+      String relationQueryAlias,
+      int index,
+      TableRelation tableRelation,
+      ColumnCount column,
+      ColumnExpression<dynamic> expression) {
+    var uniqueRelationQueryAlias =
+        buildUniqueQueryAlias(whereAnyPrefix, relationQueryAlias, index);
 
     var subQuery = SelectQueryBuilder(table: tableRelation.fieldTable)
         .withWhere(column.innerWhere)

--- a/packages/serverpod/lib/src/database/many_relation.dart
+++ b/packages/serverpod/lib/src/database/many_relation.dart
@@ -21,4 +21,10 @@ class ManyRelation<T extends Table> {
     return NoneExpression(
         ColumnCount(where?.call(table), tableWithRelations.id));
   }
+
+  /// Returns all entities where any of the related entities match filtering criteria.
+  AnyExpression any([Expression Function(T)? where]) {
+    return AnyExpression(
+        ColumnCount(where?.call(table), tableWithRelations.id));
+  }
 }

--- a/packages/serverpod/test/database/database_query/filter_on_any_test.dart
+++ b/packages/serverpod/test/database/database_query/filter_on_any_test.dart
@@ -1,0 +1,95 @@
+import 'package:serverpod/database.dart';
+import 'package:serverpod/src/database/database_query.dart';
+import 'package:serverpod/src/database/table_relation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var citizenTable = Table(tableName: 'citizen');
+  var companyTable = Table(tableName: 'company');
+  var relationTable = Table(
+    tableName: companyTable.tableName,
+    tableRelation: TableRelation([
+      TableRelationEntry(
+        relationAlias: 'company',
+        field: ColumnInt('id', citizenTable),
+        foreignField: ColumnInt('id', companyTable),
+      )
+    ]),
+  );
+
+  var manyRelation = ManyRelation(
+    tableWithRelations: relationTable,
+    table: Table(
+        tableName: companyTable.tableName,
+        tableRelation: relationTable.tableRelation!.lastRelation),
+  );
+
+  group('Given SelectQueryBuilder', () {
+    group('when filtering on any many relation', () {
+      var query = SelectQueryBuilder(table: citizenTable)
+          .withWhere(manyRelation.any())
+          .build();
+      test('then a sub query is created for the filter.', () {
+        expect(
+            query,
+            contains(
+                'WITH "where_any_citizen_company_company_0" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."id" = "citizen_company_company"."id" WHERE "citizen_company_company"."id" IS NOT NULL GROUP BY "citizen"."id"'));
+      });
+      test('then a sub query is joined with a not in where in main query.', () {
+        expect(
+            query,
+            contains(
+                'WHERE "citizen"."id" IN (SELECT "where_any_citizen_company_company_0"."citizen.id" FROM "where_any_citizen_company_company_0")'));
+      });
+    });
+
+    group('when filtering on filtered any many relation', () {
+      var query = SelectQueryBuilder(table: citizenTable)
+          .withWhere(manyRelation.any((t) => t.id.equals(1)))
+          .build();
+
+      test('then filter is added with an AND statement.', () {
+        expect(
+            query,
+            contains(
+                'WHERE "citizen_company_company"."id" = 1 AND "citizen_company_company"."id" IS NOT NULL'));
+      });
+    });
+
+    group('when filtering on multiple any many relation', () {
+      var where = manyRelation.any((t) => t.id.equals(1)) & manyRelation.any();
+      var query =
+          SelectQueryBuilder(table: citizenTable).withWhere(where).build();
+
+      test('then a sub query is created for the first many relation filter.',
+          () {
+        expect(
+            query,
+            contains(
+                '"where_any_citizen_company_company_1" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."id" = "citizen_company_company"."id" WHERE "citizen_company_company"."id" = 1 AND "citizen_company_company"."id" IS NOT NULL GROUP BY "citizen"."id")'));
+      });
+
+      test('then a sub query is joined with a where in main query.', () {
+        expect(
+            query,
+            contains(
+                '"citizen"."id" IN (SELECT "where_any_citizen_company_company_1"."citizen.id" FROM "where_any_citizen_company_company_1")'));
+      });
+
+      test('then a sub query is created for the second many relation filter.',
+          () {
+        expect(
+            query,
+            contains(
+                '"where_any_citizen_company_company_2" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."id" = "citizen_company_company"."id" WHERE "citizen_company_company"."id" IS NOT NULL GROUP BY "citizen"."id")'));
+      });
+
+      test('then a sub query is joined with a where in main query.', () {
+        expect(
+            query,
+            contains(
+                '"citizen"."id" IN (SELECT "where_any_citizen_company_company_2"."citizen.id" FROM "where_any_citizen_company_company_2"'));
+      });
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/count/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/count/where_any_test.dart
@@ -1,0 +1,89 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group(
+      'Given entities with one to many relation nested in a one to one relation',
+      () {
+    tearDown(() async {
+      await Player.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Team.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Arena.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when counting entities filtered on any nested many relation then result is as expected.',
+        () async {
+      var players = await Player.db.insert(session, [
+        Player(name: 'Alex'),
+        Player(name: 'Viktor'),
+        Player(name: 'Isak'),
+      ]);
+
+      var arenas = await Arena.db.insert(session, [
+        Arena(name: 'Eagle Stadium'),
+        Arena(name: 'Bulls Arena'),
+        Arena(name: 'Shark Tank'),
+      ]);
+
+      var teams = await Team.db.insert(session, [
+        Team(name: 'Eagles', arenaId: arenas[0].id),
+        Team(name: 'Bulls', arenaId: arenas[1].id),
+        Team(name: 'Sharks', arenaId: arenas[2].id),
+      ]);
+
+      // Attach Alex and Viktor to Eagles
+      await Team.db.attach.players(session, teams[0], players.sublist(0, 2));
+      // Attach Isak to Bulls
+      await Team.db.attachRow.players(session, teams[1], players[2]);
+
+      var numberOfArenas = await Arena.db.count(
+        session,
+        // Count all arenas with teams that have any player.
+        where: (a) => a.team.players.any(),
+      );
+
+      expect(numberOfArenas, 2);
+    });
+
+    test(
+        'when fetching entities filtered on filtered any nested many relation then result is as expected.',
+        () async {
+      var players = await Player.db.insert(session, [
+        Player(name: 'Alex'),
+        Player(name: 'Viktor'),
+        Player(name: 'Isak'),
+      ]);
+
+      var arenas = await Arena.db.insert(session, [
+        Arena(name: 'Eagle Stadium'),
+        Arena(name: 'Bulls Arena'),
+        Arena(name: 'Shark Tank'),
+      ]);
+
+      var teams = await Team.db.insert(session, [
+        Team(name: 'Eagles', arenaId: arenas[0].id),
+        Team(name: 'Bulls', arenaId: arenas[1].id),
+        Team(name: 'Sharks', arenaId: arenas[2].id),
+      ]);
+
+      // Attach Alex and Viktor to Eagles
+      await Team.db.attach.players(session, teams[0], players.sublist(0, 2));
+      // Attach Isak to Bulls
+      await Team.db.attachRow.players(session, teams[1], players[2]);
+
+      var numberOfArenas = await Arena.db.count(
+        session,
+        // Count all arenas with teams that have any player with a name starting with a.
+        where: (a) => a.team.players.any((p) => p.name.ilike('a%')),
+      );
+
+      expect(numberOfArenas, 1);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/where_any_test.dart
@@ -1,0 +1,92 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group(
+      'Given entities with one to many relation nested in a one to one relation',
+      () {
+    tearDown(() async {
+      await Player.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Team.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Arena.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when fetching entities filtered on any nested many relation then result is as expected.',
+        () async {
+      var players = await Player.db.insert(session, [
+        Player(name: 'Alex'),
+        Player(name: 'Viktor'),
+        Player(name: 'Isak'),
+      ]);
+
+      var arenas = await Arena.db.insert(session, [
+        Arena(name: 'Eagle Stadium'),
+        Arena(name: 'Bulls Arena'),
+        Arena(name: 'Shark Tank'),
+      ]);
+
+      var teams = await Team.db.insert(session, [
+        Team(name: 'Eagles', arenaId: arenas[0].id),
+        Team(name: 'Bulls', arenaId: arenas[1].id),
+        Team(name: 'Sharks', arenaId: arenas[2].id),
+      ]);
+
+      // Attach Alex and Viktor to Eagles
+      await Team.db.attach.players(session, teams[0], players.sublist(0, 2));
+      // Attach Isak to Bulls
+      await Team.db.attachRow.players(session, teams[1], players[2]);
+
+      var arenasFetched = await Arena.db.find(
+        session,
+        // Fetch all arenas with teams that have any player.
+        where: (a) => a.team.players.any(),
+      );
+
+      var arenaNames = arenasFetched.map((e) => e.name);
+      expect(arenaNames, hasLength(2));
+      expect(arenaNames, containsAll(['Eagle Stadium', 'Bulls Arena']));
+    });
+
+    test(
+        'when fetching entities filtered on filtered any nested many relation then result is as expected.',
+        () async {
+      var players = await Player.db.insert(session, [
+        Player(name: 'Alex'),
+        Player(name: 'Viktor'),
+        Player(name: 'Isak'),
+      ]);
+
+      var arenas = await Arena.db.insert(session, [
+        Arena(name: 'Eagle Stadium'),
+        Arena(name: 'Bulls Arena'),
+        Arena(name: 'Shark Tank'),
+      ]);
+
+      var teams = await Team.db.insert(session, [
+        Team(name: 'Eagles', arenaId: arenas[0].id),
+        Team(name: 'Bulls', arenaId: arenas[1].id),
+        Team(name: 'Sharks', arenaId: arenas[2].id),
+      ]);
+
+      // Attach Alex and Viktor to Eagles
+      await Team.db.attach.players(session, teams[0], players.sublist(0, 2));
+      // Attach Isak to Bulls
+      await Team.db.attachRow.players(session, teams[1], players[2]);
+
+      var arenasFetched = await Arena.db.find(
+        session,
+        // Fetch all arenas with teams that have any player with a name starting with a.
+        where: (a) => a.team.players.any((p) => p.name.ilike('a%')),
+      );
+
+      var arenaNames = arenasFetched.map((e) => e.name);
+      expect(arenaNames, ['Eagle Stadium']);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/count/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/count/where_any_test.dart
@@ -1,0 +1,208 @@
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group('Given entities with one to many relation ', () {
+    tearDown(() async {
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when counting entities filtered on any many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Lisa orders
+        Order(description: 'Order 5', customerId: customers[3].id!),
+        Order(description: 'Order 6', customerId: customers[3].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers with any order
+        where: (c) => c.orders.any(),
+      );
+
+      expect(customerCount, 2);
+    });
+
+    test(
+        'when counting entities filtered on filtered any many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Order 4', customerId: customers[2].id!),
+        // Lisa orders
+        Order(description: 'Prem: Order 5', customerId: customers[3].id!),
+        Order(description: 'Order 6', customerId: customers[3].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers with any order starting with 'prem'
+        where: (c) => c.orders.any((o) => o.description.ilike('prem%')),
+      );
+
+      expect(customerCount, 2);
+    });
+
+    test(
+        'when counting entities filtered on multiple any many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        Order(description: 'Del: Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Del: Order 4', customerId: customers[2].id!),
+        // Lisa orders
+        Order(description: 'Prem: Order 5', customerId: customers[3].id!),
+        Order(description: 'Order 6', customerId: customers[3].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers with any order starting with 'del and any order starting with 'prem'
+        where: (c) =>
+            c.orders.any((o) => o.description.ilike('del%')) &
+            c.orders.any((o) => o.description.ilike('prem%')),
+      );
+
+      expect(customerCount, 1);
+    });
+  });
+
+  group('Given entities with nested one to many relation', () {
+    tearDown(() async {
+      await Comment.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when counting entities filtered on nested any many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Order 3', customerId: customers[1].id!),
+        Order(description: 'Order 4', customerId: customers[1].id!),
+        // Viktor orders
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Alex - Order 1 comments
+        Comment(description: 'Comment 1', orderId: orders[0].id!),
+        Comment(description: 'Comment 2', orderId: orders[0].id!),
+        // Isak - Order 3 comments
+        Comment(description: 'Comment 6', orderId: orders[2].id!),
+        Comment(description: 'Comment 7', orderId: orders[2].id!),
+        Comment(description: 'Comment 8', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Comment 9', orderId: orders[3].id!),
+        Comment(description: 'Comment 10', orderId: orders[3].id!),
+        Comment(description: 'Comment 11', orderId: orders[3].id!),
+      ]);
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers with any order that has any comment.
+        where: (c) => c.orders.any((o) => o.comments.any()),
+      );
+
+      expect(customerCount, 2);
+    });
+
+    test(
+        'when counting entities filtered on filtered nested any many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Order 3', customerId: customers[1].id!),
+        Order(description: 'Order 4', customerId: customers[1].id!),
+        // Viktor orders
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Alex - Order 1 comments
+        Comment(description: 'Prem: Comment 1', orderId: orders[0].id!),
+        Comment(description: 'Comment 2', orderId: orders[0].id!),
+        // Alex - Order 2 comments
+        Comment(description: 'Comment 3', orderId: orders[1].id!),
+        Comment(description: 'Comment 4', orderId: orders[1].id!),
+        Comment(description: 'Comment 5', orderId: orders[1].id!),
+        // Isak - Order 3 comments
+        Comment(description: 'Del: Comment 6', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 7', orderId: orders[2].id!),
+        Comment(description: 'Comment 8', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Del: Comment 9', orderId: orders[3].id!),
+        Comment(description: 'Del: Comment 10', orderId: orders[3].id!),
+        Comment(description: 'Comment 11', orderId: orders[3].id!),
+        // Viktor - Order 5 comments
+        Comment(description: 'Del: Comment 12', orderId: orders[4].id!),
+        Comment(description: 'Del: Comment 13', orderId: orders[4].id!),
+        Comment(description: 'Comment 14', orderId: orders[4].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        where: (c) => c.orders.any(
+            // All customers any order that has any comment starting with 'del'
+            (o) => o.comments.any((c) => c.description.ilike('del%'))),
+      );
+
+      expect(customerCount, 2);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/where_any_test.dart
@@ -1,0 +1,258 @@
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group('Given entities with one to many relation', () {
+    tearDown(() async {
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when fetching entities filtered by any many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Order 4', customerId: customers[2].id!),
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers with any order.
+        where: (c) => c.orders.any(),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, hasLength(2));
+      expect(customerNames, ['Alex', 'Viktor']);
+    });
+
+    test(
+        'when fetching entities filtered by filtered any many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Prem: Order 4', customerId: customers[2].id!),
+        Order(description: 'Prem: Order 5', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers with any order with a description starting with 'prem'.
+        where: (c) => c.orders.any((o) => o.description.ilike('prem%')),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, ['Viktor']);
+    });
+
+    test(
+        'when fetching entities filtered on any many relation in combination with other filter then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Order 4', customerId: customers[2].id!),
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers with any order or name 'Isak'
+        where: (c) => c.orders.any() | c.name.equals('Isak'),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, hasLength(3));
+      expect(customerNames, containsAll(['Alex', 'Isak', 'Viktor']));
+    });
+
+    test(
+        'when fetching entities filtered on OR filtered any many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Basic: Order 1', customerId: customers[0].id!),
+        Order(description: 'Basic: Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Prem: Order 4', customerId: customers[2].id!),
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers with any order with a description starting with 'prem'
+        // or 'basic'.
+        where: (c) => c.orders.any((o) =>
+            o.description.ilike('prem%') | o.description.ilike('basic%')),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, hasLength(2));
+      expect(customerNames, ['Alex', 'Viktor']);
+    });
+
+    test(
+        'when fetching entities filtered on multiple filtered any many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 2', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Prem: Order 4', customerId: customers[2].id!),
+        Order(description: 'Prem: Order 5', customerId: customers[2].id!),
+        Order(description: 'Basic: Order 6', customerId: customers[2].id!),
+        Order(description: 'Basic: Order 7', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers with any order with a description starting with 'prem'
+        // and any order with a description starting with 'basic'.
+        where: (c) =>
+            c.orders.any((o) => o.description.ilike('prem%')) &
+            c.orders.any((o) => o.description.ilike('basic%')),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, ['Viktor']);
+    });
+  });
+
+  group('Given entities with nested one to many relation', () {
+    tearDown(() async {
+      await Comment.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when filtering on nested any many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Order 3', customerId: customers[1].id!),
+        Order(description: 'Order 4', customerId: customers[1].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Isak - Order 3 comments
+        Comment(description: 'Comment 6', orderId: orders[2].id!),
+        Comment(description: 'Comment 7', orderId: orders[2].id!),
+        Comment(description: 'Comment 8', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Comment 9', orderId: orders[3].id!),
+        Comment(description: 'Comment 10', orderId: orders[3].id!),
+        Comment(description: 'Comment 11', orderId: orders[3].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers with any order that have any comment.
+        where: (c) => c.orders.any((o) => o.comments.any()),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, ['Isak']);
+    });
+
+    test(
+        'when fetching entities filtered on filtered nested any many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Order 3', customerId: customers[1].id!),
+        Order(description: 'Order 4', customerId: customers[1].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Alex - Order 1 comments
+        Comment(description: 'Comment 1', orderId: orders[0].id!),
+        Comment(description: 'Comment 2', orderId: orders[0].id!),
+        // Alex - Order 2 comments
+        Comment(description: 'Comment 3', orderId: orders[1].id!),
+        Comment(description: 'Comment 4', orderId: orders[1].id!),
+        Comment(description: 'Comment 5', orderId: orders[1].id!),
+        // Isak - Order 3 comments
+        Comment(description: 'Del: Comment 6', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 7', orderId: orders[2].id!),
+        Comment(description: 'Comment 8', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Del: Comment 9', orderId: orders[3].id!),
+        Comment(description: 'Del: Comment 10', orderId: orders[3].id!),
+        Comment(description: 'Comment 11', orderId: orders[3].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        where: (c) => c.orders.any(
+
+            /// All customers with any order that has any comment with a description starting with 'del'.
+            (o) => o.comments.any((c) => c.description.ilike('del%'))),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, ['Isak']);
+    });
+  });
+}


### PR DESCRIPTION
### Adds
- Support for filtering on any for filtered or unfiltered many side in 1:n relations.

### Examples
Given the following entities:
``` company.yaml
class: Company
table: company
fields:
  name: String
  employees: List<Citizen>?, relation
```

``` citizen.yaml
class: Citizen
table: citizen
fields:
  name: String
```

> We can retrieve all companies that have any employee
``` dart
Company.find(
    session,
    where: (company) => company.employees.any()
);
```
> We can retrieve all companies that have any employee with a name starting with **a**
``` dart
Company.find(
    session,
    where: (company) => company.employees.any((e) => e.name.ilike("a%"))
);
```

> We can retrieve all companies with any employees with a name starting with **a** AND any employees with a name starting with **b**
``` dart
Company.find(
    session,
    where: (company) => 
    company.employees.any((e) => e.name.ilike("a%")) 
    & company.employees.any((e) => e.name.ilike("b%"))
);
```

### Guidance for review
Best reviewed commit by commit.

Closes: https://github.com/serverpod/serverpod/issues/1403

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
