### PR TITLE
fix: Allow firebase phone auth and log auth errors.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
@@ -34,8 +34,7 @@ Future<UserInfo?> signInWithFirebase({
                     var serverResponse =
                         await caller.firebase.authenticate(idToken!);
 
-                    if (!serverResponse.success &&
-                        serverResponse.userInfo != null) {
+                    if (!serverResponse.success) {
                       // Failed to sign in.
                       if (kDebugMode) {
                         print(
@@ -73,8 +72,6 @@ Future<UserInfo?> signInWithFirebase({
   );
 
   var result = await completer.future;
-  // TODO: Fixme?
-  // ignore: use_build_context_synchronously
-  Navigator.of(context).pop();
+
   return result;
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
@@ -37,29 +37,24 @@ class FirebaseEndpoint extends Endpoint {
       session.log('Verified idToken', level: LogLevel.debug);
       var claims = token.claims;
 
-      // Verify that we at a minimum got the email address.
-      if (claims.email == null) {
-        return AuthenticationResponse(
-          success: false,
-          failReason: AuthenticationFailReason.invalidCredentials,
-        );
-      }
-
-      var email = claims.email!.toLowerCase();
+      var email = claims.email?.toLowerCase();
       var userIdentifier = token.claims.subject;
-      var userName = token.claims.nickname ?? email.split('@')[0];
       var fullName = token.claims.name;
+      var userName = token.claims.nickname ?? email?.split('@')[0];
+      userName ??= fullName;
 
       session.log('Got email: $email', level: LogLevel.debug);
-      session.log('Got userIdentifier: $email', level: LogLevel.debug);
+      session.log('Got userIdentifier: $userIdentifier', level: LogLevel.debug);
 
       UserInfo? userInfo;
-      userInfo = await Users.findUserByEmail(session, email);
+      if (email != null) {
+        userInfo = await Users.findUserByEmail(session, email);
+      }
       userInfo ??= await Users.findUserByIdentifier(session, userIdentifier);
       if (userInfo == null) {
         userInfo = UserInfo(
           userIdentifier: userIdentifier,
-          userName: userName,
+          userName: userName ?? '',
           fullName: fullName,
           email: email,
           created: DateTime.now().toUtc(),
@@ -90,6 +85,7 @@ class FirebaseEndpoint extends Endpoint {
         userInfo: userInfo,
       );
     } catch (e) {
+      session.log('Authentication failed with exception.', exception: e, level: LogLevel.error);
       return AuthenticationResponse(
         success: false,
         failReason: AuthenticationFailReason.invalidCredentials,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
@@ -40,8 +40,8 @@ class FirebaseEndpoint extends Endpoint {
       var email = claims.email?.toLowerCase();
       var userIdentifier = token.claims.subject;
       var fullName = token.claims.name;
-      var userName = token.claims.nickname ?? email?.split('@')[0];
-      userName ??= fullName;
+      var userName = token.claims.nickname ?? email?.split('@').firstOrNull;
+      userName ??= fullName ?? '';
 
       session.log('Got email: $email', level: LogLevel.debug);
       session.log('Got userIdentifier: $userIdentifier', level: LogLevel.debug);
@@ -54,7 +54,7 @@ class FirebaseEndpoint extends Endpoint {
       if (userInfo == null) {
         userInfo = UserInfo(
           userIdentifier: userIdentifier,
-          userName: userName ?? '',
+          userName: userName,
           fullName: fullName,
           email: email,
           created: DateTime.now().toUtc(),

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
@@ -85,7 +85,8 @@ class FirebaseEndpoint extends Endpoint {
         userInfo: userInfo,
       );
     } catch (e) {
-      session.log('Authentication failed with exception.', exception: e, level: LogLevel.error);
+      session.log('Authentication failed with exception.',
+          exception: e, level: LogLevel.error);
       return AuthenticationResponse(
         success: false,
         failReason: AuthenticationFailReason.invalidCredentials,


### PR DESCRIPTION
# Changes

- Removes explicit check for email from firebase, I.E. allow none email based providers to work with serverpod.
- Fixes an invalid response check in the client causing the logic to throw on a null value cast.
- Fixes bug where we would pop the view twice after login / failed to login with firebase.
- Adds log of errors when authentication fails on exception in the server, (such as invalid firebase credentials).

Closes: #417

