### PR TITLE
refactor: Rename raw query methods with prefix unsafe

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -112,7 +112,7 @@ class Users {
 
     // Update all authentication keys too.
     var json = SerializationManager.encode(scopeStrs);
-    await session.dbNext.dangerouslyQuery(
+    await session.dbNext.unsafeQuery(
         'UPDATE serverpod_auth_key SET "scopeNames"=\'$json\' WHERE "userId" = $userId');
 
     if (AuthConfig.current.onUserUpdated != null) {

--- a/packages/serverpod/lib/src/database/analyze.dart
+++ b/packages/serverpod/lib/src/database/analyze.dart
@@ -11,10 +11,10 @@ class DatabaseAnalyzer {
   /// Analyze the structure of the [database].
   static Future<DatabaseDefinition> analyze(Database database) async {
     return DatabaseDefinition(
-      name: (await database.dangerouslyQuery('SELECT current_database();'))
+      name: (await database.unsafeQuery('SELECT current_database();'))
           .first
           .first,
-      tables: await Future.wait((await database.dangerouslyQuery(
+      tables: await Future.wait((await database.unsafeQuery(
 // Get list of all tables and the schema they are in.
           '''
 SELECT schemaname, tablename
@@ -24,7 +24,7 @@ WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';
         var schemaName = tableInfo.first;
         var tableName = tableInfo.last;
 
-        var columns = (await database.dangerouslyQuery(
+        var columns = (await database.unsafeQuery(
 // Get the columns of this table and sort them based on their position.
                 '''
 SELECT column_name, column_default, is_nullable, data_type
@@ -40,7 +40,7 @@ ORDER BY ordinal_position;
                 isNullable: e[2] == 'YES'))
             .toList();
 
-        var indexes = (await database.dangerouslyQuery(
+        var indexes = (await database.unsafeQuery(
 // We want to get the name (0), tablespace (1), isUnique (2), isPrimary (3),
 // elements (4), isElementAColumn (5), predicate (6) and type of each index for this table.
 //
@@ -106,7 +106,7 @@ WHERE t.relname = '$tableName' AND n.nspname = '$schemaName';
           );
         }).toList();
 
-        var foreignKeys = (await database.dangerouslyQuery(
+        var foreignKeys = (await database.unsafeQuery(
 // We want to get the constraint name (0), on update type (1),
 // on delete type (2), match type (3), constraint columns (4)
 // referenced table (5), namespace / schema of the referenced table (6),
@@ -171,7 +171,7 @@ WHERE contype = 'f' AND t.relname = '$tableName' AND nt.nspname = '$schemaName';
 
     try {
       var rows =
-          await database.dangerouslyQuery('SELECT * FROM serverpod_migrations');
+          await database.unsafeQuery('SELECT * FROM serverpod_migrations');
       for (var row in rows) {
         migrations.add(
           DatabaseMigrationVersion(

--- a/packages/serverpod/lib/src/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/database/bulk_data.dart
@@ -120,8 +120,7 @@ class DatabaseBulkData {
       int numAffectedRows = 0;
 
       for (var query in queries) {
-        result =
-            await database.unsafeQuery(query, transaction: transaction);
+        result = await database.unsafeQuery(query, transaction: transaction);
         numAffectedRows += result.affectedRowCount;
       }
       result!;

--- a/packages/serverpod/lib/src/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/database/bulk_data.dart
@@ -68,7 +68,7 @@ class DatabaseBulkData {
     var query = 'SELECT ${columnSelects.join(', ')} FROM "$table" '
         'WHERE id > $lastId$filterQuery ORDER BY "id" LIMIT $limit';
     try {
-      data = await database.dangerouslyQuery(query);
+      data = await database.unsafeQuery(query);
     } catch (e) {
       throw BulkDataException(
         message: 'Failed to query database ($e).',
@@ -98,7 +98,7 @@ class DatabaseBulkData {
         'JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace '
         'WHERE relname = \'$table\' AND nspname = \'public\'';
 
-    var result = await database.dangerouslyQuery(query);
+    var result = await database.unsafeQuery(query);
 
     if (result.isEmpty) {
       return 0;
@@ -121,7 +121,7 @@ class DatabaseBulkData {
 
       for (var query in queries) {
         result =
-            await database.dangerouslyQuery(query, transaction: transaction);
+            await database.unsafeQuery(query, transaction: transaction);
         numAffectedRows += result.affectedRowCount;
       }
       result!;

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -242,7 +242,7 @@ class Database {
   /// the table name and value is another [Map] with the keys as column names and
   /// the value as the contents of the column.
   /// You are responsible to sanitize the query to avoid SQL injection.
-  Future<List<Map<String, Map<String, dynamic>>>> dangerouslyQueryMappedResults(
+  Future<List<Map<String, Map<String, dynamic>>>> unsafeQueryMappedResults(
     Session session,
     String query, {
     int? timeoutInSeconds,
@@ -259,7 +259,7 @@ class Database {
   /// Executes a single SQL query. A [List] of rows represented of another
   /// [List] with columns will be returned.
   /// You are responsible to sanitize the query to avoid SQL injection.
-  Future<PostgreSQLResult> dangerouslyQuery(
+  Future<PostgreSQLResult> unsafeQuery(
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,
@@ -275,7 +275,7 @@ class Database {
   /// Executes a single SQL query. Returns the number of rows that were affected
   /// by the query.
   /// You are responsible to sanitize the query to avoid SQL injection.
-  Future<int> dangerouslyExecute(
+  Future<int> unsafeExecute(
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,

--- a/packages/serverpod/lib/src/database/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migration_manager.dart
@@ -37,11 +37,11 @@ class MigrationManager {
   /// Initializing the [MigrationManager] by loading the current version
   /// from the database and available migrations.
   Future<void> initialize(Session session) async {
-    await session.dbNext.dangerouslyQuery(_queryCreateMigrations);
+    await session.dbNext.unsafeQuery(_queryCreateMigrations);
 
     // Get installed versions
     var versions = <DatabaseMigrationVersion>[];
-    var result = await session.dbNext.dangerouslyQuery(_queryGetMigrations);
+    var result = await session.dbNext.unsafeQuery(_queryGetMigrations);
     for (var row in result) {
       assert(row.length == 4);
       String module = row[0];
@@ -188,7 +188,7 @@ class MigrationManager {
       for (var newerVersion in newerVersions) {
         var migration = await Migration.load(module, newerVersion);
         try {
-          await session.dbNext.dangerouslyExecute(migration.sqlMigration);
+          await session.dbNext.unsafeExecute(migration.sqlMigration);
         } catch (e) {
           stderr.writeln('Failed to apply migration $newerVersion on $module');
           stderr.writeln('$e');
@@ -200,7 +200,7 @@ class MigrationManager {
       var migration = await Migration.load(module, latest);
 
       try {
-        await session.dbNext.dangerouslyExecute(migration.sqlDefinition);
+        await session.dbNext.unsafeExecute(migration.sqlDefinition);
       } catch (e) {
         stderr.writeln('Failed to apply definition $latest on $module');
         stderr.writeln('$e');

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -312,7 +312,7 @@ class InsightsEndpoint extends Endpoint {
   /// Executes SQL commands. Returns the number of rows affected.
   Future<int> executeSql(Session session, String sql) async {
     try {
-      return await session.dbNext.dangerouslyExecute(sql);
+      return await session.dbNext.unsafeExecute(sql);
     } catch (e) {
       throw ServerpodSqlException(
         message: '$e',

--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -110,12 +110,12 @@ class HealthCheckManager {
       // Touch all sessions that have been opened by this server.
       var touchQuery =
           'UPDATE serverpod_session_log SET touched = $now WHERE "serverId" = $serverId AND "isOpen" = TRUE AND "time" > $serverStartTime';
-      await session.dbNext.dangerouslyQuery(touchQuery);
+      await session.dbNext.unsafeQuery(touchQuery);
 
       // Close sessions that haven't been touched in 3 minutes.
       var closeQuery =
           'UPDATE serverpod_session_log SET "isOpen" = FALSE WHERE "isOpen" = TRUE AND "touched" < $threeMinutesAgo';
-      await session.dbNext.dangerouslyQuery(closeQuery);
+      await session.dbNext.unsafeQuery(closeQuery);
     } catch (e, stackTrace) {
       stderr.writeln('Failed to cleanup closed sessions: $e');
       stderr.write('$stackTrace');

--- a/tests/serverpod_test_server/lib/src/endpoints/failed_calls.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/failed_calls.dart
@@ -7,14 +7,14 @@ class FailedCallsEndpoint extends Endpoint {
 
   Future<void> failedDatabaseQuery(Session session) async {
     // This call should fail and throw an exception
-    await session.dbNext.dangerouslyQuery(
+    await session.dbNext.unsafeQuery(
       'SELECT * FROM non_existing_table LIMIT 1',
     );
   }
 
   Future<bool> failedDatabaseQueryCaughtException(Session session) async {
     try {
-      await session.dbNext.dangerouslyQuery(
+      await session.dbNext.unsafeQuery(
         'SELECT * FROM non_existing_table LIMIT 1',
       );
     } catch (e) {


### PR DESCRIPTION
Renames raw queries to `unsafeQuery` etc, prefixing all raw queries with `unsafe`.

Closes: https://github.com/serverpod/serverpod/issues/1486

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
