### PR TITLE
fix: Change signature of orderBy and orderByList to callbacks taking a typed table.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -338,18 +338,18 @@ class ChannelRepository {
     _i1.WhereExpressionBuilder<ChannelTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChannelTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<Channel>(
       where: where?.call(Channel.t),
+      orderBy: orderBy?.call(Channel.t),
+      orderByList: orderByList?.call(Channel.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -358,12 +358,17 @@ class ChannelRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ChannelTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChannelTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<Channel>(
       where: where?.call(Channel.t),
+      orderBy: orderBy?.call(Channel.t),
+      orderByList: orderByList?.call(Channel.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_images.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_images.dart
@@ -68,7 +68,7 @@ class UserImages {
       session,
       where: (t) => t.userId.equals(userId),
       orderDescending: true,
-      orderBy: UserImage.t.version,
+      orderBy: (t) => t.version,
     );
 
     // Add one to the version number or create a new version 1.

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -365,18 +365,18 @@ class EmailAuthRepository {
     _i1.WhereExpressionBuilder<EmailAuthTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailAuthTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<EmailAuth>(
       where: where?.call(EmailAuth.t),
+      orderBy: orderBy?.call(EmailAuth.t),
+      orderByList: orderByList?.call(EmailAuth.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -385,12 +385,17 @@ class EmailAuthRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailAuthTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailAuthTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<EmailAuth>(
       where: where?.call(EmailAuth.t),
+      orderBy: orderBy?.call(EmailAuth.t),
+      orderByList: orderByList?.call(EmailAuth.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -393,18 +393,18 @@ class EmailCreateAccountRequestRepository {
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<EmailCreateAccountRequest>(
       where: where?.call(EmailCreateAccountRequest.t),
+      orderBy: orderBy?.call(EmailCreateAccountRequest.t),
+      orderByList: orderByList?.call(EmailCreateAccountRequest.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -413,12 +413,17 @@ class EmailCreateAccountRequestRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<EmailCreateAccountRequest>(
       where: where?.call(EmailCreateAccountRequest.t),
+      orderBy: orderBy?.call(EmailCreateAccountRequest.t),
+      orderByList: orderByList?.call(EmailCreateAccountRequest.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -367,18 +367,18 @@ class EmailFailedSignInRepository {
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<EmailFailedSignIn>(
       where: where?.call(EmailFailedSignIn.t),
+      orderBy: orderBy?.call(EmailFailedSignIn.t),
+      orderByList: orderByList?.call(EmailFailedSignIn.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -387,12 +387,17 @@ class EmailFailedSignInRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<EmailFailedSignIn>(
       where: where?.call(EmailFailedSignIn.t),
+      orderBy: orderBy?.call(EmailFailedSignIn.t),
+      orderByList: orderByList?.call(EmailFailedSignIn.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -366,18 +366,18 @@ class EmailResetRepository {
     _i1.WhereExpressionBuilder<EmailResetTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailResetTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<EmailReset>(
       where: where?.call(EmailReset.t),
+      orderBy: orderBy?.call(EmailReset.t),
+      orderByList: orderByList?.call(EmailReset.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -386,12 +386,17 @@ class EmailResetRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailResetTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailResetTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<EmailReset>(
       where: where?.call(EmailReset.t),
+      orderBy: orderBy?.call(EmailReset.t),
+      orderByList: orderByList?.call(EmailReset.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -340,18 +340,18 @@ class GoogleRefreshTokenRepository {
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<GoogleRefreshToken>(
       where: where?.call(GoogleRefreshToken.t),
+      orderBy: orderBy?.call(GoogleRefreshToken.t),
+      orderByList: orderByList?.call(GoogleRefreshToken.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -360,12 +360,17 @@ class GoogleRefreshTokenRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<GoogleRefreshToken>(
       where: where?.call(GoogleRefreshToken.t),
+      orderBy: orderBy?.call(GoogleRefreshToken.t),
+      orderByList: orderByList?.call(GoogleRefreshToken.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -365,18 +365,18 @@ class UserImageRepository {
     _i1.WhereExpressionBuilder<UserImageTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UserImageTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<UserImage>(
       where: where?.call(UserImage.t),
+      orderBy: orderBy?.call(UserImage.t),
+      orderByList: orderByList?.call(UserImage.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -385,12 +385,17 @@ class UserImageRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<UserImageTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UserImageTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<UserImage>(
       where: where?.call(UserImage.t),
+      orderBy: orderBy?.call(UserImage.t),
+      orderByList: orderByList?.call(UserImage.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -502,18 +502,18 @@ class UserInfoRepository {
     _i1.WhereExpressionBuilder<UserInfoTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UserInfoTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<UserInfo>(
       where: where?.call(UserInfo.t),
+      orderBy: orderBy?.call(UserInfo.t),
+      orderByList: orderByList?.call(UserInfo.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -522,12 +522,17 @@ class UserInfoRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<UserInfoTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UserInfoTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<UserInfo>(
       where: where?.call(UserInfo.t),
+      orderBy: orderBy?.call(UserInfo.t),
+      orderByList: orderByList?.call(UserInfo.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/endpoints/chat_endpoint.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/endpoints/chat_endpoint.dart
@@ -182,7 +182,7 @@ class ChatEndpoint extends Endpoint {
       messages = await ChatMessage.db.find(
         session,
         where: (t) => t.channel.equals(channel) & (t.id < lastId),
-        orderBy: ChatMessage.t.id,
+        orderBy: (t) => t.id,
         orderDescending: true,
         limit: size + 1,
       );
@@ -190,7 +190,7 @@ class ChatEndpoint extends Endpoint {
       messages = await ChatMessage.db.find(
         session,
         where: (t) => t.channel.equals(channel),
-        orderBy: ChatMessage.t.id,
+        orderBy: (t) => t.id,
         orderDescending: true,
         limit: size + 1,
       );

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -493,18 +493,18 @@ class ChatMessageRepository {
     _i1.WhereExpressionBuilder<ChatMessageTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChatMessageTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ChatMessage>(
       where: where?.call(ChatMessage.t),
+      orderBy: orderBy?.call(ChatMessage.t),
+      orderByList: orderByList?.call(ChatMessage.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -513,12 +513,17 @@ class ChatMessageRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatMessageTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChatMessageTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ChatMessage>(
       where: where?.call(ChatMessage.t),
+      orderBy: orderBy?.call(ChatMessage.t),
+      orderByList: orderByList?.call(ChatMessage.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -366,18 +366,18 @@ class ChatReadMessageRepository {
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ChatReadMessage>(
       where: where?.call(ChatReadMessage.t),
+      orderBy: orderBy?.call(ChatReadMessage.t),
+      orderByList: orderByList?.call(ChatReadMessage.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -386,12 +386,17 @@ class ChatReadMessageRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ChatReadMessage>(
       where: where?.call(ChatReadMessage.t),
+      orderBy: orderBy?.call(ChatReadMessage.t),
+      orderByList: orderByList?.call(ChatReadMessage.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -33,7 +33,6 @@ class Database {
     Column? orderBy,
     List<Order>? orderByList,
     bool orderDescending = false,
-    bool useCache = true,
     Transaction? transaction,
     Include? include,
   }) async {
@@ -55,6 +54,7 @@ class Database {
     Expression? where,
     int? offset,
     Column? orderBy,
+    List<Order>? orderByList,
     bool orderDescending = false,
     Transaction? transaction,
     Include? include,
@@ -64,6 +64,7 @@ class Database {
       where: where,
       offset: offset,
       orderBy: orderBy,
+      orderByList: orderByList,
       orderDescending: orderDescending,
       transaction: transaction,
       include: include,

--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -75,6 +75,7 @@ class DatabaseConnection {
     Expression? where,
     int? offset,
     Column? orderBy,
+    List<Order>? orderByList,
     bool orderDescending = false,
     Transaction? transaction,
     Include? include,
@@ -85,6 +86,7 @@ class DatabaseConnection {
       where: where,
       offset: offset,
       orderBy: orderBy,
+      orderByList: orderByList,
       orderDescending: orderDescending,
       limit: 1,
       transaction: transaction,
@@ -683,6 +685,13 @@ class Transaction {
 /// A function that returns an [Expression] for a [Table] to be used with where
 /// clauses.
 typedef WhereExpressionBuilder<T extends Table> = Expression Function(T);
+
+/// A function that returns a Column for a Table to be used with order by
+typedef OrderByBuilder<T extends Table> = Column Function(T);
+
+/// A function that returns a list of [Order] for a [Table] to be used with
+/// order by list.
+typedef OrderByListBuilder<T extends Table> = List<Order> Function(T);
 
 /// A function that returns a [Column] for a [Table].
 typedef ColumnSelections<T extends Table> = List<Column> Function(T);

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -157,13 +157,13 @@ class InsightsEndpoint extends Endpoint {
     var metrics = await ServerHealthMetric.db.find(
       session,
       where: (t) => (t.timestamp >= start) & (t.timestamp <= end),
-      orderBy: ServerHealthMetric.t.timestamp,
+      orderBy: (t) => t.timestamp,
     );
 
     var connectionInfos = await ServerHealthConnectionInfo.db.find(
       session,
       where: (t) => (t.timestamp >= start) & (t.timestamp <= end),
-      orderBy: ServerHealthConnectionInfo.t.timestamp,
+      orderBy: (t) => t.timestamp,
     );
 
     return ServerHealthResult(

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -405,18 +405,18 @@ class AuthKeyRepository {
     _i1.WhereExpressionBuilder<AuthKeyTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<AuthKeyTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<AuthKey>(
       where: where?.call(AuthKey.t),
+      orderBy: orderBy?.call(AuthKey.t),
+      orderByList: orderByList?.call(AuthKey.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -425,12 +425,17 @@ class AuthKeyRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<AuthKeyTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<AuthKeyTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<AuthKey>(
       where: where?.call(AuthKey.t),
+      orderBy: orderBy?.call(AuthKey.t),
+      orderByList: orderByList?.call(AuthKey.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -444,18 +444,18 @@ class CloudStorageEntryRepository {
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<CloudStorageEntry>(
       where: where?.call(CloudStorageEntry.t),
+      orderBy: orderBy?.call(CloudStorageEntry.t),
+      orderByList: orderByList?.call(CloudStorageEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -464,12 +464,17 @@ class CloudStorageEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<CloudStorageEntry>(
       where: where?.call(CloudStorageEntry.t),
+      orderBy: orderBy?.call(CloudStorageEntry.t),
+      orderByList: orderByList?.call(CloudStorageEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -393,18 +393,18 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<CloudStorageDirectUploadEntry>(
       where: where?.call(CloudStorageDirectUploadEntry.t),
+      orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
+      orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -413,12 +413,17 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<CloudStorageDirectUploadEntry>(
       where: where?.call(CloudStorageDirectUploadEntry.t),
+      orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
+      orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -419,18 +419,18 @@ class FutureCallEntryRepository {
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<FutureCallEntry>(
       where: where?.call(FutureCallEntry.t),
+      orderBy: orderBy?.call(FutureCallEntry.t),
+      orderByList: orderByList?.call(FutureCallEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -439,12 +439,17 @@ class FutureCallEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<FutureCallEntry>(
       where: where?.call(FutureCallEntry.t),
+      orderBy: orderBy?.call(FutureCallEntry.t),
+      orderByList: orderByList?.call(FutureCallEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -547,18 +547,18 @@ class LogEntryRepository {
     _i1.WhereExpressionBuilder<LogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<LogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<LogEntry>(
       where: where?.call(LogEntry.t),
+      orderBy: orderBy?.call(LogEntry.t),
+      orderByList: orderByList?.call(LogEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -567,12 +567,17 @@ class LogEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<LogEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<LogEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<LogEntry>(
       where: where?.call(LogEntry.t),
+      orderBy: orderBy?.call(LogEntry.t),
+      orderByList: orderByList?.call(LogEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -550,18 +550,18 @@ class MessageLogEntryRepository {
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<MessageLogEntry>(
       where: where?.call(MessageLogEntry.t),
+      orderBy: orderBy?.call(MessageLogEntry.t),
+      orderByList: orderByList?.call(MessageLogEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -570,12 +570,17 @@ class MessageLogEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<MessageLogEntry>(
       where: where?.call(MessageLogEntry.t),
+      orderBy: orderBy?.call(MessageLogEntry.t),
+      orderByList: orderByList?.call(MessageLogEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -340,18 +340,18 @@ class MethodInfoRepository {
     _i1.WhereExpressionBuilder<MethodInfoTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MethodInfoTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<MethodInfo>(
       where: where?.call(MethodInfo.t),
+      orderBy: orderBy?.call(MethodInfo.t),
+      orderByList: orderByList?.call(MethodInfo.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -360,12 +360,17 @@ class MethodInfoRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<MethodInfoTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MethodInfoTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<MethodInfo>(
       where: where?.call(MethodInfo.t),
+      orderBy: orderBy?.call(MethodInfo.t),
+      orderByList: orderByList?.call(MethodInfo.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -550,18 +550,18 @@ class QueryLogEntryRepository {
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<QueryLogEntry>(
       where: where?.call(QueryLogEntry.t),
+      orderBy: orderBy?.call(QueryLogEntry.t),
+      orderByList: orderByList?.call(QueryLogEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -570,12 +570,17 @@ class QueryLogEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<QueryLogEntry>(
       where: where?.call(QueryLogEntry.t),
+      orderBy: orderBy?.call(QueryLogEntry.t),
+      orderByList: orderByList?.call(QueryLogEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -315,18 +315,18 @@ class ReadWriteTestEntryRepository {
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ReadWriteTestEntry>(
       where: where?.call(ReadWriteTestEntry.t),
+      orderBy: orderBy?.call(ReadWriteTestEntry.t),
+      orderByList: orderByList?.call(ReadWriteTestEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -335,12 +335,17 @@ class ReadWriteTestEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ReadWriteTestEntry>(
       where: where?.call(ReadWriteTestEntry.t),
+      orderBy: orderBy?.call(ReadWriteTestEntry.t),
+      orderByList: orderByList?.call(ReadWriteTestEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -395,18 +395,18 @@ class RuntimeSettingsRepository {
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<RuntimeSettings>(
       where: where?.call(RuntimeSettings.t),
+      orderBy: orderBy?.call(RuntimeSettings.t),
+      orderByList: orderByList?.call(RuntimeSettings.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -415,12 +415,17 @@ class RuntimeSettingsRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<RuntimeSettings>(
       where: where?.call(RuntimeSettings.t),
+      orderBy: orderBy?.call(RuntimeSettings.t),
+      orderByList: orderByList?.call(RuntimeSettings.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -448,18 +448,18 @@ class ServerHealthConnectionInfoRepository {
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ServerHealthConnectionInfo>(
       where: where?.call(ServerHealthConnectionInfo.t),
+      orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
+      orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -468,12 +468,17 @@ class ServerHealthConnectionInfoRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ServerHealthConnectionInfo>(
       where: where?.call(ServerHealthConnectionInfo.t),
+      orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
+      orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -447,18 +447,18 @@ class ServerHealthMetricRepository {
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ServerHealthMetric>(
       where: where?.call(ServerHealthMetric.t),
+      orderBy: orderBy?.call(ServerHealthMetric.t),
+      orderByList: orderByList?.call(ServerHealthMetric.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -467,12 +467,17 @@ class ServerHealthMetricRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ServerHealthMetric>(
       where: where?.call(ServerHealthMetric.t),
+      orderBy: orderBy?.call(ServerHealthMetric.t),
+      orderByList: orderByList?.call(ServerHealthMetric.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -635,18 +635,18 @@ class SessionLogEntryRepository {
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<SessionLogEntry>(
       where: where?.call(SessionLogEntry.t),
+      orderBy: orderBy?.call(SessionLogEntry.t),
+      orderByList: orderByList?.call(SessionLogEntry.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -655,12 +655,17 @@ class SessionLogEntryRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<SessionLogEntry>(
       where: where?.call(SessionLogEntry.t),
+      orderBy: orderBy?.call(SessionLogEntry.t),
+      orderByList: orderByList?.call(SessionLogEntry.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -184,7 +184,7 @@ class HealthCheckManager {
           (t.timestamp < startTime) &
           t.granularity.equals(srcGranularity) &
           t.serverId.equals(_pod.serverId),
-      orderBy: ServerHealthConnectionInfo.t.timestamp,
+      orderBy: (t) => t.timestamp,
       orderDescending: true,
       limit: srcGranularity == 1 ? 61 : 25,
     );
@@ -270,7 +270,7 @@ class HealthCheckManager {
           (t.timestamp < startTime) &
           t.granularity.equals(srcGranularity) &
           t.serverId.equals(_pod.serverId),
-      orderBy: ServerHealthMetric.t.timestamp,
+      orderBy: (t) => t.timestamp,
       orderDescending: true,
       limit: (srcGranularity == 1 ? 61 : 25) * numHealthChecks,
     );

--- a/tests/serverpod_test_server/lib/src/endpoints/database_basic.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_basic.dart
@@ -10,7 +10,7 @@ class BasicDatabase extends Endpoint {
   }) async {
     return SimpleData.db.find(
       session,
-      orderBy: SimpleData.t.id,
+      orderBy: (t) => t.id,
       limit: limit,
       offset: offset,
     );

--- a/tests/serverpod_test_server/lib/src/endpoints/entities_with_relations/one_to_many.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/entities_with_relations/one_to_many.dart
@@ -20,8 +20,7 @@ class OneToManyEndpoint extends Endpoint {
   ) async {
     return await Customer.db.find(
       session,
-      orderBy:
-          (t) => t.orders.count((o) => o.description.equals(description)),
+      orderBy: (t) => t.orders.count((o) => o.description.equals(description)),
       orderDescending: false,
     );
   }

--- a/tests/serverpod_test_server/lib/src/endpoints/entities_with_relations/one_to_many.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/entities_with_relations/one_to_many.dart
@@ -9,7 +9,7 @@ class OneToManyEndpoint extends Endpoint {
   ) async {
     return await Customer.db.find(
       session,
-      orderBy: Customer.t.orders.count(),
+      orderBy: (t) => t.orders.count(),
       orderDescending: false,
     );
   }
@@ -21,7 +21,7 @@ class OneToManyEndpoint extends Endpoint {
     return await Customer.db.find(
       session,
       orderBy:
-          Customer.t.orders.count((o) => o.description.equals(description)),
+          (t) => t.orders.count((o) => o.description.equals(description)),
       orderDescending: false,
     );
   }

--- a/tests/serverpod_test_server/lib/src/endpoints/entity_relation.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/entity_relation.dart
@@ -21,13 +21,13 @@ class RelationEndpoint extends Endpoint {
   Future<List<Citizen>> citizenFindOrderedByCompanyName(
     Session session,
   ) async {
-    return await Citizen.db.find(session, orderBy: Citizen.t.company.name);
+    return await Citizen.db.find(session, orderBy: (t) => t.company.name);
   }
 
   Future<List<Citizen>> citizenFindOrderedByCompanyTownName(
     Session session,
   ) async {
-    return await Citizen.db.find(session, orderBy: Citizen.t.company.town.name);
+    return await Citizen.db.find(session, orderBy: (t) => t.company.town.name);
   }
 
   Future<int> citizenDeleteWhereCompanyNameIs(Session session,
@@ -67,14 +67,14 @@ class RelationEndpoint extends Endpoint {
   }
 
   Future<List<Citizen>> citizenFindAll(Session session) async {
-    return await Citizen.db.find(session, orderBy: Citizen.t.id);
+    return await Citizen.db.find(session, orderBy: (t) => t.id);
   }
 
   /// Includes company and oldCompany and their respective towns
   Future<List<Citizen>> citizenFindAllWithDeepIncludes(Session session) async {
     return await Citizen.db.find(
       session,
-      orderBy: Citizen.t.id,
+      orderBy: (t) => t.id,
       include: Citizen.include(
         company: Company.include(town: Town.include()),
         oldCompany: Company.include(town: Town.include()),
@@ -88,7 +88,7 @@ class RelationEndpoint extends Endpoint {
   ) async {
     return await Citizen.db.find(
       session,
-      orderBy: Citizen.t.id,
+      orderBy: (t) => t.id,
       include: Citizen.include(
         address: Address.include(),
       ),
@@ -101,7 +101,7 @@ class RelationEndpoint extends Endpoint {
   ) async {
     return await Citizen.db.find(
       session,
-      orderBy: Citizen.t.id,
+      orderBy: (t) => t.id,
       include: Citizen.include(
         company: Company.include(),
         oldCompany: Company.include(),
@@ -117,7 +117,7 @@ class RelationEndpoint extends Endpoint {
   Future<List<Address>> addressFindAll(Session session) async {
     return await Address.db.find(
       session,
-      orderBy: Address.t.id,
+      orderBy: (t) => t.id,
       include: Address.include(
         inhabitant: Citizen.include(),
       ),
@@ -179,7 +179,7 @@ class RelationEndpoint extends Endpoint {
   }
 
   Future<List<Company>> companyFindAll(Session session) async {
-    return await Company.db.find(session, orderBy: Company.t.id);
+    return await Company.db.find(session, orderBy: (t) => t.id);
   }
 
   Future<int?> citizenInsert(Session session, Citizen citizen) async {

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/city.dart
@@ -455,19 +455,19 @@ class CityRepository {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CityTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
   }) async {
     return session.dbNext.find<City>(
       where: where?.call(City.t),
+      orderBy: orderBy?.call(City.t),
+      orderByList: orderByList?.call(City.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -477,13 +477,18 @@ class CityRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CityTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
   }) async {
     return session.dbNext.findFirstRow<City>(
       where: where?.call(City.t),
+      orderBy: orderBy?.call(City.t),
+      orderByList: orderByList?.call(City.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/organization.dart
@@ -456,19 +456,19 @@ class OrganizationRepository {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<OrganizationTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
   }) async {
     return session.dbNext.find<Organization>(
       where: where?.call(Organization.t),
+      orderBy: orderBy?.call(Organization.t),
+      orderByList: orderByList?.call(Organization.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -478,13 +478,18 @@ class OrganizationRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<OrganizationTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Organization>(
       where: where?.call(Organization.t),
+      orderBy: orderBy?.call(Organization.t),
+      orderByList: orderByList?.call(Organization.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/person.dart
@@ -440,19 +440,19 @@ class PersonRepository {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PersonTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
   }) async {
     return session.dbNext.find<Person>(
       where: where?.call(Person.t),
+      orderBy: orderBy?.call(Person.t),
+      orderByList: orderByList?.call(Person.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -462,13 +462,18 @@ class PersonRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PersonTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Person>(
       where: where?.call(Person.t),
+      orderBy: orderBy?.call(Person.t),
+      orderByList: orderByList?.call(Person.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/course.dart
@@ -388,19 +388,19 @@ class CourseRepository {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CourseTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
   }) async {
     return session.dbNext.find<Course>(
       where: where?.call(Course.t),
+      orderBy: orderBy?.call(Course.t),
+      orderByList: orderByList?.call(Course.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -410,13 +410,18 @@ class CourseRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CourseTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Course>(
       where: where?.call(Course.t),
+      orderBy: orderBy?.call(Course.t),
+      orderByList: orderByList?.call(Course.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/enrollment.dart
@@ -431,19 +431,19 @@ class EnrollmentRepository {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EnrollmentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
   }) async {
     return session.dbNext.find<Enrollment>(
       where: where?.call(Enrollment.t),
+      orderBy: orderBy?.call(Enrollment.t),
+      orderByList: orderByList?.call(Enrollment.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -453,13 +453,18 @@ class EnrollmentRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EnrollmentTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Enrollment>(
       where: where?.call(Enrollment.t),
+      orderBy: orderBy?.call(Enrollment.t),
+      orderByList: orderByList?.call(Enrollment.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/student.dart
@@ -384,19 +384,19 @@ class StudentRepository {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<StudentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
   }) async {
     return session.dbNext.find<Student>(
       where: where?.call(Student.t),
+      orderBy: orderBy?.call(Student.t),
+      orderByList: orderByList?.call(Student.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -406,13 +406,18 @@ class StudentRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<StudentTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Student>(
       where: where?.call(Student.t),
+      orderBy: orderBy?.call(Student.t),
+      orderByList: orderByList?.call(Student.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/arena.dart
@@ -362,19 +362,19 @@ class ArenaRepository {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ArenaTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
   }) async {
     return session.dbNext.find<Arena>(
       where: where?.call(Arena.t),
+      orderBy: orderBy?.call(Arena.t),
+      orderByList: orderByList?.call(Arena.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -384,13 +384,18 @@ class ArenaRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ArenaTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Arena>(
       where: where?.call(Arena.t),
+      orderBy: orderBy?.call(Arena.t),
+      orderByList: orderByList?.call(Arena.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/player.dart
@@ -386,19 +386,19 @@ class PlayerRepository {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PlayerTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
   }) async {
     return session.dbNext.find<Player>(
       where: where?.call(Player.t),
+      orderBy: orderBy?.call(Player.t),
+      orderByList: orderByList?.call(Player.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -408,13 +408,18 @@ class PlayerRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PlayerTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Player>(
       where: where?.call(Player.t),
+      orderBy: orderBy?.call(Player.t),
+      orderByList: orderByList?.call(Player.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/team.dart
@@ -456,19 +456,19 @@ class TeamRepository {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TeamTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
   }) async {
     return session.dbNext.find<Team>(
       where: where?.call(Team.t),
+      orderBy: orderBy?.call(Team.t),
+      orderByList: orderByList?.call(Team.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -478,13 +478,18 @@ class TeamRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TeamTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Team>(
       where: where?.call(Team.t),
+      orderBy: orderBy?.call(Team.t),
+      orderByList: orderByList?.call(Team.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/comment.dart
@@ -385,19 +385,19 @@ class CommentRepository {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CommentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
   }) async {
     return session.dbNext.find<Comment>(
       where: where?.call(Comment.t),
+      orderBy: orderBy?.call(Comment.t),
+      orderByList: orderByList?.call(Comment.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -407,13 +407,18 @@ class CommentRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CommentTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Comment>(
       where: where?.call(Comment.t),
+      orderBy: orderBy?.call(Comment.t),
+      orderByList: orderByList?.call(Comment.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/customer.dart
@@ -386,19 +386,19 @@ class CustomerRepository {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CustomerTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
   }) async {
     return session.dbNext.find<Customer>(
       where: where?.call(Customer.t),
+      orderBy: orderBy?.call(Customer.t),
+      orderByList: orderByList?.call(Customer.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -408,13 +408,18 @@ class CustomerRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CustomerTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Customer>(
       where: where?.call(Customer.t),
+      orderBy: orderBy?.call(Customer.t),
+      orderByList: orderByList?.call(Customer.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/order.dart
@@ -455,19 +455,19 @@ class OrderRepository {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<OrderTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
   }) async {
     return session.dbNext.find<Order>(
       where: where?.call(Order.t),
+      orderBy: orderBy?.call(Order.t),
+      orderByList: orderByList?.call(Order.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -477,13 +477,18 @@ class OrderRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<OrderTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Order>(
       where: where?.call(Order.t),
+      orderBy: orderBy?.call(Order.t),
+      orderByList: orderByList?.call(Order.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/address.dart
@@ -388,19 +388,19 @@ class AddressRepository {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<AddressTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
   }) async {
     return session.dbNext.find<Address>(
       where: where?.call(Address.t),
+      orderBy: orderBy?.call(Address.t),
+      orderByList: orderByList?.call(Address.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -410,13 +410,18 @@ class AddressRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<AddressTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Address>(
       where: where?.call(Address.t),
+      orderBy: orderBy?.call(Address.t),
+      orderByList: orderByList?.call(Address.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/citizen.dart
@@ -495,19 +495,19 @@ class CitizenRepository {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CitizenTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
   }) async {
     return session.dbNext.find<Citizen>(
       where: where?.call(Citizen.t),
+      orderBy: orderBy?.call(Citizen.t),
+      orderByList: orderByList?.call(Citizen.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -517,13 +517,18 @@ class CitizenRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CitizenTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Citizen>(
       where: where?.call(Citizen.t),
+      orderBy: orderBy?.call(Citizen.t),
+      orderByList: orderByList?.call(Citizen.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/company.dart
@@ -384,19 +384,19 @@ class CompanyRepository {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CompanyTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
   }) async {
     return session.dbNext.find<Company>(
       where: where?.call(Company.t),
+      orderBy: orderBy?.call(Company.t),
+      orderByList: orderByList?.call(Company.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -406,13 +406,18 @@ class CompanyRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CompanyTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Company>(
       where: where?.call(Company.t),
+      orderBy: orderBy?.call(Company.t),
+      orderByList: orderByList?.call(Company.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/town.dart
@@ -386,19 +386,19 @@ class TownRepository {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TownTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
   }) async {
     return session.dbNext.find<Town>(
       where: where?.call(Town.t),
+      orderBy: orderBy?.call(Town.t),
+      orderByList: orderByList?.call(Town.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -408,13 +408,18 @@ class TownRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TownTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Town>(
       where: where?.call(Town.t),
+      orderBy: orderBy?.call(Town.t),
+      orderByList: orderByList?.call(Town.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/blocking.dart
@@ -432,19 +432,19 @@ class BlockingRepository {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<BlockingTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
   }) async {
     return session.dbNext.find<Blocking>(
       where: where?.call(Blocking.t),
+      orderBy: orderBy?.call(Blocking.t),
+      orderByList: orderByList?.call(Blocking.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -454,13 +454,18 @@ class BlockingRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<BlockingTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Blocking>(
       where: where?.call(Blocking.t),
+      orderBy: orderBy?.call(Blocking.t),
+      orderByList: orderByList?.call(Blocking.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/member.dart
@@ -451,19 +451,19 @@ class MemberRepository {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MemberTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
   }) async {
     return session.dbNext.find<Member>(
       where: where?.call(Member.t),
+      orderBy: orderBy?.call(Member.t),
+      orderByList: orderByList?.call(Member.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -473,13 +473,18 @@ class MemberRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MemberTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Member>(
       where: where?.call(Member.t),
+      orderBy: orderBy?.call(Member.t),
+      orderByList: orderByList?.call(Member.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_many/cat.dart
@@ -456,19 +456,19 @@ class CatRepository {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CatTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
   }) async {
     return session.dbNext.find<Cat>(
       where: where?.call(Cat.t),
+      orderBy: orderBy?.call(Cat.t),
+      orderByList: orderByList?.call(Cat.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -478,13 +478,18 @@ class CatRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CatTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Cat>(
       where: where?.call(Cat.t),
+      orderBy: orderBy?.call(Cat.t),
+      orderByList: orderByList?.call(Cat.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_one/post.dart
@@ -433,19 +433,19 @@ class PostRepository {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PostTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
   }) async {
     return session.dbNext.find<Post>(
       where: where?.call(Post.t),
+      orderBy: orderBy?.call(Post.t),
+      orderByList: orderByList?.call(Post.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -455,13 +455,18 @@ class PostRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PostTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
   }) async {
     return session.dbNext.findFirstRow<Post>(
       where: where?.call(Post.t),
+      orderBy: orderBy?.call(Post.t),
+      orderByList: orderByList?.call(Post.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -346,18 +346,18 @@ class ObjectFieldScopesRepository {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectFieldScopes>(
       where: where?.call(ObjectFieldScopes.t),
+      orderBy: orderBy?.call(ObjectFieldScopes.t),
+      orderByList: orderByList?.call(ObjectFieldScopes.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -366,12 +366,17 @@ class ObjectFieldScopesRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectFieldScopes>(
       where: where?.call(ObjectFieldScopes.t),
+      orderBy: orderBy?.call(ObjectFieldScopes.t),
+      orderByList: orderByList?.call(ObjectFieldScopes.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -312,18 +312,18 @@ class ObjectWithByteDataRepository {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithByteData>(
       where: where?.call(ObjectWithByteData.t),
+      orderBy: orderBy?.call(ObjectWithByteData.t),
+      orderByList: orderByList?.call(ObjectWithByteData.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -332,12 +332,17 @@ class ObjectWithByteDataRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithByteData>(
       where: where?.call(ObjectWithByteData.t),
+      orderBy: orderBy?.call(ObjectWithByteData.t),
+      orderByList: orderByList?.call(ObjectWithByteData.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -311,18 +311,18 @@ class ObjectWithDurationRepository {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithDuration>(
       where: where?.call(ObjectWithDuration.t),
+      orderBy: orderBy?.call(ObjectWithDuration.t),
+      orderByList: orderByList?.call(ObjectWithDuration.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -331,12 +331,17 @@ class ObjectWithDurationRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithDuration>(
       where: where?.call(ObjectWithDuration.t),
+      orderBy: orderBy?.call(ObjectWithDuration.t),
+      orderByList: orderByList?.call(ObjectWithDuration.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -409,18 +409,18 @@ class ObjectWithEnumRepository {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithEnum>(
       where: where?.call(ObjectWithEnum.t),
+      orderBy: orderBy?.call(ObjectWithEnum.t),
+      orderByList: orderByList?.call(ObjectWithEnum.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -429,12 +429,17 @@ class ObjectWithEnumRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithEnum>(
       where: where?.call(ObjectWithEnum.t),
+      orderBy: orderBy?.call(ObjectWithEnum.t),
+      orderByList: orderByList?.call(ObjectWithEnum.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -335,18 +335,18 @@ class ObjectWithIndexRepository {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithIndex>(
       where: where?.call(ObjectWithIndex.t),
+      orderBy: orderBy?.call(ObjectWithIndex.t),
+      orderByList: orderByList?.call(ObjectWithIndex.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -355,12 +355,17 @@ class ObjectWithIndexRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithIndex>(
       where: where?.call(ObjectWithIndex.t),
+      orderBy: orderBy?.call(ObjectWithIndex.t),
+      orderByList: orderByList?.call(ObjectWithIndex.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -442,18 +442,18 @@ class ObjectWithObjectRepository {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithObject>(
       where: where?.call(ObjectWithObject.t),
+      orderBy: orderBy?.call(ObjectWithObject.t),
+      orderByList: orderByList?.call(ObjectWithObject.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -462,12 +462,17 @@ class ObjectWithObjectRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithObject>(
       where: where?.call(ObjectWithObject.t),
+      orderBy: orderBy?.call(ObjectWithObject.t),
+      orderByList: orderByList?.call(ObjectWithObject.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -310,18 +310,18 @@ class ObjectWithParentRepository {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithParent>(
       where: where?.call(ObjectWithParent.t),
+      orderBy: orderBy?.call(ObjectWithParent.t),
+      orderByList: orderByList?.call(ObjectWithParent.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -330,12 +330,17 @@ class ObjectWithParentRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithParent>(
       where: where?.call(ObjectWithParent.t),
+      orderBy: orderBy?.call(ObjectWithParent.t),
+      orderByList: orderByList?.call(ObjectWithParent.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -310,18 +310,18 @@ class ObjectWithSelfParentRepository {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithSelfParent>(
       where: where?.call(ObjectWithSelfParent.t),
+      orderBy: orderBy?.call(ObjectWithSelfParent.t),
+      orderByList: orderByList?.call(ObjectWithSelfParent.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -330,12 +330,17 @@ class ObjectWithSelfParentRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithSelfParent>(
       where: where?.call(ObjectWithSelfParent.t),
+      orderBy: orderBy?.call(ObjectWithSelfParent.t),
+      orderByList: orderByList?.call(ObjectWithSelfParent.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -336,18 +336,18 @@ class ObjectWithUuidRepository {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<ObjectWithUuid>(
       where: where?.call(ObjectWithUuid.t),
+      orderBy: orderBy?.call(ObjectWithUuid.t),
+      orderByList: orderByList?.call(ObjectWithUuid.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -356,12 +356,17 @@ class ObjectWithUuidRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<ObjectWithUuid>(
       where: where?.call(ObjectWithUuid.t),
+      orderBy: orderBy?.call(ObjectWithUuid.t),
+      orderByList: orderByList?.call(ObjectWithUuid.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -388,19 +388,19 @@ class RelatedUniqueDataRepository {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
   }) async {
     return session.dbNext.find<RelatedUniqueData>(
       where: where?.call(RelatedUniqueData.t),
+      orderBy: orderBy?.call(RelatedUniqueData.t),
+      orderByList: orderByList?.call(RelatedUniqueData.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
       include: include,
     );
@@ -410,13 +410,18 @@ class RelatedUniqueDataRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
   }) async {
     return session.dbNext.findFirstRow<RelatedUniqueData>(
       where: where?.call(RelatedUniqueData.t),
+      orderBy: orderBy?.call(RelatedUniqueData.t),
+      orderByList: orderByList?.call(RelatedUniqueData.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
       include: include,
     );

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -316,18 +316,18 @@ class SimpleDataRepository {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SimpleDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<SimpleData>(
       where: where?.call(SimpleData.t),
+      orderBy: orderBy?.call(SimpleData.t),
+      orderByList: orderByList?.call(SimpleData.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -336,12 +336,17 @@ class SimpleDataRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SimpleDataTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<SimpleData>(
       where: where?.call(SimpleData.t),
+      orderBy: orderBy?.call(SimpleData.t),
+      orderByList: orderByList?.call(SimpleData.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -314,18 +314,18 @@ class SimpleDateTimeRepository {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<SimpleDateTime>(
       where: where?.call(SimpleDateTime.t),
+      orderBy: orderBy?.call(SimpleDateTime.t),
+      orderByList: orderByList?.call(SimpleDateTime.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -334,12 +334,17 @@ class SimpleDateTimeRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<SimpleDateTime>(
       where: where?.call(SimpleDateTime.t),
+      orderBy: orderBy?.call(SimpleDateTime.t),
+      orderByList: orderByList?.call(SimpleDateTime.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -504,18 +504,18 @@ class TypesRepository {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TypesTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<Types>(
       where: where?.call(Types.t),
+      orderBy: orderBy?.call(Types.t),
+      orderByList: orderByList?.call(Types.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -524,12 +524,17 @@ class TypesRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TypesTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<Types>(
       where: where?.call(Types.t),
+      orderBy: orderBy?.call(Types.t),
+      orderByList: orderByList?.call(Types.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -334,18 +334,18 @@ class UniqueDataRepository {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UniqueDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.find<UniqueData>(
       where: where?.call(UniqueData.t),
+      orderBy: orderBy?.call(UniqueData.t),
+      orderByList: orderByList?.call(UniqueData.t),
+      orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
-      orderByList: orderByList,
-      orderDescending: orderDescending,
       transaction: transaction,
     );
   }
@@ -354,12 +354,17 @@ class UniqueDataRepository {
     _i1.Session session, {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UniqueDataTable>? orderBy,
     bool orderDescending = false,
+    _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
     return session.dbNext.findFirstRow<UniqueData>(
       where: where?.call(UniqueData.t),
+      orderBy: orderBy?.call(UniqueData.t),
+      orderByList: orderByList?.call(UniqueData.t),
+      orderDescending: orderDescending,
+      offset: offset,
       transaction: transaction,
     );
   }

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/read_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/read_test.dart
@@ -1,0 +1,33 @@
+import 'package:serverpod/database.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  tearDown(() async {
+    await UniqueData.db.deleteWhere(session, where: (_) => Constant.bool(true));
+  });
+
+  test(
+      'Given a list of entries when finding the first row by ordering and offsetting the query then the correct row is returned.',
+      () async {
+    var data = <UniqueData>[
+      UniqueData(number: 1, email: 'info@serverpod.dev'),
+      UniqueData(number: 2, email: 'dev@serverpod.dev'),
+      UniqueData(number: 3, email: 'career@serverpod.dev'),
+    ];
+
+    await UniqueData.db.insert(session, data);
+
+    var dev = await UniqueData.db.findFirstRow(
+      session,
+      orderBy: (t) => t.number,
+      orderDescending: true,
+      offset: 1,
+    );
+
+    expect(dev?.email, 'dev@serverpod.dev');
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
@@ -163,7 +163,7 @@ void main() async {
 
     var organizations = await Organization.db.find(
       session,
-      orderBy: Organization.t.id,
+      orderBy: (t) => t.id,
       include: Organization.include(
         people: Person.includeList(),
       ),
@@ -673,7 +673,7 @@ void main() async {
 
     var cities = await City.db.find(
       session,
-      orderBy: City.t.id,
+      orderBy: (t) => t.id,
       include: City.include(
         citizens: Person.includeList(limit: 2, offset: 1, orderBy: Person.t.id),
       ),

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/order_by_test.dart
@@ -57,13 +57,13 @@ void main() async {
       var citiesFetched = await City.db.find(
         session,
         // Order cities by number of citizens and then the number of organizations
-        orderByList: [
+        orderByList: (t) => [
           db.Order(
-            column: City.t.citizens.count(),
+            column: t.citizens.count(),
             orderDescending: true,
           ),
           db.Order(
-            column: City.t.organizations.count(),
+            column: t.organizations.count(),
             orderDescending: true,
           )
         ],

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/find/order_by_test.dart
@@ -43,7 +43,7 @@ void main() async {
       var studentsFetched = await Student.db.find(
         session,
         // Fetch all students ordered by number of courses they are enrolled to.
-        orderBy: Student.t.enrollments.count(),
+        orderBy: (t) => t.enrollments.count(),
         orderDescending: true,
       );
 
@@ -87,8 +87,8 @@ void main() async {
       var studentsFetched = await Student.db.find(
         session,
         // Fetch all students ordered by the number of level 2 courses they are enrolled to.
-        orderBy: Student.t.enrollments
-            .count((e) => e.course.name.ilike('level 2:%')),
+        orderBy: (t) =>
+            t.enrollments.count((e) => e.course.name.ilike('level 2:%')),
         orderDescending: true,
       );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/order_by_test.dart
@@ -98,14 +98,14 @@ void main() async {
       var arenasFetched = await Arena.db.find(session,
           // Fetch all arenas with teams that have any player with a name starting with a.
           orderByList: (t) => [
-            db.Order(
-              column: t.team.players.count((p) => p.name.ilike('a%')),
-              orderDescending: true,
-            ),
-            db.Order(
-              column: t.name,
-            )
-          ]);
+                db.Order(
+                  column: t.team.players.count((p) => p.name.ilike('a%')),
+                  orderDescending: true,
+                ),
+                db.Order(
+                  column: t.name,
+                )
+              ]);
 
       var arenaNames = arenasFetched.map((e) => e.name);
       expect(arenaNames, [

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/find/order_by_test.dart
@@ -46,13 +46,13 @@ void main() async {
       var arenasFetched = await Arena.db.find(
         session,
         // Order arenas by number of players in their teams and then their name.
-        orderByList: [
+        orderByList: (t) => [
           db.Order(
-            column: Arena.t.team.players.count(),
+            column: t.team.players.count(),
             orderDescending: true,
           ),
           db.Order(
-            column: Arena.t.name,
+            column: t.name,
           )
         ],
       );
@@ -97,13 +97,13 @@ void main() async {
 
       var arenasFetched = await Arena.db.find(session,
           // Fetch all arenas with teams that have any player with a name starting with a.
-          orderByList: [
+          orderByList: (t) => [
             db.Order(
-              column: Arena.t.team.players.count((p) => p.name.ilike('a%')),
+              column: t.team.players.count((p) => p.name.ilike('a%')),
               orderDescending: true,
             ),
             db.Order(
-              column: Arena.t.name,
+              column: t.name,
             )
           ]);
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/order_by_test.dart
@@ -35,7 +35,7 @@ void main() async {
       var fetchedCustomers = await Customer.db.find(
         session,
         // Order by number of orders in descending order
-        orderBy: Customer.t.orders.count(),
+        orderBy: (t) => t.orders.count(),
         orderDescending: true,
       );
 
@@ -65,7 +65,7 @@ void main() async {
       var fetchedCustomers = await Customer.db.find(
         session,
         // Order by number of Prem orders in descending order
-        orderBy: Customer.t.orders.count((o) => o.description.ilike('prem%')),
+        orderBy: (t) => t.orders.count((o) => o.description.ilike('prem%')),
         orderDescending: true,
       );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/where_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/find/where_count_test.dart
@@ -185,7 +185,7 @@ void main() async {
         // All customers with more than one order with a description starting with 'prem'
         where: (c) => c.orders.count((o) => o.description.ilike('prem%')) > 1,
         // Order by number of orders with descriptions starting with 'basic'
-        orderBy: Customer.t.orders.count((o) => o.description.ilike('basic%')),
+        orderBy: (t) => t.orders.count((o) => o.description.ilike('basic%')),
         orderDescending: true,
       );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_one/find/include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_one/find/include_test.dart
@@ -28,7 +28,7 @@ void main() async {
       var companiesFetched = await Company.db.find(
         session,
         include: Company.include(town: Town.include()),
-        orderBy: Company.t.name,
+        orderBy: (t) => t.name,
       );
 
       var companyNames = companiesFetched.map((c) => c.name);
@@ -67,7 +67,7 @@ void main() async {
         session,
         include:
             Citizen.include(company: Company.include(town: Town.include())),
-        orderBy: Citizen.t.name,
+        orderBy: (t) => t.name,
       );
 
       var citizenNames = citizensFetched.map((c) => c.name);

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_one/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_one/find/order_by_test.dart
@@ -29,9 +29,9 @@ void main() async {
       var companiesFetched = await Company.db.find(
         session,
         // Order by company town name and then company name
-        orderByList: [
-          db.Order(column: Company.t.town.name),
-          db.Order(column: Company.t.name),
+        orderByList: (t) => [
+          db.Order(column: t.town.name),
+          db.Order(column: t.name),
         ],
       );
 
@@ -77,9 +77,9 @@ void main() async {
       var citizens = await Citizen.db.find(
         session,
         // Order by citizen company town name and then citizen name
-        orderByList: [
-          db.Order(column: Citizen.t.company.town.name),
-          db.Order(column: Citizen.t.name),
+        orderByList: (t) => [
+          db.Order(column: t.company.town.name),
+          db.Order(column: t.name),
         ],
       );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/find/order_by_test.dart
@@ -40,7 +40,7 @@ void main() async {
 
         var fetchedMembers = await Member.db.find(
           session,
-          orderBy: Member.t.blocking.count(),
+          orderBy: (t) => t.blocking.count(),
         );
 
         var memberNames = fetchedMembers.map((e) => e.name);
@@ -73,16 +73,19 @@ void main() async {
         Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
       ]);
 
-      var fetchedMembers = await Member.db.find(session, orderByList: [
-        db.Order(
-          column: Member.t.blocking.count(
-            (c) => c.blockedId.equals(member[0].id!),
+      var fetchedMembers = await Member.db.find(
+        session,
+        orderByList: (t) => [
+          db.Order(
+            column: t.blocking.count(
+              (c) => c.blockedId.equals(member[0].id!),
+            ),
           ),
-        ),
-        db.Order(
-          column: Member.t.name,
-        )
-      ]);
+          db.Order(
+            column: t.name,
+          )
+        ],
+      );
 
       var memberNames = fetchedMembers.map((e) => e.name);
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/find/order_by_test.dart
@@ -27,9 +27,9 @@ void main() async {
       var fetchedCats = await Cat.db.find(
         session,
         // Order by number of kittens in descending order
-        orderByList: [
-          db.Order(column: Cat.t.kittens.count(), orderDescending: true),
-          db.Order(column: Cat.t.name),
+        orderByList: (t) => [
+          db.Order(column: t.kittens.count(), orderDescending: true),
+          db.Order(column: t.name),
         ],
         orderDescending: true,
       );
@@ -55,7 +55,7 @@ void main() async {
       var fetchedCats = await Cat.db.find(
         session,
         // Order by number of kittens named Smul... in descending order
-        orderBy: Cat.t.kittens.count((k) => k.name.ilike('smul%')),
+        orderBy: (t) => t.kittens.count((k) => k.name.ilike('smul%')),
         orderDescending: true,
       );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/find/where_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/find/where_count_test.dart
@@ -148,7 +148,7 @@ void main() async {
         var fetchedCats = await Cat.db.find(
           session,
           where: (t) => (t.kittens.count((t) => t.name.ilike('kitt%')) > 1),
-          orderBy: Cat.t.kittens.count((t) => t.name.ilike('zelda%')),
+          orderBy: (t) => t.kittens.count((t) => t.name.ilike('zelda%')),
           orderDescending: true,
         );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_one/find/include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_one/find/include_test.dart
@@ -28,7 +28,7 @@ void main() async {
       var postsFetched = await Post.db.find(
         session,
         include: Post.include(next: Post.include()),
-        orderBy: Post.t.id,
+        orderBy: (t) => t.id,
       );
 
       expect(postsFetched[0].next?.content, 'Hello again!');
@@ -59,7 +59,7 @@ void main() async {
       var postsFetched = await Post.db.find(
         session,
         include: Post.include(next: Post.include(next: Post.include())),
-        orderBy: Post.t.id,
+        orderBy: (t) => t.id,
       );
 
       expect(postsFetched[0].next?.next?.content, 'Hello a third time!');

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_one/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_one/find/order_by_test.dart
@@ -27,7 +27,7 @@ void main() async {
 
         var postsFetched = await Post.db.find(
           session,
-          orderBy: Post.t.next.content,
+          orderBy: (t) => t.next.content,
         );
 
         expect(postsFetched[0].content, '3 Hello a third time!'); // next is 1
@@ -56,10 +56,13 @@ void main() async {
       await Post.db.attachRow.next(session, post[0], post[1]);
       await Post.db.attachRow.next(session, post[1], post[2]);
 
-      var postsFetched = await Post.db.find(session, orderByList: [
-        db.Order(column: Post.t.next.next.content),
-        db.Order(column: Post.t.content),
-      ]);
+      var postsFetched = await Post.db.find(
+        session,
+        orderByList: (t) => [
+          db.Order(column: t.next.next.content),
+          db.Order(column: t.content),
+        ],
+      );
 
       expect(postsFetched[0].content, '2 Hello world!'); // next.next is 1
       expect(postsFetched[1].content, '1 Hello again!'); // next.next is null

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -249,10 +249,7 @@ class BuildRepositoryClass {
           ..name = 'offset'
           ..named = true),
         Parameter((p) => p
-          ..type = TypeReference((b) => b
-            ..isNullable = true
-            ..symbol = 'Column'
-            ..url = 'package:serverpod/serverpod.dart')
+          ..type = typeOrderByBuilder(className, serverCode)
           ..name = 'orderBy'
           ..named = true),
         Parameter((p) => p
@@ -261,10 +258,7 @@ class BuildRepositoryClass {
           ..defaultTo = const Code('false')
           ..named = true),
         Parameter((p) => p
-          ..type = TypeReference((t) => t
-            ..symbol = 'List'
-            ..isNullable = true
-            ..types.add(refer('Order', 'package:serverpod/serverpod.dart')))
+          ..type = typeOrderByListBuilder(className, serverCode)
           ..name = 'orderByList'
           ..named = true),
         Parameter((p) => p
@@ -290,11 +284,15 @@ class BuildRepositoryClass {
             'where': refer('where').nullSafeProperty('call').call(
               [refer(className).property('t')],
             ),
+            'orderBy': refer('orderBy').nullSafeProperty('call').call(
+              [refer(className).property('t')],
+            ),
+            'orderByList': refer('orderByList').nullSafeProperty('call').call(
+              [refer(className).property('t')],
+            ),
+            'orderDescending': refer('orderDescending'),
             'limit': refer('limit'),
             'offset': refer('offset'),
-            'orderBy': refer('orderBy'),
-            'orderByList': refer('orderByList'),
-            'orderDescending': refer('orderDescending'),
             'transaction': refer('transaction'),
             if (objectRelationFields.isNotEmpty) 'include': refer('include'),
           }, [
@@ -339,16 +337,17 @@ class BuildRepositoryClass {
           ..name = 'offset'
           ..named = true),
         Parameter((p) => p
-          ..type = TypeReference((b) => b
-            ..isNullable = true
-            ..symbol = 'Column'
-            ..url = 'package:serverpod/serverpod.dart')
+          ..type = typeOrderByBuilder(className, serverCode)
           ..name = 'orderBy'
           ..named = true),
         Parameter((p) => p
           ..type = refer('bool')
           ..name = 'orderDescending'
           ..defaultTo = const Code('false')
+          ..named = true),
+        Parameter((p) => p
+          ..type = typeOrderByListBuilder(className, serverCode)
+          ..name = 'orderByList'
           ..named = true),
         Parameter((p) => p
           ..type = TypeReference((b) => b
@@ -375,6 +374,14 @@ class BuildRepositoryClass {
               'where': refer('where').nullSafeProperty('call').call(
                 [refer(className).property('t')],
               ),
+              'orderBy': refer('orderBy').nullSafeProperty('call').call(
+                [refer(className).property('t')],
+              ),
+              'orderByList': refer('orderByList').nullSafeProperty('call').call(
+                [refer(className).property('t')],
+              ),
+              'orderDescending': refer('orderDescending'),
+              'offset': refer('offset'),
               'transaction': refer('transaction'),
               if (objectRelationFields.isNotEmpty) 'include': refer('include'),
             },

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
@@ -30,9 +30,49 @@ TypeReference typeWhereExpressionBuilder(
   bool serverCode, {
   nullable = true,
 }) {
+  return _typeWithTableCallback(
+    className,
+    'WhereExpressionBuilder',
+    serverCode,
+    nullable: nullable,
+  );
+}
+
+TypeReference typeOrderByBuilder(
+  String className,
+  bool serverCode, {
+  nullable = true,
+}) {
+  return _typeWithTableCallback(
+    className,
+    'OrderByBuilder',
+    serverCode,
+    nullable: nullable,
+  );
+}
+
+TypeReference typeOrderByListBuilder(
+  String className,
+  bool serverCode, {
+  nullable = true,
+}) {
+  return _typeWithTableCallback(
+    className,
+    'OrderByListBuilder',
+    serverCode,
+    nullable: nullable,
+  );
+}
+
+TypeReference _typeWithTableCallback(
+  String className,
+  String typeName,
+  bool serverCode, {
+  nullable = true,
+}) {
   return TypeReference(
     (t) => t
-      ..symbol = 'WhereExpressionBuilder'
+      ..symbol = typeName
       ..types.addAll([
         refer('${className}Table'),
       ])

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
@@ -123,7 +123,7 @@ void main() {
         test('that takes the orderBy column as an optional param', () {
           expect(
             findMethod?.parameters?.toSource(),
-            contains('Column? orderBy'),
+            contains('OrderByBuilder<ExampleTable>? orderBy'),
           );
         });
 
@@ -137,7 +137,7 @@ void main() {
         test('that takes the orderByList as an optional param', () {
           expect(
             findMethod?.parameters?.toSource(),
-            contains('orderByList'),
+            contains('OrderByListBuilder<ExampleTable>? orderByList'),
           );
         });
 
@@ -203,7 +203,15 @@ void main() {
           var params = findRowMethod?.parameters?.toSource();
           expect(
             params,
-            contains('Column? orderBy'),
+            contains('OrderByBuilder<ExampleTable>? orderBy'),
+          );
+        });
+
+        test('that takes the orderBy as a named optional param', () {
+          var params = findRowMethod?.parameters?.toSource();
+          expect(
+            params,
+            contains('OrderByListBuilder<ExampleTable>? orderByList'),
           );
         });
 


### PR DESCRIPTION
# Changes

* Modify orderBy and orderBy list to take a callback with the typed table.
* Fix bug in `findFirstRow` where orderBy and offset was not passed to the real method.
* Add orderByList to `findFirstRow`.

Example usage:

New syntax:
```dart
Example.db.find(
  session,
  orderBy: (t) => t.columnName,
);
```

```dart
Example.db.find(
  session,
  orderByList: (t) => [Order(column: t.columnName)],
);
```

Old syntax:
```dart
Example.db.find(
  session,
  orderBy: Example.t.columnName,
);
```

```dart
Example.db.find(
  session,
  orderByList: [Order(column: Example.t.columnName)],
);
```


Closes: https://github.com/serverpod/serverpod/issues/1546

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
