### PR TITLE
test: Wait for ports to be available before executing the nest e2e test.

### DIFF
--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -455,7 +455,6 @@ void main() async {
   return (serverDir, flutterDir, clientDir);
 }
 
-/// Determine if a port is unused by trying to binding it.
 Future<bool> isNetworkPortAvailable(int port) async {
   try {
     var socket = await ServerSocket.bind(InternetAddress.anyIPv4, port);

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -37,6 +37,8 @@ void main() async {
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
       );
+
+      while (!await isNetworkPortAvailable(8090));
     });
 
     test(
@@ -102,6 +104,7 @@ void main() async {
         ['compose', 'down', '-v'],
         workingDirectory: commandRootPath,
       );
+      while (!await isNetworkPortAvailable(8090));
     });
 
     group('when creating a new project', () {
@@ -338,6 +341,7 @@ void main() async {
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
       );
+      while (!await isNetworkPortAvailable(8090));
     });
 
     test(
@@ -449,4 +453,15 @@ void main() async {
   final clientDir = path.join(projectName, '${projectName}_client');
 
   return (serverDir, flutterDir, clientDir);
+}
+
+/// Determine if a port is unused by trying to binding it.
+Future<bool> isNetworkPortAvailable(int port) async {
+  try {
+    var socket = await ServerSocket.bind(InternetAddress.anyIPv4, port);
+    await socket.close();
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1,4 +1,4 @@
-@Timeout(Duration(minutes: 5))
+@Timeout(Duration(minutes: 8))
 
 import 'dart:convert';
 import 'dart:io';

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -165,7 +165,6 @@ class SerializableEntityAnalyzer {
   ]) {
     YamlDocument document;
     try {
-      print(sourceUri.path);
       document = loadYamlDocument(
         yaml,
         sourceUrl: sourceUri,


### PR DESCRIPTION
# Fix

Resolve flaky e2e test

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.
