### PR TITLE
Store endpoints in named fields

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -300,6 +300,14 @@ class LibraryGenerator {
         (c) => c
           ..name = 'Endpoints'
           ..extend = refer('EndpointDispatch', serverpodUrl(true))
+          ..fields.addAll([
+            for (var endpoint in protocolDefinition.endpoints)
+              Field((f) => f
+                ..modifier = FieldModifier.final$
+                ..name = endpoint.name.camelCase
+                ..assignment = refer(endpoint.className, endpointPath(endpoint))
+                    .call([]).code),
+          ])
           // Init method
           ..methods.add(
             Method.returnsVoid(
@@ -314,17 +322,15 @@ class LibraryGenerator {
                   refer('var endpoints')
                       .assign(literalMap({
                         for (var endpoint in protocolDefinition.endpoints)
-                          endpoint.name:
-                              refer(endpoint.className, endpointPath(endpoint))
-                                  .call([])
-                                  .cascade('initialize')
-                                  .call([
-                                    refer('server'),
-                                    literalString(endpoint.name),
-                                    config.type != PackageType.module
-                                        ? refer('null')
-                                        : literalString(config.name)
-                                  ])
+                          endpoint.name: refer(endpoint.name.camelCase)
+                              .cascade('initialize')
+                              .call([
+                            refer('server'),
+                            literalString(endpoint.name),
+                            config.type != PackageType.module
+                                ? refer('null')
+                                : literalString(config.name)
+                          ])
                       }, refer('String'),
                           refer('Endpoint', serverpodUrl(true))))
                       .statement,


### PR DESCRIPTION
Partially addresses #1009.

Allows you to call an endpoint using a field in `Endpoints`.

Although this requires a casting from `EndpointDispatch` to `Endpoints` to get the field references -- therefore, I am submitting this for further discussion about how this could all be refactored. With this change you can call:

```dart
((session.server.endpoints) as Endpoints).someEndpointName.someMethodName(session, someParams);
```

Ideally I want to just be able to call an endpoint like

```dart
session.server.endpoints.someEndpointName.someMethodName(session, someParams);
```

Before the change:

![image](https://github.com/serverpod/serverpod/assets/811305/3109180d-4cfe-4731-afca-c708e65bb44a)

After the change:

![image](https://github.com/serverpod/serverpod/assets/811305/938f7fd2-348f-49a0-839f-b9261cab4a86)


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
