### PR TITLE
fix: Reset error message state when endpoint call was successful in template project.

### DIFF
--- a/templates/serverpod_templates/projectname_flutter/lib/main.dart
+++ b/templates/serverpod_templates/projectname_flutter/lib/main.dart
@@ -53,6 +53,7 @@ class MyHomePageState extends State<MyHomePage> {
     try {
       final result = await client.example.hello(_textEditingController.text);
       setState(() {
+        _errorMessage = null;
         _resultMessage = result;
       });
     } catch (e) {


### PR DESCRIPTION
# Fix

Reset error state if successful call to endpoint was made.

Closes: https://github.com/serverpod/serverpod/issues/1028

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
