### PR TITLE
fix: Prevent double relation definition for entity fields.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -292,6 +292,25 @@ class ObjectRelationDefinition extends RelationDefinition {
   }) : super(name, isForeignKeyOrigin);
 }
 
+enum UnresolvableReason {
+  relationAlreadyDefinedForField,
+}
+
+/// Stores information about a relation that could not be resolved.
+/// This is used to report errors to the user in the analyzer.
+class UnresolvableObjectRelationDefinition extends RelationDefinition {
+  final UnresolvedObjectRelationDefinition objectRelationDefinition;
+  final UnresolvableReason reason;
+
+  UnresolvableObjectRelationDefinition(
+    this.objectRelationDefinition,
+    this.reason,
+  ) : super(
+          objectRelationDefinition.name,
+          objectRelationDefinition.isForeignKeyOrigin,
+        );
+}
+
 class UnresolvedObjectRelationDefinition extends RelationDefinition {
   /// References the field in the current object that points to the foreign table.
   final String? fieldName;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
@@ -187,6 +187,14 @@ class EntityDependencyResolver {
     var field = classDefinition.findField(relationFieldName);
     if (field == null) return;
 
+    if (field.relation != null) {
+      fieldDefinition.relation = UnresolvableObjectRelationDefinition(
+        relation,
+        UnresolvableReason.relationAlreadyDefinedForField,
+      );
+      return;
+    }
+
     field.relation = ForeignRelationDefinition(
       name: relation.name,
       parentTable: tableName,


### PR DESCRIPTION
### Changes
- Prevents defining the relation keyword on both the foreign key name and on the object relation. Error message shows up on the object relation informing the user that the foreign key field already contains a relation definition.

Closes: https://github.com/serverpod/serverpod/issues/1321

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
