### PR TITLE
fix: Prevent generate watch from crashing.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -52,25 +52,27 @@ class GenerateCommand extends ServerpodCommand {
 
     var endpointsAnalyzer = EndpointsAnalyzer(config);
 
-    bool success = await log.progress(
-      'Generating code',
-      () => performGenerate(
-        config: config,
-        endpointsAnalyzer: endpointsAnalyzer,
-      ),
-    );
+    bool success = true;
     if (watch) {
       log.info('Initial code generation complete. Listening for changes.');
       success = await performGenerateContinuously(
         config: config,
         endpointsAnalyzer: endpointsAnalyzer,
       );
-    } else if (success) {
-      log.info('Done.', type: TextLogType.success);
+    } else {
+      success = await log.progress(
+        'Generating code',
+        () => performGenerate(
+          config: config,
+          endpointsAnalyzer: endpointsAnalyzer,
+        ),
+      );
     }
 
     if (!success) {
       throw ExitException();
+    } else {
+      log.info('Done.', type: TextLogType.success);
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/generator/generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator.dart
@@ -8,7 +8,6 @@ import 'package:serverpod_cli/src/util/protocol_helper.dart';
 /// Analyze the server package and generate the code.
 Future<bool> performGenerate({
   bool dartFormat = true,
-  String? changedFile,
   required GeneratorConfig config,
   required EndpointsAnalyzer endpointsAnalyzer,
 }) async {


### PR DESCRIPTION
# Changes

- Remove unused param in internal method.
- Prevent crashes of --watch mode in serverpod generate command
- Prints all stack traces incase of an error in --watch mode.

Closes: https://github.com/serverpod/serverpod/issues/1633

Review note: Tested this manually as this will be very hard/annoying to test in an automated way.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.
