### PR TITLE
Upgrade intl dependency to version 0.18.1

### DIFF
--- a/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^6.0.0
-  intl: ">=0.17.0 <0.19.0"intl: ">=0.17.0 <0.19.0"
+  intl: ^0.18.0
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: #1.2.0-rc.1

--- a/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^6.0.0
-  intl: ^0.18.1
+  intl: ">=0.17.0 <0.19.0"intl: ">=0.17.0 <0.19.0"
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: #1.2.0-rc.1

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^6.0.0
-  intl: ">=0.17.0 <0.19.0"
+  intl: ^0.18.0
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^6.0.0
-  intl: ^0.18.1
+  intl: ">=0.17.0 <0.19.0"
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: #--CONDITIONAL_COMMENT--#VERSION

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   http: ">=0.13.0 <2.0.0"
-  intl: ^0.18.1
+  intl: ">=0.17.0 <0.19.0"
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   http: ">=0.13.0 <2.0.0"
-  intl: ">=0.17.0 <0.19.0"
+  intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   http: ">=0.13.0 <2.0.0"
-  intl: ^0.18.1
+  intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0


### PR DESCRIPTION
Serverpod uses an old version of `intl`, which causes a conflict with multiple other libraries I need to depend upon.

This PR upgrades the Serverpod `intl` dependency version from `0.17.0` to `0.18.1`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
