### PR TITLE
fix: Allow named relations on id fields.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
@@ -156,13 +156,14 @@ class EntityRelations {
     var relationName = fieldRelation.name;
     if (relationName == null) return [];
 
-  
-    String? foreignClassName = extractReferenceClassName(field);
-    var foreignClasses = findAllByClassName(foreignClassName);
+    List<SerializableEntityDefinition> foreignClasses;
 
     var relation = field.relation;
     if (field.type.isIdType && relation is ForeignRelationDefinition) {
       foreignClasses = findAllByTableName(relation.parentTable);
+    } else {
+      String? foreignClassName = extractReferenceClassName(field);
+      foreignClasses = findAllByClassName(foreignClassName);
     }
 
     if (foreignClasses.isEmpty) return [];

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
@@ -156,9 +156,15 @@ class EntityRelations {
     var relationName = fieldRelation.name;
     if (relationName == null) return [];
 
+  
     String? foreignClassName = extractReferenceClassName(field);
-
     var foreignClasses = findAllByClassName(foreignClassName);
+
+    var relation = field.relation;
+    if (field.type.isIdType && relation is ForeignRelationDefinition) {
+      foreignClasses = findAllByTableName(relation.parentTable);
+    }
+
     if (foreignClasses.isEmpty) return [];
 
     var foreignClass = foreignClasses.first;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/yaml_definitions/class_yaml_definition.dart
@@ -67,7 +67,6 @@ class ClassYamlDefinition {
                 nested: {
                   ValidateNode(
                     Keyword.parent,
-                    mutuallyExclusiveKeys: {Keyword.name},
                     keyRestriction: restrictions.validateParentKey,
                     valueRestriction: restrictions.validateParentName,
                   ),
@@ -97,7 +96,6 @@ class ClassYamlDefinition {
                   ),
                   ValidateNode(
                     Keyword.name,
-                    mutuallyExclusiveKeys: {Keyword.parent},
                     valueRestriction: restrictions.validateRelationName,
                   ),
                 },


### PR DESCRIPTION
Allow the following protocol definition to be made:
```yaml
# employees.yaml
class: Employee
table: employee
fields:
  companyId: int, relation(name=company_employees, parent=company)

# company.yaml
class: Company
table: company
fields:
  employees: List<Employee>?, relation(name=company_employees)
```


Closes: #1485 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

