### PR TITLE
fix: Prevent crashing when trying to load corrupt migration folder.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -8,7 +8,7 @@ import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 
 class CreateMigrationCommand extends ServerpodCommand {
-  static const _runModes = <String>['development', 'staging', 'production'];
+  static const runModes = <String>['development', 'staging', 'production'];
 
   @override
   final name = 'create-migration';
@@ -40,7 +40,7 @@ class CreateMigrationCommand extends ServerpodCommand {
       'mode',
       abbr: 'm',
       defaultsTo: 'development',
-      allowed: _runModes,
+      allowed: runModes,
       help: 'Use together with --repair to specify which database to repair.',
     );
     argParser.addOption(

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -93,8 +93,9 @@ class CreateMigrationCommand extends ServerpodCommand {
       projectName: projectName,
     );
 
+    var success = false;
     if (repair) {
-      await log.progress('Creating repair migration', () async {
+      success = await log.progress('Creating repair migration', () async {
         var migration = await generator.repairMigration(
           tag: tag,
           force: force,
@@ -104,7 +105,7 @@ class CreateMigrationCommand extends ServerpodCommand {
         return migration != null;
       });
     } else {
-      var success = await log.progress('Creating migration', () async {
+      success = await log.progress('Creating migration', () async {
         var migration = await generator.createMigration(
           tag: tag,
           force: force,
@@ -113,12 +114,12 @@ class CreateMigrationCommand extends ServerpodCommand {
 
         return migration != null;
       });
-      if (success) {
-        log.info(
-          'Done.',
-          type: TextLogType.success,
-        );
-      }
     }
+
+    if (!success) {
+      throw ExitException();
+    }
+
+    log.info('Done.', type: TextLogType.success);
   }
 }

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -23,7 +23,6 @@ extension DatabaseComparisons on DatabaseDefinition {
     var diff = generateDatabaseMigration(
       srcDatabase: this,
       dstDatabase: other,
-      warnings: [],
       priority: -1,
     );
     return diff.isEmpty;

--- a/tools/serverpod_cli/lib/src/database/migration.dart
+++ b/tools/serverpod_cli/lib/src/database/migration.dart
@@ -5,9 +5,9 @@ import 'extensions.dart';
 DatabaseMigration generateDatabaseMigration({
   required DatabaseDefinition srcDatabase,
   required DatabaseDefinition dstDatabase,
-  required List<DatabaseMigrationWarning> warnings,
   required int priority,
 }) {
+  var warnings = <DatabaseMigrationWarning>[];
   var actions = <DatabaseMigrationAction>[];
 
   // Find deleted tables
@@ -84,7 +84,7 @@ DatabaseMigration generateDatabaseMigration({
 
   return DatabaseMigration(
     actions: actions,
-    warnings: [],
+    warnings: warnings,
     priority: priority,
     migrationApiVersion: DatabaseConstants.migrationApiVersion,
   );

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -121,14 +121,13 @@ class MigrationGenerator {
       priority: priority,
     );
 
-    var warnings = <DatabaseMigrationWarning>[];
     var migration = generateDatabaseMigration(
       srcDatabase: srcDatabase,
       dstDatabase: dstDatabase,
-      warnings: warnings,
       priority: priority,
     );
 
+    var warnings = migration.warnings;
     _printWarnings(warnings);
 
     if (warnings.isNotEmpty && !force) {
@@ -185,14 +184,13 @@ class MigrationGenerator {
     var liveDatabase = await client.insights.getLiveDatabaseDefinition();
 
     // Print warnings, if any exists.
-    var warnings = <DatabaseMigrationWarning>[];
     var migration = generateDatabaseMigration(
       srcDatabase: liveDatabase,
       dstDatabase: dstDatabase,
-      warnings: warnings,
       priority: 0,
     );
 
+    var warnings = migration.warnings;
     _printWarnings(warnings);
     if (warnings.isNotEmpty && !force) {
       log.info('Migration aborted. Use --force to ignore warnings.');

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -160,7 +160,6 @@ class MigrationGenerator {
     required bool force,
     required String runMode,
   }) async {
-    var client = ConfigInfo(runMode).createServiceClient();
     var versions = <String, String>{};
 
     // Load the latest migration from all modules.
@@ -181,6 +180,7 @@ class MigrationGenerator {
     );
 
     // Get the live database definition from the server.
+    var client = ConfigInfo(runMode).createServiceClient();
     var liveDatabase = await client.insights.getLiveDatabaseDefinition();
 
     // Print warnings, if any exists.

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -52,13 +52,11 @@ class MigrationGenerator {
     return names;
   }
 
-  List<String> getMigrationVersions({
-    String? module,
-  }) {
+  List<String> getMigrationVersions(String module) {
     var migrationsDirectory = Directory(
       path.join(
         migrationsBaseDirectory.path,
-        module ?? projectName,
+        module,
       ),
     );
     if (!migrationsDirectory.existsSync()) {
@@ -76,13 +74,13 @@ class MigrationGenerator {
   }
 
   Future<MigrationVersion> getMigrationVersion(
-    String versionName, {
-    String? module,
-  }) async {
+    String versionName,
+    String module,
+  ) async {
     var migrationsDirectory = Directory(
       path.join(
         migrationsBaseDirectory.path,
-        module ?? projectName,
+        module,
       ),
     );
     return await MigrationVersion.load(
@@ -91,16 +89,16 @@ class MigrationGenerator {
     );
   }
 
-  Future<MigrationVersion?> getLatestMigrationVersion({
-    String? module,
-  }) async {
-    var versions = getMigrationVersions(module: module);
+  Future<MigrationVersion?> getLatestMigrationVersion(
+    String module,
+  ) async {
+    var versions = getMigrationVersions(module);
     if (versions.isEmpty) {
       return null;
     }
     return await getMigrationVersion(
       versions.last,
-      module: module,
+      module,
     );
   }
 
@@ -110,9 +108,7 @@ class MigrationGenerator {
     required int priority,
     bool write = true,
   }) async {
-    var versionName = createVersionName(tag);
-
-    var latest = await getLatestMigrationVersion();
+    var latest = await getLatestMigrationVersion(projectName);
 
     var srcDatabase = latest?.databaseDefinition ??
         DatabaseDefinition(
@@ -145,6 +141,7 @@ class MigrationGenerator {
       return null;
     }
 
+    var versionName = createVersionName(tag);
     var migrationVersion = MigrationVersion(
       migrationsDirectory: migrationsProjectDirectory,
       versionName: versionName,
@@ -171,7 +168,7 @@ class MigrationGenerator {
     var modules = getMigrationModules();
     var dstDefinitions = <DatabaseDefinition>[];
     for (var module in modules) {
-      var version = await getLatestMigrationVersion(module: module);
+      var version = await getLatestMigrationVersion(module);
       if (version == null) {
         continue;
       }

--- a/tools/serverpod_cli/test/migrations/migration_generator_test.dart
+++ b/tools/serverpod_cli/test/migrations/migration_generator_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/commands/create_migration.dart';
+import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/logger/loggers/void_logger.dart';
+import 'package:test/test.dart';
+
+class TestLogger extends VoidLogger {
+  final List<String> _errorLogs = [];
+
+  void clearLogs() {
+    _errorLogs.clear();
+  }
+
+  List<String> get errorLogs => _errorLogs;
+
+  @override
+  void error(
+    String message, {
+    bool newParagraph = false,
+    StackTrace? stackTrace,
+    LogType type = const RawLogType(),
+  }) {
+    _errorLogs.add(message);
+  }
+}
+
+void main() {
+  var testAssetsPath = p.join('test', 'migrations', 'test_assets');
+
+  setUpAll(() => initializeLoggerWith(TestLogger()));
+  setUp(() => (log as TestLogger).clearLogs());
+
+  group('Given a latest version migration folder that is empty', () {
+    var projectDirectory = Directory(p.join(testAssetsPath, 'empty_migration'));
+    var projectName = 'test_project';
+    var generator = MigrationGenerator(
+      directory: projectDirectory,
+      projectName: projectName,
+    );
+
+    group('when creating migration', () {
+      test('then null is returned.', () async {
+        expect(
+            await generator.createMigration(force: false, priority: 0), isNull);
+      });
+
+      test('then expected error messages are logged.', () async {
+        await generator.createMigration(force: false, priority: 0);
+
+        var logs = (log as TestLogger).errorLogs;
+
+        expect(logs, hasLength(2));
+        expect(
+          logs.first,
+          startsWith(
+              'Unable to determine latest database definition due to a corrupted'),
+        );
+        expect(
+          logs.first,
+          endsWith('Migration version: "00000000000000".'),
+        );
+        expect(
+          logs.last,
+          startsWith('PathNotFoundException: Cannot open file'),
+        );
+      });
+    });
+
+    group('when creating repair migration', () {
+      test('then null is returned.', () async {
+        expect(
+            await generator.repairMigration(
+              runMode: CreateMigrationCommand.runModes.first /* development */,
+              force: false,
+            ),
+            isNull);
+      });
+
+      test('then expected error message is logged.', () async {
+        await generator.repairMigration(
+          runMode: CreateMigrationCommand.runModes.first /* development */,
+          force: false,
+        );
+
+        var logs = (log as TestLogger).errorLogs;
+
+        expect(logs, hasLength(2));
+        expect(
+          logs.first,
+          startsWith(
+              'Unable to determine latest database definition due to a corrupted'),
+        );
+        expect(
+          logs.first,
+          endsWith(
+              'Migration version: "00000000000000" for module "test_project".'),
+        );
+        expect(
+          logs.last,
+          startsWith('PathNotFoundException: Cannot open file'),
+        );
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/migrations/migration_generator_test.dart
+++ b/tools/serverpod_cli/test/migrations/migration_generator_test.dart
@@ -43,8 +43,12 @@ void main() {
 
     group('when creating migration', () {
       test('then null is returned.', () async {
-        expect(
-            await generator.createMigration(force: false, priority: 0), isNull);
+        var migration = await generator.createMigration(
+          force: false,
+          priority: 0,
+        );
+
+        expect(migration, isNull);
       });
 
       test('then expected error messages are logged.', () async {
@@ -71,12 +75,11 @@ void main() {
 
     group('when creating repair migration', () {
       test('then null is returned.', () async {
-        expect(
-            await generator.repairMigration(
-              runMode: CreateMigrationCommand.runModes.first /* development */,
-              force: false,
-            ),
-            isNull);
+        var repairSql = await generator.repairMigration(
+          runMode: CreateMigrationCommand.runModes.first /* development */,
+          force: false,
+        );
+        expect(repairSql, isNull);
       });
 
       test('then expected error message is logged.', () async {


### PR DESCRIPTION
### Change
- Prevents crashing when corrupted migrations are attempted to be loaded.
- Informs users about what has occurred and what actions to take.

<img width="737" alt="Screenshot 2023-11-06 at 12 13 45" src="https://github.com/serverpod/serverpod/assets/137198655/3b4624a2-bedf-4323-b37d-dff11285d7ba">

#### Minor refactors
- Command returns exit code != 0 if migration could not be created.
- Always use explicit module name for methods.
- Remove inout parameter in favor of existing warning mechanism.
- Initialize client just before it is used to enable unit testing error handling logic.

Closes: #1512 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
