### PR TITLE
fix: Remove support for tag in create repair migration command.

### DIFF
--- a/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
+++ b/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
@@ -164,7 +164,6 @@ abstract class MigrationTestUtils {
   }
 
   static Future<int> runCreateRepairMigration({
-    String tag = 'test',
     bool force = false,
     String? targetVersion,
   }) async {
@@ -172,8 +171,6 @@ abstract class MigrationTestUtils {
       'serverpod',
       arguments: [
         'create-repair-migration',
-        '--tag',
-        tag,
         '--mode',
         'production',
         if (targetVersion != null) ...['--version', targetVersion],

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -5,7 +5,6 @@ import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/exit_exception.dart';
 import 'package:serverpod_cli/src/util/project_name.dart';
-import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
 class CreateRepairMigrationCommand extends ServerpodCommand {
@@ -43,27 +42,13 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
       help: 'Used to specify which database to fetch the live database '
           'definition from.',
     );
-    argParser.addOption(
-      'tag',
-      abbr: 't',
-      help: 'Add a tag to the revision to easier identify it.',
-    );
   }
 
   @override
   void run() async {
     bool force = argResults!['force'];
     String mode = argResults!['mode'];
-    String? tag = argResults!['tag'];
     String? targetVersion = argResults!['version'];
-
-    if (tag != null && !StringValidators.isValidTagName(tag)) {
-      log.error(
-        'Invalid tag name. Tag names can only contain lowercase letters, '
-        'number, and dashes.',
-      );
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
-    }
 
     var config = await GeneratorConfig.load();
     if (config == null) {
@@ -91,7 +76,6 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
     var success = await log.progress('Creating repair migration', () async {
       try {
         return await generator.repairMigration(
-          tag: tag,
           force: force,
           runMode: mode,
           targetMigration: targetMigration,


### PR DESCRIPTION
### Change
- Removes support for tag for repair migrations.

Since we always replace the existing repair migration there is no need to tag them.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
