### PR TITLE
fix: Prevent overwriting the same migration when creating migrations.

### DIFF
--- a/packages/serverpod_shared/lib/src/migration_exceptions.dart
+++ b/packages/serverpod_shared/lib/src/migration_exceptions.dart
@@ -57,3 +57,14 @@ class MigrationRepairTargetNotFoundException implements Exception {
 /// Exception thrown when the migration failed to create a database definition
 /// from the projects entity files.
 class GenerateMigrationDatabaseDefinitionException implements Exception {}
+
+/// Exception thrown when the migration directory already exists.
+class MigrationVersionAlreadyExistsException implements Exception {
+  /// The path to the directory that already exists.
+  final String directoryPath;
+
+  /// Creates a new [MigrationVersionAlreadyExistsException].
+  MigrationVersionAlreadyExistsException({
+    required this.directoryPath,
+  });
+}

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -94,6 +94,11 @@ class CreateMigrationCommand extends ServerpodCommand {
         log.error(e.exception);
       } on GenerateMigrationDatabaseDefinitionException {
         log.error('Unable to generate database definition for project.');
+      } on MigrationVersionAlreadyExistsException catch (e) {
+        log.error(
+          'Unable to create migration. A directory with the same name already '
+          'exists: "${e.directoryPath}".',
+        );
       }
 
       return migration != null;

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -418,19 +418,26 @@ class MigrationVersion {
   Future<void> write({
     required String module,
   }) async {
+    var versionDir = Directory(
+      path.join(migrationsDirectory.path, versionName),
+    );
+
+    if (versionDir.existsSync()) {
+      throw MigrationVersionAlreadyExistsException(
+        directoryPath: versionDir.path,
+      );
+    }
+    await versionDir.create(recursive: true);
+
     // Create sql for definition and migration
     var definitionSql = databaseDefinition.toPgSql(
       module: module,
       version: versionName,
     );
+
     var migrationSql = migration.toPgSql(
       versions: {module: versionName},
     );
-
-    var versionDir = Directory(
-      path.join(migrationsDirectory.path, versionName),
-    );
-    await versionDir.create(recursive: true);
 
     // Write the database definition JSON file
     var definitionFile = File(path.join(

--- a/tools/serverpod_cli/lib/src/test_util/builders/migration_version_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/migration_version_builder.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:serverpod_cli/src/migrations/generator.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+
+class MigrationVersionBuilder {
+  String _versionName = '00000000000000';
+  DatabaseMigration _migration = DatabaseMigration(
+    actions: [],
+    warnings: [],
+    priority: 0,
+    migrationApiVersion: 0,
+  );
+  DatabaseDefinition _databaseDefinition = DatabaseDefinition(
+    tables: [],
+    migrationApiVersion: 0,
+  );
+  Directory _migrationsDirectory = Directory.current;
+
+  MigrationVersionBuilder withVersionName(String versionName) {
+    _versionName = versionName;
+    return this;
+  }
+
+  MigrationVersionBuilder withMigration(DatabaseMigration migration) {
+    _migration = migration;
+    return this;
+  }
+
+  MigrationVersionBuilder withDatabaseDefinition(
+    DatabaseDefinition databaseDefinition,
+  ) {
+    _databaseDefinition = databaseDefinition;
+    return this;
+  }
+
+  MigrationVersionBuilder withMigrationsDirectory(
+    Directory migrationsDirectory,
+  ) {
+    _migrationsDirectory = migrationsDirectory;
+    return this;
+  }
+
+  MigrationVersion build() {
+    return MigrationVersion(
+      versionName: _versionName,
+      migration: _migration,
+      databaseDefinition: _databaseDefinition,
+      migrationsDirectory: _migrationsDirectory,
+    );
+  }
+}

--- a/tools/serverpod_cli/test/migrations/migration_version_test.dart
+++ b/tools/serverpod_cli/test/migrations/migration_version_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/test_util/builders/migration_version_builder.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var testAssetsPath = path.join('test', 'migrations', 'test_assets');
+  var tempDirectory = Directory(path.join(testAssetsPath, 'temp'));
+
+  setUp(() {
+    tempDirectory.createSync();
+  });
+
+  tearDown(() {
+    tempDirectory.deleteSync(recursive: true);
+  });
+
+  test(
+      'Given an existing directory when writing migration version with same name then exception is thrown.',
+      () async {
+    var versionName = '00000000000000';
+    var versionDirectory = Directory(path.join(
+      tempDirectory.path,
+      versionName,
+    ));
+    versionDirectory.createSync();
+
+    var migrationVersion = MigrationVersionBuilder()
+        .withMigrationsDirectory(tempDirectory)
+        .withVersionName(versionName)
+        .build();
+
+    expect(
+      () => migrationVersion.write(module: 'test_module'),
+      throwsA(isA<MigrationVersionAlreadyExistsException>()),
+    );
+  });
+}


### PR DESCRIPTION
### Changes:
- Display a warning and stops migration creation if migration with the same name already exists.

This likely only happens if migrations are created as part of a CI chain as they would need to call date time during the same second.

- Closes: #1582 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
