### PR TITLE
fix: Give explicit error on implicit many-to-many relations in protocols.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -416,6 +416,16 @@ class Restrictions {
     return isLocalFieldForeignKeyOrigin || isForeignFieldForeignKeyOrigin;
   }
 
+  bool _isImplicitManyToManyRelation(
+    SerializableEntityFieldDefinition field,
+    SerializableEntityFieldDefinition foreignField,
+  ) {
+    if (!field.type.isListType) return false;
+    if (!foreignField.type.isListType) return false;
+
+    return true;
+  }
+
   bool _isForeignKeyDefinedOnBothSides(
     SerializableEntityFieldDefinition field,
     List<SerializableEntityFieldDefinition> foreignFields,
@@ -794,6 +804,15 @@ class Restrictions {
       return [
         SourceSpanSeverityException(
           'Unable to resolve ambiguous relation, there are several named relations with name "$name" on the class "$foreignClassName".',
+          span,
+        )
+      ];
+    }
+
+    if (_isImplicitManyToManyRelation(field, foreignFields.first)) {
+      return [
+        SourceSpanSeverityException(
+          'A named relation to another list field is not supported.',
           span,
         )
       ];

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_many_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_many_to_many_test.dart
@@ -1,0 +1,45 @@
+import 'package:serverpod_cli/src/analyzer/entities/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/protocol_source_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given a class with an implicit many to many relation then an error is collected that it is not supported.',
+      () {
+    var protocols = [
+      ProtocolSourceBuilder().withFileName('post').withYaml(
+        '''
+        class: Post
+        table: post
+        fields:
+          title: String
+          categories: List<Category>?, relation(name=post_category)
+        ''',
+      ).build(),
+      ProtocolSourceBuilder().withFileName('category').withYaml(
+        '''
+        class: Category
+        table: category
+        fields:
+          name: String
+          posts: List<Post>?, relation(name=post_category)
+        ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      protocols,
+      onErrorsCollector(collector),
+    );
+    analyzer.validateAll();
+    var errors = collector.errors;
+
+    expect(errors, isNotEmpty);
+    expect(
+      errors.first.message,
+      contains('A named relation to another list field is not supported.'),
+    );
+  });
+}


### PR DESCRIPTION
Gives an explicit warning if a m:n relation is specified without a third protocol file.

Closes: https://github.com/serverpod/serverpod/issues/1506

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.


