### PR TITLE
fix: Prevent crash when creating repair migration without access to server.

### DIFF
--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -221,7 +221,16 @@ class MigrationGenerator {
 
     // Get the live database definition from the server.
     var client = ConfigInfo(runMode).createServiceClient();
-    var liveDatabase = await client.insights.getLiveDatabaseDefinition();
+    DatabaseDefinition liveDatabase;
+    try {
+      liveDatabase = await client.insights.getLiveDatabaseDefinition();
+    } catch (e) {
+      log.error('Unable to fetch live database schema from server. '
+          'Make sure the server is running and is connected to the '
+          'database.');
+      log.error(e.toString());
+      return null;
+    }
 
     // Print warnings, if any exists.
     var migration = generateDatabaseMigration(


### PR DESCRIPTION
### Changes
- Adds error handling for retrieving live database definition from server when creating a repair migration for database.

### Before change
<img width="813" alt="Screenshot 2023-11-13 at 11 31 41" src="https://github.com/serverpod/serverpod/assets/137198655/c1bdd31d-4828-4a6a-9692-b7726765b47a">


### After change
<img width="812" alt="Screenshot 2023-11-13 at 11 30 05" src="https://github.com/serverpod/serverpod/assets/137198655/df366c11-4388-42b0-ad48-d95fe031e0a1">

Closes: #1318 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None.
