### PR TITLE
fix: Load migration versions for modules to project config.

### DIFF
--- a/examples/auth_example/auth_example_client/pubspec.yaml
+++ b/examples/auth_example/auth_example_client/pubspec.yaml
@@ -2,7 +2,7 @@ name: auth_example_client
 description: Starting point for a Serverpod client.
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod_client:

--- a/examples/auth_example/auth_example_server/pubspec.yaml
+++ b/examples/auth_example/auth_example_server/pubspec.yaml
@@ -4,7 +4,7 @@ description: Starting point for a Serverpod server.
 # homepage: https://www.example.com
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   mailer: ^6.0.1

--- a/examples/chat/chat_client/pubspec.yaml
+++ b/examples/chat/chat_client/pubspec.yaml
@@ -2,7 +2,7 @@ name: chat_client
 description: Starting point for a Serverpod client.
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod_client:

--- a/examples/chat/chat_server/pubspec.yaml
+++ b/examples/chat/chat_server/pubspec.yaml
@@ -2,7 +2,7 @@ name: chat_server
 description: Starting point for a Serverpod server.
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod:

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -7,7 +7,7 @@ description: Command line tools for Serverpod.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   archive: ^3.3.7

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2707,13 +2707,13 @@ class EndpointSubDirTest extends _i1.EndpointRef {
 
 class _Modules {
   _Modules(Client client) {
-    module = _i29.Caller(client);
     auth = _i3.Caller(client);
+    module = _i29.Caller(client);
   }
 
-  late final _i29.Caller module;
-
   late final _i3.Caller auth;
+
+  late final _i29.Caller module;
 }
 
 class Client extends _i1.ServerpodClient {
@@ -2898,7 +2898,7 @@ class Client extends _i1.ServerpodClient {
 
   @override
   Map<String, _i1.ModuleEndpointCaller> get moduleLookup => {
-        'module': modules.module,
         'auth': modules.auth,
+        'module': modules.module,
       };
 }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -1081,10 +1081,10 @@ class Protocol extends _i1.SerializationManager {
           : null) as T;
     }
     try {
-      return _i49.Protocol().deserialize<T>(data, t);
+      return _i66.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     try {
-      return _i66.Protocol().deserialize<T>(data, t);
+      return _i49.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -1092,13 +1092,13 @@ class Protocol extends _i1.SerializationManager {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i49.Protocol().getClassNameForObject(data);
-    if (className != null) {
-      return 'serverpod_test_module.$className';
-    }
     className = _i66.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
+    }
+    className = _i49.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod_test_module.$className';
     }
     if (data is _i64.CustomClass) {
       return 'CustomClass';
@@ -1252,13 +1252,13 @@ class Protocol extends _i1.SerializationManager {
 
   @override
   dynamic deserializeByClassName(Map<String, dynamic> data) {
-    if (data['className'].startsWith('serverpod_test_module.')) {
-      data['className'] = data['className'].substring(22);
-      return _i49.Protocol().deserializeByClassName(data);
-    }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
       return _i66.Protocol().deserializeByClassName(data);
+    }
+    if (data['className'].startsWith('serverpod_test_module.')) {
+      data['className'] = data['className'].substring(22);
+      return _i49.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
       return deserialize<_i64.CustomClass>(data['data']);

--- a/tests/serverpod_test_client/pubspec.yaml
+++ b/tests/serverpod_test_client/pubspec.yaml
@@ -6,7 +6,7 @@ description: Part of tests for Serverpod.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   serverpod_client:

--- a/tests/serverpod_test_module/serverpod_test_module_client/pubspec.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_client/pubspec.yaml
@@ -6,7 +6,7 @@ description: Tests for Serverpod modules
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod_client:

--- a/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
@@ -6,7 +6,7 @@ description: A simple Serverpod module.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod:

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -5995,8 +5995,8 @@ class Endpoints extends _i1.EndpointDispatch {
         )
       },
     );
+    modules['serverpod_auth'] = _i67.Endpoints()..initializeEndpoints(server);
     modules['serverpod_test_module'] = _i66.Endpoints()
       ..initializeEndpoints(server);
-    modules['serverpod_auth'] = _i67.Endpoints()..initializeEndpoints(server);
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -11,8 +11,8 @@ library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixe
 
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
-import 'package:serverpod_test_module_server/module.dart' as _i3;
-import 'package:serverpod_auth_server/module.dart' as _i4;
+import 'package:serverpod_auth_server/module.dart' as _i3;
+import 'package:serverpod_test_module_server/module.dart' as _i4;
 import 'entities_with_list_relations/city.dart' as _i5;
 import 'entities_with_list_relations/organization.dart' as _i6;
 import 'entities_with_list_relations/person.dart' as _i7;
@@ -2369,13 +2369,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i3.ModuleClass>) {
-      return (data as List).map((e) => deserialize<_i3.ModuleClass>(e)).toList()
+    if (t == List<_i4.ModuleClass>) {
+      return (data as List).map((e) => deserialize<_i4.ModuleClass>(e)).toList()
           as dynamic;
     }
-    if (t == Map<String, _i3.ModuleClass>) {
+    if (t == Map<String, _i4.ModuleClass>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i3.ModuleClass>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i4.ModuleClass>(v)))
           as dynamic;
     }
     if (t == List<int>) {
@@ -2954,11 +2954,11 @@ class Protocol extends _i1.SerializationManagerServer {
     String? className;
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_test_module.$className';
+      return 'serverpod_auth.$className';
     }
     className = _i4.Protocol().getClassNameForObject(data);
     if (className != null) {
-      return 'serverpod_auth.$className';
+      return 'serverpod_test_module.$className';
     }
     if (data is _i68.CustomClass) {
       return 'CustomClass';
@@ -3118,12 +3118,12 @@ class Protocol extends _i1.SerializationManagerServer {
 
   @override
   dynamic deserializeByClassName(Map<String, dynamic> data) {
-    if (data['className'].startsWith('serverpod_test_module.')) {
-      data['className'] = data['className'].substring(22);
-      return _i3.Protocol().deserializeByClassName(data);
-    }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
+      return _i3.Protocol().deserializeByClassName(data);
+    }
+    if (data['className'].startsWith('serverpod_test_module.')) {
+      data['className'] = data['className'].substring(22);
       return _i4.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {

--- a/tests/serverpod_test_shared/pubspec.yaml
+++ b/tests/serverpod_test_shared/pubspec.yaml
@@ -5,7 +5,7 @@ description: Code shared between the test server and client
 version: 1.0.0
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   freezed_annotation: ^2.2.0

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -181,8 +181,8 @@ class GeneratorConfig {
     if (generatorConfig['modules'] != null) {
       Map modulesData = generatorConfig['modules'];
       for (var package in modulesData.keys) {
-        var nickname = modulesData[package]['nickname'];
-        manualModules[package] = nickname is String? ? nickname : null;
+        var nickname = modulesData[package]?['nickname'];
+        manualModules[package] = nickname is String ? nickname : null;
       }
     }
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -177,41 +177,23 @@ class GeneratorConfig {
       return null;
     }
 
-    // Load module settings
-    var modules = <ModuleConfig>[];
-    try {
-      if (generatorConfig['modules'] != null) {
-        Map modulesData = generatorConfig['modules'];
-        for (var package in modulesData.keys) {
-          modules.add(ModuleConfig._withMap(package, modulesData[package]));
-        }
+    var manualModules = <String, String?>{};
+    if (generatorConfig['modules'] != null) {
+      Map modulesData = generatorConfig['modules'];
+      for (var package in modulesData.keys) {
+        var nickname = modulesData[package]['nickname'];
+        manualModules[package] = nickname is String? ? nickname : null;
       }
-    } catch (e) {
-      throw const FormatException('Failed to load module config');
     }
 
-    // Autodetect modules.
-    var automagicModules = await locateModules(
+    var modules = await locateModules(
       directory: Directory(dir),
-      exludePackages: [serverPackage],
+      excludePackages: [serverPackage],
+      manualModules: manualModules,
     );
 
-    if (automagicModules == null) {
+    if (modules == null) {
       return null;
-    }
-
-    for (var autoModule in automagicModules) {
-      bool hasOverride = false;
-      for (var module in modules) {
-        if (module.name == autoModule.name) {
-          hasOverride = true;
-          break;
-        }
-      }
-
-      if (!hasOverride) {
-        modules.add(autoModule);
-      }
     }
 
     // Load extraClasses
@@ -237,15 +219,16 @@ class GeneratorConfig {
     }
 
     return GeneratorConfig(
-        name: name,
-        type: type,
-        serverPackage: serverPackage,
-        dartClientPackage: dartClientPackage,
-        dartClientDependsOnServiceClient: dartClientDependsOnServiceClient,
-        serverPackageDirectoryPathParts: serverPackageDirectoryPathParts,
-        relativeDartClientPackagePathParts: relativeDartClientPackagePathParts,
-        modules: modules,
-        extraClasses: extraClasses);
+      name: name,
+      type: type,
+      serverPackage: serverPackage,
+      dartClientPackage: dartClientPackage,
+      dartClientDependsOnServiceClient: dartClientDependsOnServiceClient,
+      serverPackageDirectoryPathParts: serverPackageDirectoryPathParts,
+      relativeDartClientPackagePathParts: relativeDartClientPackagePathParts,
+      modules: modules,
+      extraClasses: extraClasses,
+    );
   }
 
   @override
@@ -280,15 +263,13 @@ class ModuleConfig {
   /// The name of the server package.
   String serverPackage;
 
-  ModuleConfig._withMap(String name, Map map)
-      : this(
-          name: name,
-          nickname: map['nickname']!,
-        );
+  /// The migration versions of the module.
+  List<String> migrationVersions;
 
   ModuleConfig({
     required this.name,
     required this.nickname,
+    required this.migrationVersions,
   })  : dartClientPackage = '${name}_client',
         serverPackage = '${name}_server';
 
@@ -301,7 +282,8 @@ class ModuleConfig {
     return '''name: $name
 nickname: $nickname
 clientPackage: $dartClientPackage
-serverPackage: $serverPackage;
+serverPackage: $serverPackage
+migrationVersions: $migrationVersions 
 ''';
   }
 }

--- a/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
@@ -59,6 +59,7 @@ class GeneratorConfigBuilder {
       ModuleConfig(
         name: 'serverpod_auth',
         nickname: 'auth',
+        migrationVersions: ['0000000000000000000'],
       ),
     );
     return this;

--- a/tools/serverpod_cli/lib/src/test_util/builders/module_config_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/module_config_builder.dart
@@ -3,10 +3,12 @@ import 'package:serverpod_cli/src/config/config.dart';
 class ModuleConfigBuilder {
   String _name;
   String _nickname;
+  List<String> _migrationVersions;
 
   ModuleConfigBuilder(String name, [String? nickname])
       : _name = name,
-        _nickname = nickname ?? name;
+        _nickname = nickname ?? name,
+        _migrationVersions = [];
 
   ModuleConfigBuilder withNickname(String nickname) {
     _nickname = nickname;
@@ -18,7 +20,16 @@ class ModuleConfigBuilder {
     return this;
   }
 
+  ModuleConfigBuilder withMigrationVersions(List<String> migrationVersions) {
+    _migrationVersions = migrationVersions;
+    return this;
+  }
+
   ModuleConfig build() {
-    return ModuleConfig(name: _name, nickname: _nickname);
+    return ModuleConfig(
+      name: _name,
+      nickname: _nickname,
+      migrationVersions: _migrationVersions,
+    );
   }
 }

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -111,6 +111,7 @@ List<String> findAllMigrationVersionsSync({
     var migrationVersions =
         migrationsDir.map((dir) => path.split(dir.path).last).toList();
 
+    migrationVersions.sort();
     return migrationVersions;
   } catch (e) {
     return [];

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -3,13 +3,16 @@ import 'dart:io';
 import 'package:package_config/package_config.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:yaml/yaml.dart';
+import 'package:path/path.dart' as path;
 
 const _serverSuffix = '_server';
 
 Future<List<ModuleConfig>?> locateModules({
   required Directory directory,
-  List<String> exludePackages = const [],
+  List<String> excludePackages = const [],
+  Map<String, String?> manualModules = const {},
 }) async {
   var modules = <ModuleConfig>[];
 
@@ -18,7 +21,7 @@ Future<List<ModuleConfig>?> locateModules({
     for (var packageInfo in packageConfig.packages) {
       try {
         var packageName = packageInfo.name;
-        if (exludePackages.contains(packageName)) {
+        if (excludePackages.contains(packageName)) {
           continue;
         }
 
@@ -28,11 +31,12 @@ Future<List<ModuleConfig>?> locateModules({
         var moduleName = moduleNameFromServerPackageName(packageName);
 
         var packageSrcRoot = packageInfo.packageUriRoot;
-        var generatorConfigSegments =
-            List<String>.from(packageSrcRoot.pathSegments)
-              ..removeLast()
-              ..removeLast()
-              ..addAll(['config', 'generator.yaml']);
+        var moduleProjectRoot = List<String>.from(packageSrcRoot.pathSegments)
+          ..removeLast()
+          ..removeLast();
+        var generatorConfigSegments = path
+            .joinAll([...moduleProjectRoot, 'config', 'generator.yaml']).split(
+                path.separator);
 
         var generatorConfigUri = packageSrcRoot.replace(
           pathSegments: generatorConfigSegments,
@@ -43,13 +47,26 @@ Future<List<ModuleConfig>?> locateModules({
           continue;
         }
 
+        var moduleProjectUri = packageSrcRoot.replace(
+          pathSegments: moduleProjectRoot,
+        );
+
+        var migrationVersions = findAllMigrationVersionsSync(
+          directory: Directory.fromUri(moduleProjectUri),
+          moduleName: moduleName,
+        );
+
         var moduleInfo = _ModuleGeneratorConfigLite(generatorConfigFile);
-        if (moduleInfo.nickname == null) {
-          continue;
-        }
+
+        var manualNickname = manualModules[moduleName];
+        var nickname = manualNickname ?? moduleInfo.nickname ?? moduleName;
 
         modules.add(
-          ModuleConfig(name: moduleName, nickname: moduleInfo.nickname!),
+          ModuleConfig(
+            name: moduleName,
+            nickname: nickname,
+            migrationVersions: migrationVersions,
+          ),
         );
       } catch (e) {
         continue;
@@ -76,6 +93,27 @@ class _ModuleGeneratorConfigLite {
       throw const FormatException('Not a module config');
     }
     nickname = map['nickname'];
+  }
+}
+
+List<String> findAllMigrationVersionsSync({
+  required Directory directory,
+  required String moduleName,
+}) {
+  try {
+    var migrationRoot = Directory(path.join(
+      MigrationConstants.migrationsBaseDirectory(directory).path,
+      moduleName,
+    ));
+
+    var migrationsDir = migrationRoot.listSync().whereType<Directory>();
+
+    var migrationVersions =
+        migrationsDir.map((dir) => path.split(dir.path).last).toList();
+
+    return migrationVersions;
+  } catch (e) {
+    return [];
   }
 }
 

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -8,7 +8,7 @@ description: Command line tools for Serverpod.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   archive: ^3.3.7

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/approximate_1.1.0/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/approximate_1.1.0/pubspec.yaml
@@ -7,7 +7,7 @@ description: Command line tools for Serverpod.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod_shared: ^1.1.0

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/corrupted_pubspec/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/corrupted_pubspec/pubspec.yaml
@@ -7,7 +7,7 @@ description: Command line tools for Serverpod.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod_shared: 1.1.0

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/explicit_1.1.0/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/explicit_1.1.0/pubspec.yaml
@@ -7,7 +7,7 @@ description: Command line tools for Serverpod.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod_shared: 1.1.0

--- a/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/vendor/serverpod/pubspec.yaml
+++ b/tools/serverpod_cli/test/serverpod_packages_version_check/test_assets/vendor/serverpod/pubspec.yaml
@@ -7,7 +7,7 @@ description: Command line tools for Serverpod.
 repository: https://github.com/serverpod/serverpod
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   serverpod_shared: ^1.1.0


### PR DESCRIPTION
# Changes

Add migration version list to module in config.
Load modules even if they have no nickname defined (defaults to the module name instead).
Improve logic for loading modules, manual configurations now only overload the nickname from disk.

Related: [1499](https://github.com/serverpod/serverpod/issues/1499)

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
