### PR TITLE
Serialize enum values as String

### DIFF
--- a/packages/serverpod/lib/src/database/columns.dart
+++ b/packages/serverpod/lib/src/database/columns.dart
@@ -63,7 +63,7 @@ class ColumnEnumSerializedAsString<E extends Enum>
   Expression _encodeValueForQuery(value) => EscapedExpression(value.name);
 }
 
-/// A [Column] holding an enum serialized as an int.
+/// A [Column] holding an enum serialized as an integer.
 class ColumnEnumSerializedAsInteger<E extends Enum>
     extends _ValueOperatorColumn<E> with _NullableColumnDefaultOperations<E> {
   /// Creates a new [Column], this is typically done in generated code only.

--- a/packages/serverpod/lib/src/database/columns.dart
+++ b/packages/serverpod/lib/src/database/columns.dart
@@ -53,11 +53,21 @@ abstract class _ValueOperatorColumn<T> extends Column<T> {
   Expression _encodeValueForQuery(T value);
 }
 
-/// A [Column] holding an enum.
-class ColumnEnum<E extends Enum> extends _ValueOperatorColumn<E>
-    with _NullableColumnDefaultOperations<E> {
+/// A [Column] holding an enum serialized as a string.
+class ColumnEnumSerializedAsString<E extends Enum>
+    extends _ValueOperatorColumn<E> with _NullableColumnDefaultOperations<E> {
   /// Creates a new [Column], this is typically done in generated code only.
-  ColumnEnum(super.columnName, super.table);
+  ColumnEnumSerializedAsString(super.columnName, super.table);
+
+  @override
+  Expression _encodeValueForQuery(value) => EscapedExpression(value.name);
+}
+
+/// A [Column] holding an enum serialized as an int.
+class ColumnEnumSerializedAsInteger<E extends Enum>
+    extends _ValueOperatorColumn<E> with _NullableColumnDefaultOperations<E> {
+  /// Creates a new [Column], this is typically done in generated code only.
+  ColumnEnumSerializedAsInteger(super.columnName, super.table);
 
   @override
   Expression _encodeValueForQuery(value) => Expression(value.index);

--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
-import 'package:retry/retry.dart';
+
 import 'package:postgres_pool/postgres_pool.dart';
+import 'package:retry/retry.dart';
 import 'package:serverpod/src/database/columns.dart';
 import 'package:serverpod/src/database/database_connection_legacy.dart';
 import 'package:serverpod/src/database/database_query.dart';
@@ -629,7 +630,8 @@ class DatabaseConnection {
     if (column is ColumnString) return 'text';
     if (column is ColumnBool) return 'boolean';
     if (column is ColumnInt) return 'integer';
-    if (column is ColumnEnum) return 'integer';
+    if (column is ColumnEnumSerializedAsInteger) return 'integer';
+    if (column is ColumnEnumSerializedAsString) return 'text';
     if (column is ColumnDouble) return 'double precision';
     if (column is ColumnDateTime) return 'timestamp without time zone';
     if (column is ColumnByteData) return 'bytea';

--- a/packages/serverpod/lib/src/database/value_encoder.dart
+++ b/packages/serverpod/lib/src/database/value_encoder.dart
@@ -20,6 +20,22 @@ class ValueEncoder extends PostgresTextEncoder {
           escapeStrings: escapeStrings);
     } else if (input is UuidValue) {
       return "'${input.uuid}'";
+    } else if (input is Enum) {
+      // Determine whether the Enum is serialized as an integer or as a String
+      var enumValueAsJson = (input as dynamic)?.toJson();
+      if (enumValueAsJson is int) {
+        // Enum is serialized as an integer.
+        return enumValueAsJson.toString();
+      } else if (enumValueAsJson is String) {
+        // Enum is serialized as a String.
+        // Encode enum values without extra quotes (which would otherwise be
+        // added by JSON encoding during `SerializationManager.encode` below,
+        // i.e. as "\"'${input.name}'\"").
+        return "'${input.name}'";
+      } else {
+        // Should not happen
+        throw 'Invalid enum Json type';
+      }
     } else if (input is String &&
         input.startsWith('decode(\'') &&
         input.endsWith('\', \'base64\')')) {

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -436,7 +436,7 @@ class LogEntryTable extends _i1.Table {
       'time',
       this,
     );
-    logLevel = _i1.ColumnEnum<_i2.LogLevel>(
+    logLevel = _i1.ColumnEnumSerializedAsInteger<_i2.LogLevel>(
       'logLevel',
       this,
     );
@@ -474,7 +474,7 @@ class LogEntryTable extends _i1.Table {
   late final _i1.ColumnDateTime time;
 
   /// The log level of this entry.
-  late final _i1.ColumnEnum<_i2.LogLevel> logLevel;
+  late final _i1.ColumnEnumSerializedAsInteger<_i2.LogLevel> logLevel;
 
   /// The logging message.
   late final _i1.ColumnString message;

--- a/packages/serverpod/test/database/columns/column_enum_test.dart
+++ b/packages/serverpod/test/database/columns/column_enum_test.dart
@@ -8,80 +8,159 @@ enum TestEnum {
 }
 
 void main() {
-  group('Given a ColumnEnum', () {
+  group('Given a ColumnEnumSerializedAsString', () {
     var columnName = 'color';
-    var column = ColumnEnum<TestEnum>(columnName, Table(tableName: 'test'));
+    var columnSerializedAsString = ColumnEnumSerializedAsString<TestEnum>(
+        columnName, Table(tableName: 'test'));
+    var columnSerializedAsInteger = ColumnEnumSerializedAsInteger<TestEnum>(
+        columnName, Table(tableName: 'test'));
 
     test(
         'when toString is called then column name withing double quotes is returned.',
         () {
-      expect(column.toString(), '"test"."$columnName"');
+      expect(columnSerializedAsString.toString(), '"test"."$columnName"');
     });
 
     test('when columnName getter is called then column name is returned.', () {
-      expect(column.columnName, columnName);
+      expect(columnSerializedAsString.columnName, columnName);
     });
 
     test('when type is called then TestEnum is returned.', () {
-      expect(column.type, TestEnum);
+      expect(columnSerializedAsString.type, TestEnum);
     });
 
     group('with _ColumnDefaultOperations mixin', () {
       test(
-          'when equals compared to NULL value then output is IS NULL expression.',
-          () {
-        var comparisonExpression = column.equals(null);
+          'when equals compared to NULL value then output is IS NULL expression.'
+          ' (serializeEnumValuesAsStrings == true)', () {
+        var comparisonExpression = columnSerializedAsString.equals(null);
 
-        expect(comparisonExpression.toString(), '$column IS NULL');
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsString IS NULL');
       });
 
       test(
-          'when equals compared to enum value then output is equals expression.',
-          () {
-        var comparisonExpression = column.equals(TestEnum.blue);
+          'when equals compared to NULL value then output is IS NULL expression.'
+          ' (serializeEnumValuesAsStrings == false)', () {
+        var comparisonExpression = columnSerializedAsInteger.equals(null);
 
-        expect(comparisonExpression.toString(), '$column = 1');
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsInteger IS NULL');
       });
 
       test(
-          'when NOT equals compared to NULL value then output is IS NOT NULL expression.',
-          () {
-        var comparisonExpression = column.notEquals(null);
+          'when equals compared to enum value then output is equals expression.'
+          ' (serializeEnumValuesAsStrings == true)', () {
+        var comparisonExpression =
+            columnSerializedAsString.equals(TestEnum.blue);
 
-        expect(comparisonExpression.toString(), '$column IS NOT NULL');
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsString = \'blue\'');
       });
 
       test(
-          'when NOT equals compared to enum value then output is NOT equals expression.',
-          () {
-        var comparisonExpression = column.notEquals(TestEnum.blue);
+          'when equals compared to enum value then output is equals expression.'
+          ' (serializeEnumValuesAsStrings == false)', () {
+        var comparisonExpression =
+            columnSerializedAsInteger.equals(TestEnum.blue);
 
-        expect(comparisonExpression.toString(), '$column IS DISTINCT FROM 1');
+        expect(
+            comparisonExpression.toString(), '$columnSerializedAsInteger = 1');
       });
 
       test(
-          'when checking if expression is in value set then output is IN expression.',
-          () {
-        var comparisonExpression = column.inSet(<TestEnum>{
-          TestEnum.red,
-          TestEnum.blue,
-          TestEnum.green,
-        });
+          'when NOT equals compared to NULL value then output is IS NOT NULL expression.'
+          ' (serializeEnumValuesAsStrings == true)', () {
+        var comparisonExpression = columnSerializedAsString.notEquals(null);
 
-        expect(comparisonExpression.toString(), '$column IN (0, 1, 2)');
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsString IS NOT NULL');
       });
 
       test(
-          'when checking if expression is NOT in value set then output is NOT IN expression.',
-          () {
-        var comparisonExpression = column.notInSet(<TestEnum>{
+          'when NOT equals compared to NULL value then output is IS NOT NULL expression.'
+          ' (serializeEnumValuesAsStrings == false)', () {
+        var comparisonExpression = columnSerializedAsInteger.notEquals(null);
+
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsInteger IS NOT NULL');
+      });
+
+      test(
+          'when NOT equals compared to enum value then output is NOT equals expression.'
+          ' (serializeEnumValuesAsStrings == true)', () {
+        var comparisonExpression =
+            columnSerializedAsString.notEquals(TestEnum.blue);
+
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsString IS DISTINCT FROM \'blue\'');
+      });
+
+      test(
+          'when NOT equals compared to enum value then output is NOT equals expression.'
+          ' (serializeEnumValuesAsStrings == false)', () {
+        var comparisonExpression =
+            columnSerializedAsInteger.notEquals(TestEnum.blue);
+
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsInteger IS DISTINCT FROM 1');
+      });
+
+      test(
+          'when checking if expression is in value set then output is IN expression.'
+          ' (serializeEnumValuesAsStrings == true)', () {
+        var comparisonExpression = columnSerializedAsString.inSet(<TestEnum>{
           TestEnum.red,
           TestEnum.blue,
           TestEnum.green,
         });
 
         expect(comparisonExpression.toString(),
-            '($column NOT IN (0, 1, 2) OR $column IS NULL)');
+            '$columnSerializedAsString IN (\'red\', \'blue\', \'green\')');
+      });
+
+      test(
+          'when checking if expression is in value set then output is IN expression.'
+          ' (serializeEnumValuesAsStrings == false)', () {
+        var comparisonExpression = columnSerializedAsInteger.inSet(<TestEnum>{
+          TestEnum.red,
+          TestEnum.blue,
+          TestEnum.green,
+        });
+
+        expect(comparisonExpression.toString(),
+            '$columnSerializedAsString IN (0, 1, 2)');
+      });
+
+      test(
+          'when checking if expression is NOT in value set then output is NOT IN expression.'
+          ' (serializeEnumValuesAsStrings == true)', () {
+        var comparisonExpression = columnSerializedAsString.notInSet(<TestEnum>{
+          TestEnum.red,
+          TestEnum.blue,
+          TestEnum.green,
+        });
+
+        expect(
+            comparisonExpression.toString(),
+            '($columnSerializedAsString NOT IN (\'red\', \'blue\', \'green\') '
+            'OR $columnSerializedAsString IS NULL)');
+      });
+
+      test(
+          'when checking if expression is NOT in value set then output is NOT IN expression.'
+          ' (serializeEnumValuesAsStrings == false)', () {
+        var comparisonExpression =
+            columnSerializedAsInteger.notInSet(<TestEnum>{
+          TestEnum.red,
+          TestEnum.blue,
+          TestEnum.green,
+        });
+
+        expect(
+            comparisonExpression.toString(),
+            '($columnSerializedAsInteger NOT IN (0, 1, 2) '
+            'OR $columnSerializedAsInteger IS NULL)');
       });
     });
   });

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -323,11 +323,11 @@ class _ObjectWithEnumImpl extends ObjectWithEnum {
 class ObjectWithEnumTable extends _i1.Table {
   ObjectWithEnumTable({super.tableRelation})
       : super(tableName: 'object_with_enum') {
-    testEnum = _i1.ColumnEnum<_i2.TestEnum>(
+    testEnum = _i1.ColumnEnumSerializedAsInteger<_i2.TestEnum>(
       'testEnum',
       this,
     );
-    nullableEnum = _i1.ColumnEnum<_i2.TestEnum>(
+    nullableEnum = _i1.ColumnEnumSerializedAsInteger<_i2.TestEnum>(
       'nullableEnum',
       this,
     );
@@ -345,9 +345,9 @@ class ObjectWithEnumTable extends _i1.Table {
     );
   }
 
-  late final _i1.ColumnEnum<_i2.TestEnum> testEnum;
+  late final _i1.ColumnEnumSerializedAsInteger<_i2.TestEnum> testEnum;
 
-  late final _i1.ColumnEnum<_i2.TestEnum> nullableEnum;
+  late final _i1.ColumnEnumSerializedAsInteger<_i2.TestEnum> nullableEnum;
 
   late final _i1.ColumnSerializable enumList;
 

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -422,7 +422,7 @@ class TypesTable extends _i1.Table {
       'aUuid',
       this,
     );
-    anEnum = _i1.ColumnEnum<_i3.TestEnum>(
+    anEnum = _i1.ColumnEnumSerializedAsInteger<_i3.TestEnum>(
       'anEnum',
       this,
     );
@@ -444,7 +444,7 @@ class TypesTable extends _i1.Table {
 
   late final _i1.ColumnUuid aUuid;
 
-  late final _i1.ColumnEnum<_i3.TestEnum> anEnum;
+  late final _i1.ColumnEnumSerializedAsInteger<_i3.TestEnum> anEnum;
 
   @override
   List<_i1.Column> get columns => [

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -24,7 +24,7 @@ enum PackageType {
 
 /// The configuration of the generation and analyzing process.
 class GeneratorConfig {
-  const GeneratorConfig({
+  GeneratorConfig({
     required this.name,
     required this.type,
     required this.serverPackage,
@@ -35,7 +35,11 @@ class GeneratorConfig {
     required this.modules,
     required this.extraClasses,
     required this.serializeEnumValuesAsStrings,
-  }) : _relativeDartClientPackagePathParts = relativeDartClientPackagePathParts;
+  }) : _relativeDartClientPackagePathParts =
+            relativeDartClientPackagePathParts {
+    assert(_instance == null, 'GeneratorConfig should only be loaded once.');
+    _instance = this;
+  }
 
   /// The current [GeneratorConfig] instance.
   static GeneratorConfig? _instance;
@@ -261,7 +265,7 @@ class GeneratorConfig {
       }
     }
 
-    var config = GeneratorConfig(
+    return GeneratorConfig(
         name: name,
         type: type,
         serverPackage: serverPackage,
@@ -272,11 +276,6 @@ class GeneratorConfig {
         modules: modules,
         extraClasses: extraClasses,
         serializeEnumValuesAsStrings: serializeEnumValuesAsStrings);
-
-    assert(_instance == null, 'GeneratorConfig should only be loaded once.');
-    _instance = config;
-
-    return config;
   }
 
   @override

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -241,6 +241,8 @@ class GeneratorConfig {
     }
     var serializeEnumValuesAsStrings =
         // TODO: switch the default from `false` to `true` in Serverpod 2.0.
+        // Also switch the default in:
+        // tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
         (serializeEnumValuesAsStringsConfig as bool?) ?? false;
 
     // Load extraClasses

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -182,13 +182,12 @@ class TypeDefinition {
     // TODO: add all supported types here
     var serializeEnumValuesAsStrings =
         GeneratorConfig.instance.serializeEnumValuesAsStrings;
-    if (className == 'String' || (isEnum && serializeEnumValuesAsStrings)) {
-      return 'text';
+    if (isEnum) {
+      return serializeEnumValuesAsStrings ? 'text' : 'integer';
     }
-    if (className == 'int' || (isEnum && !serializeEnumValuesAsStrings)) {
-      return 'integer';
-    }
+    if (className == 'String') return 'text';
     if (className == 'bool') return 'boolean';
+    if (className == 'int') return 'integer';
     if (className == 'double') return 'double precision';
     if (className == 'DateTime') return 'timestamp without time zone';
     if (className == 'ByteData') return 'bytea';

--- a/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
@@ -23,7 +23,10 @@ class GeneratorConfigBuilder {
         _relativeDartClientPackagePathParts = ['..', 'example_client'],
         _modules = [],
         _extraClasses = [],
-        _serializeEnumValuesAsStrings = true;
+        // TODO: switch the default from `false` to `true` in Serverpod 2.0.
+        // Also switch the default in:
+        // tools/serverpod_cli/lib/src/config/config.dart
+        _serializeEnumValuesAsStrings = false;
 
   GeneratorConfigBuilder withName(String name) {
     _name = name;

--- a/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
@@ -11,6 +11,7 @@ class GeneratorConfigBuilder {
   List<String> _relativeDartClientPackagePathParts;
   List<ModuleConfig> _modules;
   List<TypeDefinition> _extraClasses;
+  bool _serializeEnumValuesAsStrings;
 
   GeneratorConfigBuilder()
       : _name = 'example',
@@ -21,7 +22,8 @@ class GeneratorConfigBuilder {
         _serverPackageDirectoryPathParts = [],
         _relativeDartClientPackagePathParts = ['..', 'example_client'],
         _modules = [],
-        _extraClasses = [];
+        _extraClasses = [],
+        _serializeEnumValuesAsStrings = true;
 
   GeneratorConfigBuilder withName(String name) {
     _name = name;
@@ -74,6 +76,12 @@ class GeneratorConfigBuilder {
     return this;
   }
 
+  GeneratorConfigBuilder serializeEnumsValuesAsStrings(
+      bool serializeEnumValuesAsStrings) {
+    _serializeEnumValuesAsStrings = serializeEnumValuesAsStrings;
+    return this;
+  }
+
   GeneratorConfig build() {
     return GeneratorConfig(
       name: _name,
@@ -85,6 +93,7 @@ class GeneratorConfigBuilder {
       relativeDartClientPackagePathParts: _relativeDartClientPackagePathParts,
       modules: _modules,
       extraClasses: _extraClasses,
+      serializeEnumValuesAsStrings: _serializeEnumValuesAsStrings,
     );
   }
 }

--- a/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
@@ -2,11 +2,15 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/database/create_definition.dart';
 import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/foreign_relation_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/serializable_entity_field_definition_builder.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // Cache GeneratorConfig
+  GeneratorConfigBuilder().withName('database_action_definition_test').build();
+
   test(
       'Given a class definition with a table, then generate a table with that name.',
       () {

--- a/tools/serverpod_cli/test/database/extentions/pgsql_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/pgsql_code_generation_test.dart
@@ -2,9 +2,13 @@ import 'package:recase/recase.dart';
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/database/create_definition.dart';
 import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // Cache GeneratorConfig
+  GeneratorConfigBuilder().withName('database_action_definition_test').build();
+
   group('Given classes with a circular relation when generating migration', () {
     /**
      * Citizen -> Company -> Town -> Citizen

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
@@ -1,10 +1,9 @@
+import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
 import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
-import 'package:test/test.dart';
-import 'package:path/path.dart' as path;
-
 import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:test/test.dart';
 
 const projectName = 'example_project';
 final config = GeneratorConfigBuilder().withName(projectName).build();
@@ -40,12 +39,19 @@ void main() {
     });
 
     test('then generated enum has static fromJson method', () {
-      expect(codeMap[expectedFileName],
-          contains('static Example? fromJson(int index)'));
+      expect(
+          codeMap[expectedFileName],
+          contains(config.serializeEnumValuesAsStrings
+              ? 'static Example? fromJson(String name)'
+              : 'static Example? fromJson(int index)'));
     });
 
     test('then generated enum has toJson method', () {
-      expect(codeMap[expectedFileName], contains('int toJson() => index;'));
+      expect(
+          codeMap[expectedFileName],
+          contains(config.serializeEnumValuesAsStrings
+              ? 'int toJson() => name;'
+              : 'int toJson() => index;'));
     });
   });
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
@@ -50,7 +50,7 @@ void main() {
       expect(
           codeMap[expectedFileName],
           contains(config.serializeEnumValuesAsStrings
-              ? 'int toJson() => name;'
+              ? 'String toJson() => name;'
               : 'int toJson() => index;'));
     });
   });

--- a/tools/serverpod_cli/test/util/protocol_helper_test.dart
+++ b/tools/serverpod_cli/test/util/protocol_helper_test.dart
@@ -22,17 +22,19 @@ GeneratorConfig createGeneratorConfig([
   );
 }
 
+final serverRootDir = Directory(join(
+  'test',
+  'util',
+  'test_assets',
+  'protocol_helper',
+  'has_serverpod_server_project',
+  'test_server',
+));
+
+final config = createGeneratorConfig(split(serverRootDir.path));
+
 void main() {
   group('Test path extraction.', () {
-    var serverRootDir = Directory(join(
-      'test',
-      'util',
-      'test_assets',
-      'protocol_helper',
-      'has_serverpod_server_project',
-      'test_server',
-    ));
-
     test(
         'Given a protocol path directly inside the protocol folder, then the parts list is empty.',
         () {
@@ -48,8 +50,6 @@ void main() {
         'protocol',
         'test.yaml',
       ));
-
-      var config = createGeneratorConfig(split(serverRootDir.path));
 
       var pathParts = ProtocolHelper.extractPathFromProtocolRoot(
         config,
@@ -77,8 +77,6 @@ void main() {
         'test.yaml',
       ));
 
-      var config = createGeneratorConfig(split(serverRootDir.path));
-
       var pathParts = ProtocolHelper.extractPathFromProtocolRoot(
         config,
         protocolFile.uri,
@@ -88,17 +86,6 @@ void main() {
     });
 
     group('Test yaml protocol loader.', () {
-      var serverRootDir = Directory(join(
-        'test',
-        'util',
-        'test_assets',
-        'protocol_helper',
-        'has_serverpod_server_project',
-        'test_server',
-      ));
-
-      var config = createGeneratorConfig(split(serverRootDir.path));
-
       test(
           'Given a serverpod project with protocol files, then the converted protocol path has the file uri set.',
           () async {

--- a/tools/serverpod_cli/test/util/protocol_helper_test.dart
+++ b/tools/serverpod_cli/test/util/protocol_helper_test.dart
@@ -18,6 +18,7 @@ GeneratorConfig createGeneratorConfig([
     relativeDartClientPackagePathParts: [],
     modules: [],
     extraClasses: [],
+    serializeEnumValuesAsStrings: true,
   );
 }
 


### PR DESCRIPTION
Obsoletes #1080.
Fixes #885.

Allow enums to be serialized as strings rather than integers, for robustness.

Rebased on latest git.
Complete with tests.

I want to enable this by default for 1.2, but some of you said that should wait until 2.0, so the option is set to false by default.

I hope you can please merge this soon, because this is the most annoying PR to have to keep in sync with upstream, since the generated code keeps causing merge conflicts with the generated code you have checked into git. Thanks!

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.