### PR TITLE
fix: Allow deeply nested Maps and Lists in protocol files.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/converter/converter.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/util/string_manipulation.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
@@ -97,10 +98,7 @@ List<String> _extractStringifiedNodes(String? input) {
   if (input == null) return [];
 
   // Split on comma, but not if the comma is inside < > or ( )
-  return input
-      .split(RegExp(r',(?![^(]*\))(?![^<]*>)'))
-      .map((e) => e.trim())
-      .toList();
+  return splitIgnoringBrackets(input);
 }
 
 Iterable<Map<YamlScalar, YamlNode>> _extractKeyValuePairs(

--- a/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/entities/entity_parser/entity_parser.dart
@@ -171,9 +171,8 @@ class EntityParser {
     if (typeValue is! String) return [];
 
     var fieldDocumentation = docsExtractor.getDocumentation(key.span.start);
-    var typeResult = parseAndAnalyzeType(
-      typeValue.replaceAll(' ', ''),
-      sourceSpan: typeNode.span,
+    var typeResult = parseType(
+      typeValue,
     );
 
     var scope = _parseClassFieldScope(node);
@@ -191,7 +190,7 @@ class EntityParser {
         relation: relation,
         shouldPersist: _shouldNeverPersist(relation) ? false : shouldPersist,
         scope: scope,
-        type: typeResult.type,
+        type: typeResult,
         documentation: fieldDocumentation,
       )
     ];
@@ -206,7 +205,7 @@ class EntityParser {
 
   static RelationDefinition? _parseRelation(
     String fieldName,
-    TypeParseResult typeResult,
+    TypeDefinition typeResult,
     YamlMap node,
   ) {
     if (!_isRelation(node)) return null;
@@ -221,12 +220,12 @@ class EntityParser {
 
     var optionalRelation = _isOptionalRelation(node);
 
-    if (typeResult.type.isListType) {
+    if (typeResult.isListType) {
       return UnresolvedListRelationDefinition(
         name: relationName,
         nullableRelation: optionalRelation,
       );
-    } else if (typeResult.type.isIdType && parentTable != null) {
+    } else if (typeResult.isIdType && parentTable != null) {
       return ForeignRelationDefinition(
         name: relationName,
         parentTable: parentTable,
@@ -234,7 +233,7 @@ class EntityParser {
         onUpdate: onUpdate,
         onDelete: onDelete,
       );
-    } else if (!typeResult.type.isIdType) {
+    } else if (!typeResult.isIdType) {
       return UnresolvedObjectRelationDefinition(
         name: relationName,
         fieldName: relationFieldName,

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -209,11 +209,10 @@ class GeneratorConfig {
       try {
         for (var extraClassConfig in generatorConfig['extraClasses']) {
           extraClasses.add(
-            parseAndAnalyzeType(
+            parseType(
               extraClassConfig,
               analyzingExtraClasses: true,
-              sourceSpan: generatorConfig['extraClasses'].span,
-            ).type,
+            ),
           );
         }
       } on SourceSpanException catch (_) {

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -392,22 +392,24 @@ TypeDefinition parseType(
   String input, {
   bool analyzingExtraClasses = false,
 }) {
-  var start = input.indexOf('<');
-  var end = input.lastIndexOf('>');
+  var trimmedInput = input.trim();
+
+  var start = trimmedInput.indexOf('<');
+  var end = trimmedInput.lastIndexOf('>');
 
   var generics = <TypeDefinition>[];
   if (start != -1 && end != -1) {
-    var internalTypes = input.substring(start + 1, end);
+    var internalTypes = trimmedInput.substring(start + 1, end);
 
     var genericsInputs = splitIgnoringBrackets(internalTypes);
 
     generics = genericsInputs.map((generic) => parseType(generic)).toList();
   }
 
-  bool isNullable = input[input.length - 1] == '?';
-  int terminatedAt = _findLastClassToken(start, input, isNullable);
+  bool isNullable = trimmedInput[trimmedInput.length - 1] == '?';
+  int terminatedAt = _findLastClassToken(start, trimmedInput, isNullable);
 
-  String className = input.substring(0, terminatedAt);
+  String className = trimmedInput.substring(0, terminatedAt).trim();
 
   return TypeDefinition.mixedUrlAndClassName(
     mixed: className,

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -380,12 +380,7 @@ class TypeDefinition {
   }
 }
 
-/// Analyze the type at the start of [input].
-/// [input] must not contain spaces.
-/// Returns a [_TypeResult] containing the type,
-/// as well as the position of the last parsed character.
-/// So when calling with "List<List<String?>?>,database",
-/// the position will point at the ','.
+/// Parses a type from a string and deals with whitespace and generics.
 /// If [analyzingExtraClasses] is true, the root element might be marked as
 /// [TypeDefinition.customClass].
 TypeDefinition parseType(

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -423,15 +423,3 @@ int _findLastClassToken(int start, String input, bool isNullable) {
 
   return input.length;
 }
-
-/// The result when running [parseType].
-class TypeParseResult {
-  /// The position of the next unparsed character.
-  final int parsedPosition;
-
-  /// The type that was parsed.
-  final TypeDefinition type;
-
-  /// Create a new [TypeParseResult].
-  const TypeParseResult(this.parsedPosition, this.type);
-}

--- a/tools/serverpod_cli/lib/src/util/string_manipulation.dart
+++ b/tools/serverpod_cli/lib/src/util/string_manipulation.dart
@@ -1,0 +1,30 @@
+import 'package:super_string/super_string.dart';
+
+List<String> splitIgnoringBrackets(
+  String input, {
+  String separator = ',',
+}) {
+  List<String> result = [];
+  StringBuffer current = StringBuffer();
+  int depth = 0;
+
+  for (var char in input.iterable) {
+    if (char == separator && depth == 0) {
+      result.add(current.toString().trim());
+      current.clear();
+    } else {
+      current.write(char);
+      if (char == '<' || char == '(') {
+        depth++;
+      } else if (char == '>' || char == ')') {
+        depth--;
+      }
+    }
+  }
+
+  if (current.isNotEmpty) {
+    result.add(current.toString().trim());
+  }
+
+  return result;
+}

--- a/tools/serverpod_cli/lib/src/util/string_manipulation.dart
+++ b/tools/serverpod_cli/lib/src/util/string_manipulation.dart
@@ -1,5 +1,7 @@
 import 'package:super_string/super_string.dart';
 
+/// Splits a string on the separator token unless the token is inside
+/// brackets or angle brackets, ( ) and < >.
 List<String> splitIgnoringBrackets(
   String input, {
   String separator = ',',

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_datatype_test.dart
@@ -163,6 +163,56 @@ void main() {
     });
 
     test(
+        'Given a class with a field of a Map type with a lot of whitespace, then all the data types components are extracted.',
+        () {
+      var protocols = [
+        ProtocolSourceBuilder().withYaml(
+          '''
+          class: Example
+          fields:
+            customField: Map<  String  , CustomClass  ? > ?   
+          ''',
+        ).build()
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer analyzer = StatefulAnalyzer(
+        protocols,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+      var definition = definitions.first as ClassDefinition;
+
+      expect(
+        definition.fields.first.type.className,
+        'Map',
+        reason: 'Expected the field to be of type Map, but it was not.',
+      );
+
+      expect(definition.fields.first.type.nullable, isTrue,
+          reason: 'Expected the Map to be nullable but it was not.');
+
+      expect(
+        definition.fields.first.type.generics.first.className,
+        'String',
+        reason: 'Expected the first generic type to be String, but it was not.',
+      );
+
+      expect(
+        definition.fields.first.type.generics.last.className,
+        'CustomClass',
+        reason:
+            'Expected the last generic type to be CustomClass, but it was not.',
+      );
+
+      expect(
+        definition.fields.first.type.generics.last.nullable,
+        isTrue,
+        reason: 'Expected the CustomClass to be nullable but it was not.',
+      );
+    });
+
+    test(
       'Given a class with a field of a Map type, then all the data types components are extracted.',
       () {
         var protocols = [
@@ -213,6 +263,8 @@ void main() {
       'invalid-type',
       'Map<String, invalid-type>',
       'List<invalid-type>',
+      'Map<String, List<invalid-type>>',
+      'List<List<invalid-type>>',
     ];
 
     for (var datatype in invalidDatatypes) {

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_datatype_test.dart
@@ -19,6 +19,9 @@ void main() {
       'List<String?>?',
       'List<List<Map<String,int>>>',
       'Map<String,String>',
+      'Map<String,List<int>>',
+      'Map<String,Map<String,int>>',
+      'Map<String,Map<String,List<List<Map<String,int>>>>>',
     ];
 
     for (var datatype in datatypes) {

--- a/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_source_location_test.dart
+++ b/tools/serverpod_cli/test/analyzer/entities/stateful_analyzer/protocol_validation/field_source_location_test.dart
@@ -132,7 +132,7 @@ fields:
   );
 
   test(
-    'Given a class with a field with an empty string entry at the end, then collect an error that locates the empty string in the comma separated string.',
+    'Given a class with a field with an empty string entry at the end, then no errors was generated.',
     () {
       var protocols = [
         ProtocolSourceBuilder().withYaml(
@@ -150,16 +150,8 @@ fields:
 
       expect(
         collector.errors,
-        isNotEmpty,
-        reason: 'Expected an error but none was generated.',
+        isEmpty,
       );
-
-      var error = collector.errors.last;
-      expect(error.span, isNotNull);
-      expect(error.span!.start.line, 3);
-      expect(error.span!.start.column, 24);
-      expect(error.span!.end.line, 3);
-      expect(error.span!.end.column, 24);
     },
   );
 

--- a/tools/serverpod_cli/test/util/string_manipulation_test.dart
+++ b/tools/serverpod_cli/test/util/string_manipulation_test.dart
@@ -1,0 +1,75 @@
+import 'package:serverpod_cli/src/util/string_manipulation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given a string without the separator token then the result is a list with only the string as the first entry.',
+      () {
+    var result = splitIgnoringBrackets('example');
+    expect(result, ['example']);
+  });
+
+  test(
+      'Given a string with one separator token then the result contains both the strings.',
+      () {
+    var result = splitIgnoringBrackets('example,string');
+    expect(result, ['example', 'string']);
+  });
+
+  test(
+      'Given a string that ends with the separator token then the result contains one entry.',
+      () {
+    var result = splitIgnoringBrackets('example,');
+    expect(result, ['example']);
+  });
+
+  test(
+      'Given a string with the separator token within angle brackets then the string is not split.',
+      () {
+    var result = splitIgnoringBrackets('Map<String, String>');
+    expect(result, ['Map<String, String>']);
+  });
+
+  test(
+      'Given a string with the separator token within parenthesis brackets the string is not split.',
+      () {
+    var result = splitIgnoringBrackets('method(String, String)');
+    expect(result, ['method(String, String)']);
+  });
+
+  test(
+      'Given string with the separator token within nested brackets then the string is not split.',
+      () {
+    var result = splitIgnoringBrackets(
+      'method(Map<String, Map<String, List<int>>>, String)',
+    );
+    expect(result, ['method(Map<String, Map<String, List<int>>>, String)']);
+  });
+
+  test(
+      'Given a string with the separator token both in nested brackets and outside then the string is only split on the tokens outside the brackets.',
+      () {
+    var result = splitIgnoringBrackets(
+      'method(Map<String, Map<String, List<int>>>, String), String',
+    );
+
+    expect(result, [
+      'method(Map<String, Map<String, List<int>>>, String)',
+      'String',
+    ]);
+  });
+
+  test(
+      'Given a string with a custom separator token when splitting with that separator token then the string is split.',
+      () {
+    var result = splitIgnoringBrackets(
+      'String; String',
+      separator: ';',
+    );
+
+    expect(result, [
+      'String',
+      'String',
+    ]);
+  });
+}


### PR DESCRIPTION
# Changes

- Refactors parsing of types logic to a cleaner interface.
- Changes the logic to split the strings on , to allow for deeply nested Maps and Lists.
- Allows trailing commas in protocol files.

Discussion point: 

The previous implementation did "validation" of the type string. It only handled a single invalid scenario namely if the programmer forgot the close a bracket with `>`. This validation is removed in the new implementation, we could implement a proper validation, but to get a complete type validation it requires quite a bit of extra information, hence I propse we do that in a future PR. Issue tracked here: https://github.com/serverpod/serverpod/issues/282

Closes: #1104

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
