### PR TITLE
fix: Add unique index requirement on one to one object relations.

### DIFF
--- a/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/definition.json
+++ b/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/definition.json
@@ -61,6 +61,20 @@
           "isUnique": true,
           "isPrimary": true,
           "predicate": null
+        },
+        {
+          "indexName": "inhabitant_index_idx",
+          "tableSpace": null,
+          "elements": [
+            {
+              "type": 0,
+              "definition": "inhabitantId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false,
+          "predicate": null
         }
       ],
       "managed": true
@@ -1828,6 +1842,20 @@
           "type": "btree",
           "isUnique": true,
           "isPrimary": true,
+          "predicate": null
+        },
+        {
+          "indexName": "arena_index_idx",
+          "tableSpace": null,
+          "elements": [
+            {
+              "type": 0,
+              "definition": "arenaId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false,
           "predicate": null
         }
       ],
@@ -3982,19 +4010,25 @@
     {
       "id": null,
       "module": "serverpod_test",
-      "version": "20231201112821617",
+      "version": "20231202120948541",
       "timestamp": null
     },
     {
       "id": null,
       "module": "serverpod_auth",
-      "version": "20231201112742518",
+      "version": "20231202120936381",
       "timestamp": null
     },
     {
       "id": null,
       "module": "serverpod",
-      "version": "20231201112723288",
+      "version": "20231202120932276",
+      "timestamp": null
+    },
+    {
+      "id": null,
+      "module": "serverpod_test_module",
+      "version": "20231202120944481",
       "timestamp": null
     }
   ],

--- a/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/definition.sql
+++ b/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/definition.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 --
--- ACTION CREATE TABLE
+-- Class Address as table address
 --
 CREATE TABLE "address" (
     "id" serial PRIMARY KEY,
@@ -9,8 +9,11 @@ CREATE TABLE "address" (
     "inhabitantId" integer
 );
 
+-- Indexes
+CREATE UNIQUE INDEX "inhabitant_index_idx" ON "address" USING btree ("inhabitantId");
+
 --
--- ACTION CREATE TABLE
+-- Class Arena as table arena
 --
 CREATE TABLE "arena" (
     "id" serial PRIMARY KEY,
@@ -18,7 +21,7 @@ CREATE TABLE "arena" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Blocking as table blocking
 --
 CREATE TABLE "blocking" (
     "id" serial PRIMARY KEY,
@@ -30,7 +33,7 @@ CREATE TABLE "blocking" (
 CREATE UNIQUE INDEX "blocking_blocked_unique_idx" ON "blocking" USING btree ("blockedId", "blockedById");
 
 --
--- ACTION CREATE TABLE
+-- Class Cat as table cat
 --
 CREATE TABLE "cat" (
     "id" serial PRIMARY KEY,
@@ -39,7 +42,7 @@ CREATE TABLE "cat" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Citizen as table citizen
 --
 CREATE TABLE "citizen" (
     "id" serial PRIMARY KEY,
@@ -49,7 +52,7 @@ CREATE TABLE "citizen" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class City as table city
 --
 CREATE TABLE "city" (
     "id" serial PRIMARY KEY,
@@ -57,7 +60,7 @@ CREATE TABLE "city" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Comment as table comment
 --
 CREATE TABLE "comment" (
     "id" serial PRIMARY KEY,
@@ -66,7 +69,7 @@ CREATE TABLE "comment" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Company as table company
 --
 CREATE TABLE "company" (
     "id" serial PRIMARY KEY,
@@ -75,7 +78,7 @@ CREATE TABLE "company" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Course as table course
 --
 CREATE TABLE "course" (
     "id" serial PRIMARY KEY,
@@ -83,7 +86,7 @@ CREATE TABLE "course" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Customer as table customer
 --
 CREATE TABLE "customer" (
     "id" serial PRIMARY KEY,
@@ -91,7 +94,7 @@ CREATE TABLE "customer" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Enrollment as table enrollment
 --
 CREATE TABLE "enrollment" (
     "id" serial PRIMARY KEY,
@@ -103,7 +106,7 @@ CREATE TABLE "enrollment" (
 CREATE UNIQUE INDEX "enrollment_index_idx" ON "enrollment" USING btree ("studentId", "courseId");
 
 --
--- ACTION CREATE TABLE
+-- Class Member as table member
 --
 CREATE TABLE "member" (
     "id" serial PRIMARY KEY,
@@ -111,7 +114,7 @@ CREATE TABLE "member" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectFieldScopes as table object_field_scopes
 --
 CREATE TABLE "object_field_scopes" (
     "id" serial PRIMARY KEY,
@@ -120,7 +123,7 @@ CREATE TABLE "object_field_scopes" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithByteData as table object_with_bytedata
 --
 CREATE TABLE "object_with_bytedata" (
     "id" serial PRIMARY KEY,
@@ -128,7 +131,7 @@ CREATE TABLE "object_with_bytedata" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithDuration as table object_with_duration
 --
 CREATE TABLE "object_with_duration" (
     "id" serial PRIMARY KEY,
@@ -136,7 +139,7 @@ CREATE TABLE "object_with_duration" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithEnum as table object_with_enum
 --
 CREATE TABLE "object_with_enum" (
     "id" serial PRIMARY KEY,
@@ -148,7 +151,7 @@ CREATE TABLE "object_with_enum" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithIndex as table object_with_index
 --
 CREATE TABLE "object_with_index" (
     "id" serial PRIMARY KEY,
@@ -160,7 +163,7 @@ CREATE TABLE "object_with_index" (
 CREATE INDEX "object_with_index_test_index" ON "object_with_index" USING brin ("indexed", "indexed2");
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithObject as table object_with_object
 --
 CREATE TABLE "object_with_object" (
     "id" serial PRIMARY KEY,
@@ -173,7 +176,7 @@ CREATE TABLE "object_with_object" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithParent as table object_with_parent
 --
 CREATE TABLE "object_with_parent" (
     "id" serial PRIMARY KEY,
@@ -181,7 +184,7 @@ CREATE TABLE "object_with_parent" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithSelfParent as table object_with_self_parent
 --
 CREATE TABLE "object_with_self_parent" (
     "id" serial PRIMARY KEY,
@@ -189,7 +192,7 @@ CREATE TABLE "object_with_self_parent" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class ObjectWithUuid as table object_with_uuid
 --
 CREATE TABLE "object_with_uuid" (
     "id" serial PRIMARY KEY,
@@ -198,7 +201,7 @@ CREATE TABLE "object_with_uuid" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Order as table order
 --
 CREATE TABLE "order" (
     "id" serial PRIMARY KEY,
@@ -207,7 +210,7 @@ CREATE TABLE "order" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Organization as table organization
 --
 CREATE TABLE "organization" (
     "id" serial PRIMARY KEY,
@@ -216,7 +219,7 @@ CREATE TABLE "organization" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Person as table person
 --
 CREATE TABLE "person" (
     "id" serial PRIMARY KEY,
@@ -226,7 +229,7 @@ CREATE TABLE "person" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Player as table player
 --
 CREATE TABLE "player" (
     "id" serial PRIMARY KEY,
@@ -235,7 +238,7 @@ CREATE TABLE "player" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Post as table post
 --
 CREATE TABLE "post" (
     "id" serial PRIMARY KEY,
@@ -247,7 +250,7 @@ CREATE TABLE "post" (
 CREATE UNIQUE INDEX "next_unique_idx" ON "post" USING btree ("nextId");
 
 --
--- ACTION CREATE TABLE
+-- Class RelatedUniqueData as table related_unique_data
 --
 CREATE TABLE "related_unique_data" (
     "id" serial PRIMARY KEY,
@@ -256,7 +259,7 @@ CREATE TABLE "related_unique_data" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class SimpleData as table simple_data
 --
 CREATE TABLE "simple_data" (
     "id" serial PRIMARY KEY,
@@ -264,7 +267,7 @@ CREATE TABLE "simple_data" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class SimpleDateTime as table simple_date_time
 --
 CREATE TABLE "simple_date_time" (
     "id" serial PRIMARY KEY,
@@ -272,7 +275,7 @@ CREATE TABLE "simple_date_time" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Student as table student
 --
 CREATE TABLE "student" (
     "id" serial PRIMARY KEY,
@@ -280,7 +283,7 @@ CREATE TABLE "student" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Team as table team
 --
 CREATE TABLE "team" (
     "id" serial PRIMARY KEY,
@@ -288,8 +291,11 @@ CREATE TABLE "team" (
     "arenaId" integer
 );
 
+-- Indexes
+CREATE UNIQUE INDEX "arena_index_idx" ON "team" USING btree ("arenaId");
+
 --
--- ACTION CREATE TABLE
+-- Class Town as table town
 --
 CREATE TABLE "town" (
     "id" serial PRIMARY KEY,
@@ -298,7 +304,7 @@ CREATE TABLE "town" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class Types as table types
 --
 CREATE TABLE "types" (
     "id" serial PRIMARY KEY,
@@ -315,7 +321,7 @@ CREATE TABLE "types" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class UniqueData as table unique_data
 --
 CREATE TABLE "unique_data" (
     "id" serial PRIMARY KEY,
@@ -327,7 +333,7 @@ CREATE TABLE "unique_data" (
 CREATE UNIQUE INDEX "email_index_idx" ON "unique_data" USING btree ("email");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailAuth as table serverpod_email_auth
 --
 CREATE TABLE "serverpod_email_auth" (
     "id" serial PRIMARY KEY,
@@ -340,7 +346,7 @@ CREATE TABLE "serverpod_email_auth" (
 CREATE UNIQUE INDEX "serverpod_email_auth_email" ON "serverpod_email_auth" USING btree ("email");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailCreateAccountRequest as table serverpod_email_create_request
 --
 CREATE TABLE "serverpod_email_create_request" (
     "id" serial PRIMARY KEY,
@@ -354,7 +360,7 @@ CREATE TABLE "serverpod_email_create_request" (
 CREATE UNIQUE INDEX "serverpod_email_auth_create_account_request_idx" ON "serverpod_email_create_request" USING btree ("email");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailFailedSignIn as table serverpod_email_failed_sign_in
 --
 CREATE TABLE "serverpod_email_failed_sign_in" (
     "id" serial PRIMARY KEY,
@@ -368,7 +374,7 @@ CREATE INDEX "serverpod_email_failed_sign_in_email_idx" ON "serverpod_email_fail
 CREATE INDEX "serverpod_email_failed_sign_in_time_idx" ON "serverpod_email_failed_sign_in" USING btree ("time");
 
 --
--- ACTION CREATE TABLE
+-- Class EmailReset as table serverpod_email_reset
 --
 CREATE TABLE "serverpod_email_reset" (
     "id" serial PRIMARY KEY,
@@ -381,7 +387,7 @@ CREATE TABLE "serverpod_email_reset" (
 CREATE UNIQUE INDEX "serverpod_email_reset_verification_idx" ON "serverpod_email_reset" USING btree ("verificationCode");
 
 --
--- ACTION CREATE TABLE
+-- Class GoogleRefreshToken as table serverpod_google_refresh_token
 --
 CREATE TABLE "serverpod_google_refresh_token" (
     "id" serial PRIMARY KEY,
@@ -393,7 +399,7 @@ CREATE TABLE "serverpod_google_refresh_token" (
 CREATE UNIQUE INDEX "serverpod_google_refresh_token_userId_idx" ON "serverpod_google_refresh_token" USING btree ("userId");
 
 --
--- ACTION CREATE TABLE
+-- Class UserImage as table serverpod_user_image
 --
 CREATE TABLE "serverpod_user_image" (
     "id" serial PRIMARY KEY,
@@ -406,7 +412,7 @@ CREATE TABLE "serverpod_user_image" (
 CREATE INDEX "serverpod_user_image_user_id" ON "serverpod_user_image" USING btree ("userId", "version");
 
 --
--- ACTION CREATE TABLE
+-- Class UserInfo as table serverpod_user_info
 --
 CREATE TABLE "serverpod_user_info" (
     "id" serial PRIMARY KEY,
@@ -425,7 +431,7 @@ CREATE UNIQUE INDEX "serverpod_user_info_user_identifier" ON "serverpod_user_inf
 CREATE INDEX "serverpod_user_info_email" ON "serverpod_user_info" USING btree ("email");
 
 --
--- ACTION CREATE TABLE
+-- Class AuthKey as table serverpod_auth_key
 --
 CREATE TABLE "serverpod_auth_key" (
     "id" serial PRIMARY KEY,
@@ -439,7 +445,7 @@ CREATE TABLE "serverpod_auth_key" (
 CREATE INDEX "serverpod_auth_key_userId_idx" ON "serverpod_auth_key" USING btree ("userId");
 
 --
--- ACTION CREATE TABLE
+-- Class CloudStorageEntry as table serverpod_cloud_storage
 --
 CREATE TABLE "serverpod_cloud_storage" (
     "id" serial PRIMARY KEY,
@@ -456,7 +462,7 @@ CREATE UNIQUE INDEX "serverpod_cloud_storage_path_idx" ON "serverpod_cloud_stora
 CREATE INDEX "serverpod_cloud_storage_expiration" ON "serverpod_cloud_storage" USING btree ("expiration");
 
 --
--- ACTION CREATE TABLE
+-- Class CloudStorageDirectUploadEntry as table serverpod_cloud_storage_direct_upload
 --
 CREATE TABLE "serverpod_cloud_storage_direct_upload" (
     "id" serial PRIMARY KEY,
@@ -470,7 +476,7 @@ CREATE TABLE "serverpod_cloud_storage_direct_upload" (
 CREATE UNIQUE INDEX "serverpod_cloud_storage_direct_upload_storage_path" ON "serverpod_cloud_storage_direct_upload" USING btree ("storageId", "path");
 
 --
--- ACTION CREATE TABLE
+-- Class FutureCallEntry as table serverpod_future_call
 --
 CREATE TABLE "serverpod_future_call" (
     "id" serial PRIMARY KEY,
@@ -487,7 +493,7 @@ CREATE INDEX "serverpod_future_call_serverId_idx" ON "serverpod_future_call" USI
 CREATE INDEX "serverpod_future_call_identifier_idx" ON "serverpod_future_call" USING btree ("identifier");
 
 --
--- ACTION CREATE TABLE
+-- Class ServerHealthConnectionInfo as table serverpod_health_connection_info
 --
 CREATE TABLE "serverpod_health_connection_info" (
     "id" serial PRIMARY KEY,
@@ -503,7 +509,7 @@ CREATE TABLE "serverpod_health_connection_info" (
 CREATE UNIQUE INDEX "serverpod_health_connection_info_timestamp_idx" ON "serverpod_health_connection_info" USING btree ("timestamp", "serverId", "granularity");
 
 --
--- ACTION CREATE TABLE
+-- Class ServerHealthMetric as table serverpod_health_metric
 --
 CREATE TABLE "serverpod_health_metric" (
     "id" serial PRIMARY KEY,
@@ -519,7 +525,7 @@ CREATE TABLE "serverpod_health_metric" (
 CREATE UNIQUE INDEX "serverpod_health_metric_timestamp_idx" ON "serverpod_health_metric" USING btree ("timestamp", "serverId", "name", "granularity");
 
 --
--- ACTION CREATE TABLE
+-- Class LogEntry as table serverpod_log
 --
 CREATE TABLE "serverpod_log" (
     "id" serial PRIMARY KEY,
@@ -539,7 +545,7 @@ CREATE TABLE "serverpod_log" (
 CREATE INDEX "serverpod_log_sessionLogId_idx" ON "serverpod_log" USING btree ("sessionLogId");
 
 --
--- ACTION CREATE TABLE
+-- Class MessageLogEntry as table serverpod_message_log
 --
 CREATE TABLE "serverpod_message_log" (
     "id" serial PRIMARY KEY,
@@ -556,7 +562,7 @@ CREATE TABLE "serverpod_message_log" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class MethodInfo as table serverpod_method
 --
 CREATE TABLE "serverpod_method" (
     "id" serial PRIMARY KEY,
@@ -568,7 +574,7 @@ CREATE TABLE "serverpod_method" (
 CREATE UNIQUE INDEX "serverpod_method_endpoint_method_idx" ON "serverpod_method" USING btree ("endpoint", "method");
 
 --
--- ACTION CREATE TABLE
+-- Class DatabaseMigrationVersion as table serverpod_migrations
 --
 CREATE TABLE "serverpod_migrations" (
     "id" serial PRIMARY KEY,
@@ -581,7 +587,7 @@ CREATE TABLE "serverpod_migrations" (
 CREATE UNIQUE INDEX "serverpod_migrations_ids" ON "serverpod_migrations" USING btree ("module");
 
 --
--- ACTION CREATE TABLE
+-- Class QueryLogEntry as table serverpod_query_log
 --
 CREATE TABLE "serverpod_query_log" (
     "id" serial PRIMARY KEY,
@@ -601,7 +607,7 @@ CREATE TABLE "serverpod_query_log" (
 CREATE INDEX "serverpod_query_log_sessionLogId_idx" ON "serverpod_query_log" USING btree ("sessionLogId");
 
 --
--- ACTION CREATE TABLE
+-- Class ReadWriteTestEntry as table serverpod_readwrite_test
 --
 CREATE TABLE "serverpod_readwrite_test" (
     "id" serial PRIMARY KEY,
@@ -609,7 +615,7 @@ CREATE TABLE "serverpod_readwrite_test" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class RuntimeSettings as table serverpod_runtime_settings
 --
 CREATE TABLE "serverpod_runtime_settings" (
     "id" serial PRIMARY KEY,
@@ -620,7 +626,7 @@ CREATE TABLE "serverpod_runtime_settings" (
 );
 
 --
--- ACTION CREATE TABLE
+-- Class SessionLogEntry as table serverpod_session_log
 --
 CREATE TABLE "serverpod_session_log" (
     "id" serial PRIMARY KEY,
@@ -645,7 +651,7 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "address" table
 --
 ALTER TABLE ONLY "address"
     ADD CONSTRAINT "address_fk_0"
@@ -655,7 +661,7 @@ ALTER TABLE ONLY "address"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "blocking" table
 --
 ALTER TABLE ONLY "blocking"
     ADD CONSTRAINT "blocking_fk_0"
@@ -671,7 +677,7 @@ ALTER TABLE ONLY "blocking"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "cat" table
 --
 ALTER TABLE ONLY "cat"
     ADD CONSTRAINT "cat_fk_0"
@@ -681,7 +687,7 @@ ALTER TABLE ONLY "cat"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "citizen" table
 --
 ALTER TABLE ONLY "citizen"
     ADD CONSTRAINT "citizen_fk_0"
@@ -697,7 +703,7 @@ ALTER TABLE ONLY "citizen"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "comment" table
 --
 ALTER TABLE ONLY "comment"
     ADD CONSTRAINT "comment_fk_0"
@@ -707,7 +713,7 @@ ALTER TABLE ONLY "comment"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "company" table
 --
 ALTER TABLE ONLY "company"
     ADD CONSTRAINT "company_fk_0"
@@ -717,7 +723,7 @@ ALTER TABLE ONLY "company"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "enrollment" table
 --
 ALTER TABLE ONLY "enrollment"
     ADD CONSTRAINT "enrollment_fk_0"
@@ -733,7 +739,7 @@ ALTER TABLE ONLY "enrollment"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "object_with_parent" table
 --
 ALTER TABLE ONLY "object_with_parent"
     ADD CONSTRAINT "object_with_parent_fk_0"
@@ -743,7 +749,7 @@ ALTER TABLE ONLY "object_with_parent"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "object_with_self_parent" table
 --
 ALTER TABLE ONLY "object_with_self_parent"
     ADD CONSTRAINT "object_with_self_parent_fk_0"
@@ -753,7 +759,7 @@ ALTER TABLE ONLY "object_with_self_parent"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "order" table
 --
 ALTER TABLE ONLY "order"
     ADD CONSTRAINT "order_fk_0"
@@ -763,7 +769,7 @@ ALTER TABLE ONLY "order"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "organization" table
 --
 ALTER TABLE ONLY "organization"
     ADD CONSTRAINT "organization_fk_0"
@@ -773,7 +779,7 @@ ALTER TABLE ONLY "organization"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "person" table
 --
 ALTER TABLE ONLY "person"
     ADD CONSTRAINT "person_fk_0"
@@ -789,7 +795,7 @@ ALTER TABLE ONLY "person"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "player" table
 --
 ALTER TABLE ONLY "player"
     ADD CONSTRAINT "player_fk_0"
@@ -799,7 +805,7 @@ ALTER TABLE ONLY "player"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "post" table
 --
 ALTER TABLE ONLY "post"
     ADD CONSTRAINT "post_fk_0"
@@ -809,7 +815,7 @@ ALTER TABLE ONLY "post"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "related_unique_data" table
 --
 ALTER TABLE ONLY "related_unique_data"
     ADD CONSTRAINT "related_unique_data_fk_0"
@@ -819,7 +825,7 @@ ALTER TABLE ONLY "related_unique_data"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "team" table
 --
 ALTER TABLE ONLY "team"
     ADD CONSTRAINT "team_fk_0"
@@ -829,7 +835,7 @@ ALTER TABLE ONLY "team"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "town" table
 --
 ALTER TABLE ONLY "town"
     ADD CONSTRAINT "town_fk_0"
@@ -839,7 +845,7 @@ ALTER TABLE ONLY "town"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_log" table
 --
 ALTER TABLE ONLY "serverpod_log"
     ADD CONSTRAINT "serverpod_log_fk_0"
@@ -849,7 +855,7 @@ ALTER TABLE ONLY "serverpod_log"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_message_log" table
 --
 ALTER TABLE ONLY "serverpod_message_log"
     ADD CONSTRAINT "serverpod_message_log_fk_0"
@@ -859,7 +865,7 @@ ALTER TABLE ONLY "serverpod_message_log"
     ON UPDATE NO ACTION;
 
 --
--- ACTION CREATE FOREIGN KEY
+-- Foreign relations for "serverpod_query_log" table
 --
 ALTER TABLE ONLY "serverpod_query_log"
     ADD CONSTRAINT "serverpod_query_log_fk_0"
@@ -873,25 +879,33 @@ ALTER TABLE ONLY "serverpod_query_log"
 -- MIGRATION VERSION FOR serverpod_test
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_test', '20231201112821617', now())
+    VALUES ('serverpod_test', '20231202120948541', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20231201112821617', "timestamp" = now();
+    DO UPDATE SET "version" = '20231202120948541', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth', '20231201112742518', now())
+    VALUES ('serverpod_auth', '20231202120936381', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20231201112742518', "timestamp" = now();
+    DO UPDATE SET "version" = '20231202120936381', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod', '20231201112723288', now())
+    VALUES ('serverpod', '20231202120932276', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20231201112723288', "timestamp" = now();
+    DO UPDATE SET "version" = '20231202120932276', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_test_module
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_test_module', '20231202120944481', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20231202120944481', "timestamp" = now();
 
 
 COMMIT;

--- a/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/definition_project.json
+++ b/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/definition_project.json
@@ -61,6 +61,20 @@
           "isUnique": true,
           "isPrimary": true,
           "predicate": null
+        },
+        {
+          "indexName": "inhabitant_index_idx",
+          "tableSpace": null,
+          "elements": [
+            {
+              "type": 0,
+              "definition": "inhabitantId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false,
+          "predicate": null
         }
       ],
       "managed": true
@@ -1829,6 +1843,20 @@
           "isUnique": true,
           "isPrimary": true,
           "predicate": null
+        },
+        {
+          "indexName": "arena_index_idx",
+          "tableSpace": null,
+          "elements": [
+            {
+              "type": 0,
+              "definition": "arenaId"
+            }
+          ],
+          "type": "btree",
+          "isUnique": true,
+          "isPrimary": false,
+          "predicate": null
         }
       ],
       "managed": true
@@ -2067,13 +2095,19 @@
     {
       "id": null,
       "module": "serverpod_auth",
-      "version": "20231201112742518",
+      "version": "20231202120936381",
       "timestamp": null
     },
     {
       "id": null,
       "module": "serverpod",
-      "version": "20231201112723288",
+      "version": "20231202120932276",
+      "timestamp": null
+    },
+    {
+      "id": null,
+      "module": "serverpod_test_module",
+      "version": "20231202120944481",
       "timestamp": null
     }
   ],

--- a/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/migration.json
+++ b/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/migration.json
@@ -63,6 +63,20 @@
             "isUnique": true,
             "isPrimary": true,
             "predicate": null
+          },
+          {
+            "indexName": "inhabitant_index_idx",
+            "tableSpace": null,
+            "elements": [
+              {
+                "type": 0,
+                "definition": "inhabitantId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false,
+            "predicate": null
           }
         ],
         "managed": true
@@ -1980,6 +1994,20 @@
             "type": "btree",
             "isUnique": true,
             "isPrimary": true,
+            "predicate": null
+          },
+          {
+            "indexName": "arena_index_idx",
+            "tableSpace": null,
+            "elements": [
+              {
+                "type": 0,
+                "definition": "arenaId"
+              }
+            ],
+            "type": "btree",
+            "isUnique": true,
+            "isPrimary": false,
             "predicate": null
           }
         ],

--- a/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/migration.sql
+++ b/tests/serverpod_test_server/generated/migration/migrations/20231202120948541/migration.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 --
--- Class Address as table address
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "address" (
     "id" serial PRIMARY KEY,
@@ -9,8 +9,11 @@ CREATE TABLE "address" (
     "inhabitantId" integer
 );
 
+-- Indexes
+CREATE UNIQUE INDEX "inhabitant_index_idx" ON "address" USING btree ("inhabitantId");
+
 --
--- Class Arena as table arena
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "arena" (
     "id" serial PRIMARY KEY,
@@ -18,7 +21,7 @@ CREATE TABLE "arena" (
 );
 
 --
--- Class Blocking as table blocking
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "blocking" (
     "id" serial PRIMARY KEY,
@@ -30,7 +33,7 @@ CREATE TABLE "blocking" (
 CREATE UNIQUE INDEX "blocking_blocked_unique_idx" ON "blocking" USING btree ("blockedId", "blockedById");
 
 --
--- Class Cat as table cat
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "cat" (
     "id" serial PRIMARY KEY,
@@ -39,7 +42,7 @@ CREATE TABLE "cat" (
 );
 
 --
--- Class Citizen as table citizen
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "citizen" (
     "id" serial PRIMARY KEY,
@@ -49,7 +52,7 @@ CREATE TABLE "citizen" (
 );
 
 --
--- Class City as table city
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "city" (
     "id" serial PRIMARY KEY,
@@ -57,7 +60,7 @@ CREATE TABLE "city" (
 );
 
 --
--- Class Comment as table comment
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "comment" (
     "id" serial PRIMARY KEY,
@@ -66,7 +69,7 @@ CREATE TABLE "comment" (
 );
 
 --
--- Class Company as table company
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "company" (
     "id" serial PRIMARY KEY,
@@ -75,7 +78,7 @@ CREATE TABLE "company" (
 );
 
 --
--- Class Course as table course
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "course" (
     "id" serial PRIMARY KEY,
@@ -83,7 +86,7 @@ CREATE TABLE "course" (
 );
 
 --
--- Class Customer as table customer
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "customer" (
     "id" serial PRIMARY KEY,
@@ -91,7 +94,7 @@ CREATE TABLE "customer" (
 );
 
 --
--- Class Enrollment as table enrollment
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "enrollment" (
     "id" serial PRIMARY KEY,
@@ -103,7 +106,7 @@ CREATE TABLE "enrollment" (
 CREATE UNIQUE INDEX "enrollment_index_idx" ON "enrollment" USING btree ("studentId", "courseId");
 
 --
--- Class Member as table member
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "member" (
     "id" serial PRIMARY KEY,
@@ -111,7 +114,7 @@ CREATE TABLE "member" (
 );
 
 --
--- Class ObjectFieldScopes as table object_field_scopes
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_field_scopes" (
     "id" serial PRIMARY KEY,
@@ -120,7 +123,7 @@ CREATE TABLE "object_field_scopes" (
 );
 
 --
--- Class ObjectWithByteData as table object_with_bytedata
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_bytedata" (
     "id" serial PRIMARY KEY,
@@ -128,7 +131,7 @@ CREATE TABLE "object_with_bytedata" (
 );
 
 --
--- Class ObjectWithDuration as table object_with_duration
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_duration" (
     "id" serial PRIMARY KEY,
@@ -136,7 +139,7 @@ CREATE TABLE "object_with_duration" (
 );
 
 --
--- Class ObjectWithEnum as table object_with_enum
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_enum" (
     "id" serial PRIMARY KEY,
@@ -148,7 +151,7 @@ CREATE TABLE "object_with_enum" (
 );
 
 --
--- Class ObjectWithIndex as table object_with_index
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_index" (
     "id" serial PRIMARY KEY,
@@ -160,7 +163,7 @@ CREATE TABLE "object_with_index" (
 CREATE INDEX "object_with_index_test_index" ON "object_with_index" USING brin ("indexed", "indexed2");
 
 --
--- Class ObjectWithObject as table object_with_object
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_object" (
     "id" serial PRIMARY KEY,
@@ -173,7 +176,7 @@ CREATE TABLE "object_with_object" (
 );
 
 --
--- Class ObjectWithParent as table object_with_parent
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_parent" (
     "id" serial PRIMARY KEY,
@@ -181,7 +184,7 @@ CREATE TABLE "object_with_parent" (
 );
 
 --
--- Class ObjectWithSelfParent as table object_with_self_parent
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_self_parent" (
     "id" serial PRIMARY KEY,
@@ -189,7 +192,7 @@ CREATE TABLE "object_with_self_parent" (
 );
 
 --
--- Class ObjectWithUuid as table object_with_uuid
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "object_with_uuid" (
     "id" serial PRIMARY KEY,
@@ -198,7 +201,7 @@ CREATE TABLE "object_with_uuid" (
 );
 
 --
--- Class Order as table order
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "order" (
     "id" serial PRIMARY KEY,
@@ -207,7 +210,7 @@ CREATE TABLE "order" (
 );
 
 --
--- Class Organization as table organization
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "organization" (
     "id" serial PRIMARY KEY,
@@ -216,7 +219,7 @@ CREATE TABLE "organization" (
 );
 
 --
--- Class Person as table person
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "person" (
     "id" serial PRIMARY KEY,
@@ -226,7 +229,7 @@ CREATE TABLE "person" (
 );
 
 --
--- Class Player as table player
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "player" (
     "id" serial PRIMARY KEY,
@@ -235,7 +238,7 @@ CREATE TABLE "player" (
 );
 
 --
--- Class Post as table post
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "post" (
     "id" serial PRIMARY KEY,
@@ -247,7 +250,7 @@ CREATE TABLE "post" (
 CREATE UNIQUE INDEX "next_unique_idx" ON "post" USING btree ("nextId");
 
 --
--- Class RelatedUniqueData as table related_unique_data
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "related_unique_data" (
     "id" serial PRIMARY KEY,
@@ -256,7 +259,7 @@ CREATE TABLE "related_unique_data" (
 );
 
 --
--- Class SimpleData as table simple_data
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "simple_data" (
     "id" serial PRIMARY KEY,
@@ -264,7 +267,7 @@ CREATE TABLE "simple_data" (
 );
 
 --
--- Class SimpleDateTime as table simple_date_time
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "simple_date_time" (
     "id" serial PRIMARY KEY,
@@ -272,7 +275,7 @@ CREATE TABLE "simple_date_time" (
 );
 
 --
--- Class Student as table student
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "student" (
     "id" serial PRIMARY KEY,
@@ -280,7 +283,7 @@ CREATE TABLE "student" (
 );
 
 --
--- Class Team as table team
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "team" (
     "id" serial PRIMARY KEY,
@@ -288,8 +291,11 @@ CREATE TABLE "team" (
     "arenaId" integer
 );
 
+-- Indexes
+CREATE UNIQUE INDEX "arena_index_idx" ON "team" USING btree ("arenaId");
+
 --
--- Class Town as table town
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "town" (
     "id" serial PRIMARY KEY,
@@ -298,7 +304,7 @@ CREATE TABLE "town" (
 );
 
 --
--- Class Types as table types
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "types" (
     "id" serial PRIMARY KEY,
@@ -315,7 +321,7 @@ CREATE TABLE "types" (
 );
 
 --
--- Class UniqueData as table unique_data
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "unique_data" (
     "id" serial PRIMARY KEY,
@@ -327,7 +333,7 @@ CREATE TABLE "unique_data" (
 CREATE UNIQUE INDEX "email_index_idx" ON "unique_data" USING btree ("email");
 
 --
--- Class EmailAuth as table serverpod_email_auth
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_email_auth" (
     "id" serial PRIMARY KEY,
@@ -340,7 +346,7 @@ CREATE TABLE "serverpod_email_auth" (
 CREATE UNIQUE INDEX "serverpod_email_auth_email" ON "serverpod_email_auth" USING btree ("email");
 
 --
--- Class EmailCreateAccountRequest as table serverpod_email_create_request
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_email_create_request" (
     "id" serial PRIMARY KEY,
@@ -354,7 +360,7 @@ CREATE TABLE "serverpod_email_create_request" (
 CREATE UNIQUE INDEX "serverpod_email_auth_create_account_request_idx" ON "serverpod_email_create_request" USING btree ("email");
 
 --
--- Class EmailFailedSignIn as table serverpod_email_failed_sign_in
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_email_failed_sign_in" (
     "id" serial PRIMARY KEY,
@@ -368,7 +374,7 @@ CREATE INDEX "serverpod_email_failed_sign_in_email_idx" ON "serverpod_email_fail
 CREATE INDEX "serverpod_email_failed_sign_in_time_idx" ON "serverpod_email_failed_sign_in" USING btree ("time");
 
 --
--- Class EmailReset as table serverpod_email_reset
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_email_reset" (
     "id" serial PRIMARY KEY,
@@ -381,7 +387,7 @@ CREATE TABLE "serverpod_email_reset" (
 CREATE UNIQUE INDEX "serverpod_email_reset_verification_idx" ON "serverpod_email_reset" USING btree ("verificationCode");
 
 --
--- Class GoogleRefreshToken as table serverpod_google_refresh_token
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_google_refresh_token" (
     "id" serial PRIMARY KEY,
@@ -393,7 +399,7 @@ CREATE TABLE "serverpod_google_refresh_token" (
 CREATE UNIQUE INDEX "serverpod_google_refresh_token_userId_idx" ON "serverpod_google_refresh_token" USING btree ("userId");
 
 --
--- Class UserImage as table serverpod_user_image
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_user_image" (
     "id" serial PRIMARY KEY,
@@ -406,7 +412,7 @@ CREATE TABLE "serverpod_user_image" (
 CREATE INDEX "serverpod_user_image_user_id" ON "serverpod_user_image" USING btree ("userId", "version");
 
 --
--- Class UserInfo as table serverpod_user_info
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_user_info" (
     "id" serial PRIMARY KEY,
@@ -425,7 +431,7 @@ CREATE UNIQUE INDEX "serverpod_user_info_user_identifier" ON "serverpod_user_inf
 CREATE INDEX "serverpod_user_info_email" ON "serverpod_user_info" USING btree ("email");
 
 --
--- Class AuthKey as table serverpod_auth_key
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_auth_key" (
     "id" serial PRIMARY KEY,
@@ -439,7 +445,7 @@ CREATE TABLE "serverpod_auth_key" (
 CREATE INDEX "serverpod_auth_key_userId_idx" ON "serverpod_auth_key" USING btree ("userId");
 
 --
--- Class CloudStorageEntry as table serverpod_cloud_storage
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_cloud_storage" (
     "id" serial PRIMARY KEY,
@@ -456,7 +462,7 @@ CREATE UNIQUE INDEX "serverpod_cloud_storage_path_idx" ON "serverpod_cloud_stora
 CREATE INDEX "serverpod_cloud_storage_expiration" ON "serverpod_cloud_storage" USING btree ("expiration");
 
 --
--- Class CloudStorageDirectUploadEntry as table serverpod_cloud_storage_direct_upload
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_cloud_storage_direct_upload" (
     "id" serial PRIMARY KEY,
@@ -470,7 +476,7 @@ CREATE TABLE "serverpod_cloud_storage_direct_upload" (
 CREATE UNIQUE INDEX "serverpod_cloud_storage_direct_upload_storage_path" ON "serverpod_cloud_storage_direct_upload" USING btree ("storageId", "path");
 
 --
--- Class FutureCallEntry as table serverpod_future_call
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_future_call" (
     "id" serial PRIMARY KEY,
@@ -487,7 +493,7 @@ CREATE INDEX "serverpod_future_call_serverId_idx" ON "serverpod_future_call" USI
 CREATE INDEX "serverpod_future_call_identifier_idx" ON "serverpod_future_call" USING btree ("identifier");
 
 --
--- Class ServerHealthConnectionInfo as table serverpod_health_connection_info
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_health_connection_info" (
     "id" serial PRIMARY KEY,
@@ -503,7 +509,7 @@ CREATE TABLE "serverpod_health_connection_info" (
 CREATE UNIQUE INDEX "serverpod_health_connection_info_timestamp_idx" ON "serverpod_health_connection_info" USING btree ("timestamp", "serverId", "granularity");
 
 --
--- Class ServerHealthMetric as table serverpod_health_metric
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_health_metric" (
     "id" serial PRIMARY KEY,
@@ -519,7 +525,7 @@ CREATE TABLE "serverpod_health_metric" (
 CREATE UNIQUE INDEX "serverpod_health_metric_timestamp_idx" ON "serverpod_health_metric" USING btree ("timestamp", "serverId", "name", "granularity");
 
 --
--- Class LogEntry as table serverpod_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_log" (
     "id" serial PRIMARY KEY,
@@ -539,7 +545,7 @@ CREATE TABLE "serverpod_log" (
 CREATE INDEX "serverpod_log_sessionLogId_idx" ON "serverpod_log" USING btree ("sessionLogId");
 
 --
--- Class MessageLogEntry as table serverpod_message_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_message_log" (
     "id" serial PRIMARY KEY,
@@ -556,7 +562,7 @@ CREATE TABLE "serverpod_message_log" (
 );
 
 --
--- Class MethodInfo as table serverpod_method
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_method" (
     "id" serial PRIMARY KEY,
@@ -568,7 +574,7 @@ CREATE TABLE "serverpod_method" (
 CREATE UNIQUE INDEX "serverpod_method_endpoint_method_idx" ON "serverpod_method" USING btree ("endpoint", "method");
 
 --
--- Class DatabaseMigrationVersion as table serverpod_migrations
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_migrations" (
     "id" serial PRIMARY KEY,
@@ -581,7 +587,7 @@ CREATE TABLE "serverpod_migrations" (
 CREATE UNIQUE INDEX "serverpod_migrations_ids" ON "serverpod_migrations" USING btree ("module");
 
 --
--- Class QueryLogEntry as table serverpod_query_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_query_log" (
     "id" serial PRIMARY KEY,
@@ -601,7 +607,7 @@ CREATE TABLE "serverpod_query_log" (
 CREATE INDEX "serverpod_query_log_sessionLogId_idx" ON "serverpod_query_log" USING btree ("sessionLogId");
 
 --
--- Class ReadWriteTestEntry as table serverpod_readwrite_test
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_readwrite_test" (
     "id" serial PRIMARY KEY,
@@ -609,7 +615,7 @@ CREATE TABLE "serverpod_readwrite_test" (
 );
 
 --
--- Class RuntimeSettings as table serverpod_runtime_settings
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_runtime_settings" (
     "id" serial PRIMARY KEY,
@@ -620,7 +626,7 @@ CREATE TABLE "serverpod_runtime_settings" (
 );
 
 --
--- Class SessionLogEntry as table serverpod_session_log
+-- ACTION CREATE TABLE
 --
 CREATE TABLE "serverpod_session_log" (
     "id" serial PRIMARY KEY,
@@ -645,7 +651,7 @@ CREATE INDEX "serverpod_session_log_touched_idx" ON "serverpod_session_log" USIN
 CREATE INDEX "serverpod_session_log_isopen_idx" ON "serverpod_session_log" USING btree ("isOpen");
 
 --
--- Foreign relations for "address" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "address"
     ADD CONSTRAINT "address_fk_0"
@@ -655,7 +661,7 @@ ALTER TABLE ONLY "address"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "blocking" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "blocking"
     ADD CONSTRAINT "blocking_fk_0"
@@ -671,7 +677,7 @@ ALTER TABLE ONLY "blocking"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "cat" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "cat"
     ADD CONSTRAINT "cat_fk_0"
@@ -681,7 +687,7 @@ ALTER TABLE ONLY "cat"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "citizen" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "citizen"
     ADD CONSTRAINT "citizen_fk_0"
@@ -697,7 +703,7 @@ ALTER TABLE ONLY "citizen"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "comment" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "comment"
     ADD CONSTRAINT "comment_fk_0"
@@ -707,7 +713,7 @@ ALTER TABLE ONLY "comment"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "company" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "company"
     ADD CONSTRAINT "company_fk_0"
@@ -717,7 +723,7 @@ ALTER TABLE ONLY "company"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "enrollment" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "enrollment"
     ADD CONSTRAINT "enrollment_fk_0"
@@ -733,7 +739,7 @@ ALTER TABLE ONLY "enrollment"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "object_with_parent" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "object_with_parent"
     ADD CONSTRAINT "object_with_parent_fk_0"
@@ -743,7 +749,7 @@ ALTER TABLE ONLY "object_with_parent"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "object_with_self_parent" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "object_with_self_parent"
     ADD CONSTRAINT "object_with_self_parent_fk_0"
@@ -753,7 +759,7 @@ ALTER TABLE ONLY "object_with_self_parent"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "order" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "order"
     ADD CONSTRAINT "order_fk_0"
@@ -763,7 +769,7 @@ ALTER TABLE ONLY "order"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "organization" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "organization"
     ADD CONSTRAINT "organization_fk_0"
@@ -773,7 +779,7 @@ ALTER TABLE ONLY "organization"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "person" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "person"
     ADD CONSTRAINT "person_fk_0"
@@ -789,7 +795,7 @@ ALTER TABLE ONLY "person"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "player" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "player"
     ADD CONSTRAINT "player_fk_0"
@@ -799,7 +805,7 @@ ALTER TABLE ONLY "player"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "post" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "post"
     ADD CONSTRAINT "post_fk_0"
@@ -809,7 +815,7 @@ ALTER TABLE ONLY "post"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "related_unique_data" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "related_unique_data"
     ADD CONSTRAINT "related_unique_data_fk_0"
@@ -819,7 +825,7 @@ ALTER TABLE ONLY "related_unique_data"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "team" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "team"
     ADD CONSTRAINT "team_fk_0"
@@ -829,7 +835,7 @@ ALTER TABLE ONLY "team"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "town" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "town"
     ADD CONSTRAINT "town_fk_0"
@@ -839,7 +845,7 @@ ALTER TABLE ONLY "town"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_log"
     ADD CONSTRAINT "serverpod_log_fk_0"
@@ -849,7 +855,7 @@ ALTER TABLE ONLY "serverpod_log"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_message_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_message_log"
     ADD CONSTRAINT "serverpod_message_log_fk_0"
@@ -859,7 +865,7 @@ ALTER TABLE ONLY "serverpod_message_log"
     ON UPDATE NO ACTION;
 
 --
--- Foreign relations for "serverpod_query_log" table
+-- ACTION CREATE FOREIGN KEY
 --
 ALTER TABLE ONLY "serverpod_query_log"
     ADD CONSTRAINT "serverpod_query_log_fk_0"
@@ -873,25 +879,33 @@ ALTER TABLE ONLY "serverpod_query_log"
 -- MIGRATION VERSION FOR serverpod_test
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_test', '20231201112821617', now())
+    VALUES ('serverpod_test', '20231202120948541', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20231201112821617', "timestamp" = now();
+    DO UPDATE SET "version" = '20231202120948541', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod_auth
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod_auth', '20231201112742518', now())
+    VALUES ('serverpod_auth', '20231202120936381', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20231201112742518', "timestamp" = now();
+    DO UPDATE SET "version" = '20231202120936381', "timestamp" = now();
 
 --
 -- MIGRATION VERSION FOR serverpod
 --
 INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
-    VALUES ('serverpod', '20231201112723288', now())
+    VALUES ('serverpod', '20231202120932276', now())
     ON CONFLICT ("module")
-    DO UPDATE SET "version" = '20231201112723288', "timestamp" = now();
+    DO UPDATE SET "version" = '20231202120932276', "timestamp" = now();
+
+--
+-- MIGRATION VERSION FOR serverpod_test_module
+--
+INSERT INTO "serverpod_migrations" ("module", "version", "timestamp")
+    VALUES ('serverpod_test_module', '20231202120944481', now())
+    ON CONFLICT ("module")
+    DO UPDATE SET "version" = '20231202120944481', "timestamp" = now();
 
 
 COMMIT;

--- a/tests/serverpod_test_server/generated/migration/migrations/migration_registry.txt
+++ b/tests/serverpod_test_server/generated/migration/migrations/migration_registry.txt
@@ -4,4 +4,4 @@
 ### manually. If a collision is detected in this file when doing a code merge, resolve
 ### the conflict by removing and recreating the conflicting migration.
 
-20231201112821617
+20231202120948541

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -197,7 +197,20 @@ class Protocol extends _i1.SerializationManagerServer {
           type: 'btree',
           isUnique: true,
           isPrimary: true,
-        )
+        ),
+        _i2.IndexDefinition(
+          indexName: 'inhabitant_index_idx',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'inhabitantId',
+            )
+          ],
+          type: 'btree',
+          isUnique: true,
+          isPrimary: false,
+        ),
       ],
       managed: true,
     ),
@@ -1769,7 +1782,20 @@ class Protocol extends _i1.SerializationManagerServer {
           type: 'btree',
           isUnique: true,
           isPrimary: true,
-        )
+        ),
+        _i2.IndexDefinition(
+          indexName: 'arena_index_idx',
+          tableSpace: null,
+          elements: [
+            _i2.IndexElementDefinition(
+              type: _i2.IndexElementDefinitionType.column,
+              definition: 'arenaId',
+            )
+          ],
+          type: 'btree',
+          isUnique: true,
+          isPrimary: false,
+        ),
       ],
       managed: true,
     ),

--- a/tests/serverpod_test_server/lib/src/protocol/entities_with_relations/nested_one_to_many/team.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/entities_with_relations/nested_one_to_many/team.yaml
@@ -5,3 +5,7 @@ fields:
   arenaId: int?
   arena: Arena?, relation(name=arena_team, field=arenaId, onDelete=SetNull)
   players: List<Player>?, relation(name=team_player)
+indexes:
+  arena_index_idx:
+    fields: arenaId
+    unique: true

--- a/tests/serverpod_test_server/lib/src/protocol/entities_with_relations/one_to_one/address.yaml
+++ b/tests/serverpod_test_server/lib/src/protocol/entities_with_relations/one_to_one/address.yaml
@@ -4,3 +4,7 @@ fields:
   street: String
   inhabitantId: int?
   inhabitant: Citizen?, relation(name=citizen_address, field=inhabitantId, onDelete=Cascade)
+indexes:
+  inhabitant_index_idx:
+    fields: inhabitantId
+    unique: true

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -106,6 +106,9 @@ class SerializableEntityFieldDefinition {
   /// The documentation of this field, line by line.
   final List<String>? documentation;
 
+  /// Indexes that this field is part of.
+  List<SerializableEntityIndexDefinition> indexes = [];
+
   /// Create a new [SerializableEntityFieldDefinition].
   SerializableEntityFieldDefinition({
     required this.name,

--- a/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/definitions.dart
@@ -44,7 +44,7 @@ class ClassDefinition extends SerializableEntityDefinition {
   /// this class.
   ///
   /// The index over the primary key `id` is not part of this list.
-  final List<SerializableEntityIndexDefinition>? indexes;
+  final List<SerializableEntityIndexDefinition> indexes;
 
   /// The documentation of this class, line by line.
   final List<String>? documentation;
@@ -61,7 +61,7 @@ class ClassDefinition extends SerializableEntityDefinition {
     required super.serverOnly,
     required this.isException,
     this.tableName,
-    this.indexes,
+    this.indexes = const [],
     super.subDirParts,
     this.documentation,
   });

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_dependency_resolver.dart
@@ -12,6 +12,7 @@ class EntityDependencyResolver {
   ) {
     entityDefinitions.whereType<ClassDefinition>().forEach((classDefinition) {
       for (var fieldDefinition in classDefinition.fields) {
+        _resolveFieldIndexes(fieldDefinition, classDefinition);
         _resolveProtocolReference(fieldDefinition, entityDefinitions);
         _resolveEnumType(fieldDefinition, entityDefinitions);
         _resolveObjectRelationReference(
@@ -26,6 +27,20 @@ class EntityDependencyResolver {
         );
       }
     });
+  }
+
+  static void _resolveFieldIndexes(
+    SerializableEntityFieldDefinition fieldDefinition,
+    ClassDefinition classDefinition,
+  ) {
+    var indexes = classDefinition.indexes;
+    if (indexes.isEmpty) return;
+
+    var indexesContainingField = indexes
+        .where((index) => index.fields.contains(fieldDefinition.name))
+        .toList();
+
+    fieldDefinition.indexes = indexesContainingField;
   }
 
   static TypeDefinition _resolveProtocolReference(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -372,12 +372,12 @@ class EntityParser {
     return null;
   }
 
-  static List<SerializableEntityIndexDefinition>? _parseIndexes(
+  static List<SerializableEntityIndexDefinition> _parseIndexes(
     YamlMap documentContents,
     List<SerializableEntityFieldDefinition> fields,
   ) {
     var indexesNode = documentContents.nodes[Keyword.indexes];
-    if (indexesNode is! YamlMap) return null;
+    if (indexesNode is! YamlMap) return [];
 
     var indexes = indexesNode.nodes.entries.map((node) {
       var keyScalar = node.key;

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/entity_relations.dart
@@ -58,7 +58,6 @@ class EntityRelations {
     for (var entity in entities) {
       if (entity is ClassDefinition) {
         var indexes = entity.indexes;
-        if (indexes == null) continue;
 
         for (var index in indexes) {
           indexNames.update(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/validation/restrictions.dart
@@ -554,8 +554,7 @@ class Restrictions {
   ) {
     if (field == null) return false;
 
-    var fieldIndexesWithUnique =
-        field.indexes.where((index) => index.unique).toList();
+    var fieldIndexesWithUnique = field.indexes.where((index) => index.unique);
 
     return fieldIndexesWithUnique.any((index) => index.fields.length == 1);
   }

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -45,8 +45,7 @@ DatabaseDefinition createDatabaseDefinitionFromEntities(
               isUnique: true,
               isPrimary: true,
             ),
-            for (var index in classDefinition.indexes ??
-                <SerializableEntityIndexDefinition>[])
+            for (var index in classDefinition.indexes)
               IndexDefinition(
                 indexName: index.name,
                 elements: [

--- a/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
@@ -17,7 +17,7 @@ class ClassDefinitionBuilder {
   bool _isException;
   String? _tableName;
   List<_FieldBuilder> _fields;
-  List<SerializableEntityIndexDefinition>? _indexes;
+  List<SerializableEntityIndexDefinition> _indexes;
   List<String>? _documentation;
 
   ClassDefinitionBuilder()
@@ -27,7 +27,8 @@ class ClassDefinitionBuilder {
         _fields = [],
         _subDirParts = [],
         _serverOnly = false,
-        _isException = false;
+        _isException = false,
+        _indexes = [];
 
   ClassDefinition build() {
     if (_tableName != null) {
@@ -237,7 +238,7 @@ class ClassDefinitionBuilder {
   }
 
   ClassDefinitionBuilder withIndexes(
-    List<SerializableEntityIndexDefinition>? indexes,
+    List<SerializableEntityIndexDefinition> indexes,
   ) {
     _indexes = indexes;
     return this;

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/indexes_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/indexes_properties_test.dart
@@ -339,8 +339,8 @@ void main() {
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
-      var index = definition.indexes?.first;
-      expect(index!.name, 'example_index');
+      var index = definition.indexes.first;
+      expect(index.name, 'example_index');
     },
   );
 
@@ -366,8 +366,8 @@ void main() {
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
-      var index = definition.indexes?.first;
-      var field = index?.fields.first;
+      var index = definition.indexes.first;
+      var field = index.fields.first;
 
       expect(field, 'name');
     },
@@ -396,9 +396,9 @@ void main() {
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
-      var index = definition.indexes?.first;
-      var field1 = index?.fields.first;
-      var field2 = index?.fields.last;
+      var index = definition.indexes.first;
+      var field1 = index.fields.first;
+      var field2 = index.fields.last;
 
       expect(field1, 'name');
       expect(field2, 'foo');
@@ -430,11 +430,11 @@ void main() {
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
-      var index1 = definition.indexes?.first;
-      var index2 = definition.indexes?.last;
+      var index1 = definition.indexes.first;
+      var index2 = definition.indexes.last;
 
-      expect(index1!.name, 'example_index');
-      expect(index2!.name, 'example_index2');
+      expect(index1.name, 'example_index');
+      expect(index2.name, 'example_index2');
     },
   );
 
@@ -492,8 +492,8 @@ void main() {
     var definitions = analyzer.validateAll();
     var definition = definitions.first as ClassDefinition;
 
-    var index = definition.indexes?.first;
-    expect(index!.unique, false);
+    var index = definition.indexes.first;
+    expect(index.unique, false);
   });
 
   test(
@@ -519,8 +519,8 @@ void main() {
     var definitions = analyzer.validateAll();
     var definition = definitions.first as ClassDefinition;
 
-    var index = definition.indexes?.first;
-    expect(index!.unique, false);
+    var index = definition.indexes.first;
+    expect(index.unique, false);
   });
 
   test(
@@ -546,8 +546,8 @@ void main() {
     var definitions = analyzer.validateAll();
     var definition = definitions.first as ClassDefinition;
 
-    var index = definition.indexes?.first;
-    expect(index!.unique, true);
+    var index = definition.indexes.first;
+    expect(index.unique, true);
   });
 
   test(
@@ -670,9 +670,9 @@ void main() {
 
         var definition = definitions.first as ClassDefinition;
 
-        var index = definition.indexes?.first;
+        var index = definition.indexes.first;
 
-        expect(index?.type, indexType);
+        expect(index.type, indexType);
       });
     }
 
@@ -699,9 +699,9 @@ void main() {
 
       var definition = definitions.first as ClassDefinition;
 
-      var index = definition.indexes?.first;
+      var index = definition.indexes.first;
 
-      expect(index?.type, 'btree');
+      expect(index.type, 'btree');
     });
 
     test(

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/indexes_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/indexes_properties_test.dart
@@ -344,8 +344,8 @@ void main() {
     },
   );
 
-  test(
-    'Given a class with an index with a defined field, then the definition contains the fields of the index.',
+  group(
+    'Given a class with an index with a defined field',
     () {
       var protocols = [
         ProtocolSourceBuilder().withYaml(
@@ -364,17 +364,31 @@ void main() {
       var collector = CodeGenerationCollector();
       var analyzer = StatefulAnalyzer(protocols, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
-      var definition = definitions.first as ClassDefinition;
 
-      var index = definition.indexes.first;
-      var field = index.fields.first;
+      var errors = collector.errors;
+      test('then no errors are collected.', () {
+        expect(errors, isEmpty);
+      });
 
-      expect(field, 'name');
+      var definition = definitions.firstOrNull as ClassDefinition?;
+      test('then the index definition contains the fields of the index.', () {
+        var index = definition?.indexes.first;
+        var field = index?.fields.first;
+        expect(field, 'name');
+      }, skip: errors.isNotEmpty);
+
+      test('then the field definition contains index.', () {
+        var field =
+            definition?.fields.firstWhere((field) => field.name == 'name');
+        var index = field?.indexes.firstOrNull;
+
+        expect(index?.name, 'example_index');
+      }, skip: errors.isNotEmpty);
     },
   );
 
-  test(
-    'Given a class with an index with two defined fields, then the definition contains the fields of the index.',
+  group(
+    'Given a class with an index with two defined fields',
     () {
       var protocols = [
         ProtocolSourceBuilder().withYaml(
@@ -394,14 +408,42 @@ void main() {
       var collector = CodeGenerationCollector();
       var analyzer = StatefulAnalyzer(protocols, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
-      var definition = definitions.first as ClassDefinition;
 
-      var index = definition.indexes.first;
-      var field1 = index.fields.first;
-      var field2 = index.fields.last;
+      var errors = collector.errors;
+      test('then no errors are collected.', () {
+        expect(errors, isEmpty);
+      });
 
-      expect(field1, 'name');
-      expect(field2, 'foo');
+      var definition = definitions.firstOrNull as ClassDefinition?;
+      test('then index definition contains the first field.', () {
+        var index = definition?.indexes.first;
+        var indexFields = index?.fields;
+
+        expect(indexFields, contains('name'));
+      });
+
+      test('then index definition contains the second field.', () {
+        var index = definition?.indexes.first;
+        var indexFields = index?.fields;
+
+        expect(indexFields, contains('foo'));
+      });
+
+      test('then first field definition contains index.', () {
+        var field =
+            definition?.fields.firstWhere((field) => field.name == 'name');
+        var index = field?.indexes.firstOrNull;
+
+        expect(index?.name, 'example_index');
+      });
+
+      test('then second field definition contains index.', () {
+        var field =
+            definition?.fields.firstWhere((field) => field.name == 'foo');
+        var index = field?.indexes.firstOrNull;
+
+        expect(index?.name, 'example_index');
+      });
     },
   );
 

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_database_action_test.dart
@@ -200,6 +200,10 @@ table: user
 fields:
   addressId: int
   address: Address?, relation(name=user_address, field=addressId)
+indexes:
+  address_index_idx:
+    fields: addressId
+    unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('address').withYaml(
@@ -260,6 +264,10 @@ table: user
 fields:
   addressId: int
   address: Address?, relation(name=user_address, field=addressId)
+indexes:
+  address_index_idx:
+    fields: addressId
+    unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('address').withYaml(

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_manual_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_manual_field_test.dart
@@ -16,6 +16,10 @@ void main() {
         fields:
           myParentId: int
           parent: ExampleParent?, relation(field=myParentId)
+        indexes:
+          my_parent_index_idx:
+            fields: myParentId
+            unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('example_parent').withYaml(
@@ -298,6 +302,11 @@ fields:
         fields:
           parentId: int?
           parent: ExampleParent?, relation(name=example_parent, field=parentId)
+        indexes:
+          parent_index_idx:
+            fields: parentId
+            unique: true
+        
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('example_parent').withYaml(

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_manual_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_manual_field_test.dart
@@ -446,7 +446,7 @@ fields:
         () {
       expect(
         errors.first.message,
-        'The field referenced does not have a unique index which is required to be used in a one-to-one relation.',
+        'The field "addressId" does not have a unique index which is required to be used in a one-to-one relation.',
       );
     }, skip: errors.isEmpty);
   });
@@ -492,7 +492,7 @@ fields:
         () {
       expect(
         errors.first.message,
-        'The field referenced does not have a unique index which is required to be used in a one-to-one relation.',
+        'The field "addressId" does not have a unique index which is required to be used in a one-to-one relation.',
       );
     }, skip: errors.isEmpty);
   });
@@ -540,7 +540,7 @@ fields:
         () {
       expect(
         errors.first.message,
-        'The field referenced does not have a unique index which is required to be used in a one-to-one relation.',
+        'The field "addressId" does not have a unique index which is required to be used in a one-to-one relation.',
       );
     }, skip: errors.isEmpty);
   });

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_one_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_one_test.dart
@@ -258,56 +258,6 @@ void main() {
   });
 
   test(
-      'Given a class with a one to one relation where the relationship is ambiguous where the field names are the same in both models then an error is collected that the reference cannot be resolved.',
-      () {
-    var protocols = [
-      ProtocolSourceBuilder().withFileName('company').withYaml(
-        '''
-        class: Company
-        table: company
-        fields:
-          addressCompany: int
-          address: Address?, relation(name=company_address, field=addressCompany)
-          oldAddressId: int
-          oldAddress: Address?, relation(name=company_address, field=oldAddressId)
-        indexes:
-          address_index_idx:
-            fields: addressCompany
-            unique: true
-          old_address_index_idx:
-            fields: oldAddressId
-            unique: true
-        ''',
-      ).build(),
-      ProtocolSourceBuilder().withFileName('address').withYaml(
-        '''
-        class: Address
-        table: address
-        fields:
-          addressCompany: Company?, relation(name=company_address)
-        ''',
-      ).build(),
-    ];
-
-    var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(protocols, onErrorsCollector(collector));
-    analyzer.validateAll();
-
-    expect(
-      collector.errors,
-      isNotEmpty,
-      reason: 'Expected an error but none was found.',
-    );
-
-    var error = collector.errors.first;
-
-    expect(
-      error.message,
-      'Unable to resolve ambiguous relation, there are several named relations with name "company_address" on the class "Company".',
-    );
-  });
-
-  test(
       'Given a class with a one to one relation where the id column is manually defined on both sides of the relation, then give an error that the field only can be defined on one side.',
       () {
     var protocols = [

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_one_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_one_to_one_test.dart
@@ -16,6 +16,10 @@ void main() {
         fields:
           addressId: int
           address: Address?, relation(name=user_address, field=addressId)
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('address').withYaml(
@@ -216,6 +220,13 @@ void main() {
           address: Address?, relation(name=company_address, field=addressId)
           oldAddressId: int
           oldAddress: Address?, relation(name=company_address, field=oldAddressId)
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
+          old_address_index_idx:
+            fields: oldAddressId
+            unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('address').withYaml(
@@ -259,6 +270,13 @@ void main() {
           address: Address?, relation(name=company_address, field=addressCompany)
           oldAddressId: int
           oldAddress: Address?, relation(name=company_address, field=oldAddressId)
+        indexes:
+          address_index_idx:
+            fields: addressCompany
+            unique: true
+          old_address_index_idx:
+            fields: oldAddressId
+            unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('address').withYaml(
@@ -300,6 +318,10 @@ void main() {
         fields:
           addressId: int
           address: Address?, relation(name=company_address, field=addressId)
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('address').withYaml(
@@ -309,6 +331,10 @@ void main() {
         fields:
           addressCompanyId: int
           addressCompany: Company?, relation(name=company_address, field=addressCompanyId)
+        indexes:
+          address_company_index_idx:
+            fields: addressCompanyId
+            unique: true
         ''',
       ).build(),
     ];
@@ -343,7 +369,12 @@ void main() {
         class: User
         table: user
         fields:
-          address: Address?, relation(name=user_address)
+          addressId: int
+          address: Address?, relation(name=user_address, field=addressId)
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
         ''',
       ).build(),
       ProtocolSourceBuilder().withFileName('address').withYaml(

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_self_one_to_one_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/relation_self_one_to_one_test.dart
@@ -18,6 +18,10 @@ void main() {
           previous: Post?, relation(name=next_previous_post)
           nextId: int?
           next: Post?, relation(name=next_previous_post, field=nextId)
+        indexes:
+          next_index_idx:
+            fields: nextId
+            unique: true
         ''',
       ).build(),
     ];
@@ -26,16 +30,16 @@ void main() {
     var analyzer = StatefulAnalyzer(protocols, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
-    var postDefinition = definitions.first as ClassDefinition;
-
     var errors = collector.errors;
 
     test('then no errors are collected.', () {
       expect(errors, isEmpty);
     });
 
+    var postDefinition = definitions.firstOrNull as ClassDefinition?;
+
     group('then the successor field relation', () {
-      var field = postDefinition.findField('next');
+      var field = postDefinition?.findField('next');
       var relation = field?.relation;
 
       test('name is null.', () {
@@ -69,10 +73,10 @@ void main() {
 
         expect(relation.foreignFieldName, 'id');
       });
-    });
+    }, skip: errors.isNotEmpty);
 
     group('then the predecessor field relation', () {
-      var field = postDefinition.findField('previous');
+      var field = postDefinition?.findField('previous');
       var relation = field?.relation;
 
       test('name is defined', () {
@@ -97,7 +101,7 @@ void main() {
         relation as ObjectRelationDefinition;
 
         expect(relation.fieldName, 'id');
-      });
+      }, skip: definitions.isEmpty);
 
       test(
           'has the foreign key field set to manually defined foreign key on the other side.',
@@ -106,10 +110,10 @@ void main() {
 
         expect(relation.foreignFieldName, 'nextId');
       });
-    });
+    }, skip: errors.isNotEmpty);
 
     group('then the successorId field relation', () {
-      var field = postDefinition.findField('nextId');
+      var field = postDefinition?.findField('nextId');
       var relation = field?.relation;
 
       test('name is defined', () {
@@ -135,7 +139,7 @@ void main() {
 
         expect(relation.foreignFieldName, 'id');
       });
-    });
+    }, skip: errors.isNotEmpty);
   });
 
   group(
@@ -151,6 +155,10 @@ void main() {
           successorId: int?
           successor: User?, relation(name=user_predecessor, field=successorId)
           predecessor: User?, relation(name=user_predecessor)
+        indexes:
+          successor_index_idx:
+            fields: successorId
+            unique: true
         ''',
       ).build(),
     ];
@@ -159,16 +167,16 @@ void main() {
     var analyzer = StatefulAnalyzer(protocols, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
-    var userDefinition = definitions.first as ClassDefinition;
-
     var errors = collector.errors;
 
     test('then no errors are collected.', () {
       expect(errors, isEmpty);
     });
 
+    var userDefinition = definitions.firstOrNull as ClassDefinition?;
+
     group('then the successor field relation', () {
-      var field = userDefinition.findField('successor');
+      var field = userDefinition?.findField('successor');
       var relation = field?.relation;
 
       test('name is null', () {
@@ -202,10 +210,10 @@ void main() {
 
         expect(relation.foreignFieldName, 'id');
       });
-    });
+    }, skip: errors.isNotEmpty);
 
     group('then the predecessor field relation', () {
-      var field = userDefinition.findField('predecessor');
+      var field = userDefinition?.findField('predecessor');
       var relation = field?.relation;
 
       test('name is defined', () {
@@ -239,10 +247,10 @@ void main() {
 
         expect(relation.foreignFieldName, 'successorId');
       });
-    });
+    }, skip: errors.isNotEmpty);
 
     group('then the successorId field relation', () {
-      var field = userDefinition.findField('successorId');
+      var field = userDefinition?.findField('successorId');
       var relation = field?.relation;
 
       test('name is defined', () {
@@ -268,7 +276,7 @@ void main() {
 
         expect(relation.foreignFieldName, 'id');
       });
-    });
+    }, skip: errors.isNotEmpty);
   });
 
   group(


### PR DESCRIPTION
### Changes:
- Adds a requirement to declare a unique index when defining one to one object relations. This is needed to ensure that it actually is a one-to-one relation once the ORM methods are generated.

- Closes: #1619 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes