### PR TITLE
Serialize enums

### DIFF
--- a/packages/serverpod/lib/src/database/value_encoder.dart
+++ b/packages/serverpod/lib/src/database/value_encoder.dart
@@ -29,7 +29,7 @@ class ValueEncoder extends PostgresTextEncoder {
       // encoded to base64. Best would be to find a better way to detect when we
       // are trying to store a ByteData.
       return input;
-    } else if (input is List || input is Map || input is Set) {
+    } else if (input is List || input is Map || input is Set || input is Enum) {
       return super.convert(SerializationManager.encode(input),
           escapeStrings: escapeStrings);
     }


### PR DESCRIPTION
Enum serialization to int used to work (I think), without my changes to serialize enum values as strings, but for whatever reason, on a clean checkout of Serverpod from git master, I get an error when PostGres tries to serialize `Enum` objects directly, and fails. Or maybe serializing enums to int for storage in the database never worked? I didn't look to see if there is a test for this, but it's very much broken right now without this change.

This change is needed until #1521 is in place -- at which point though, this PR will probably be superceded. When enums are serialized as strings, they have to be converted differently so that they're not double-quoted -- see my changes to `value_encoder.dart` in #1521.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
