### PR TITLE
fix: Rename `migrate` command to `create-migration`.

### DIFF
--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -8,7 +8,7 @@ import 'package:serverpod_cli/src/commands/create.dart';
 import 'package:serverpod_cli/src/commands/generate_pubspecs.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
-import 'package:serverpod_cli/src/commands/migrate.dart';
+import 'package:serverpod_cli/src/commands/create_migration.dart';
 import 'package:serverpod_cli/src/commands/version.dart';
 import 'package:serverpod_cli/src/generated/version.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
@@ -62,7 +62,7 @@ ServerpodCommandRunner buildCommandRunner() {
     ..addCommand(GenerateCommand())
     ..addCommand(GeneratePubspecsCommand())
     ..addCommand(LanguageServerCommand())
-    ..addCommand(MigrateCommand())
+    ..addCommand(CreateMigrationCommand())
     ..addCommand(VersionCommand());
 }
 

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -104,7 +104,7 @@ class CreateMigrationCommand extends ServerpodCommand {
         return migration != null;
       });
     } else {
-      await log.progress('Creating migration', () async {
+      var success = await log.progress('Creating migration', () async {
         var migration = await generator.createMigration(
           tag: tag,
           force: force,
@@ -113,10 +113,12 @@ class CreateMigrationCommand extends ServerpodCommand {
 
         return migration != null;
       });
-      log.info(
-        'Done.',
-        type: TextLogType.success,
-      );
+      if (success) {
+        log.info(
+          'Done.',
+          type: TextLogType.success,
+        );
+      }
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -7,17 +7,17 @@ import 'package:serverpod_cli/src/util/exit_exception.dart';
 import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 
-class MigrateCommand extends ServerpodCommand {
+class CreateMigrationCommand extends ServerpodCommand {
   static const _runModes = <String>['development', 'staging', 'production'];
 
   @override
-  final name = 'migrate';
+  final name = 'create-migration';
 
   @override
   final description =
       'Creates a migration from the last migration to the current state of the database.';
 
-  MigrateCommand() {
+  CreateMigrationCommand() {
     argParser.addFlag(
       'force',
       abbr: 'f',


### PR DESCRIPTION
### Changes
- Renames the command for creating migrations from `migrate` to `create-migration`.
- Fixes an issue where `Done` would be printed even if the migration failed to be created.


#### Before done fix
<img width="740" alt="Screenshot 2023-11-01 at 12 00 26" src="https://github.com/serverpod/serverpod/assets/137198655/c1c17ce1-122b-4e5e-9ac8-d795939aacf7">


#### After done fix
<img width="740" alt="Screenshot 2023-11-01 at 11 59 00" src="https://github.com/serverpod/serverpod/assets/137198655/00efad76-3d4f-4b56-a769-b8471817da35">

Closes: #1502

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - This renames a non released command.