### PR TITLE
fix: Remove isDistinctFrom and isNotDistinctFrom column operations.

### DIFF
--- a/packages/serverpod/lib/src/database/columns.dart
+++ b/packages/serverpod/lib/src/database/columns.dart
@@ -239,13 +239,14 @@ mixin _NullableColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
 
   /// Creates an [Expression] checking if the value in the column does not equal
   /// the specified value.
+  ///
+  /// A non null [value] will include rows where the column is null.
   Expression notEquals(T? value) {
     if (value == null) {
       return _IsNotNullExpression(this);
     }
 
-    return _NotEqualsExpression(this, _encodeValueForQuery(value)) |
-        _IsNullExpression(this);
+    return _IsDistinctFromExpression(this, _encodeValueForQuery(value));
   }
 
   /// Creates and [Expression] checking if the value in the column is included

--- a/packages/serverpod/lib/src/database/columns.dart
+++ b/packages/serverpod/lib/src/database/columns.dart
@@ -224,18 +224,6 @@ mixin _ColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
 
     return _NotInSetExpression(this, valuesAsExpressions);
   }
-
-  /// Creates an [Expression] checking if the value in the column is distinct
-  /// from the specified value.
-  Expression isDistinctFrom(T value) {
-    return _IsDistinctFromExpression(this, _encodeValueForQuery(value));
-  }
-
-  /// Creates an [Expression] checking if the value in the column is distinct
-  /// from the specified value.
-  Expression isNotDistinctFrom(T value) {
-    return _IsNotDistinctFromExpression(this, _encodeValueForQuery(value));
-  }
 }
 
 mixin _NullableColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
@@ -277,18 +265,6 @@ mixin _NullableColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
 
     return _NotInSetExpression(this, valuesAsExpressions) |
         _IsNullExpression(this);
-  }
-
-  /// Creates an [Expression] checking if the value in the column is distinct
-  /// from the specified value.
-  Expression isDistinctFrom(T value) {
-    return _IsDistinctFromExpression(this, _encodeValueForQuery(value));
-  }
-
-  /// Creates an [Expression] checking if the value in the column is distinct
-  /// from the specified value.
-  Expression isNotDistinctFrom(T value) {
-    return _IsNotDistinctFromExpression(this, _encodeValueForQuery(value));
   }
 }
 
@@ -556,13 +532,6 @@ class _IsDistinctFromExpression<T> extends _TwoPartColumnExpression<T> {
 
   @override
   String get operator => 'IS DISTINCT FROM';
-}
-
-class _IsNotDistinctFromExpression<T> extends _TwoPartColumnExpression<T> {
-  _IsNotDistinctFromExpression(super.column, super.other);
-
-  @override
-  String get operator => 'IS NOT DISTINCT FROM';
 }
 
 abstract class _MinMaxColumnExpression<T> extends ColumnExpression<T> {

--- a/packages/serverpod/test/database/columns/column_bool_test.dart
+++ b/packages/serverpod/test/database/columns/column_bool_test.dart
@@ -55,24 +55,6 @@ void main() {
       });
 
       test(
-          'when is distinct from compared to bool value then output is IS DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isDistinctFrom(true);
-
-        expect(
-            comparisonExpression.toString(), '$column IS DISTINCT FROM true');
-      });
-
-      test(
-          'when is NOT distinct from compared to bool value then output is IS NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isNotDistinctFrom(true);
-
-        expect(comparisonExpression.toString(),
-            '$column IS NOT DISTINCT FROM true');
-      });
-
-      test(
           'when checking if expression is in value set then output is IN expression.',
           () {
         var comparisonExpression = column.inSet(<bool>{true, false});

--- a/packages/serverpod/test/database/columns/column_bool_test.dart
+++ b/packages/serverpod/test/database/columns/column_bool_test.dart
@@ -50,8 +50,8 @@ void main() {
           () {
         var comparisonExpression = column.notEquals(true);
 
-        expect(comparisonExpression.toString(),
-            '($column != true OR $column IS NULL)');
+        expect(
+            comparisonExpression.toString(), '$column IS DISTINCT FROM true');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_count_test.dart
+++ b/packages/serverpod/test/database/columns/column_count_test.dart
@@ -90,24 +90,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '$countColumnInExpression NOT IN (10, 11, 12)');
       });
-
-      test(
-          'when is distinct from compared to int value then output is IS DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isDistinctFrom(10);
-
-        expect(comparisonExpression.toString(),
-            '$countColumnInExpression IS DISTINCT FROM 10');
-      });
-
-      test(
-          'when is NOT distinct from compared to int value then output is IS NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isNotDistinctFrom(10);
-
-        expect(comparisonExpression.toString(),
-            '$countColumnInExpression IS NOT DISTINCT FROM 10');
-      });
     });
 
     group('with _ColumnNumberOperations mixin', () {

--- a/packages/serverpod/test/database/columns/column_date_time_test.dart
+++ b/packages/serverpod/test/database/columns/column_date_time_test.dart
@@ -52,7 +52,7 @@ void main() {
         var comparisonExpression = column.notEquals(DateTime.utc(1991, 5, 28));
 
         expect(comparisonExpression.toString(),
-            '($column != \'"1991-05-28T00:00:00.000Z"\' OR $column IS NULL)');
+            '$column IS DISTINCT FROM \'"1991-05-28T00:00:00.000Z"\'');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_date_time_test.dart
+++ b/packages/serverpod/test/database/columns/column_date_time_test.dart
@@ -80,26 +80,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '($column NOT IN (\'"1991-05-28T00:00:00.000Z"\', \'"1991-05-29T00:00:00.000Z"\', \'"1991-05-30T00:00:00.000Z"\') OR $column IS NULL)');
       });
-
-      test(
-          'when is distinct from compared to date time value then output is IS DISTINCT FROM expression.',
-          () {
-        var comparisonExpression =
-            column.isDistinctFrom(DateTime.utc(1991, 5, 28));
-
-        expect(comparisonExpression.toString(),
-            '$column IS DISTINCT FROM \'"1991-05-28T00:00:00.000Z"\'');
-      });
-
-      test(
-          'when is NOT distinct from compared to date time value then output is IS NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression =
-            column.isNotDistinctFrom(DateTime.utc(1991, 5, 28));
-
-        expect(comparisonExpression.toString(),
-            '$column IS NOT DISTINCT FROM \'"1991-05-28T00:00:00.000Z"\'');
-      });
     });
 
     group('with _ColumnNumberOperations mixin', () {

--- a/packages/serverpod/test/database/columns/column_double_test.dart
+++ b/packages/serverpod/test/database/columns/column_double_test.dart
@@ -50,8 +50,8 @@ void main() {
           () {
         var comparisonExpression = column.notEquals(10.0);
 
-        expect(comparisonExpression.toString(),
-            '($column != 10.0 OR $column IS NULL)');
+        expect(
+            comparisonExpression.toString(), '$column IS DISTINCT FROM 10.0');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_double_test.dart
+++ b/packages/serverpod/test/database/columns/column_double_test.dart
@@ -89,24 +89,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '($column NOT IN (10.0, 11.0, 12.0) OR $column IS NULL)');
       });
-
-      test(
-          'when is distinct from compared to double value then output is IS DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isDistinctFrom(10.0);
-
-        expect(
-            comparisonExpression.toString(), '$column IS DISTINCT FROM 10.0');
-      });
-
-      test(
-          'when is NOT distinct from compared to double value then output is IS NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isNotDistinctFrom(10.0);
-
-        expect(comparisonExpression.toString(),
-            '$column IS NOT DISTINCT FROM 10.0');
-      });
     });
 
     group('with _ColumnNumberOperations mixin', () {

--- a/packages/serverpod/test/database/columns/column_duration_test.dart
+++ b/packages/serverpod/test/database/columns/column_duration_test.dart
@@ -79,25 +79,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '($column NOT IN (\'36000000\', \'39600000\', \'43200000\') OR $column IS NULL)');
       });
-      test(
-          'when is distinct from compared to duration value then output is IS DISTINCT FROM expression.',
-          () {
-        var comparisonExpression =
-            column.isDistinctFrom(const Duration(hours: 10));
-
-        expect(comparisonExpression.toString(),
-            '$column IS DISTINCT FROM \'36000000\'');
-      });
-
-      test(
-          'when is NOT distinct from compared to duration value then output is IS NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression =
-            column.isNotDistinctFrom(const Duration(hours: 10));
-
-        expect(comparisonExpression.toString(),
-            '$column IS NOT DISTINCT FROM \'36000000\'');
-      });
     });
 
     group('with _ColumnNumberOperations mixin', () {

--- a/packages/serverpod/test/database/columns/column_duration_test.dart
+++ b/packages/serverpod/test/database/columns/column_duration_test.dart
@@ -51,7 +51,7 @@ void main() {
         var comparisonExpression = column.notEquals(const Duration(hours: 10));
 
         expect(comparisonExpression.toString(),
-            '($column != \'36000000\' OR $column IS NULL)');
+            '$column IS DISTINCT FROM \'36000000\'');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_enum_test.dart
+++ b/packages/serverpod/test/database/columns/column_enum_test.dart
@@ -84,23 +84,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '($column NOT IN (0, 1, 2) OR $column IS NULL)');
       });
-
-      test(
-          'when checking if expression is distinct from value then output is DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isDistinctFrom(TestEnum.blue);
-
-        expect(comparisonExpression.toString(), '$column IS DISTINCT FROM 1');
-      });
-
-      test(
-          'when checking if expression is NOT distinct from value then output is NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isNotDistinctFrom(TestEnum.blue);
-
-        expect(
-            comparisonExpression.toString(), '$column IS NOT DISTINCT FROM 1');
-      });
     });
   });
 }

--- a/packages/serverpod/test/database/columns/column_enum_test.dart
+++ b/packages/serverpod/test/database/columns/column_enum_test.dart
@@ -56,8 +56,7 @@ void main() {
           () {
         var comparisonExpression = column.notEquals(TestEnum.blue);
 
-        expect(comparisonExpression.toString(),
-            '($column != 1 OR $column IS NULL)');
+        expect(comparisonExpression.toString(), '$column IS DISTINCT FROM 1');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_int_test.dart
+++ b/packages/serverpod/test/database/columns/column_int_test.dart
@@ -87,23 +87,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '($column NOT IN (10, 11, 12) OR $column IS NULL)');
       });
-
-      test(
-          'when is distinct from compared to int value then output is IS DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isDistinctFrom(10);
-
-        expect(comparisonExpression.toString(), '$column IS DISTINCT FROM 10');
-      });
-
-      test(
-          'when is NOT distinct from compared to int value then output is IS NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isNotDistinctFrom(10);
-
-        expect(
-            comparisonExpression.toString(), '$column IS NOT DISTINCT FROM 10');
-      });
     });
 
     group('with _ColumnNumberOperations mixin', () {

--- a/packages/serverpod/test/database/columns/column_int_test.dart
+++ b/packages/serverpod/test/database/columns/column_int_test.dart
@@ -50,8 +50,7 @@ void main() {
           () {
         var comparisonExpression = column.notEquals(10);
 
-        expect(comparisonExpression.toString(),
-            '($column != 10 OR $column IS NULL)');
+        expect(comparisonExpression.toString(), '$column IS DISTINCT FROM 10');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_string_test.dart
+++ b/packages/serverpod/test/database/columns/column_string_test.dart
@@ -109,24 +109,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '($column NOT IN (\'a\', \'b\', \'c\') OR $column IS NULL)');
       });
-
-      test(
-          'when checking if expression is distinct from value then output is DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isDistinctFrom('test');
-
-        expect(comparisonExpression.toString(),
-            '$column IS DISTINCT FROM \'test\'');
-      });
-
-      test(
-          'when checking if expression is NOT distinct from value then output is NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression = column.isNotDistinctFrom('test');
-
-        expect(comparisonExpression.toString(),
-            '$column IS NOT DISTINCT FROM \'test\'');
-      });
     });
   });
 }

--- a/packages/serverpod/test/database/columns/column_string_test.dart
+++ b/packages/serverpod/test/database/columns/column_string_test.dart
@@ -51,7 +51,7 @@ void main() {
         var comparisonExpression = column.notEquals('test');
 
         expect(comparisonExpression.toString(),
-            '($column != \'test\' OR $column IS NULL)');
+            '$column IS DISTINCT FROM \'test\'');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_uuid_test.dart
+++ b/packages/serverpod/test/database/columns/column_uuid_test.dart
@@ -53,7 +53,7 @@ void main() {
             column.notEquals(UuidValue(Uuid.NAMESPACE_NIL));
 
         expect(comparisonExpression.toString(),
-            '($column != \'00000000-0000-0000-0000-000000000000\' OR $column IS NULL)');
+            '$column IS DISTINCT FROM \'00000000-0000-0000-0000-000000000000\'');
       });
 
       test(

--- a/packages/serverpod/test/database/columns/column_uuid_test.dart
+++ b/packages/serverpod/test/database/columns/column_uuid_test.dart
@@ -81,26 +81,6 @@ void main() {
         expect(comparisonExpression.toString(),
             '($column NOT IN (\'testuuid1\', \'testuuid2\', \'testuuid3\') OR $column IS NULL)');
       });
-
-      test(
-          'when is distinct from compared to uuid value then output is IS DISTINCT FROM expression.',
-          () {
-        var comparisonExpression =
-            column.isDistinctFrom(UuidValue(Uuid.NAMESPACE_NIL));
-
-        expect(comparisonExpression.toString(),
-            '$column IS DISTINCT FROM \'00000000-0000-0000-0000-000000000000\'');
-      });
-
-      test(
-          'when is NOT distinct from compared to uuid value then output is IS NOT DISTINCT FROM expression.',
-          () {
-        var comparisonExpression =
-            column.isNotDistinctFrom(UuidValue(Uuid.NAMESPACE_NIL));
-
-        expect(comparisonExpression.toString(),
-            '$column IS NOT DISTINCT FROM \'00000000-0000-0000-0000-000000000000\'');
-      });
     });
   });
 }

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -384,20 +384,6 @@ class EndpointColumnBoolLegacy extends _i1.EndpointRef {
         'notInSet',
         {'value': value},
       );
-
-  _i2.Future<List<_i6.Types>> isDistinctFrom(bool value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnBoolLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(bool value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnBoolLegacy',
-        'isNotDistinctFrom',
-        {'value': value},
-      );
 }
 
 /// {@category Endpoint}
@@ -452,20 +438,6 @@ class EndpointColumnDateTimeLegacy extends _i1.EndpointRef {
       caller.callServerEndpoint<List<_i6.Types>>(
         'columnDateTimeLegacy',
         'notInSet',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isDistinctFrom(DateTime value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnDateTimeLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(DateTime value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnDateTimeLegacy',
-        'isNotDistinctFrom',
         {'value': value},
       );
 
@@ -579,20 +551,6 @@ class EndpointColumnDoubleLegacy extends _i1.EndpointRef {
         {'value': value},
       );
 
-  _i2.Future<List<_i6.Types>> isDistinctFrom(double value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnDoubleLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(double value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnDoubleLegacy',
-        'isNotDistinctFrom',
-        {'value': value},
-      );
-
   _i2.Future<List<_i6.Types>> greaterThan(double value) =>
       caller.callServerEndpoint<List<_i6.Types>>(
         'columnDoubleLegacy',
@@ -700,20 +658,6 @@ class EndpointColumnDurationLegacy extends _i1.EndpointRef {
       caller.callServerEndpoint<List<_i6.Types>>(
         'columnDurationLegacy',
         'notInSet',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isDistinctFrom(Duration value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnDurationLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(Duration value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnDurationLegacy',
-        'isNotDistinctFrom',
         {'value': value},
       );
 
@@ -826,20 +770,6 @@ class EndpointColumnEnumLegacy extends _i1.EndpointRef {
         'notInSet',
         {'value': value},
       );
-
-  _i2.Future<List<_i6.Types>> isDistinctFrom(_i7.TestEnum value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnEnumLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(_i7.TestEnum value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnEnumLegacy',
-        'isNotDistinctFrom',
-        {'value': value},
-      );
 }
 
 /// {@category Endpoint}
@@ -894,20 +824,6 @@ class EndpointColumnIntLegacy extends _i1.EndpointRef {
       caller.callServerEndpoint<List<_i6.Types>>(
         'columnIntLegacy',
         'notInSet',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isDistinctFrom(int value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnIntLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(int value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnIntLegacy',
-        'isNotDistinctFrom',
         {'value': value},
       );
 
@@ -1021,20 +937,6 @@ class EndpointColumnStringLegacy extends _i1.EndpointRef {
         {'value': value},
       );
 
-  _i2.Future<List<_i6.Types>> isDistinctFrom(String value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnStringLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(String value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnStringLegacy',
-        'isNotDistinctFrom',
-        {'value': value},
-      );
-
   _i2.Future<List<_i6.Types>> like(String value) =>
       caller.callServerEndpoint<List<_i6.Types>>(
         'columnStringLegacy',
@@ -1102,20 +1004,6 @@ class EndpointColumnUuidLegacy extends _i1.EndpointRef {
       caller.callServerEndpoint<List<_i6.Types>>(
         'columnUuidLegacy',
         'notInSet',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isDistinctFrom(_i5.UuidValue value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnUuidLegacy',
-        'isDistinctFrom',
-        {'value': value},
-      );
-
-  _i2.Future<List<_i6.Types>> isNotDistinctFrom(_i5.UuidValue value) =>
-      caller.callServerEndpoint<List<_i6.Types>>(
-        'columnUuidLegacy',
-        'isNotDistinctFrom',
         {'value': value},
       );
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_bool.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_bool.dart
@@ -48,18 +48,4 @@ class ColumnBoolLegacyEndpoint extends Endpoint {
       where: (t) => t.aBool.notInSet(value.toSet()),
     );
   }
-
-  Future<List<Types>> isDistinctFrom(Session session, bool value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aBool.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(Session session, bool value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aBool.isNotDistinctFrom(value),
-    );
-  }
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_date_time.dart
@@ -49,20 +49,6 @@ class ColumnDateTimeLegacyEndpoint extends Endpoint {
     );
   }
 
-  Future<List<Types>> isDistinctFrom(Session session, DateTime value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aDateTime.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(Session session, DateTime value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aDateTime.isNotDistinctFrom(value),
-    );
-  }
-
   Future<List<Types>> greaterThan(Session session, DateTime value) async {
     return await Types.find(
       session,

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_double.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_double.dart
@@ -49,20 +49,6 @@ class ColumnDoubleLegacyEndpoint extends Endpoint {
     );
   }
 
-  Future<List<Types>> isDistinctFrom(Session session, double value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aDouble.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(Session session, double value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aDouble.isNotDistinctFrom(value),
-    );
-  }
-
   Future<List<Types>> greaterThan(Session session, double value) async {
     return await Types.find(
       session,

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_duration.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_duration.dart
@@ -49,20 +49,6 @@ class ColumnDurationLegacyEndpoint extends Endpoint {
     );
   }
 
-  Future<List<Types>> isDistinctFrom(Session session, Duration value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aDuration.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(Session session, Duration value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aDuration.isNotDistinctFrom(value),
-    );
-  }
-
   Future<List<Types>> greaterThan(Session session, Duration value) async {
     return await Types.find(
       session,

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_enum.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_enum.dart
@@ -48,18 +48,4 @@ class ColumnEnumLegacyEndpoint extends Endpoint {
       where: (t) => t.anEnum.notInSet(value.toSet()),
     );
   }
-
-  Future<List<Types>> isDistinctFrom(Session session, TestEnum value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.anEnum.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(Session session, TestEnum value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.anEnum.isNotDistinctFrom(value),
-    );
-  }
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_int.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_int.dart
@@ -49,20 +49,6 @@ class ColumnIntLegacyEndpoint extends Endpoint {
     );
   }
 
-  Future<List<Types>> isDistinctFrom(Session session, int value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.anInt.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(Session session, int value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.anInt.isNotDistinctFrom(value),
-    );
-  }
-
   Future<List<Types>> greaterThan(Session session, int value) async {
     return await Types.find(
       session,

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_string.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_string.dart
@@ -49,20 +49,6 @@ class ColumnStringLegacyEndpoint extends Endpoint {
     );
   }
 
-  Future<List<Types>> isDistinctFrom(Session session, String value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aString.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(Session session, String value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aString.isNotDistinctFrom(value),
-    );
-  }
-
   Future<List<Types>> like(Session session, String value) async {
     return await Types.find(
       session,

--- a/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/column_operations_legacy/column_uuid.dart
@@ -48,19 +48,4 @@ class ColumnUuidLegacyEndpoint extends Endpoint {
       where: (t) => t.aUuid.notInSet(value.toSet()),
     );
   }
-
-  Future<List<Types>> isDistinctFrom(Session session, UuidValue value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aUuid.isDistinctFrom(value),
-    );
-  }
-
-  Future<List<Types>> isNotDistinctFrom(
-      Session session, UuidValue value) async {
-    return await Types.find(
-      session,
-      where: (t) => t.aUuid.isNotDistinctFrom(value),
-    );
-  }
 }

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -1039,44 +1039,6 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<bool>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnBoolLegacy'] as _i7.ColumnBoolLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<bool>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnBoolLegacy'] as _i7.ColumnBoolLegacyEndpoint)
-                  .isNotDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
       },
     );
     connectors['columnDateTimeLegacy'] = _i1.EndpointConnector(
@@ -1201,46 +1163,6 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['columnDateTimeLegacy']
                       as _i8.ColumnDateTimeLegacyEndpoint)
                   .notInSet(
-            session,
-            params['value'],
-          ),
-        ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<DateTime>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnDateTimeLegacy']
-                      as _i8.ColumnDateTimeLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<DateTime>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnDateTimeLegacy']
-                      as _i8.ColumnDateTimeLegacyEndpoint)
-                  .isNotDistinctFrom(
             session,
             params['value'],
           ),
@@ -1505,46 +1427,6 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<double>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnDoubleLegacy']
-                      as _i9.ColumnDoubleLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<double>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnDoubleLegacy']
-                      as _i9.ColumnDoubleLegacyEndpoint)
-                  .isNotDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
         'greaterThan': _i1.MethodConnector(
           name: 'greaterThan',
           params: {
@@ -1805,46 +1687,6 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<Duration>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnDurationLegacy']
-                      as _i10.ColumnDurationLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<Duration>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnDurationLegacy']
-                      as _i10.ColumnDurationLegacyEndpoint)
-                  .isNotDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
         'greaterThan': _i1.MethodConnector(
           name: 'greaterThan',
           params: {
@@ -2098,44 +1940,6 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<_i45.TestEnum>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnEnumLegacy'] as _i11.ColumnEnumLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<_i45.TestEnum>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnEnumLegacy'] as _i11.ColumnEnumLegacyEndpoint)
-                  .isNotDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
       },
     );
     connectors['columnIntLegacy'] = _i1.EndpointConnector(
@@ -2253,44 +2057,6 @@ class Endpoints extends _i1.EndpointDispatch {
           ) async =>
               (endpoints['columnIntLegacy'] as _i12.ColumnIntLegacyEndpoint)
                   .notInSet(
-            session,
-            params['value'],
-          ),
-        ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<int>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnIntLegacy'] as _i12.ColumnIntLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<int>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnIntLegacy'] as _i12.ColumnIntLegacyEndpoint)
-                  .isNotDistinctFrom(
             session,
             params['value'],
           ),
@@ -2549,46 +2315,6 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<String>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnStringLegacy']
-                      as _i13.ColumnStringLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<String>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnStringLegacy']
-                      as _i13.ColumnStringLegacyEndpoint)
-                  .isNotDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
         'like': _i1.MethodConnector(
           name: 'like',
           params: {
@@ -2746,44 +2472,6 @@ class Endpoints extends _i1.EndpointDispatch {
           ) async =>
               (endpoints['columnUuidLegacy'] as _i14.ColumnUuidLegacyEndpoint)
                   .notInSet(
-            session,
-            params['value'],
-          ),
-        ),
-        'isDistinctFrom': _i1.MethodConnector(
-          name: 'isDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<_i43.UuidValue>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnUuidLegacy'] as _i14.ColumnUuidLegacyEndpoint)
-                  .isDistinctFrom(
-            session,
-            params['value'],
-          ),
-        ),
-        'isNotDistinctFrom': _i1.MethodConnector(
-          name: 'isNotDistinctFrom',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<_i43.UuidValue>(),
-              nullable: false,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['columnUuidLegacy'] as _i14.ColumnUuidLegacyEndpoint)
-                  .isNotDistinctFrom(
             session,
             params['value'],
           ),

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_bool_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_bool_test.dart
@@ -66,20 +66,5 @@ void main() async {
 
       expect(result.length, 2);
     });
-
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await client.columnBoolLegacy.isDistinctFrom(true);
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await client.columnBoolLegacy.isNotDistinctFrom(true);
-
-      expect(result.first.aBool, true);
-    });
   });
 }

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_date_time_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_date_time_test.dart
@@ -76,22 +76,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await client.columnDateTimeLegacy.isDistinctFrom(firstDate);
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result =
-          await client.columnDateTimeLegacy.isNotDistinctFrom(firstDate);
-
-      expect(result.first.aDateTime, firstDate);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await client.columnDateTimeLegacy.greaterThan(firstDate);

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_double_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_double_test.dart
@@ -72,21 +72,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await client.columnDoubleLegacy.isDistinctFrom(1.0);
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await client.columnDoubleLegacy.isNotDistinctFrom(1.0);
-
-      expect(result.first.aDouble, 1.0);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await client.columnDoubleLegacy.greaterThan(1.0);

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_duration_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_duration_test.dart
@@ -76,23 +76,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result =
-          await client.columnDurationLegacy.isDistinctFrom(firstDuration);
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result =
-          await client.columnDurationLegacy.isNotDistinctFrom(firstDuration);
-
-      expect(result.first.aDuration, firstDuration);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await client.columnDurationLegacy.greaterThan(firstDuration);

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_enum_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_enum_test.dart
@@ -69,21 +69,5 @@ void main() async {
 
       expect(result.length, 2);
     });
-
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await client.columnEnumLegacy.isDistinctFrom(TestEnum.one);
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result =
-          await client.columnEnumLegacy.isNotDistinctFrom(TestEnum.one);
-
-      expect(result.first.anEnum, TestEnum.one);
-    });
   });
 }

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_int_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_int_test.dart
@@ -71,21 +71,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await client.columnIntLegacy.isDistinctFrom(1);
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await client.columnIntLegacy.isNotDistinctFrom(1);
-
-      expect(result.first.anInt, 1);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await client.columnIntLegacy.greaterThan(1);

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_string_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_string_test.dart
@@ -67,21 +67,6 @@ void main() async {
       expect(result.length, 2);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await client.columnStringLegacy.isDistinctFrom('one');
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await client.columnStringLegacy.isNotDistinctFrom('one');
-
-      expect(result.first.aString, 'one');
-    });
-
     test(
         'when filtering using isNotDistinctFrom then matching row is returned.',
         () async {

--- a/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_uuid_test.dart
+++ b/tests/serverpod_test_server/test_e2e/column_operations_legacy/column_uuid_test.dart
@@ -76,20 +76,5 @@ void main() async {
 
       expect(result.length, 2);
     });
-
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await client.columnUuidLegacy.isDistinctFrom(firstUuid);
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await client.columnUuidLegacy.isNotDistinctFrom(firstUuid);
-
-      expect(result.first.aUuid, firstUuid);
-    });
   });
 }

--- a/tests/serverpod_test_server/test_integration/column_operations/column_bool_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_bool_test.dart
@@ -92,26 +92,5 @@ void main() async {
 
       expect(result.length, 2);
     });
-
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aBool.isDistinctFrom(true),
-      );
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aBool.isNotDistinctFrom(true),
-      );
-
-      expect(result.first.aBool, true);
-    });
   });
 }

--- a/tests/serverpod_test_server/test_integration/column_operations/column_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_count_test.dart
@@ -162,58 +162,6 @@ void main() async {
       expect(resultNames, contains(customers[2].name));
     });
 
-    test('when filtering on isDistinctFrom then matching rows are returned.',
-        () async {
-      var customers = await Customer.db.insert(session, [
-        Customer(name: 'Customer 1'),
-        Customer(name: 'Customer 2'),
-        Customer(name: 'Customer 3'),
-      ]);
-
-      await Order.db.insert(session, [
-        // Customer 1 orders
-        Order(description: 'Order 1', customerId: customers[0].id!),
-        // Customer 2 orders
-        Order(description: 'Order 2', customerId: customers[1].id!),
-        Order(description: 'Order 3', customerId: customers[1].id!),
-      ]);
-
-      var result = await Customer.db.find(
-        session,
-        where: (c) => c.orders.count().isDistinctFrom(1),
-      );
-
-      expect(result, hasLength(2));
-      var resultNames = result.map((e) => e.name);
-      expect(resultNames, contains(customers[1].name));
-      expect(resultNames, contains(customers[2].name));
-    });
-
-    test('when filtering on isNotDistinctFrom then matching row is returned.',
-        () async {
-      var customers = await Customer.db.insert(session, [
-        Customer(name: 'Customer 1'),
-        Customer(name: 'Customer 2'),
-        Customer(name: 'Customer 3'),
-      ]);
-
-      await Order.db.insert(session, [
-        // Customer 1 orders
-        Order(description: 'Order 1', customerId: customers[0].id!),
-        // Customer 2 orders
-        Order(description: 'Order 2', customerId: customers[1].id!),
-        Order(description: 'Order 3', customerId: customers[1].id!),
-      ]);
-
-      var result = await Customer.db.find(
-        session,
-        where: (c) => c.orders.count().isNotDistinctFrom(1),
-      );
-
-      expect(result, hasLength(1));
-      expect(result.first.name, customers[0].name);
-    });
-
     test('when filtering on greater than then matching rows are returned.',
         () async {
       var customers = await Customer.db.insert(session, [

--- a/tests/serverpod_test_server/test_integration/column_operations/column_date_time_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_date_time_test.dart
@@ -97,27 +97,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aDateTime.isDistinctFrom(firstDate),
-      );
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aDateTime.isNotDistinctFrom(firstDate),
-      );
-
-      expect(result.first.aDateTime, firstDate);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await Types.db.find(

--- a/tests/serverpod_test_server/test_integration/column_operations/column_double_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_double_test.dart
@@ -94,27 +94,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aDouble.isDistinctFrom(1.0),
-      );
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aDouble.isNotDistinctFrom(1.0),
-      );
-
-      expect(result.first.aDouble, 1.0);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await Types.db.find(

--- a/tests/serverpod_test_server/test_integration/column_operations/column_duration_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_duration_test.dart
@@ -98,27 +98,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aDuration.isDistinctFrom(firstDuration),
-      );
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aDuration.isNotDistinctFrom(firstDuration),
-      );
-
-      expect(result.first.aDuration, firstDuration);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await Types.db.find(

--- a/tests/serverpod_test_server/test_integration/column_operations/column_enum_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_enum_test.dart
@@ -97,26 +97,5 @@ void main() async {
 
       expect(result.length, 2);
     });
-
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.anEnum.isDistinctFrom(TestEnum.one),
-      );
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.anEnum.isNotDistinctFrom(TestEnum.one),
-      );
-
-      expect(result.first.anEnum, TestEnum.one);
-    });
   });
 }

--- a/tests/serverpod_test_server/test_integration/column_operations/column_int_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_int_test.dart
@@ -94,27 +94,6 @@ void main() async {
       expect(result.length, 3);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.anInt.isDistinctFrom(1),
-      );
-
-      expect(result.length, 3);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.anInt.isNotDistinctFrom(1),
-      );
-
-      expect(result.first.anInt, 1);
-    });
-
     test('when filtering using greater than then matching rows are returned.',
         () async {
       var result = await Types.db.find(

--- a/tests/serverpod_test_server/test_integration/column_operations/column_string_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_string_test.dart
@@ -93,27 +93,6 @@ void main() async {
       expect(result.length, 2);
     });
 
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aString.isDistinctFrom('one'),
-      );
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aString.isNotDistinctFrom('one'),
-      );
-
-      expect(result.first.aString, 'one');
-    });
-
     test('when filtering using like then matching row is returned.', () async {
       var result = await Types.db.find(
         session,

--- a/tests/serverpod_test_server/test_integration/column_operations/column_uuid_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_uuid_test.dart
@@ -95,26 +95,5 @@ void main() async {
 
       expect(result.length, 2);
     });
-
-    test('when filtering using isDistinctFrom then matching rows are returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aUuid.isDistinctFrom(firstUuid),
-      );
-
-      expect(result.length, 2);
-    });
-
-    test(
-        'when filtering using isNotDistinctFrom then matching row is returned.',
-        () async {
-      var result = await Types.db.find(
-        session,
-        where: (t) => t.aUuid.isNotDistinctFrom(firstUuid),
-      );
-
-      expect(result.first.aUuid, firstUuid);
-    });
   });
 }


### PR DESCRIPTION
### Changes
Removes `isDistinctFrom(...)` and `isNotDistinctFrom(...)` column operations since the functionality is already provided in the ORM through the null aware `equals(...)` and `notEquals(...)` operations.

Closes: https://github.com/serverpod/serverpod/issues/1475

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - removes functionality that has not yet been part of a released version of Serverpod.