### PR TITLE
chore: Adds version number to devtools extension.

### DIFF
--- a/templates/pubspecs/packages/serverpod/extension/devtools/config.yaml
+++ b/templates/pubspecs/packages/serverpod/extension/devtools/config.yaml
@@ -3,5 +3,5 @@
 
 name: serverpod
 issueTracker: https://github.com/serverpod/serverpod/issues
-version: 1.1.0
+version: VERSION
 materialIconCodePoint: '0xf0372'


### PR DESCRIPTION
Keeps Dart Devtools extension version in sync with Serverpod version.