### PR TITLE
fix: Validate docker volume names when creating new project.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -348,10 +348,20 @@ class Serverpod {
       int? maxAttempts =
           commandLineArgs.role == ServerpodRole.maintenance ? 6 : null;
 
-      var session = await _connectToDatabase(
-        enableLogging: false,
-        maxAttempts: maxAttempts,
-      );
+      Session session;
+
+      try {
+        session = await _connectToDatabase(
+          enableLogging: false,
+          maxAttempts: maxAttempts,
+        );
+      } catch (e) {
+        _exitCode = 1;
+        stderr.writeln(
+          'Failed to connect to the database. $e',
+        );
+        exit(_exitCode);
+      }
 
       try {
         logVerbose('Initializing migration manager.');

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -95,7 +95,7 @@ Future<bool> performCreate(
         'also install and configure Postgres and Redis manually and run this '
         'command with the -f flag added.';
     var strIssueDockerVolume =
-        'A docker volume with the nameg "${SetupConstants.dockerVolumeName(name)}" already exists. '
+        'A docker volume with the name "${SetupConstants.dockerVolumeName(name)}" already exists. '
         'Create a project with a different name or remove the volume before running the create command again.';
 
     log.error(strIssue);

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -5,6 +5,8 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/create/database_setup.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/shared/environment.dart';
+import 'package:serverpod_cli/src/util/constants.dart';
+import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
@@ -71,7 +73,11 @@ Future<bool> performCreate(
       ) &&
       await CommandLineTools.isDockerRunning();
 
-  if ((!portsAvailable || !dockerConfigured) &&
+  var isDockerVolumeAvailable = await CommandLineTools.isDockerVolumeAvailable(
+    name,
+  );
+
+  if ((!portsAvailable || !dockerConfigured || !isDockerVolumeAvailable) &&
       template == ServerpodTemplateType.server &&
       !force) {
     var strIssue =
@@ -89,6 +95,9 @@ Future<bool> performCreate(
         'Docker Desktop from https://www.docker.com/get-started but you can '
         'also install and configure Postgres and Redis manually and run this '
         'command with the -f flag added.';
+    var strIssueDockerVolume =
+        'A docker volume with the name "${SetupConstants.dockerVolumeName(name)}" already exists. '
+        'Create a project with a different name or remove the volume before running the create command again.';
 
     log.error(strIssue);
 
@@ -115,6 +124,14 @@ Future<bool> performCreate(
         newParagraph: true,
       );
     }
+
+    if (!isDockerVolumeAvailable) {
+      log.error(
+        strIssueDockerVolume,
+        newParagraph: true,
+      );
+    }
+
     return false;
   }
 

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -6,7 +6,6 @@ import 'package:serverpod_cli/src/create/database_setup.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/shared/environment.dart';
 import 'package:serverpod_cli/src/util/constants.dart';
-import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
@@ -96,7 +95,7 @@ Future<bool> performCreate(
         'also install and configure Postgres and Redis manually and run this '
         'command with the -f flag added.';
     var strIssueDockerVolume =
-        'A docker volume with the name "${SetupConstants.dockerVolumeName(name)}" already exists. '
+        'A docker volume with the nameg "${SetupConstants.dockerVolumeName(name)}" already exists. '
         'Create a project with a different name or remove the volume before running the create command again.';
 
     log.error(strIssue);

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:serverpod_cli/src/logger/logger.dart';
+import 'package:serverpod_cli/src/util/constants.dart';
 
 class CommandLineTools {
   static Future<bool> dartPubGet(Directory dir) async {
@@ -56,6 +57,18 @@ class CommandLineTools {
       arguments: ['info'],
     );
     return exitCode == 0;
+  }
+
+  static Future<bool> isDockerVolumeAvailable(String projectName) async {
+    var exitCode = await _runProcessWithDefaultLogger(
+      executable: 'docker',
+      arguments: [
+        'volume',
+        'inspect',
+        SetupConstants.dockerVolumeName(projectName),
+      ],
+    );
+    return exitCode != 0;
   }
 
   static Future<bool> startDockerContainer(Directory dir) async {

--- a/tools/serverpod_cli/lib/src/util/constants.dart
+++ b/tools/serverpod_cli/lib/src/util/constants.dart
@@ -1,4 +1,7 @@
 class SetupConstants {
+  /// The name of the docker volume used to store the database.
+  /// This name is a combination of the folder name the compose file is in
+  /// and the volume name defined in the compose file.
   static String dockerVolumeName(String projectName) =>
       '${projectName}_server_${projectName}_data';
 }

--- a/tools/serverpod_cli/lib/src/util/constants.dart
+++ b/tools/serverpod_cli/lib/src/util/constants.dart
@@ -1,0 +1,4 @@
+class SetupConstants {
+  static String dockerVolumeName(String projectName) =>
+      '${projectName}_server_${projectName}_data';
+}


### PR DESCRIPTION
# Changes

- Checks that the docker volume does not exist, if it does give an error to the user.
- In maintenance mode only try to reconnect to the database 6 times before giving up.

Closes: #531

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
