### PR TITLE
fix: Reintroduce generation of protocol.yaml removed in #771.

### DIFF
--- a/packages/serverpod/generated/protocol.yaml
+++ b/packages/serverpod/generated/protocol.yaml
@@ -11,3 +11,9 @@ insights:
   - hotReload:
   - getTargetDatabaseDefinition:
   - getLiveDatabaseDefinition:
+  - getDatabaseDefinitions:
+  - fetchDatabaseBulkData:
+  - runQueries:
+  - getDatabaseRowCount:
+  - executeSql:
+  - fetchFile:

--- a/tests/serverpod_test_server/generated/protocol.yaml
+++ b/tests/serverpod_test_server/generated/protocol.yaml
@@ -33,6 +33,96 @@ s3CloudStorage:
   - getPublicUrlForFile:
   - getDirectFilePostUrl:
   - verifyDirectFileUpload:
+columnBoolLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
+columnDateTimeLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
+  - greaterThan:
+  - greaterOrEqualThan:
+  - lessThan:
+  - lessOrEqualThan:
+  - between:
+  - notBetween:
+columnDoubleLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
+  - greaterThan:
+  - greaterOrEqualThan:
+  - lessThan:
+  - lessOrEqualThan:
+  - between:
+  - notBetween:
+columnDurationLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
+  - greaterThan:
+  - greaterOrEqualThan:
+  - lessThan:
+  - lessOrEqualThan:
+  - between:
+  - notBetween:
+columnEnumLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
+columnIntLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
+  - greaterThan:
+  - greaterOrEqualThan:
+  - lessThan:
+  - lessOrEqualThan:
+  - between:
+  - notBetween:
+columnStringLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
+  - like:
+  - ilike:
+columnUuidLegacy:
+  - insert:
+  - deleteAll:
+  - findAll:
+  - equals:
+  - notEquals:
+  - inSet:
+  - notInSet:
 customTypes:
   - returnCustomClass:
   - returnCustomClassNullable:
@@ -43,6 +133,18 @@ customTypes:
   - returnFreezedCustomClass:
   - returnFreezedCustomClassNullable:
 basicDatabase:
+  - findSimpleData:
+  - findFirstRowSimpleData:
+  - findByIdSimpleData:
+  - insertRowSimpleData:
+  - updateRowSimpleData:
+  - deleteRowSimpleData:
+  - deleteWhereSimpleData:
+  - countSimpleData:
+  - insertTypes:
+  - updateTypes:
+  - deleteAll:
+basicDatabaseLegacy:
   - storeTypes:
   - getTypes:
   - storeObjectWithEnum:
@@ -61,11 +163,83 @@ basicDatabase:
   - getObjectWithObject:
   - testByteDataStore:
   - testDurationStore:
+databaseBatch:
+  - batchInsert:
+  - batchInsertTypes:
+  - batchUpdate:
+  - batchUpdateTypes:
+  - batchDelete:
+  - insertRelatedUniqueData:
+  - findByEmail:
+  - findById:
+  - findAll:
+  - deleteAll:
+databaseBatchGenerated:
+  - batchInsert:
+  - batchInsertTypes:
+  - batchUpdate:
+  - batchUpdateTypes:
+  - batchDelete:
+  - insertRelatedUniqueData:
+  - findByEmail:
+  - findById:
+  - findAll:
+  - deleteAll:
+databaseListRelationMethods:
+  - insertCity:
+  - insertOrganization:
+  - insertPerson:
+  - implicitAttachRowCitizen:
+  - implicitAttachCitizens:
+  - implicitDetachRowCitizens:
+  - implicitDetachCitizens:
+  - cityFindById:
+  - explicitAttachRowPeople:
+  - explicitAttachPeople:
+  - explicitDetachRowPeople:
+  - explicitDetachPeople:
+  - organizationFindById:
+  - deleteAll:
 transactionsDatabase:
   - removeRow:
   - updateInsertDelete:
+oneToMany:
+  - customerOrderByOrderCountAscending:
+  - customerOrderByOrderCountAscendingWhereDescriptionIs:
+  - commentInsert:
+  - orderInsert:
+  - customerInsert:
+  - deleteAll:
+relation:
+  - citizenFindWhereCompanyNameIs:
+  - citizenFindWhereCompanyTownNameIs:
+  - citizenFindOrderedByCompanyName:
+  - citizenFindOrderedByCompanyTownName:
+  - citizenDeleteWhereCompanyNameIs:
+  - citizenDeleteWhereCompanyTownNameIs:
+  - citizenCountWhereCompanyNameIs:
+  - citizenCountWhereCompanyTownNameIs:
+  - citizenFindAll:
+  - citizenFindAllWithDeepIncludes:
+  - citizenFindAllWithNamedRelationNoneOriginSide:
+  - citizenFindAllWithShallowIncludes:
+  - citizenFindByIdWithIncludes:
+  - addressFindAll:
+  - addressFindById:
+  - findAllPostsIncludingNextAndPrevious:
+  - citizenAttachCompany:
+  - citizenAttachAddress:
+  - citizenDetachAddress:
+  - addressAttachCitizen:
+  - addressDetachCitizen:
+  - companyFindAll:
+  - citizenInsert:
+  - companyInsert:
+  - townInsert:
+  - addressInsert:
+  - postInsert:
+  - deleteAll:
 exceptionTest:
-  - throwSerializableException:
   - throwNormalException:
   - throwExceptionWithData:
   - workingWithoutException:
@@ -138,6 +312,7 @@ mapParameters:
 moduleSerialization:
   - serializeModuleObject:
   - modifyModuleObject:
+  - serializeNestedModuleObject:
 namedParameters:
   - namedParametersMethod:
   - namedParametersMethodEqualInts:
@@ -158,6 +333,7 @@ simple:
   - setGlobalInt:
   - addToGlobalInt:
   - getGlobalInt:
+  - hello:
 streaming:
 streamingLogging:
 subSubDirTest:

--- a/tools/serverpod_cli/lib/src/generator/serverpod_code_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/serverpod_code_generator.dart
@@ -8,6 +8,7 @@ import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
 import 'package:serverpod_cli/src/generator/dart/temp_protocol_generator.dart';
 import 'package:serverpod_cli/src/generator/psql/legacy_pgsql_generator.dart';
+import 'package:serverpod_cli/src/generator/yaml/endpoint_description_generator.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/util/internal_error.dart';
 
@@ -17,6 +18,7 @@ abstract class ServerpodCodeGenerator {
     const DartServerCodeGenerator(),
     const DartClientCodeGenerator(),
     const LegacyPgsqlCodeGenerator(),
+    const EndpointDescriptionGenerator(),
   ];
 
   /// Generate from [CodeGenerator.generateSerializableEntitiesCode] for all

--- a/tools/serverpod_cli/lib/src/generator/yaml/endpoint_description_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/yaml/endpoint_description_generator.dart
@@ -1,0 +1,31 @@
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generator.dart';
+import 'package:path/path.dart' as p;
+
+class EndpointDescriptionGenerator extends CodeGenerator {
+  const EndpointDescriptionGenerator();
+
+  @override
+  Map<String, String> generateSerializableEntitiesCode({
+    required List<SerializableEntityDefinition> entities,
+    required GeneratorConfig config,
+  }) {
+    return {};
+  }
+
+  @override
+  Map<String, String> generateProtocolCode({
+    required ProtocolDefinition protocolDefinition,
+    required GeneratorConfig config,
+  }) {
+    var out = '';
+    for (var endpoint in protocolDefinition.endpoints) {
+      out += '${endpoint.name}:\n';
+      for (var method in endpoint.methods) {
+        out += '  - ${method.name}:\n';
+      }
+    }
+
+    return {p.join('generated', 'protocol.yaml'): out};
+  }
+}

--- a/tools/serverpod_cli/lib/src/test_util/builders/endpoint_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/endpoint_definition_builder.dart
@@ -1,0 +1,54 @@
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+
+class EndpointDefinitionBuilder {
+  String _name = 'example';
+  String? _documentationComment;
+  String _className = 'ExampleEndpoint';
+  String _filePath = 'example.dart';
+  List<MethodDefinition> _methods = [];
+  List<String> _subDirParts = [];
+
+  EndpointDefinitionBuilder();
+
+  EndpointDefinitionBuilder withName(String name) {
+    _name = name;
+    return this;
+  }
+
+  EndpointDefinitionBuilder withDocumentationComment(
+      String? documentationComment) {
+    _documentationComment = documentationComment;
+    return this;
+  }
+
+  EndpointDefinitionBuilder withClassName(String className) {
+    _className = className;
+    return this;
+  }
+
+  EndpointDefinitionBuilder withFilePath(String filePath) {
+    _filePath = filePath;
+    return this;
+  }
+
+  EndpointDefinitionBuilder withMethods(List<MethodDefinition> methods) {
+    _methods = methods;
+    return this;
+  }
+
+  EndpointDefinitionBuilder withSubDirParts(List<String> subDirParts) {
+    _subDirParts = subDirParts;
+    return this;
+  }
+
+  EndpointDefinition build() {
+    return EndpointDefinition(
+      name: _name,
+      documentationComment: _documentationComment,
+      className: _className,
+      filePath: _filePath,
+      methods: _methods,
+      subDirParts: _subDirParts,
+    );
+  }
+}

--- a/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
@@ -1,0 +1,57 @@
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dart';
+
+class MethodDefinitionBuilder {
+  String _name = 'example';
+  String? _documentationComment;
+  TypeDefinition _returnType =
+      TypeDefinitionBuilder().withFutureOf('String').build();
+  List<ParameterDefinition> _parameters = [];
+  List<ParameterDefinition> _parametersPositional = [];
+  List<ParameterDefinition> _parametersNamed = [];
+
+  MethodDefinitionBuilder withName(String name) {
+    _name = name;
+    return this;
+  }
+
+  MethodDefinitionBuilder withDocumentationComment(
+      String? documentationComment) {
+    _documentationComment = documentationComment;
+    return this;
+  }
+
+  MethodDefinitionBuilder withReturnType(TypeDefinition returnType) {
+    _returnType = returnType;
+    return this;
+  }
+
+  MethodDefinitionBuilder withParameters(List<ParameterDefinition> parameters) {
+    _parameters = parameters;
+    return this;
+  }
+
+  MethodDefinitionBuilder withParametersPositional(
+      List<ParameterDefinition> parametersPositional) {
+    _parametersPositional = parametersPositional;
+    return this;
+  }
+
+  MethodDefinitionBuilder withParametersNamed(
+      List<ParameterDefinition> parametersNamed) {
+    _parametersNamed = parametersNamed;
+    return this;
+  }
+
+  MethodDefinition build() {
+    return MethodDefinition(
+      name: _name,
+      documentationComment: _documentationComment,
+      returnType: _returnType,
+      parameters: _parameters,
+      parametersPositional: _parametersPositional,
+      parametersNamed: _parametersNamed,
+    );
+  }
+}

--- a/tools/serverpod_cli/lib/src/test_util/builders/parameter_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/parameter_definition_builder.dart
@@ -1,0 +1,42 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dart';
+
+class ParameterDefinitionBuilder {
+  String _name = 'example';
+  TypeDefinition _type =
+      TypeDefinitionBuilder().withClassName('String').build();
+  bool _required = false;
+  ParameterElement? _dartParameter;
+
+  ParameterDefinitionBuilder withName(String name) {
+    _name = name;
+    return this;
+  }
+
+  ParameterDefinitionBuilder withType(TypeDefinition type) {
+    _type = type;
+    return this;
+  }
+
+  ParameterDefinitionBuilder withRequired(bool required) {
+    _required = required;
+    return this;
+  }
+
+  ParameterDefinitionBuilder withDartParameter(
+      ParameterElement? dartParameter) {
+    _dartParameter = dartParameter;
+    return this;
+  }
+
+  ParameterDefinition build() {
+    return ParameterDefinition(
+      name: _name,
+      type: _type,
+      required: _required,
+      dartParameter: _dartParameter,
+    );
+  }
+}

--- a/tools/serverpod_cli/lib/src/test_util/builders/type_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/type_definition_builder.dart
@@ -29,6 +29,18 @@ class TypeDefinitionBuilder {
     return this;
   }
 
+  TypeDefinitionBuilder withFutureOf(
+    String className, [
+    bool nullable = false,
+  ]) {
+    _className = 'Future';
+    _generics.add(TypeDefinitionBuilder()
+        .withClassName(className)
+        .withNullable(nullable)
+        .build());
+    return this;
+  }
+
   TypeDefinitionBuilder withListOf(String className, [bool nullable = false]) {
     _className = 'List';
     _generics.add(TypeDefinitionBuilder()
@@ -38,8 +50,11 @@ class TypeDefinitionBuilder {
     return this;
   }
 
-  TypeDefinitionBuilder withMapOf(String keyClassName, String valueClassName,
-      [bool nullable = false]) {
+  TypeDefinitionBuilder withMapOf(
+    String keyClassName,
+    String valueClassName, [
+    bool nullable = false,
+  ]) {
     _className = 'Map';
     _generics.add(TypeDefinitionBuilder().withClassName(keyClassName).build());
     _generics.add(TypeDefinitionBuilder()

--- a/tools/serverpod_cli/test/generator/yaml/endpoint_description_test.dart
+++ b/tools/serverpod_cli/test/generator/yaml/endpoint_description_test.dart
@@ -145,7 +145,7 @@ example:
   });
 
   test(
-      'Given multiple endpoints with multiple methods when generating protocol files then the protocol.yaml then all endpoints and methods are defined',
+      'Given multiple endpoints with multiple methods when generating protocol files then the protocol.yaml has all endpoints and methods defined',
       () {
     var protocolDefinition = ProtocolDefinition(
       endpoints: [

--- a/tools/serverpod_cli/test/generator/yaml/endpoint_description_test.dart
+++ b/tools/serverpod_cli/test/generator/yaml/endpoint_description_test.dart
@@ -1,0 +1,190 @@
+import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/generator/yaml/endpoint_description_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/method_definition_builder.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = EndpointDescriptionGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    'generated',
+    'protocol.yaml',
+  );
+  test(
+      'Given an empty protocol definition when generating protocol files then an empty protocol.yaml file is created.',
+      () {
+    var protocolDefinition = const ProtocolDefinition(
+      endpoints: [],
+      entities: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    expect(codeMap, contains(expectedFileName));
+    expect(codeMap[expectedFileName], equals(''));
+  });
+
+  test(
+      'Given an endpoint without any methods when generating protocol files then the protocol.yaml has only the endpoint defined',
+      () {
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint')
+            .withName('example')
+            .withMethods([]).build()
+      ],
+      entities: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    expect(codeMap[expectedFileName], equals('example:\n'));
+  });
+
+  test(
+      'Given two endpoint without any methods when generating protocol files then the protocol.yaml has both the endpoints defined',
+      () {
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint')
+            .withName('example')
+            .withMethods([]).build(),
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint2')
+            .withName('example2')
+            .withMethods([]).build()
+      ],
+      entities: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    expect(
+      codeMap[expectedFileName],
+      equals('''
+example:
+example2:
+'''),
+    );
+  });
+
+  test(
+      'Given one endpoint with a method when generating protocol files then the protocol.yaml has the endpoint defined with the method as a list entry',
+      () {
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint')
+            .withName('example')
+            .withMethods([
+          MethodDefinitionBuilder().withName('method').build(),
+        ]).build(),
+      ],
+      entities: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    expect(
+      codeMap[expectedFileName],
+      equals('''
+example:
+  - method:
+'''),
+    );
+  });
+
+  test(
+      'Given one endpoint with two methods when generating protocol files then the protocol.yaml has the endpoint defined with the methods as list entry',
+      () {
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint')
+            .withName('example')
+            .withMethods([
+          MethodDefinitionBuilder().withName('method').build(),
+          MethodDefinitionBuilder().withName('method2').build(),
+        ]).build(),
+      ],
+      entities: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    expect(
+      codeMap[expectedFileName],
+      equals('''
+example:
+  - method:
+  - method2:
+'''),
+    );
+  });
+
+  test(
+      'Given multiple endpoints with multiple methods when generating protocol files then the protocol.yaml then all endpoints and methods are defined',
+      () {
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint')
+            .withName('example')
+            .withMethods([
+          MethodDefinitionBuilder().withName('method').build(),
+          MethodDefinitionBuilder().withName('method2').build(),
+        ]).build(),
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint2')
+            .withName('example2')
+            .withMethods([]).build(),
+        EndpointDefinitionBuilder()
+            .withClassName('ExampleEndpoint3')
+            .withName('example3')
+            .withMethods([
+          MethodDefinitionBuilder().withName('method').build(),
+        ]).build(),
+      ],
+      entities: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    expect(
+      codeMap[expectedFileName],
+      equals('''
+example:
+  - method:
+  - method2:
+example2:
+example3:
+  - method:
+'''),
+    );
+  });
+}


### PR DESCRIPTION
# Adds:

Code generation class for the protocol.yaml file.
Unit test suit for the code generator.

Closes: https://github.com/serverpod/serverpod/issues/1566

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

