### PR TITLE
fix: Prevent `create-migration` command from crashing CLI when run outside serverpod project.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -73,6 +73,9 @@ class CreateMigrationCommand extends ServerpodCommand {
     }
 
     var projectName = await getProjectName();
+    if (projectName == null) {
+      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+    }
 
     int priority;
     var packageType = config.type;

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -67,12 +67,12 @@ class CreateMigrationCommand extends ServerpodCommand {
       }
     }
 
-    var projectName = await getProjectName();
-
     var config = await GeneratorConfig.load();
     if (config == null) {
-      throw ExitException();
+      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
+
+    var projectName = await getProjectName();
 
     int priority;
     var packageType = config.type;

--- a/tools/serverpod_cli/lib/src/util/project_name.dart
+++ b/tools/serverpod_cli/lib/src/util/project_name.dart
@@ -1,29 +1,31 @@
 import 'dart:io';
+import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/util/locate_modules.dart';
 import 'package:yaml/yaml.dart';
 
-Future<String> getProjectName() async {
+Future<String?> getProjectName() async {
   var pubspecFile = File('pubspec.yaml');
   if (!await pubspecFile.exists()) {
-    throw Exception(
-      'No pubspec.yaml file found in current directory.',
-    );
+    log.error('No pubspec.yaml file found in current directory.');
+    return null;
   }
 
   var pubspec = loadYaml(await pubspecFile.readAsString());
   if (pubspec == null) {
-    throw Exception(
-      'Failed to parse pubspec.yaml file.',
-    );
+    log.error('Failed to parse pubspec.yaml file.');
+    return null;
   }
 
   String? name = pubspec['name'];
   if (name == null) {
-    throw Exception(
-      'No name found in pubspec.yaml file.',
-    );
+    log.error('No name found in pubspec.yaml file.');
+    return null;
   }
 
-  name = moduleNameFromServerPackageName(name);
-  return name;
+  try {
+    return moduleNameFromServerPackageName(name);
+  } catch (e) {
+    log.error(e.toString());
+    return null;
+  }
 }


### PR DESCRIPTION
### Changes
- Prints error message and exits with exit code `Command Invoked Cannot Execute` when creating migrations outside of Serverpod folder.
- Prints error messages and exits with same exit code when there is an issue determining the name of a project.

### Before change.
<img width="800" alt="Screenshot 2023-11-13 at 10 45 41" src="https://github.com/serverpod/serverpod/assets/137198655/6f67a188-0bd6-4c89-bc6c-b67292c952c2">

### After change.
<img width="654" alt="Screenshot 2023-11-13 at 10 44 55" src="https://github.com/serverpod/serverpod/assets/137198655/a2d91c06-32c3-4679-8009-70cc30a75c28">

Closes: #1402

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Changes behavior of a new command in Serverpod 1.2.
