### PR TITLE
fix: Add back repair migration ux.

### DIFF
--- a/packages/serverpod_shared/lib/src/migration_exceptions.dart
+++ b/packages/serverpod_shared/lib/src/migration_exceptions.dart
@@ -45,7 +45,7 @@ class MigrationRepairTargetNotFoundException implements Exception {
   final List<String> versionsFound;
 
   /// The name of the target that was not found.
-  final String targetName;
+  final String? targetName;
 
   /// Creates a new [MigrationRepairTargetNotFoundException].
   MigrationRepairTargetNotFoundException({

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -157,6 +157,8 @@ class MigrationGenerator {
     var migrationVersion =
         targetMigrationVersion ?? _getLatestMigrationVersion();
 
+    _validateRepairMigrationVersion(migrationVersion);
+
     DatabaseDefinition dstDatabase = await _getSourceDatabaseDefinition(
       projectName,
       migrationVersion,
@@ -215,6 +217,20 @@ class MigrationGenerator {
       installedModules,
       removedModules,
     );
+  }
+
+  void _validateRepairMigrationVersion(String? migrationVersion) {
+    var migrationRegistry = MigrationRegistry.load(
+      MigrationConstants.migrationsBaseDirectory(directory),
+    );
+
+    if (migrationVersion == null ||
+        !migrationRegistry.versions.contains(migrationVersion)) {
+      throw MigrationRepairTargetNotFoundException(
+        targetName: migrationVersion,
+        versionsFound: migrationRegistry.versions,
+      );
+    }
   }
 
   List<DatabaseMigrationVersion> _removedModulesDiff(


### PR DESCRIPTION
### Changes
- Adds back a helpful message displayed when the repair migration target can't be found.


We don't have any tests for this area right now, but I have manually validated the output.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
