### PR TITLE
fix: Prevent endpoint analyzer from crashing when unsupported type is used.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -1,11 +1,11 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_class_analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/dart/element_extensions.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
 
 const _excludedMethodNameSet = {
   'streamOpened',
@@ -104,6 +104,7 @@ abstract class EndpointMethodAnalyzer {
         dartElement.span,
       );
     }
+
     var innerType = typeArguments[0];
 
     if (innerType is VoidType) {
@@ -113,6 +114,15 @@ abstract class EndpointMethodAnalyzer {
     if (innerType is DynamicType) {
       return SourceSpanSeverityException(
         'Future must have a type defined. E.g. Future<String>.',
+        dartElement.span,
+      );
+    }
+
+    try {
+      TypeDefinition.fromDartType(innerType);
+    } on FromDartTypeClassNameException catch (e) {
+      return SourceSpanSeverityException(
+        'The type "${e.type}" is not a supported endpoint return type.',
         dartElement.span,
       );
     }

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -72,6 +72,8 @@ class TypeDefinition {
   }
 
   /// Creates an [TypeDefinition] from a given [DartType].
+  /// throws [FromDartTypeClassNameException] if the class name could not be
+  /// determined.
   factory TypeDefinition.fromDartType(DartType type) {
     var generics = (type is ParameterizedType)
         ? type.typeArguments.map((e) => TypeDefinition.fromDartType(e)).toList()
@@ -82,7 +84,7 @@ class TypeDefinition {
     var className = type is! VoidType ? type.element?.displayName : 'void';
 
     if (className == null) {
-      throw ArgumentError('Failed to determine class name from type $type');
+      throw FromDartTypeClassNameException(type);
     }
 
     return TypeDefinition(
@@ -423,4 +425,15 @@ int _findLastClassToken(int start, String input, bool isNullable) {
   if (isNullable) return input.length - 1;
 
   return input.length;
+}
+
+class FromDartTypeClassNameException implements Exception {
+  final DartType type;
+
+  FromDartTypeClassNameException(this.type);
+
+  @override
+  String toString() {
+    return 'Failed to determine class name from type $type';
+  }
 }

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
@@ -421,4 +421,48 @@ class ExampleEndpoint extends Endpoint {
       expect(required, isFalse);
     });
   });
+
+  group('Given an endpoint method with a function parameter when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+typedef TestFunctionBuilder = String Function();
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, TestFunctionBuilder functionParam) async {
+    return functionParam();
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test(
+        'then a validation error is reported that informs the type is not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'The type "String Function()" is not a supported endpoint parameter type.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
### Change:
- Adds check in method validator ensuring we can convert the return type to our internal dart type.
- Adds check in parameter validator ensuring we can convert parameter to our internal dart type.

This PR is more of a catch all to remove the crashing issue.

More validation with specific errors should be added here to ensure the user is properly informed about what is supported.
These validation messages will be added once we can validate the classes used as return type and parameters.

Task for implementing full support for records is tracked here: https://github.com/serverpod/serverpod/issues/588

This PR depends on: https://github.com/serverpod/serverpod/pull/1672
- Closes: #1574,
- Closes: #1275,
- Closes: #1299,
- Closes: #1390. 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
