### PR TITLE
fix: provide link to generated migration after it is generated.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
@@ -77,8 +78,8 @@ class CreateMigrationCommand extends ServerpodCommand {
       projectName: projectName,
     );
 
-    var success = await log.progress('Creating migration', () async {
-      MigrationVersion? migration;
+    MigrationVersion? migration;
+    await log.progress('Creating migration', () async {
       try {
         migration = await generator.createMigration(
           tag: tag,
@@ -105,10 +106,24 @@ class CreateMigrationCommand extends ServerpodCommand {
       return migration != null;
     });
 
-    if (!success) {
+    var projectDirectory = migration?.projectDirectory;
+    var migrationName = migration?.versionName;
+    if (migration == null ||
+        projectDirectory == null ||
+        migrationName == null) {
       throw ExitException();
     }
 
+    log.info(
+      'Migration created: ${path.relative(
+        MigrationConstants.migrationVersionDirectory(
+          projectDirectory,
+          migrationName,
+        ).path,
+        from: Directory.current.path,
+      )}',
+      type: TextLogType.bullet,
+    );
     log.info('Done.', type: TextLogType.success);
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
@@ -80,9 +81,10 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
       projectName: projectName,
     );
 
-    var success = await log.progress('Creating repair migration', () async {
+    File? repairMigration;
+    await log.progress('Creating repair migration', () async {
       try {
-        return await generator.repairMigration(
+        repairMigration = await generator.repairMigration(
           tag: tag,
           force: force,
           runMode: mode,
@@ -114,13 +116,21 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
         log.error(e.exception);
       }
 
-      return false;
+      return repairMigration != null;
     });
 
-    if (!success) {
+    var repairMigrationPath = repairMigration?.path;
+    if (repairMigration == null || repairMigrationPath == null) {
       throw ExitException();
     }
 
+    log.info(
+      'Repair migration created: ${path.relative(
+        repairMigrationPath,
+        from: Directory.current.path,
+      )}',
+      type: TextLogType.bullet,
+    );
     log.info('Done.', type: TextLogType.success);
   }
 }


### PR DESCRIPTION
### Change
- Add a link to the created migration directory or repair file when creating migrations or repair migrations.

#### Creating migration
<img width="861" alt="Screenshot 2023-11-30 at 10 06 20" src="https://github.com/serverpod/serverpod/assets/137198655/5691c2cd-edeb-4817-9164-47da6c363e08">

#### Creating repair migration
<img width="876" alt="Screenshot 2023-11-30 at 10 11 04" src="https://github.com/serverpod/serverpod/assets/137198655/e3d2d0f7-3d6b-4a89-854b-cc10a2d750b3">

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
