### PR TITLE
fix: Typo in reset password example email.

### DIFF
--- a/examples/auth_example/auth_example_server/lib/server.dart
+++ b/examples/auth_example/auth_example_server/lib/server.dart
@@ -85,7 +85,7 @@ void run(List<String> args) async {
         ..from = Address(gmailEmail)
         ..recipients.add(userInfo.email!)
         ..subject = 'Password reset link for Serverpod'
-        ..html = 'Here is your password reset code: $validationCode>';
+        ..html = 'Here is your password reset code: $validationCode';
 
       // Send the email message.
       try {


### PR DESCRIPTION
# Fix

Typo in example auth project.

Closes: https://github.com/serverpod/serverpod/issues/1428


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
