### PR TITLE
fix: Throw descriptive error if google auth secret is not loaded on the server.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
@@ -27,11 +27,14 @@ class GoogleEndpoint extends Endpoint {
     String authenticationCode,
     String? redirectUri,
   ) async {
-    assert(
-        GoogleAuth.clientSecret != null, 'Google client secret is not loaded.');
+    var clientSecret = GoogleAuth.clientSecret;
+
+    if (clientSecret == null) {
+      throw StateError('The server side Google client secret is not loaded.');
+    }
 
     var authClient = await _GoogleUtils.clientViaClientSecretAndCode(
-      GoogleAuth.clientSecret!,
+      clientSecret,
       authenticationCode,
       [
         'https://www.googleapis.com/auth/userinfo.profile',


### PR DESCRIPTION
Give an error if the google auth secret is not loaded.

Fix: https://github.com/serverpod/serverpod/issues/1532

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

