### PR TITLE
fix: Use typed callback for order by in include list.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -227,18 +227,18 @@ abstract class Channel extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ChannelTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChannelTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ChannelTable>? orderByList,
     ChannelInclude? include,
   }) {
     return ChannelIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Channel.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Channel.t),
       include: include,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -241,18 +241,18 @@ abstract class EmailAuth extends _i1.TableRow {
     _i1.WhereExpressionBuilder<EmailAuthTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailAuthTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     EmailAuthInclude? include,
   }) {
     return EmailAuthIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(EmailAuth.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(EmailAuth.t),
       include: include,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -256,18 +256,18 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow {
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     EmailCreateAccountRequestInclude? include,
   }) {
     return EmailCreateAccountRequestIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(EmailCreateAccountRequest.t),
       include: include,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -243,18 +243,18 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     EmailFailedSignInInclude? include,
   }) {
     return EmailFailedSignInIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(EmailFailedSignIn.t),
       include: include,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -242,18 +242,18 @@ abstract class EmailReset extends _i1.TableRow {
     _i1.WhereExpressionBuilder<EmailResetTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EmailResetTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     EmailResetInclude? include,
   }) {
     return EmailResetIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(EmailReset.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(EmailReset.t),
       include: include,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -228,18 +228,18 @@ abstract class GoogleRefreshToken extends _i1.TableRow {
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     GoogleRefreshTokenInclude? include,
   }) {
     return GoogleRefreshTokenIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(GoogleRefreshToken.t),
       include: include,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -241,18 +241,18 @@ abstract class UserImage extends _i1.TableRow {
     _i1.WhereExpressionBuilder<UserImageTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UserImageTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<UserImageTable>? orderByList,
     UserImageInclude? include,
   }) {
     return UserImageIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(UserImage.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(UserImage.t),
       include: include,
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -317,18 +317,18 @@ abstract class UserInfo extends _i1.TableRow {
     _i1.WhereExpressionBuilder<UserInfoTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UserInfoTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     UserInfoInclude? include,
   }) {
     return UserInfoIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(UserInfo.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(UserInfo.t),
       include: include,
     );
   }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -316,18 +316,18 @@ abstract class ChatMessage extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ChatMessageTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChatMessageTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     ChatMessageInclude? include,
   }) {
     return ChatMessageIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ChatMessage.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ChatMessage.t),
       include: include,
     );
   }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -242,18 +242,18 @@ abstract class ChatReadMessage extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     ChatReadMessageInclude? include,
   }) {
     return ChatReadMessageIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ChatReadMessage.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ChatReadMessage.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -265,18 +265,18 @@ abstract class AuthKey extends _i1.TableRow {
     _i1.WhereExpressionBuilder<AuthKeyTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<AuthKeyTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     AuthKeyInclude? include,
   }) {
     return AuthKeyIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(AuthKey.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(AuthKey.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -284,18 +284,18 @@ abstract class CloudStorageEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     CloudStorageEntryInclude? include,
   }) {
     return CloudStorageEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(CloudStorageEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(CloudStorageEntry.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -256,18 +256,18 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     CloudStorageDirectUploadEntryInclude? include,
   }) {
     return CloudStorageDirectUploadEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -242,18 +242,18 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow {
     _i1.WhereExpressionBuilder<DatabaseMigrationVersionTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     DatabaseMigrationVersionInclude? include,
   }) {
     return DatabaseMigrationVersionIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(DatabaseMigrationVersion.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -269,18 +269,18 @@ abstract class FutureCallEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     FutureCallEntryInclude? include,
   }) {
     return FutureCallEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(FutureCallEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(FutureCallEntry.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -340,18 +340,18 @@ abstract class LogEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<LogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<LogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     LogEntryInclude? include,
   }) {
     return LogEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(LogEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(LogEntry.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -340,18 +340,18 @@ abstract class MessageLogEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     MessageLogEntryInclude? include,
   }) {
     return MessageLogEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(MessageLogEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(MessageLogEntry.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -228,18 +228,18 @@ abstract class MethodInfo extends _i1.TableRow {
     _i1.WhereExpressionBuilder<MethodInfoTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MethodInfoTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     MethodInfoInclude? include,
   }) {
     return MethodInfoIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(MethodInfo.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(MethodInfo.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -340,18 +340,18 @@ abstract class QueryLogEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     QueryLogEntryInclude? include,
   }) {
     return QueryLogEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(QueryLogEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(QueryLogEntry.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -215,18 +215,18 @@ abstract class ReadWriteTestEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     ReadWriteTestEntryInclude? include,
   }) {
     return ReadWriteTestEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ReadWriteTestEntry.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -258,18 +258,18 @@ abstract class RuntimeSettings extends _i1.TableRow {
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     RuntimeSettingsInclude? include,
   }) {
     return RuntimeSettingsIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(RuntimeSettings.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(RuntimeSettings.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -286,18 +286,18 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     ServerHealthConnectionInfoInclude? include,
   }) {
     return ServerHealthConnectionInfoIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -286,18 +286,18 @@ abstract class ServerHealthMetric extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     ServerHealthMetricInclude? include,
   }) {
     return ServerHealthMetricIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ServerHealthMetric.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ServerHealthMetric.t),
       include: include,
     );
   }

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -385,18 +385,18 @@ abstract class SessionLogEntry extends _i1.TableRow {
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     SessionLogEntryInclude? include,
   }) {
     return SessionLogEntryIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(SessionLogEntry.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(SessionLogEntry.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/city.dart
@@ -244,18 +244,18 @@ abstract class City extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CityTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CityTable>? orderByList,
     CityInclude? include,
   }) {
     return CityIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(City.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(City.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/organization.dart
@@ -257,18 +257,18 @@ abstract class Organization extends _i1.TableRow {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<OrganizationTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     OrganizationInclude? include,
   }) {
     return OrganizationIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Organization.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Organization.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_list_relations/person.dart
@@ -249,18 +249,18 @@ abstract class Person extends _i1.TableRow {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PersonTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<PersonTable>? orderByList,
     PersonInclude? include,
   }) {
     return PersonIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Person.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Person.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/course.dart
@@ -229,18 +229,18 @@ abstract class Course extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CourseTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CourseTable>? orderByList,
     CourseInclude? include,
   }) {
     return CourseIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Course.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Course.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/enrollment.dart
@@ -258,18 +258,18 @@ abstract class Enrollment extends _i1.TableRow {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<EnrollmentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     EnrollmentInclude? include,
   }) {
     return EnrollmentIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Enrollment.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Enrollment.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/many_to_many/student.dart
@@ -229,18 +229,18 @@ abstract class Student extends _i1.TableRow {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<StudentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<StudentTable>? orderByList,
     StudentInclude? include,
   }) {
     return StudentIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Student.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Student.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/arena.dart
@@ -229,18 +229,18 @@ abstract class Arena extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ArenaTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ArenaTable>? orderByList,
     ArenaInclude? include,
   }) {
     return ArenaIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Arena.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Arena.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/player.dart
@@ -242,18 +242,18 @@ abstract class Player extends _i1.TableRow {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PlayerTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<PlayerTable>? orderByList,
     PlayerInclude? include,
   }) {
     return PlayerIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Player.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Player.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/nested_one_to_many/team.dart
@@ -257,18 +257,18 @@ abstract class Team extends _i1.TableRow {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TeamTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<TeamTable>? orderByList,
     TeamInclude? include,
   }) {
     return TeamIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Team.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Team.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/comment.dart
@@ -243,18 +243,18 @@ abstract class Comment extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CommentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CommentTable>? orderByList,
     CommentInclude? include,
   }) {
     return CommentIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Comment.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Comment.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/customer.dart
@@ -229,18 +229,18 @@ abstract class Customer extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CustomerTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CustomerTable>? orderByList,
     CustomerInclude? include,
   }) {
     return CustomerIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Customer.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Customer.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_many/order.dart
@@ -258,18 +258,18 @@ abstract class Order extends _i1.TableRow {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<OrderTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<OrderTable>? orderByList,
     OrderInclude? include,
   }) {
     return OrderIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Order.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Order.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/address.dart
@@ -243,18 +243,18 @@ abstract class Address extends _i1.TableRow {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<AddressTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<AddressTable>? orderByList,
     AddressInclude? include,
   }) {
     return AddressIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Address.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Address.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/citizen.dart
@@ -281,18 +281,18 @@ abstract class Citizen extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CitizenTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CitizenTable>? orderByList,
     CitizenInclude? include,
   }) {
     return CitizenIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Citizen.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Citizen.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/company.dart
@@ -242,18 +242,18 @@ abstract class Company extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CompanyTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CompanyTable>? orderByList,
     CompanyInclude? include,
   }) {
     return CompanyIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Company.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Company.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/one_to_one/town.dart
@@ -242,18 +242,18 @@ abstract class Town extends _i1.TableRow {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TownTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<TownTable>? orderByList,
     TownInclude? include,
   }) {
     return TownIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Town.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Town.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/blocking.dart
@@ -258,18 +258,18 @@ abstract class Blocking extends _i1.TableRow {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<BlockingTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<BlockingTable>? orderByList,
     BlockingInclude? include,
   }) {
     return BlockingIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Blocking.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Blocking.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/many_to_many/member.dart
@@ -244,18 +244,18 @@ abstract class Member extends _i1.TableRow {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<MemberTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<MemberTable>? orderByList,
     MemberInclude? include,
   }) {
     return MemberIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Member.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Member.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_many/cat.dart
@@ -257,18 +257,18 @@ abstract class Cat extends _i1.TableRow {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<CatTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<CatTable>? orderByList,
     CatInclude? include,
   }) {
     return CatIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Cat.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Cat.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/entities_with_relations/self_relation/one_to_one/post.dart
@@ -258,18 +258,18 @@ abstract class Post extends _i1.TableRow {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<PostTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<PostTable>? orderByList,
     PostInclude? include,
   }) {
     return PostIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Post.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Post.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -232,18 +232,18 @@ abstract class ObjectFieldScopes extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     ObjectFieldScopesInclude? include,
   }) {
     return ObjectFieldScopesIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectFieldScopes.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -213,18 +213,18 @@ abstract class ObjectWithByteData extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     ObjectWithByteDataInclude? include,
   }) {
     return ObjectWithByteDataIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithByteData.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithByteData.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -212,18 +212,18 @@ abstract class ObjectWithDuration extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     ObjectWithDurationInclude? include,
   }) {
     return ObjectWithDurationIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithDuration.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithDuration.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -265,18 +265,18 @@ abstract class ObjectWithEnum extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     ObjectWithEnumInclude? include,
   }) {
     return ObjectWithEnumIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithEnum.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithEnum.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -225,18 +225,18 @@ abstract class ObjectWithIndex extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     ObjectWithIndexInclude? include,
   }) {
     return ObjectWithIndexIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithIndex.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithIndex.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -280,18 +280,18 @@ abstract class ObjectWithObject extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     ObjectWithObjectInclude? include,
   }) {
     return ObjectWithObjectIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithObject.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithObject.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -211,18 +211,18 @@ abstract class ObjectWithParent extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     ObjectWithParentInclude? include,
   }) {
     return ObjectWithParentIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithParent.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithParent.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -211,18 +211,18 @@ abstract class ObjectWithSelfParent extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     ObjectWithSelfParentInclude? include,
   }) {
     return ObjectWithSelfParentIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithSelfParent.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -225,18 +225,18 @@ abstract class ObjectWithUuid extends _i1.TableRow {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     ObjectWithUuidInclude? include,
   }) {
     return ObjectWithUuidIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(ObjectWithUuid.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(ObjectWithUuid.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -243,18 +243,18 @@ abstract class RelatedUniqueData extends _i1.TableRow {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     RelatedUniqueDataInclude? include,
   }) {
     return RelatedUniqueDataIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(RelatedUniqueData.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(RelatedUniqueData.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -215,18 +215,18 @@ abstract class SimpleData extends _i1.TableRow {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SimpleDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     SimpleDataInclude? include,
   }) {
     return SimpleDataIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(SimpleData.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(SimpleData.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -214,18 +214,18 @@ abstract class SimpleDateTime extends _i1.TableRow {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     SimpleDateTimeInclude? include,
   }) {
     return SimpleDateTimeIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(SimpleDateTime.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(SimpleDateTime.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -331,18 +331,18 @@ abstract class Types extends _i1.TableRow {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<TypesTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<TypesTable>? orderByList,
     TypesInclude? include,
   }) {
     return TypesIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(Types.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(Types.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -225,18 +225,18 @@ abstract class UniqueData extends _i1.TableRow {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? limit,
     int? offset,
-    _i1.Column? orderBy,
+    _i1.OrderByBuilder<UniqueDataTable>? orderBy,
     bool orderDescending = false,
-    List<_i1.Order>? orderByList,
+    _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     UniqueDataInclude? include,
   }) {
     return UniqueDataIncludeList._(
       where: where,
       limit: limit,
       offset: offset,
-      orderBy: orderBy,
+      orderBy: orderBy?.call(UniqueData.t),
       orderDescending: orderDescending,
-      orderByList: orderByList,
+      orderByList: orderByList?.call(UniqueData.t),
       include: include,
     );
   }

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
@@ -304,7 +304,7 @@ void main() async {
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(
-          orderBy: Person.t.id,
+          orderBy: (t) => t.id,
           include: Person.include(
             organization: Organization.include(),
           ),
@@ -374,7 +374,7 @@ void main() async {
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(
-          orderBy: Person.t.id,
+          orderBy: (t) => t.id,
           include: Person.include(
             organization: Organization.include(
               people: Person.includeList(),
@@ -476,7 +476,7 @@ void main() async {
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(
-          orderBy: Person.t.name,
+          orderBy: (t) => t.name,
           limit: 10,
         ),
       ),
@@ -511,7 +511,7 @@ void main() async {
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(
-          orderBy: Person.t.name,
+          orderBy: (t) => t.name,
           orderDescending: true,
         ),
       ),
@@ -546,16 +546,15 @@ void main() async {
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(
-          orderByList: [
-            pod.Order(
-              column: Person.t.name,
-            ),
-            pod.Order(
-              column: Person.t.id,
-              orderDescending: true,
-            ),
-          ],
-        ),
+            orderByList: (t) => [
+                  pod.Order(
+                    column: t.name,
+                  ),
+                  pod.Order(
+                    column: t.id,
+                    orderDescending: true,
+                  ),
+                ]),
       ),
     );
 
@@ -618,7 +617,7 @@ void main() async {
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(
-          orderBy: Person.t.id,
+          orderBy: (t) => t.id,
           limit: 2,
           offset: 1,
         ),
@@ -675,7 +674,7 @@ void main() async {
       session,
       orderBy: (t) => t.id,
       include: City.include(
-        citizens: Person.includeList(limit: 2, offset: 1, orderBy: Person.t.id),
+        citizens: Person.includeList(limit: 2, offset: 1, orderBy: (t) => t.id),
       ),
     );
 
@@ -736,8 +735,9 @@ void main() async {
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(
-          orderBy:
-              Person.t.organization.people.count((p) => p.name.ilike('A%')),
+          orderBy: (t) => t.organization.people.count(
+            (p) => p.name.ilike('A%'),
+          ),
           orderDescending: true,
           limit: 2,
           include: Person.include(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/entities_library_generator.dart
@@ -591,10 +591,7 @@ class SerializableEntityLibraryGenerator {
             (p) => p
               ..name = 'orderBy'
               ..named = true
-              ..type = refer(
-                'Column?',
-                serverpodUrl(serverCode),
-              ),
+              ..type = typeOrderByBuilder(className, serverCode),
           ),
           Parameter(
             (p) => p
@@ -603,20 +600,12 @@ class SerializableEntityLibraryGenerator {
               ..defaultTo = const Code('false')
               ..type = refer('bool'),
           ),
-          Parameter((p) => p
-            ..name = 'orderByList'
-            ..named = true
-            ..type = TypeReference(
-              (t) => t
-                ..symbol = 'List'
-                ..types.addAll([
-                  refer(
-                    'Order',
-                    serverpodUrl(serverCode),
-                  ),
-                ])
-                ..isNullable = true,
-            )),
+          Parameter(
+            (p) => p
+              ..name = 'orderByList'
+              ..named = true
+              ..type = typeOrderByListBuilder(className, serverCode),
+          ),
           Parameter((p) => p
             ..name = 'include'
             ..named = true
@@ -628,9 +617,13 @@ class SerializableEntityLibraryGenerator {
               'where': refer('where'),
               'limit': refer('limit'),
               'offset': refer('offset'),
-              'orderBy': refer('orderBy'),
+              'orderBy': refer('orderBy').nullSafeProperty('call').call(
+                [refer(className).property('t')],
+              ),
               'orderDescending': refer('orderDescending'),
-              'orderByList': refer('orderByList'),
+              'orderByList': refer('orderByList').nullSafeProperty('call').call(
+                [refer(className).property('t')],
+              ),
               'include': refer('include'),
             })
             .returned


### PR DESCRIPTION
### Change
- Add typed order by callback for include list method.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - new functionality so no problem.
