### PR TITLE
fix: Exclude test files when analyzing endpoints.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -39,8 +39,9 @@ class EndpointsAnalyzer {
     for (var context in collection.contexts) {
       var analyzedFiles = context.contextRoot.analyzedFiles().toList();
       analyzedFiles.sort();
-      var analyzedDartFiles =
-          analyzedFiles.where((path) => path.endsWith('.dart'));
+      var analyzedDartFiles = analyzedFiles
+          .where((path) => path.endsWith('.dart'))
+          .where((path) => !path.endsWith('_test.dart'));
 
       for (var filePath in analyzedDartFiles) {
         var library = await context.currentSession.getResolvedLibrary(filePath);

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_file_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_file_test.dart
@@ -148,4 +148,44 @@ class ExampleEndpoint extends Endpoint {
       expect(subDirParts?.first, 'subdirectory');
     });
   });
+
+  group(
+      'Given a valid endpoint file with name ending with _test.dart when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile =
+          File(path.join(testDirectory.path, 'endpoint_test.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no parsing errors are reported.', () {
+      expect(analyzer.getErrors(), completion(isEmpty));
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then no endpoint definition is created.', () {
+      expect(endpointDefinitions, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
### Change
- Excludes files with a name ending with `_test.dart` when analyzing endpoint files.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
