### PR TITLE
feat: Add support for every filter on 1:n relations.

### DIFF
--- a/packages/serverpod/lib/src/database/columns.dart
+++ b/packages/serverpod/lib/src/database/columns.dart
@@ -440,6 +440,26 @@ class AnyExpression<T> extends _IsNotNullExpression<T> {
   }
 }
 
+/// A database expression that returns all rows where all of the related rows
+/// match the filtering criteria.
+class EveryExpression<T> extends _IsNullExpression<T> {
+  /// Creates a new [EveryExpression].
+  EveryExpression(super.column);
+
+  @override
+  String _formatColumnName(ColumnCount columnCount) {
+    var tableRelation = columnCount.table.tableRelation;
+    if (tableRelation == null) {
+      throw StateError('Table relation is null for ColumnCount.');
+    }
+
+    // When ColumnCount appears in a NoneExpression it is always expressed as a
+    // sub query. Therefore, we reference the column from the last table in
+    // the relation without any query alias.
+    return tableRelation.lastRelation.foreignFieldNameWithJoins;
+  }
+}
+
 class _IsNotNullExpression<T> extends ColumnExpression<T> {
   _IsNotNullExpression(super.column);
 

--- a/packages/serverpod/lib/src/database/columns.dart
+++ b/packages/serverpod/lib/src/database/columns.dart
@@ -453,7 +453,7 @@ class EveryExpression<T> extends _IsNullExpression<T> {
       throw StateError('Table relation is null for ColumnCount.');
     }
 
-    // When ColumnCount appears in a NoneExpression it is always expressed as a
+    // When ColumnCount appears in a EveryExpression it is always expressed as a
     // sub query. Therefore, we reference the column from the last table in
     // the relation without any query alias.
     return tableRelation.lastRelation.foreignFieldNameWithJoins;

--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -582,28 +582,22 @@ String? _buildWhereQuery({
   var whereQuery = '';
 
   if (where != null) {
+    whereQuery += wrapWhereInNot ? 'NOT ' : '';
     whereQuery += _resolveWhereQuery(where: where, subQueries: subQueries);
-
-    if (wrapWhereInNot) {
-      whereQuery = 'NOT $whereQuery';
-    }
   }
 
   if (listQueryAdditions != null) {
-    if (whereQuery.isNotEmpty) {
-      whereQuery += ' AND ';
-    }
-
+    whereQuery += whereQuery.isNotEmpty ? ' AND ' : '';
     whereQuery += '${listQueryAdditions.whereAddition}';
   }
 
   if (manyRelationWhereAddition != null) {
-    if (whereQuery.isNotEmpty) {
-      if (manyRelationWhereAddition is EveryExpression) {
-        whereQuery += ' OR ';
-      } else {
-        whereQuery += ' AND ';
-      }
+    if (whereQuery.isEmpty) {
+      whereQuery += '';
+    } else if (manyRelationWhereAddition is EveryExpression) {
+      whereQuery += ' OR ';
+    } else {
+      whereQuery += ' AND ';
     }
 
     whereQuery += '$manyRelationWhereAddition';

--- a/packages/serverpod/lib/src/database/database_query.dart
+++ b/packages/serverpod/lib/src/database/database_query.dart
@@ -24,6 +24,7 @@ class SelectQueryBuilder {
   Include? _include;
   _ListQueryAdditions? _listQueryAdditions;
   bool _joinOneLevelManyRelationWhereExpressions = false;
+  bool _wrapWhereInNot = false;
   TableRelation? _countTableRelation;
 
   /// Creates a new [SelectQueryBuilder].
@@ -79,10 +80,12 @@ class SelectQueryBuilder {
     );
 
     var where = _buildWhereQuery(
-        where: _where,
-        manyRelationWhereAddition: _manyRelationWhereAddition,
-        listQueryAdditions: _listQueryAdditions,
-        subQueries: subQueries);
+      where: _where,
+      manyRelationWhereAddition: _manyRelationWhereAddition,
+      listQueryAdditions: _listQueryAdditions,
+      subQueries: subQueries,
+      wrapWhereInNot: _wrapWhereInNot,
+    );
 
     var orderBy = _buildOrderByQuery(orderBy: _orderBy, subQueries: subQueries);
 
@@ -267,6 +270,12 @@ class SelectQueryBuilder {
   /// where expression.
   SelectQueryBuilder enableOneLevelWhereExpressionJoins() {
     _joinOneLevelManyRelationWhereExpressions = true;
+    return this;
+  }
+
+  /// Wraps the where expression in a NOT statement.
+  SelectQueryBuilder _wrapWhereInNotStatement() {
+    _wrapWhereInNot = true;
     return this;
   }
 
@@ -568,26 +577,39 @@ String? _buildWhereQuery({
   Expression? manyRelationWhereAddition,
   _SubQueries? subQueries,
   _ListQueryAdditions? listQueryAdditions,
+  bool wrapWhereInNot = false,
 }) {
-  List<String> whereQuery = [];
+  var whereQuery = '';
 
   if (where != null) {
-    whereQuery.add(_resolveWhereQuery(where: where, subQueries: subQueries));
+    whereQuery += _resolveWhereQuery(where: where, subQueries: subQueries);
+
+    if (wrapWhereInNot) {
+      whereQuery = 'NOT $whereQuery';
+    }
   }
 
   if (listQueryAdditions != null) {
-    whereQuery.add('${listQueryAdditions.whereAddition}');
+    if (whereQuery.isNotEmpty) {
+      whereQuery += ' AND ';
+    }
+
+    whereQuery += '${listQueryAdditions.whereAddition}';
   }
 
   if (manyRelationWhereAddition != null) {
-    whereQuery.add('$manyRelationWhereAddition');
+    if (whereQuery.isNotEmpty) {
+      if (manyRelationWhereAddition is EveryExpression) {
+        whereQuery += ' OR ';
+      } else {
+        whereQuery += ' AND ';
+      }
+    }
+
+    whereQuery += '$manyRelationWhereAddition';
   }
 
-  if (whereQuery.isEmpty) {
-    return null;
-  }
-
-  return whereQuery.join(' AND ');
+  return whereQuery.isEmpty ? null : whereQuery;
 }
 
 String _resolveWhereQuery(
@@ -606,6 +628,9 @@ String _resolveWhereQuery(
         .map((e) => _resolveWhereQuery(where: e, subQueries: subQueries))
         .join(' ${where.operator} ');
     whereQuery += ')';
+  } else if (where is NotExpression) {
+    whereQuery += where.wrapExpression(
+        _resolveWhereQuery(where: where.subExpression, subQueries: subQueries));
   } else if (where is ColumnExpression && where.isManyRelationExpression) {
     var column = where.column;
     var tableRelation = column.table.tableRelation;
@@ -624,7 +649,7 @@ String _resolveWhereQuery(
           'Sub query for expression index \'$expressionIndex\' is null');
     }
 
-    if (where is NoneExpression) {
+    if (where is NoneExpression || where is EveryExpression) {
       whereQuery = '${tableRelation.fieldNameWithJoins} NOT IN '
           '(SELECT "${subQuery.alias}"."${tableRelation.fieldQueryAlias}" '
           'FROM "${subQuery.alias}")';
@@ -666,6 +691,7 @@ class _SubQueries {
   static const String whereCountPrefix = 'where_count';
   static const String whereNonePrefix = 'where_none';
   static const String whereAnyPrefix = 'where_any';
+  static const String whereEveryPrefix = 'where_every';
   final Map<int, _SubQuery> _orderByQueries = {};
   final Map<int, _SubQuery> _whereCountQueries = {};
 
@@ -764,6 +790,14 @@ class _SubQueries {
           column,
           expression,
         );
+      } else if (expression is EveryExpression) {
+        subQueries[index] = _buildWhereEverySubQuery(
+          relationQueryAlias,
+          index,
+          tableRelation,
+          column,
+          expression,
+        );
       } else {
         subQueries[index] = _buildWhereCountSubQuery(
           relationQueryAlias,
@@ -831,6 +865,27 @@ class _SubQueries {
         .withManyRelationWhereAddition(expression)
         .withSelectFields([tableRelation.fieldColumn])
         .enableOneLevelWhereExpressionJoins()
+        .forceGroupBy()
+        .build();
+
+    return _SubQuery(subQuery, uniqueRelationQueryAlias);
+  }
+
+  static _SubQuery _buildWhereEverySubQuery(
+      String relationQueryAlias,
+      int index,
+      TableRelation tableRelation,
+      ColumnCount column,
+      ColumnExpression<dynamic> expression) {
+    var uniqueRelationQueryAlias =
+        buildUniqueQueryAlias(whereEveryPrefix, relationQueryAlias, index);
+
+    var subQuery = SelectQueryBuilder(table: tableRelation.fieldTable)
+        .withWhere(column.innerWhere)
+        .withManyRelationWhereAddition(expression)
+        .withSelectFields([tableRelation.fieldColumn])
+        .enableOneLevelWhereExpressionJoins()
+        ._wrapWhereInNotStatement()
         .forceGroupBy()
         .build();
 

--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -104,6 +104,34 @@ class Constant extends Expression {
   }
 }
 
+/// A database expression to invert the result of another expression.
+class NotExpression extends Expression {
+  /// Creates a new [NotExpression].
+  NotExpression(Expression super.expression);
+
+  @override
+  Iterable<Expression> get depthFirst sync* {
+    yield* super.depthFirst;
+    yield* super._expression.depthFirst;
+  }
+
+  /// Returns the expression wrapped in NOT.
+  Expression get subExpression => _expression;
+
+  @override
+  List<Column> get columns => _expression.columns;
+
+  /// Returns the expression as a string wrapped in NOT.
+  String wrapExpression(String expression) {
+    return 'NOT $_expression';
+  }
+
+  @override
+  String toString() {
+    return 'NOT $_expression';
+  }
+}
+
 /// A database expression with two parts.
 abstract class TwoPartExpression extends Expression {
   final Expression _other;

--- a/packages/serverpod/lib/src/database/many_relation.dart
+++ b/packages/serverpod/lib/src/database/many_relation.dart
@@ -27,4 +27,10 @@ class ManyRelation<T extends Table> {
     return AnyExpression(
         ColumnCount(where?.call(table), tableWithRelations.id));
   }
+
+  /// Returns all entities where all of the related entities match filtering criteria.
+  EveryExpression every(Expression Function(T) where) {
+    return EveryExpression(
+        ColumnCount(where.call(table), tableWithRelations.id));
+  }
 }

--- a/packages/serverpod/lib/test_util/many_relation_builder.dart
+++ b/packages/serverpod/lib/test_util/many_relation_builder.dart
@@ -1,0 +1,25 @@
+import 'package:serverpod/database.dart';
+
+/// Test util for building a many relation.
+class ManyRelationBuilder {
+  final Table _table;
+
+  /// Creates a new [ManyRelationBuilder] for the given [table].
+  /// Throws [ArgumentError] if [table] does not have a table relation.
+  ManyRelationBuilder(this._table) {
+    if (_table.tableRelation == null) {
+      throw ArgumentError('Table must have a table relation.');
+    }
+  }
+
+  /// Builds a many relation.
+  ManyRelation build() {
+    return ManyRelation(
+      tableWithRelations: _table,
+      table: Table(
+        tableName: _table.tableName,
+        tableRelation: _table.tableRelation!.lastRelation,
+      ),
+    );
+  }
+}

--- a/packages/serverpod/lib/test_util/table_relation_builder.dart
+++ b/packages/serverpod/lib/test_util/table_relation_builder.dart
@@ -1,0 +1,63 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/database/table_relation.dart';
+
+/// Test util for building a table with relations.
+class TableRelationBuilder {
+  final List<TableRelationEntry> _entries = [];
+  final Table _table;
+
+  /// Creates a new [TableRelationBuilder] for the given [table].
+  TableRelationBuilder(this._table);
+
+  /// In iteration order, adds relations from the relation list
+  /// using the relation aliases.
+  ///
+  /// Uses the ID column as key for the relation on both sides for the tables.
+  TableRelationBuilder withRelationsFrom(List<BuilderRelation> relations) {
+    var firstRelation = relations.first;
+    var table = firstRelation.table;
+    var relationAlias = firstRelation.relationAlias;
+
+    for (var relation in relations.skip(1)) {
+      _addRelationBetween(table, relation.table, relationAlias);
+      table = relation.table;
+      relationAlias = relation.relationAlias;
+    }
+
+    _addRelationBetween(table, _table, relationAlias);
+
+    return this;
+  }
+
+  /// Builds a table with the relations added.
+  Table build() {
+    return Table(
+      tableName: _table.tableName,
+      tableRelation: TableRelation(_entries),
+    );
+  }
+
+  void _addRelationBetween(
+    Table table,
+    Table foreignTable,
+    String relationAlias,
+  ) {
+    _entries.add(TableRelationEntry(
+      relationAlias: relationAlias,
+      field: table.id,
+      foreignField: foreignTable.id,
+    ));
+  }
+}
+
+/// A relation used by the [ManyRelationBuilder].
+class BuilderRelation {
+  /// The table to be joined.
+  final Table table;
+
+  /// The alias of the relation.
+  final String relationAlias;
+
+  /// Creates a new [BuilderRelation].
+  BuilderRelation(this.table, this.relationAlias);
+}

--- a/packages/serverpod/test/database/database_query/filter_on_any_test.dart
+++ b/packages/serverpod/test/database/database_query/filter_on_any_test.dart
@@ -1,28 +1,16 @@
 import 'package:serverpod/database.dart';
 import 'package:serverpod/src/database/database_query.dart';
-import 'package:serverpod/src/database/table_relation.dart';
+import 'package:serverpod/test_util/many_relation_builder.dart';
+import 'package:serverpod/test_util/table_relation_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
   var citizenTable = Table(tableName: 'citizen');
   var companyTable = Table(tableName: 'company');
-  var relationTable = Table(
-    tableName: companyTable.tableName,
-    tableRelation: TableRelation([
-      TableRelationEntry(
-        relationAlias: 'company',
-        field: ColumnInt('id', citizenTable),
-        foreignField: ColumnInt('id', companyTable),
-      )
-    ]),
-  );
-
-  var manyRelation = ManyRelation(
-    tableWithRelations: relationTable,
-    table: Table(
-        tableName: companyTable.tableName,
-        tableRelation: relationTable.tableRelation!.lastRelation),
-  );
+  var relationTable = TableRelationBuilder(companyTable).withRelationsFrom([
+    BuilderRelation(citizenTable, 'company'),
+  ]).build();
+  var manyRelation = ManyRelationBuilder(relationTable).build();
 
   group('Given SelectQueryBuilder', () {
     group('when filtering on any many relation', () {

--- a/packages/serverpod/test/database/database_query/filter_on_count_test.dart
+++ b/packages/serverpod/test/database/database_query/filter_on_count_test.dart
@@ -1,28 +1,16 @@
 import 'package:serverpod/database.dart';
 import 'package:serverpod/src/database/database_query.dart';
-import 'package:serverpod/src/database/table_relation.dart';
+import 'package:serverpod/test_util/many_relation_builder.dart';
+import 'package:serverpod/test_util/table_relation_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
   var citizenTable = Table(tableName: 'citizen');
   var companyTable = Table(tableName: 'company');
-  var relationTable = Table(
-    tableName: companyTable.tableName,
-    tableRelation: TableRelation([
-      TableRelationEntry(
-        relationAlias: 'company',
-        field: ColumnInt('id', citizenTable),
-        foreignField: ColumnInt('id', companyTable),
-      )
-    ]),
-  );
-
-  var manyRelation = ManyRelation(
-    tableWithRelations: relationTable,
-    table: Table(
-        tableName: companyTable.tableName,
-        tableRelation: relationTable.tableRelation!.lastRelation),
-  );
+  var relationTable = TableRelationBuilder(companyTable).withRelationsFrom([
+    BuilderRelation(citizenTable, 'company'),
+  ]).build();
+  var manyRelation = ManyRelationBuilder(relationTable).build();
 
   group('Given SelectQueryBuilder', () {
     group('when filtering on many relation count', () {

--- a/packages/serverpod/test/database/database_query/filter_on_every_test.dart
+++ b/packages/serverpod/test/database/database_query/filter_on_every_test.dart
@@ -1,0 +1,101 @@
+import 'package:serverpod/database.dart';
+import 'package:serverpod/src/database/database_query.dart';
+import 'package:serverpod/src/database/table_relation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var citizenTable = Table(tableName: 'citizen');
+  var companyTable = Table(tableName: 'company');
+  var relationTable = Table(
+    tableName: companyTable.tableName,
+    tableRelation: TableRelation([
+      TableRelationEntry(
+        relationAlias: 'company',
+        field: ColumnInt('id', citizenTable),
+        foreignField: ColumnInt('id', companyTable),
+      )
+    ]),
+  );
+
+  var manyRelation = ManyRelation(
+    tableWithRelations: relationTable,
+    table: Table(
+        tableName: companyTable.tableName,
+        tableRelation: relationTable.tableRelation!.lastRelation),
+  );
+
+  group('Given SelectQueryBuilder', () {
+    group('when filtering on filtered every many relation', () {
+      var query = SelectQueryBuilder(table: citizenTable)
+          .withWhere(manyRelation.every((t) => t.id.equals(1)))
+          .build();
+      test('then a sub query is created for the filter.', () {
+        expect(
+            query,
+            contains(
+                'WITH "where_every_citizen_company_company_0" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."id" = "citizen_company_company"."id" WHERE NOT "citizen_company_company"."id" = 1 OR "citizen_company_company"."id" IS NULL GROUP BY "citizen"."id"'));
+      });
+      test('then a sub query is joined with a not in where in main query.', () {
+        expect(
+            query,
+            contains(
+                'WHERE "citizen"."id" NOT IN (SELECT "where_every_citizen_company_company_0"."citizen.id" FROM "where_every_citizen_company_company_0")'));
+      });
+    });
+
+    group('when filtering on advanced filtered every many relation', () {
+      var query = SelectQueryBuilder(table: citizenTable)
+          .withWhere(manyRelation.every((t) => t.id.equals(1) | t.id.equals(2)))
+          .build();
+      test('then a sub query is created for the filter.', () {
+        expect(
+            query,
+            contains(
+                'WITH "where_every_citizen_company_company_0" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."id" = "citizen_company_company"."id" WHERE NOT ("citizen_company_company"."id" = 1 OR "citizen_company_company"."id" = 2) OR "citizen_company_company"."id" IS NULL GROUP BY "citizen"."id"'));
+      });
+      test('then a sub query is joined with a not in where in main query.', () {
+        expect(
+            query,
+            contains(
+                'WHERE "citizen"."id" NOT IN (SELECT "where_every_citizen_company_company_0"."citizen.id" FROM "where_every_citizen_company_company_0")'));
+      });
+    });
+
+    group('when filtering on multiple every many relation', () {
+      var where = manyRelation.every((t) => t.id.equals(1)) |
+          manyRelation.every((t) => t.id.equals(2));
+      var query =
+          SelectQueryBuilder(table: citizenTable).withWhere(where).build();
+
+      test('then a sub query is created for the first many relation filter.',
+          () {
+        expect(
+            query,
+            contains(
+                '"where_every_citizen_company_company_1" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."id" = "citizen_company_company"."id" WHERE NOT "citizen_company_company"."id" = 1 OR "citizen_company_company"."id" IS NULL GROUP BY "citizen"."id")'));
+      });
+
+      test('then a sub query is joined with a where in main query.', () {
+        expect(
+            query,
+            contains(
+                '"citizen"."id" NOT IN (SELECT "where_every_citizen_company_company_1"."citizen.id" FROM "where_every_citizen_company_company_1")'));
+      });
+
+      test('then a sub query is created for the second many relation filter.',
+          () {
+        expect(
+            query,
+            contains(
+                '"where_every_citizen_company_company_2" AS (SELECT "citizen"."id" AS "citizen.id" FROM "citizen" LEFT JOIN "company" AS "citizen_company_company" ON "citizen"."id" = "citizen_company_company"."id" WHERE NOT "citizen_company_company"."id" = 2 OR "citizen_company_company"."id" IS NULL GROUP BY "citizen"."id")'));
+      });
+
+      test('then a sub query is joined with a where in main query.', () {
+        expect(
+            query,
+            contains(
+                '"citizen"."id" NOT IN (SELECT "where_every_citizen_company_company_2"."citizen.id" FROM "where_every_citizen_company_company_2"'));
+      });
+    });
+  });
+}

--- a/packages/serverpod/test/database/database_query/filter_on_every_test.dart
+++ b/packages/serverpod/test/database/database_query/filter_on_every_test.dart
@@ -1,28 +1,16 @@
 import 'package:serverpod/database.dart';
 import 'package:serverpod/src/database/database_query.dart';
-import 'package:serverpod/src/database/table_relation.dart';
+import 'package:serverpod/test_util/many_relation_builder.dart';
+import 'package:serverpod/test_util/table_relation_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
   var citizenTable = Table(tableName: 'citizen');
   var companyTable = Table(tableName: 'company');
-  var relationTable = Table(
-    tableName: companyTable.tableName,
-    tableRelation: TableRelation([
-      TableRelationEntry(
-        relationAlias: 'company',
-        field: ColumnInt('id', citizenTable),
-        foreignField: ColumnInt('id', companyTable),
-      )
-    ]),
-  );
-
-  var manyRelation = ManyRelation(
-    tableWithRelations: relationTable,
-    table: Table(
-        tableName: companyTable.tableName,
-        tableRelation: relationTable.tableRelation!.lastRelation),
-  );
+  var relationTable = TableRelationBuilder(companyTable).withRelationsFrom([
+    BuilderRelation(citizenTable, 'company'),
+  ]).build();
+  var manyRelation = ManyRelationBuilder(relationTable).build();
 
   group('Given SelectQueryBuilder', () {
     group('when filtering on filtered every many relation', () {

--- a/packages/serverpod/test/database/database_query/filter_on_none_test.dart
+++ b/packages/serverpod/test/database/database_query/filter_on_none_test.dart
@@ -1,28 +1,16 @@
 import 'package:serverpod/database.dart';
 import 'package:serverpod/src/database/database_query.dart';
-import 'package:serverpod/src/database/table_relation.dart';
+import 'package:serverpod/test_util/many_relation_builder.dart';
+import 'package:serverpod/test_util/table_relation_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
   var citizenTable = Table(tableName: 'citizen');
   var companyTable = Table(tableName: 'company');
-  var relationTable = Table(
-    tableName: companyTable.tableName,
-    tableRelation: TableRelation([
-      TableRelationEntry(
-        relationAlias: 'company',
-        field: ColumnInt('id', citizenTable),
-        foreignField: ColumnInt('id', companyTable),
-      )
-    ]),
-  );
-
-  var manyRelation = ManyRelation(
-    tableWithRelations: relationTable,
-    table: Table(
-        tableName: companyTable.tableName,
-        tableRelation: relationTable.tableRelation!.lastRelation),
-  );
+  var relationTable = TableRelationBuilder(companyTable).withRelationsFrom([
+    BuilderRelation(citizenTable, 'company'),
+  ]).build();
+  var manyRelation = ManyRelationBuilder(relationTable).build();
 
   group('Given SelectQueryBuilder', () {
     group('when filtering on none many relation', () {

--- a/packages/serverpod/test/database/expressions/expression_test.dart
+++ b/packages/serverpod/test/database/expressions/expression_test.dart
@@ -26,6 +26,69 @@ void main() {
     });
   });
 
+  group('Given one expression wrapped in NOT expression', () {
+    var expression = const Expression('TRUE');
+    var notWrappedExpression = NotExpression(expression);
+
+    test('when toString is called then string matches expected.', () {
+      expect(notWrappedExpression.toString(), 'NOT TRUE');
+    });
+
+    test('when subExpression is called then wrapped expression is returned',
+        () {
+      expect(notWrappedExpression.subExpression, expression);
+    });
+
+    group('when iterating not wrapped expression', () {
+      test('then both expressions are represented.', () {
+        expect(notWrappedExpression.depthFirst, hasLength(2));
+      });
+
+      test('then first expression is NOT expression.', () {
+        expect(notWrappedExpression.depthFirst.first, notWrappedExpression);
+      });
+
+      test('then last expression is wrapped expression.', () {
+        expect(notWrappedExpression.depthFirst.last, expression);
+      });
+    });
+  });
+
+  group('Given a combined expression wrapped in NOT expression', () {
+    var expression1 = const Expression('true = true');
+    var expression2 = const Expression('"A" = "A"');
+    var combinedExpression = expression1 & expression2;
+    var notWrappedExpression = NotExpression(combinedExpression);
+
+    test('when toString is called then expression is returned', () {
+      expect(
+        notWrappedExpression.toString(),
+        'NOT (true = true AND "A" = "A")',
+      );
+    });
+
+    group('when iterating not wrapped expression', () {
+      test('then all expressions are represented.', () {
+        expect(notWrappedExpression.depthFirst, hasLength(4));
+      });
+
+      test('then order matches expressions.', () {
+        var expectedExpressions = [
+          notWrappedExpression,
+          combinedExpression,
+          expression1,
+          expression2,
+        ];
+
+        var i = 0;
+        for (var expression in notWrappedExpression.depthFirst) {
+          expect(expression, expectedExpressions[i]);
+          i++;
+        }
+      });
+    });
+  });
+
   group('Given two AND operator combined expressions', () {
     var expression1 = const Expression('true = true');
     var expression2 = const Expression('"A" = "A"');
@@ -200,6 +263,18 @@ void main() {
     var expression = EscapedExpression(expressionToEscape);
     test('when toString is called then escaped expression is returned', () {
       expect(expression.toString(), '\'; DROP TABLE users;\'');
+    });
+  });
+
+  group('Given column in expression wrapped in NotExpression', () {
+    ColumnString column = ColumnString('test', testTable);
+    var expression = column.ilike('s%');
+    var notWrappedExpression = NotExpression(expression);
+
+    test('when retrieving columns then wrapped expression column is returned',
+        () {
+      expect(notWrappedExpression.columns, hasLength(1));
+      expect(notWrappedExpression.columns.first, column);
     });
   });
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/count/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/count/where_every_test.dart
@@ -49,7 +49,7 @@ void main() async {
 
       var numberOfArenas = await Arena.db.count(
         session,
-        // Count all arenas where all players in the team have a name starting with 'a'.
+        // Count all arenas where all players in the team have a name starting with 'a' or 'A'.
         where: (a) => a.team.players.every((p) => p.name.ilike('a%')),
       );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/count/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/count/where_every_test.dart
@@ -1,0 +1,59 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group(
+      'Given entities with one to many relation nested in a one to one relation',
+      () {
+    tearDown(() async {
+      await Player.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Team.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Arena.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when fetching entities filtered on filtered every of nested many relation then result is as expected.',
+        () async {
+      var players = await Player.db.insert(session, [
+        Player(name: 'Alex'),
+        Player(name: 'Viktor'),
+        Player(name: 'Isak'),
+        Player(name: 'Anna'),
+      ]);
+
+      var arenas = await Arena.db.insert(session, [
+        Arena(name: 'Eagle Stadium'),
+        Arena(name: 'Bulls Arena'),
+        Arena(name: 'Shark Tank'),
+        Arena(name: 'Turtle Arena'),
+      ]);
+
+      var teams = await Team.db.insert(session, [
+        Team(name: 'Eagles', arenaId: arenas[0].id),
+        Team(name: 'Bulls', arenaId: arenas[1].id),
+        Team(name: 'Sharks', arenaId: arenas[2].id),
+        Team(name: 'Turtles', arenaId: arenas[3].id),
+      ]);
+
+      // Attach Alex and Viktor to Eagles
+      await Team.db.attach.players(session, teams[0], players.sublist(0, 2));
+      // Attach Isak to Bulls
+      await Team.db.attachRow.players(session, teams[1], players[2]);
+      // Attach Anna to Sharks
+      await Team.db.attachRow.players(session, teams[2], players[3]);
+
+      var numberOfArenas = await Arena.db.count(
+        session,
+        // Count all arenas where all players in the team have a name starting with 'a'.
+        where: (a) => a.team.players.every((p) => p.name.ilike('a%')),
+      );
+
+      expect(numberOfArenas, 1);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/where_every_test.dart
@@ -49,7 +49,7 @@ void main() async {
 
       var arenasFetched = await Arena.db.find(
         session,
-        // Fetch arenas where all players in the team have a name starting with 'a'.
+        // Fetch arenas where all players in the team have a name starting with 'a' or 'A'.
         where: (a) => a.team.players.every((p) => p.name.ilike('a%')),
       );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/where_every_test.dart
@@ -1,0 +1,60 @@
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group(
+      'Given entities with one to many relation nested in a one to one relation',
+      () {
+    tearDown(() async {
+      await Player.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Team.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Arena.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when fetching entities filtered on filtered every of nested many relation then result is as expected.',
+        () async {
+      var players = await Player.db.insert(session, [
+        Player(name: 'Alex'),
+        Player(name: 'Viktor'),
+        Player(name: 'Isak'),
+        Player(name: 'Anna'),
+      ]);
+
+      var arenas = await Arena.db.insert(session, [
+        Arena(name: 'Eagle Stadium'),
+        Arena(name: 'Bulls Arena'),
+        Arena(name: 'Shark Tank'),
+        Arena(name: 'Turtle Arena'),
+      ]);
+
+      var teams = await Team.db.insert(session, [
+        Team(name: 'Eagles', arenaId: arenas[0].id),
+        Team(name: 'Bulls', arenaId: arenas[1].id),
+        Team(name: 'Sharks', arenaId: arenas[2].id),
+        Team(name: 'Turtles', arenaId: arenas[3].id),
+      ]);
+
+      // Attach Alex and Viktor to Eagles
+      await Team.db.attach.players(session, teams[0], players.sublist(0, 2));
+      // Attach Isak to Bulls
+      await Team.db.attachRow.players(session, teams[1], players[2]);
+      // Attach Anna to Sharks
+      await Team.db.attachRow.players(session, teams[2], players[3]);
+
+      var arenasFetched = await Arena.db.find(
+        session,
+        // Fetch arenas where all players in the team have a name starting with 'a'.
+        where: (a) => a.team.players.every((p) => p.name.ilike('a%')),
+      );
+
+      var arenaNames = arenasFetched.map((e) => e.name);
+      expect(arenaNames, ['Shark Tank']);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/count/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/count/where_every_test.dart
@@ -1,0 +1,190 @@
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group('Given entities with one to many relation ', () {
+    tearDown(() async {
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when counting entities filtered on every many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Order 4', customerId: customers[2].id!),
+        // Lisa orders
+        Order(description: 'Prem: Order 5', customerId: customers[3].id!),
+        Order(description: 'Prem: Order 6', customerId: customers[3].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers where every order starts with 'prem'
+        where: (c) => c.orders.every((o) => o.description.ilike('prem%')),
+      );
+
+      expect(customerCount, 1);
+    });
+
+    test(
+        'when counting entities filtered on multiple every many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 2', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Order 4', customerId: customers[2].id!),
+        // Lisa orders
+        Order(description: 'Basic: Order 5', customerId: customers[3].id!),
+        Order(description: 'Basic: Order 6', customerId: customers[3].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers where every order starts with 'prem' or every order starts with 'basic'
+        where: (c) =>
+            c.orders.every((o) => o.description.ilike('basic%')) |
+            c.orders.every((o) => o.description.ilike('prem%')),
+      );
+
+      expect(customerCount, 2);
+    });
+  });
+
+  group('Given entities with nested one to many relation', () {
+    tearDown(() async {
+      await Comment.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when counting entities filtered on nested every many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Order 3', customerId: customers[1].id!),
+        Order(description: 'Order 4', customerId: customers[1].id!),
+        // Viktor orders
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Alex - Order 1 comments
+        Comment(description: 'Del: Comment 1', orderId: orders[0].id!),
+        Comment(description: 'Del: Comment 2', orderId: orders[0].id!),
+        // Alex - Order 2 comments
+        Comment(description: 'Del: Comment 3', orderId: orders[1].id!),
+        Comment(description: 'Del: Comment 4', orderId: orders[1].id!),
+        // Isak - Order 3 comments
+        Comment(description: 'Del: Comment 6', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 7', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 8', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Comment 9', orderId: orders[3].id!),
+        Comment(description: 'Comment 10', orderId: orders[3].id!),
+        Comment(description: 'Comment 11', orderId: orders[3].id!),
+        // Viktor - Order 5 comments
+        Comment(description: 'Del: Comment 12', orderId: orders[4].id!),
+        Comment(description: 'Del: Comment 13', orderId: orders[4].id!),
+        Comment(description: 'Del: Comment 14', orderId: orders[4].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers where every comment of every order starts with 'del'
+        where: (c) => c.orders
+            .every((o) => o.comments.every((c) => c.description.ilike('del%'))),
+      );
+
+      expect(customerCount, 2);
+    });
+
+    test(
+        'when counting entities filtered on nested every many relation in combination with separate filter then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Prem: Order 3', customerId: customers[1].id!),
+        Order(description: 'Prem: Order 4', customerId: customers[1].id!),
+        // Viktor orders
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Alex - Order 1 comments
+        Comment(description: 'Del: Comment 1', orderId: orders[0].id!),
+        Comment(description: 'Del: Comment 2', orderId: orders[0].id!),
+        // Alex - Order 2 comments
+        Comment(description: 'Comment 3', orderId: orders[1].id!),
+        Comment(description: 'Comment 4', orderId: orders[1].id!),
+        Comment(description: 'Comment 5', orderId: orders[1].id!),
+        // Isak - Order 3 comments
+        Comment(description: 'Del: Comment 6', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 7', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 8', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Del: Comment 9', orderId: orders[3].id!),
+        Comment(description: 'Del: Comment 10', orderId: orders[3].id!),
+        Comment(description: 'Del: Comment 11', orderId: orders[3].id!),
+        // Viktor - Order 5 comments
+        Comment(description: 'Del: Comment 12', orderId: orders[4].id!),
+        Comment(description: 'Del: Comment 13', orderId: orders[4].id!),
+        Comment(description: 'Del: Comment 14', orderId: orders[4].id!),
+      ]);
+
+      var customerCount = await Customer.db.count(
+        session,
+        // All customers where every comment for every order starts with 'del' or every order starts with 'prem'.
+        where: (c) => c.orders.every((o) =>
+            o.comments.every((c) => c.description.ilike('del%')) |
+            o.description.ilike('prem%')),
+      );
+
+      expect(customerCount, 2);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/where_every_test.dart
@@ -1,0 +1,252 @@
+import 'package:serverpod/database.dart' as db;
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  group('Given entities with one to many relation', () {
+    tearDown(() async {
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when fetching entities filtered by every many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Prem: Order 4', customerId: customers[2].id!),
+        Order(description: 'Prem: Order 5', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers where every order has a description starting with 'prem'.
+        where: (c) => c.orders.every((o) => o.description.ilike('prem%')),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, ['Viktor']);
+    });
+
+    test(
+        'when fetching entities filtered on every many relation in combination with other filter then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 2', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Order 4', customerId: customers[2].id!),
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers where every order has a description starting with 'prem' or customer name is 'Viktor'
+        where: (c) =>
+            c.orders.every((o) => o.description.ilike('prem%')) |
+            c.name.equals('Isak'),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, hasLength(2));
+      expect(customerNames, containsAll(['Alex', 'Isak']));
+    });
+
+    test(
+        'when fetching entities filtered on combined filtered every many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Basic: Order 2', customerId: customers[0].id!),
+        Order(description: 'Order 3', customerId: customers[0].id!),
+        // Viktor orders
+        Order(description: 'Prem: Order 4', customerId: customers[2].id!),
+        Order(description: 'Basic: Order 5', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers where every order has a description starting with 'prem'
+        // or 'basic'.
+        where: (c) => c.orders.every((o) =>
+            o.description.ilike('prem%') | o.description.ilike('basic%')),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, ['Viktor']);
+    });
+
+    test(
+        'when fetching entities filtered on multiple every many relation then result is as expected.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+      ]);
+      await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Prem: Order 1', customerId: customers[0].id!),
+        Order(description: 'Prem: Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Basic: Order 1', customerId: customers[1].id!),
+        Order(description: 'Basic: Order 2', customerId: customers[1].id!),
+        // Viktor orders
+        Order(description: 'Prem: Order 4', customerId: customers[2].id!),
+        Order(description: 'Prem: Order 5', customerId: customers[2].id!),
+        Order(description: 'Basic: Order 6', customerId: customers[2].id!),
+        Order(description: 'Basic: Order 7', customerId: customers[2].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers where every order has a description starting with 'prem'
+        // or every order has a description starting with 'basic'.
+        where: (c) =>
+            c.orders.every((o) => o.description.ilike('prem%')) |
+            c.orders.every((o) => o.description.ilike('basic%')),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, hasLength(2));
+      expect(customerNames, containsAll(['Isak', 'Alex']));
+    });
+  });
+
+  group('Given entities with nested one to many relation', () {
+    tearDown(() async {
+      await Comment.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Order.db.deleteWhere(session, where: (_) => db.Constant.bool(true));
+      await Customer.db
+          .deleteWhere(session, where: (_) => db.Constant.bool(true));
+    });
+
+    test(
+        'when filtering on nested every many relation then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Order 3', customerId: customers[1].id!),
+        Order(description: 'Order 4', customerId: customers[1].id!),
+        // Viktor orders
+        Order(description: 'Order 5', customerId: customers[2].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Alex - Order 1 comments
+        Comment(description: 'Del: Comment 1', orderId: orders[0].id!),
+        Comment(description: 'Del: Comment 2', orderId: orders[0].id!),
+        // Alex - Order 2 comments
+        Comment(description: 'Del: Comment 3', orderId: orders[1].id!),
+        Comment(description: 'Del: Comment 4', orderId: orders[1].id!),
+        // Isak - Order 3 comments
+        Comment(description: 'Del: Comment 6', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 7', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 8', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Comment 9', orderId: orders[3].id!),
+        Comment(description: 'Comment 10', orderId: orders[3].id!),
+        Comment(description: 'Comment 11', orderId: orders[3].id!),
+        // Viktor - Order 5 comments
+        Comment(description: 'Del: Comment 12', orderId: orders[4].id!),
+        Comment(description: 'Del: Comment 13', orderId: orders[4].id!),
+        Comment(description: 'Del: Comment 14', orderId: orders[4].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers where every comment for every order starts with del.
+        where: (c) => c.orders
+            .every((o) => o.comments.every((c) => c.description.ilike('del%'))),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, hasLength(2));
+      expect(customerNames, ['Alex', 'Viktor']);
+    });
+
+    test(
+        'when filtering on nested every many relation in combination with separate filter then result is as expected',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Alex'),
+        Customer(name: 'Isak'),
+        Customer(name: 'Viktor'),
+        Customer(name: 'Lisa'),
+      ]);
+      var orders = await Order.db.insert(session, [
+        // Alex orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        Order(description: 'Order 2', customerId: customers[0].id!),
+        // Isak orders
+        Order(description: 'Order 3', customerId: customers[1].id!),
+        Order(description: 'Order 4', customerId: customers[1].id!),
+        // Viktor orders
+        Order(description: 'Order 5', customerId: customers[2].id!),
+        // Lisa orders
+        Order(description: 'Prem: Order 5', customerId: customers[3].id!),
+      ]);
+      await Comment.db.insert(session, [
+        // Alex - Order 1 comments
+        Comment(description: 'Del: Comment 1', orderId: orders[0].id!),
+        Comment(description: 'Del: Comment 2', orderId: orders[0].id!),
+        // Alex - Order 2 comments
+        Comment(description: 'Del: Comment 3', orderId: orders[1].id!),
+        // Isak - Order 3 comments
+        Comment(description: 'Del: Comment 4', orderId: orders[2].id!),
+        Comment(description: 'Del: Comment 5', orderId: orders[2].id!),
+        Comment(description: 'Comment 6', orderId: orders[2].id!),
+        // Isak - Order 4 comments
+        Comment(description: 'Del: Comment 7', orderId: orders[3].id!),
+        Comment(description: 'Del: Comment 8', orderId: orders[3].id!),
+        Comment(description: 'Del: Comment 9', orderId: orders[3].id!),
+      ]);
+
+      var fetchedCustomers = await Customer.db.find(
+        session,
+        // All customers where every comment for every order starts with 'del' or every order starts with 'prem'.
+        where: (c) => c.orders.every((o) =>
+            o.comments.every((c) => c.description.ilike('del%')) |
+            o.description.ilike('prem%')),
+      );
+
+      var customerNames = fetchedCustomers.map((e) => e.name);
+      expect(customerNames, ['Alex', 'Lisa']);
+    });
+  });
+}


### PR DESCRIPTION
### Adds
- Support for filtering on many for filtered or unfiltered many side in 1:n relations.

### Examples
Given the following entities:
``` company.yaml
class: Company
table: company
fields:
  name: String
  employees: List<Citizen>?, relation
```

``` citizen.yaml
class: Citizen
table: citizen
fields:
  name: String
```

> We can retrieve all companies where every employee has a name starting with **a**.
``` dart
Company.find(
    session,
    where: (company) => company.employees.every((e) => e.name.ilike("a%"))
);
```

> We can retrieve all companies where every employee has a name starting with **a** OR every employee has a name starting with **b**.
``` dart
Company.find(
    session,
    where: (company) => 
    company.employees.every((e) => e.name.ilike("a%")) 
    | company.employees.every((e) => e.name.ilike("b%"))
);
```

### Guidance for review
Best reviewed commit by commit.

Closes: https://github.com/serverpod/serverpod/issues/1405

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - This is a new method for the interface.
