### PR TITLE
fix: Add flag to disable analytics reporting and disable it for CI.

### DIFF
--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -46,7 +46,7 @@ void main() async {
         () async {
       createProcess = await Process.start(
         'serverpod',
-        ['create', projectName, '-v'],
+        ['create', projectName, '-v', '--no-analytics'],
         workingDirectory: tempPath,
         environment: {
           'SERVERPOD_HOME': rootPath,
@@ -111,7 +111,7 @@ void main() async {
       setUpAll(() async {
         var process = await Process.start(
           'serverpod',
-          ['create', projectName, '-v'],
+          ['create', projectName, '-v', '--no-analytics'],
           workingDirectory: tempPath,
           environment: {
             'SERVERPOD_HOME': rootPath,
@@ -349,7 +349,7 @@ void main() async {
         () async {
       createProcess = await Process.start(
         'serverpod',
-        ['create', projectName, '-v'],
+        ['create', projectName, '-v', '--no-analytics'],
         workingDirectory: tempPath,
         environment: {
           'SERVERPOD_HOME': rootPath,

--- a/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
+++ b/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
@@ -54,6 +54,7 @@ abstract class MigrationTestUtils {
         suffixedTag,
         if (force) '--force',
         '--verbose',
+        '--no-analytics',
       ],
     );
   }
@@ -174,6 +175,7 @@ abstract class MigrationTestUtils {
         if (targetVersion != null) ...['--version', targetVersion],
         if (force) '--force',
         '--verbose',
+        '--no-analytics',
       ],
     );
   }

--- a/tools/serverpod_cli/lib/src/analytics/analytics.dart
+++ b/tools/serverpod_cli/lib/src/analytics/analytics.dart
@@ -11,9 +11,13 @@ const _projectToken = '05e8ab306c393c7482e0f41851a176d8';
 const _endpoint = 'https://api.mixpanel.com/track';
 
 class Analytics {
+  bool enabled = true;
+
   void track({
     required String event,
   }) {
+    if (!enabled) return;
+
     var payload = jsonEncode({
       'event': event,
       'properties': {

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -16,6 +16,8 @@ abstract class GlobalFlags {
   static const quietAbbr = 'q';
   static const verbose = 'verbose';
   static const verboseAbbr = 'v';
+  static const analytics = 'analytics';
+  static const analyticsAbbr = 'a';
 }
 
 typedef LoggerInit = void Function(LogLevel);
@@ -96,6 +98,14 @@ class ServerpodCommandRunner extends CommandRunner {
       help: 'Prints additional information useful for development. '
           'Overrides --q, --quiet.',
     );
+
+    argParser.addFlag(
+      GlobalFlags.analytics,
+      abbr: GlobalFlags.analyticsAbbr,
+      defaultsTo: true,
+      negatable: true,
+      help: 'Disables sending analytics data to Serverpod. ',
+    );
   }
 
   static ServerpodCommandRunner createCommandRunner(
@@ -129,6 +139,7 @@ class ServerpodCommandRunner extends CommandRunner {
   @override
   Future<void> runCommand(ArgResults topLevelResults) async {
     _setLogLevel(topLevelResults);
+    _analytics.enabled = topLevelResults[GlobalFlags.analytics];
 
     await _onPreCommandEnvironmentCheck();
     await _preCommandPrints();

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -104,7 +104,7 @@ class ServerpodCommandRunner extends CommandRunner {
       abbr: GlobalFlags.analyticsAbbr,
       defaultsTo: true,
       negatable: true,
-      help: 'Disables sending analytics data to Serverpod. ',
+      help: 'Toggles if analytics data is sent to Serverpod. ',
     );
   }
 

--- a/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
+++ b/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
@@ -166,6 +166,43 @@ void main() {
       );
       expect(fixture.command.numberOfRuns, equals(1));
     });
+
+    test('when analytics flag is omitted', () async {
+      List<String> args = [MockCommand.commandName, '--name', 'alex'];
+
+      await fixture.runner.run(args);
+
+      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.analytics.enabled, isTrue);
+    });
+
+    test('when analytics flag is provided', () async {
+      List<String> args = [
+        '--${GlobalFlags.analytics}',
+        MockCommand.commandName,
+        '--name',
+        'alex',
+      ];
+
+      await fixture.runner.run(args);
+
+      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.analytics.enabled, isTrue);
+    });
+
+    test('when no-analytics flag is provided', () async {
+      List<String> args = [
+        '--no-${GlobalFlags.analytics}',
+        MockCommand.commandName,
+        '--name',
+        'alex',
+      ];
+
+      await fixture.runner.run(args);
+
+      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.analytics.enabled, isFalse);
+    });
   });
   group('Logger Initialization - ', () {
     test('when no log level flag is provided', () async {

--- a/util/generate_all
+++ b/util/generate_all
@@ -16,45 +16,45 @@ dart pub get
 
 echo "serverpod"
 cd $BASE/packages/serverpod
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 echo "examples/chat/chat_server"
 cd $BASE/examples/chat/chat_server
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 echo "examples/auth_example/auth_example_server"
 cd $BASE/examples/auth_example/auth_example_server
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 # Templates
 
 echo "\nmodulename_server"
 cd $BASE/templates/serverpod_templates/modulename_server
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 echo "\nprojectname_server"
 cd $BASE/templates/serverpod_templates/projectname_server
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 # Auth module
 
 echo "\nserverpod_auth_server"
 cd $BASE/modules/serverpod_auth/serverpod_auth_server
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 # Chat module
 
 echo "\nserverpod_chat_server"
 cd $BASE/modules/serverpod_chat/serverpod_chat_server
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 
 # Tests
 
 echo "\ntests/serverpod_test_server"
 cd $BASE/tests/serverpod_test_server
-dart $CLI generate
+dart $CLI generate --no-analytics
 
 echo "\ntests/serverpod_test_module/serverpod_test_module_server"
 cd $BASE/tests/serverpod_test_module/serverpod_test_module_server
-dart $CLI generate
+dart $CLI generate --no-analytics

--- a/util/recreate_all_migrations
+++ b/util/recreate_all_migrations
@@ -20,30 +20,30 @@ dart pub get
 echo "serverpod"
 cd $BASE/packages/serverpod
 rm -r $MIGRATION_DIR/serverpod
-dart $CLI create-migration --disable-analytics
+dart $CLI create-migration --no-analytics
 
 # Examples
 
 echo "examples/chat/chat_server"
 cd $BASE/examples/chat/chat_server
 rm -r $MIGRATION_DIR/chat
-dart $CLI create-migration --disable-analytics
+dart $CLI create-migration --no-analytics
 
 # Modules 
 
 echo "\nserverpod_auth_server"
 cd $BASE/modules/serverpod_auth/serverpod_auth_server
 rm -r $MIGRATION_DIR/serverpod_auth
-dart $CLI create-migration --disable-analytics
+dart $CLI create-migration --no-analytics
 
 echo "\nserverpod_chat_server"
 cd $BASE/modules/serverpod_chat/serverpod_chat_server
 rm -r $MIGRATION_DIR/serverpod_chat
-dart $CLI create-migration --disable-analytics
+dart $CLI create-migration --no-analytics
 
 # Tests
 
 echo "\ntests/serverpod_test_server"
 cd $BASE/tests/serverpod_test_server
 rm -r $MIGRATION_DIR/serverpod_test
-dart $CLI create-migration --disable-analytics
+dart $CLI create-migration --no-analytics

--- a/util/recreate_all_migrations
+++ b/util/recreate_all_migrations
@@ -20,30 +20,30 @@ dart pub get
 echo "serverpod"
 cd $BASE/packages/serverpod
 rm -r $MIGRATION_DIR/serverpod
-dart $CLI create-migration
+dart $CLI create-migration --disable-analytics
 
 # Examples
 
 echo "examples/chat/chat_server"
 cd $BASE/examples/chat/chat_server
 rm -r $MIGRATION_DIR/chat
-dart $CLI create-migration
+dart $CLI create-migration --disable-analytics
 
 # Modules 
 
 echo "\nserverpod_auth_server"
 cd $BASE/modules/serverpod_auth/serverpod_auth_server
 rm -r $MIGRATION_DIR/serverpod_auth
-dart $CLI create-migration
+dart $CLI create-migration --disable-analytics
 
 echo "\nserverpod_chat_server"
 cd $BASE/modules/serverpod_chat/serverpod_chat_server
 rm -r $MIGRATION_DIR/serverpod_chat
-dart $CLI create-migration
+dart $CLI create-migration --disable-analytics
 
 # Tests
 
 echo "\ntests/serverpod_test_server"
 cd $BASE/tests/serverpod_test_server
 rm -r $MIGRATION_DIR/serverpod_test
-dart $CLI create-migration
+dart $CLI create-migration --disable-analytics


### PR DESCRIPTION
### Changes:
- Adds a flag to disable analytics reporting when using the Serverpod CLI.
- Removes all analytics reporting from our CI.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
