### PR TITLE
test: Unique uuid as tag for every migration created to avoid conflicts.

### DIFF
--- a/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
+++ b/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/src/migrations/migration_registry.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:serverpod/protocol.dart' as serverProtocol;
+import 'package:uuid/uuid.dart';
 
 abstract class MigrationTestUtils {
   static Future<void> createInitialState({
@@ -38,12 +39,13 @@ abstract class MigrationTestUtils {
       protocolFile.writeAsStringSync(contents);
     });
 
+    var suffixedTag = '$tag-${Uuid().v4()}';
     var createMigrationProcess = await Process.start(
       'serverpod',
       [
         'create-migration',
         '--tag',
-        tag,
+        suffixedTag,
         if (force) '--force',
       ],
       workingDirectory: Directory.current.path,


### PR DESCRIPTION
### Change
- Add uuid to every tag for migration tests, otherwise we could end up with a migration with the same name that caused unexpected behavior and made the tests flaky.

We should add tests for this later to give better warnings when there are collisions in created migrations.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
