### PR TITLE
fix: Allow .spy file extensions on protocols.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -10,7 +10,6 @@ import 'package:serverpod_cli/src/util/protocol_helper.dart';
 import 'package:source_span/source_span.dart';
 // ignore: implementation_imports
 import 'package:yaml/src/error_listener.dart';
-import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 import 'package:serverpod_cli/src/util/yaml_docs.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
@@ -18,11 +17,13 @@ import 'package:serverpod_cli/src/analyzer/entities/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/entities/entity_parser/entity_parser.dart';
 import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
 
-String _transformFileNameWithoutPathOrExtension(String path) {
+String _transformFileNameWithoutPathOrExtension(Uri path) {
+  var fileName = path.pathSegments.last;
+
   for (var ext in protocolFileExtensions) {
-    path = p.split(path).last.replaceAll(ext, '');
+    fileName = fileName.replaceAll(ext, '');
   }
-  return path;
+  return fileName;
 }
 
 /// Used to analyze a singe yaml protocol file.
@@ -38,7 +39,7 @@ class SerializableEntityAnalyzer {
     ProtocolSource protocolSource,
   ) {
     var outFileName = _transformFileNameWithoutPathOrExtension(
-      protocolSource.yamlSourceUri.path,
+      protocolSource.yamlSourceUri,
     );
     var yamlErrorCollector = ErrorCollector();
     YamlMap? documentContents = _loadYamlMap(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_analyzer.dart
@@ -19,7 +19,10 @@ import 'package:serverpod_cli/src/analyzer/entities/entity_parser/entity_parser.
 import 'package:serverpod_cli/src/analyzer/entities/validation/restrictions.dart';
 
 String _transformFileNameWithoutPathOrExtension(String path) {
-  return p.basenameWithoutExtension(path);
+  for (var ext in protocolFileExtensions) {
+    path = p.split(path).last.replaceAll(ext, '');
+  }
+  return path;
 }
 
 /// Used to analyze a singe yaml protocol file.

--- a/tools/serverpod_cli/lib/src/util/protocol_helper.dart
+++ b/tools/serverpod_cli/lib/src/util/protocol_helper.dart
@@ -11,6 +11,14 @@ class ProtocolSource {
   ProtocolSource(this.yaml, this.yamlSourceUri, this.protocolRootPathParts);
 }
 
+const protocolFileExtensions = [
+  '.yaml',
+  '.yml',
+  '.spy',
+  '.spy.yaml',
+  '.spy.yml',
+];
+
 class ProtocolHelper {
   static Future<List<ProtocolSource>> loadProjectYamlProtocolsFromDisk(
     GeneratorConfig config,
@@ -22,9 +30,8 @@ class ProtocolHelper {
     // are in the same order. Move this logic to the code generator instead.
     sourceFileList.sort((a, b) => a.path.compareTo(b.path));
 
-    var files = sourceFileList
-        .where((entity) => entity is File && entity.path.endsWith('.yaml'))
-        .cast<File>();
+    var files = sourceFileList.whereType<File>().where(
+        (file) => protocolFileExtensions.any((ext) => file.path.endsWith(ext)));
 
     List<ProtocolSource> sources = [];
     for (var entity in files) {


### PR DESCRIPTION
# Changes

Allow `.spy`, `.spy.yaml` and `.spy,yml` file extensions on protocol files. The extensions will be replaced with .dart when code is generated.

