### PR TITLE
fix: Add reference to all modules in config.

### DIFF
--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -106,11 +106,13 @@ class GeneratorConfig {
   /// Useful for types used in caching and streams.
   final List<TypeDefinition> extraClasses;
 
+  /// All the modules defined in the config (of type module).
   List<ModuleConfig> get modules => _modules
       .where((module) => module.type == PackageType.module)
       .where((module) => module.name != name)
       .toList();
 
+  /// All the modules including my self and internal modules.
   List<ModuleConfig> get modulesAll => _modules;
 
   /// Create a new [GeneratorConfig] by loading the configuration in the [dir].

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -32,9 +32,11 @@ class GeneratorConfig {
     required this.dartClientDependsOnServiceClient,
     required this.serverPackageDirectoryPathParts,
     required List<String> relativeDartClientPackagePathParts,
-    required this.modules,
+    required List<ModuleConfig> modules,
     required this.extraClasses,
-  }) : _relativeDartClientPackagePathParts = relativeDartClientPackagePathParts;
+  })  : _relativeDartClientPackagePathParts =
+            relativeDartClientPackagePathParts,
+        _modules = modules;
 
   /// The name of the serverpod project.
   ///
@@ -98,11 +100,16 @@ class GeneratorConfig {
       [...clientPackagePathParts, 'lib', 'src', 'protocol'];
 
   /// All the modules defined in the config.
-  final List<ModuleConfig> modules;
+  final List<ModuleConfig> _modules;
 
   /// User defined class names for complex types.
   /// Useful for types used in caching and streams.
   final List<TypeDefinition> extraClasses;
+
+  List<ModuleConfig> get modules =>
+      _modules.where((module) => module.type == PackageType.module).toList();
+
+  List<ModuleConfig> get modulesAll => _modules;
 
   /// Create a new [GeneratorConfig] by loading the configuration in the [dir].
   static Future<GeneratorConfig?> load([String dir = '']) async {
@@ -138,15 +145,12 @@ class GeneratorConfig {
       return null;
     }
 
-    var typeStr = generatorConfig!['type'];
-    late PackageType type;
-    if (typeStr == 'module') {
-      type = PackageType.module;
-    } else if (typeStr == 'internal') {
-      type = PackageType.internal;
-    } else {
-      type = PackageType.server;
+    if (generatorConfig == null) {
+      throw const FormatException(
+          'Failed to load config/generator.yaml. Is this a Serverpod project?');
     }
+
+    PackageType type = getPackageType(generatorConfig);
 
     if (generatorConfig['client_package_path'] == null) {
       throw const FormatException(
@@ -188,7 +192,6 @@ class GeneratorConfig {
 
     var modules = await locateModules(
       directory: Directory(dir),
-      excludePackages: [serverPackage],
       manualModules: manualModules,
     );
 
@@ -231,6 +234,19 @@ class GeneratorConfig {
     );
   }
 
+  static PackageType getPackageType(Map<dynamic, dynamic> generatorConfig) {
+    var typeStr = generatorConfig['type'];
+    late PackageType type;
+    if (typeStr == 'module') {
+      type = PackageType.module;
+    } else if (typeStr == 'internal') {
+      type = PackageType.internal;
+    } else {
+      type = PackageType.server;
+    }
+    return type;
+  }
+
   @override
   String toString() {
     var str = '''type: $type
@@ -251,6 +267,8 @@ generatedServerProtocol: ${p.joinAll(generatedServerProtocolPathParts)}
 
 /// Describes the configuration of a Serverpod module a package depends on.
 class ModuleConfig {
+  PackageType type;
+
   /// The user defined nickname of the module.
   String nickname;
 
@@ -267,6 +285,7 @@ class ModuleConfig {
   List<String> migrationVersions;
 
   ModuleConfig({
+    required this.type,
     required this.name,
     required this.nickname,
     required this.migrationVersions,
@@ -279,7 +298,8 @@ class ModuleConfig {
 
   @override
   String toString() {
-    return '''name: $name
+    return '''type: $type
+name: $name
 nickname: $nickname
 clientPackage: $dartClientPackage
 serverPackage: $serverPackage

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -106,8 +106,10 @@ class GeneratorConfig {
   /// Useful for types used in caching and streams.
   final List<TypeDefinition> extraClasses;
 
-  List<ModuleConfig> get modules =>
-      _modules.where((module) => module.type == PackageType.module).toList();
+  List<ModuleConfig> get modules => _modules
+      .where((module) => module.type == PackageType.module)
+      .where((module) => module.name != name)
+      .toList();
 
   List<ModuleConfig> get modulesAll => _modules;
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -240,7 +240,7 @@ class GeneratorConfig {
 
   static PackageType getPackageType(Map<dynamic, dynamic> generatorConfig) {
     var typeStr = generatorConfig['type'];
-    late PackageType type;
+    PackageType type;
     if (typeStr == 'module') {
       type = PackageType.module;
     } else if (typeStr == 'internal') {

--- a/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
@@ -57,6 +57,7 @@ class GeneratorConfigBuilder {
   GeneratorConfigBuilder withAuthModule() {
     _modules.add(
       ModuleConfig(
+        type: PackageType.module,
         name: 'serverpod_auth',
         nickname: 'auth',
         migrationVersions: ['0000000000000000000'],

--- a/tools/serverpod_cli/lib/src/test_util/builders/module_config_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/module_config_builder.dart
@@ -1,6 +1,7 @@
 import 'package:serverpod_cli/src/config/config.dart';
 
 class ModuleConfigBuilder {
+  PackageType _type;
   String _name;
   String _nickname;
   List<String> _migrationVersions;
@@ -8,7 +9,13 @@ class ModuleConfigBuilder {
   ModuleConfigBuilder(String name, [String? nickname])
       : _name = name,
         _nickname = nickname ?? name,
-        _migrationVersions = [];
+        _migrationVersions = [],
+        _type = PackageType.module;
+
+  ModuleConfigBuilder withType(PackageType type) {
+    _type = type;
+    return this;
+  }
 
   ModuleConfigBuilder withNickname(String nickname) {
     _nickname = nickname;
@@ -27,6 +34,7 @@ class ModuleConfigBuilder {
 
   ModuleConfig build() {
     return ModuleConfig(
+      type: _type,
       name: _name,
       nickname: _nickname,
       migrationVersions: _migrationVersions,

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -25,7 +25,8 @@ Future<List<ModuleConfig>?> locateModules({
           continue;
         }
 
-        if (!packageName.endsWith(_serverSuffix)) {
+        if (!packageName.endsWith(_serverSuffix) &&
+            packageName != 'serverpod') {
           continue;
         }
         var moduleName = moduleNameFromServerPackageName(packageName);
@@ -56,13 +57,14 @@ Future<List<ModuleConfig>?> locateModules({
           moduleName: moduleName,
         );
 
-        var moduleInfo = _ModuleGeneratorConfigLite(generatorConfigFile);
+        var moduleInfo = loadConfigFile(generatorConfigFile);
 
         var manualNickname = manualModules[moduleName];
-        var nickname = manualNickname ?? moduleInfo.nickname ?? moduleName;
+        var nickname = manualNickname ?? moduleInfo['nickname'] ?? moduleName;
 
         modules.add(
           ModuleConfig(
+            type: GeneratorConfig.getPackageType(moduleInfo),
             name: moduleName,
             nickname: nickname,
             migrationVersions: migrationVersions,
@@ -83,17 +85,9 @@ Future<List<ModuleConfig>?> locateModules({
   }
 }
 
-class _ModuleGeneratorConfigLite {
-  String? nickname;
-
-  _ModuleGeneratorConfigLite(File file) {
-    var yaml = file.readAsStringSync();
-    var map = loadYaml(yaml) as Map;
-    if (map['type'] != 'module') {
-      throw const FormatException('Not a module config');
-    }
-    nickname = map['nickname'];
-  }
+Map<dynamic, dynamic> loadConfigFile(File file) {
+  var yaml = file.readAsStringSync();
+  return loadYaml(yaml) as Map;
 }
 
 List<String> findAllMigrationVersionsSync({


### PR DESCRIPTION
# Add

Loads all modules including serverpod and local project when building project config.

Old modules getter still returning ONLY projects with type module.

New getter to get the entire module list.

Related #1499

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
