### PR TITLE
fix: Close session when protocol exception is thrown.

### DIFF
--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -119,17 +119,11 @@ abstract class EndpointDispatch {
 
       var result = await method.call(session, paramMap);
 
-      // Print session info
-      // var authenticatedUserId = connector.endpoint.requireLogin ? await session.auth.authenticatedUserId : null;
-
-      await session.close();
-
       return ResultSuccess(
         result,
         sendByteDataAsRaw: connector.endpoint.sendByteDataAsRaw,
       );
     } on SerializableException catch (exception) {
-      await session.close();
       return ExceptionResult(entity: exception);
     } on Exception catch (e, stackTrace) {
       var sessionLogId = await session.close(error: e, stackTrace: stackTrace);
@@ -140,6 +134,8 @@ abstract class EndpointDispatch {
       var sessionLogId = await session.close(error: e, stackTrace: stackTrace);
       return ResultInternalServerError(
           e.toString(), stackTrace, sessionLogId ?? 0);
+    } finally {
+      await session.close();
     }
   }
 

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -129,6 +129,7 @@ abstract class EndpointDispatch {
         sendByteDataAsRaw: connector.endpoint.sendByteDataAsRaw,
       );
     } on SerializableException catch (exception) {
+      await session.close();
       return ExceptionResult(entity: exception);
     } on Exception catch (e, stackTrace) {
       var sessionLogId = await session.close(error: e, stackTrace: stackTrace);


### PR DESCRIPTION
# Fix

- Close the session when throwing an exception to the client.
- Log the method call made.

Closes: https://github.com/serverpod/serverpod/issues/974

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
