### PR TITLE
fix: Print warnings from protocols and stop when generating migrations.

### DIFF
--- a/packages/serverpod_shared/lib/src/migration_exceptions.dart
+++ b/packages/serverpod_shared/lib/src/migration_exceptions.dart
@@ -53,3 +53,7 @@ class MigrationRepairTargetNotFoundException implements Exception {
     required this.targetName,
   });
 }
+
+/// Exception thrown when the migration failed to create a database definition
+/// from the projects entity files.
+class GenerateMigrationDatabaseDefinitionException implements Exception {}

--- a/tests/serverpod_test_server/test_e2e_migrations/migrations_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test_e2e_migrations/migrations_roundtrip_test.dart
@@ -1051,4 +1051,37 @@ fields:
       );
     });
   });
+
+  group('Given invalid protocol file', () {
+    tearDown(() async {
+      await MigrationTestUtils.migrationTestCleanup(
+        serviceClient: serviceClient,
+      );
+    });
+
+    test(
+        'when creating migration then create migration exits with error and migration is not created.',
+        () async {
+      var tag = 'invalid-protocol';
+      var targetStateProtocols = {
+        'migrated_table': '''
+This is not a valid protocol file, in yaml format
+'''
+      };
+
+      var createMigrationExitCode =
+          await MigrationTestUtils.createMigrationFromProtocols(
+        protocols: targetStateProtocols,
+        tag: tag,
+      );
+      expect(
+        createMigrationExitCode,
+        isNot(0),
+        reason: 'Should fail to create migration but exit code 0.',
+      );
+
+      var migrationRegistry = await MigrationTestUtils.loadMigrationRegistry();
+      expect(migrationRegistry.versions, isNot(contains(tag)));
+    });
+  });
 }

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -7,6 +7,7 @@ import 'package:serverpod_cli/src/analyzer/entities/yaml_definitions/class_yaml_
 import 'package:serverpod_cli/src/analyzer/entities/yaml_definitions/enum_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/entities/yaml_definitions/exception_yaml_definition.dart';
 import 'package:serverpod_cli/src/util/protocol_helper.dart';
+import 'package:source_span/source_span.dart';
 // ignore: implementation_imports
 import 'package:yaml/src/error_listener.dart';
 import 'package:path/path.dart' as p;
@@ -105,10 +106,16 @@ class SerializableEntityAnalyzer {
 
     var documentContents = document;
     if (documentContents is! YamlMap) {
-      collector.addError(SourceSpanSeverityException(
-        'The top level object in the class yaml file must be a Map.',
-        documentContents?.span,
-      ));
+      var firstLine = yaml.split('\n').first;
+      collector.addError(
+        SourceSpanSeverityException(
+            'The top level object in the class yaml file must be a Map.',
+            SourceSpan(
+              SourceLocation(0, sourceUrl: sourceUri),
+              SourceLocation(firstLine.length, sourceUrl: sourceUri),
+              firstLine,
+            )),
+      );
       return;
     }
 

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -92,6 +92,8 @@ class CreateMigrationCommand extends ServerpodCommand {
           'again. Migration version: "${e.versionName}".',
         );
         log.error(e.exception);
+      } on GenerateMigrationDatabaseDefinitionException {
+        log.error('Unable to generate database definition for project.');
       }
 
       return migration != null;

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/stateful_analyzer_test.dart
@@ -131,6 +131,37 @@ fields:
   });
 
   test(
+      'Given a protocol with multi line invalid yaml syntax when validating all then error is reported.',
+      () {
+    var protocolUri = Uri(path: 'lib/src/protocol/example.yaml');
+    var invalidSource = ProtocolSource(
+      '''
+this is not valid yaml
+and neither is this line
+''',
+      protocolUri,
+      [],
+    );
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer([invalidSource], onErrorsCollector(collector))
+        .validateAll();
+
+    expect(
+      collector.errors,
+      isNotEmpty,
+      reason: 'Expected an error but none was generated.',
+    );
+
+    var error = collector.errors.first;
+    expect(error.span, isNotNull);
+    expect(error.span!.start.line, 0);
+    expect(error.span!.start.column, 0);
+    expect(error.span!.end.line, 0);
+    expect(error.span!.end.column, 22);
+  });
+
+  test(
       'Given a protocol that was invalid on first validation, when validating the same protocol with an updated valid syntax, then the previous errors are cleared.',
       () {
     var protocolUri = Uri(path: 'lib/src/protocol/example.yaml');


### PR DESCRIPTION
### Changes:
- Now stops generating migration if a warning is detected when generating the database definition. This means that we are unable to understand the current entity state of the project.


### Bonus:
- Improves the error message printed when a yaml file can't be parsed on the top level.


- Closes: #1583 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
