### PR TITLE
Adds `GeographyPoint` data type for lat/long data (incomplete)

### DIFF
--- a/packages/serverpod/lib/src/generated/database/column_type.dart
+++ b/packages/serverpod/lib/src/generated/database/column_type.dart
@@ -28,6 +28,9 @@ enum ColumnType with _i1.SerializableEntity {
   /// Dart type: [DateTime]
   timestampWithoutTimeZone,
 
+  /// Dart type: [GeographyPoint]
+  geographyPoint,
+
   /// Dart type: [ByteData]
   bytea,
 
@@ -57,14 +60,16 @@ enum ColumnType with _i1.SerializableEntity {
       case 4:
         return timestampWithoutTimeZone;
       case 5:
-        return bytea;
+        return geographyPoint;
       case 6:
-        return bigint;
+        return bytea;
       case 7:
-        return uuid;
+        return bigint;
       case 8:
-        return json;
+        return uuid;
       case 9:
+        return json;
+      case 10:
         return unknown;
       default:
         return null;

--- a/packages/serverpod/lib/src/generated/database/geography_point.dart
+++ b/packages/serverpod/lib/src/generated/database/geography_point.dart
@@ -1,0 +1,83 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+/// A GeographyPoint is a point on the surface of the earth.
+abstract class GeographyPoint extends _i1.SerializableEntity {
+  GeographyPoint._({
+    required this.longitude,
+    required this.latitude,
+  });
+
+  factory GeographyPoint({
+    required double longitude,
+    required double latitude,
+  }) = _GeographyPointImpl;
+
+  factory GeographyPoint.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return GeographyPoint(
+      longitude: serializationManager
+          .deserialize<double>(jsonSerialization['longitude']),
+      latitude: serializationManager
+          .deserialize<double>(jsonSerialization['latitude']),
+    );
+  }
+
+  /// Longitude
+  double longitude;
+
+  /// Latitude
+  double latitude;
+
+  GeographyPoint copyWith({
+    double? longitude,
+    double? latitude,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'longitude': longitude,
+      'latitude': latitude,
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      'longitude': longitude,
+      'latitude': latitude,
+    };
+  }
+}
+
+class _GeographyPointImpl extends GeographyPoint {
+  _GeographyPointImpl({
+    required double longitude,
+    required double latitude,
+  }) : super._(
+          longitude: longitude,
+          latitude: latitude,
+        );
+
+  @override
+  GeographyPoint copyWith({
+    double? longitude,
+    double? latitude,
+  }) {
+    return GeographyPoint(
+      longitude: longitude ?? this.longitude,
+      latitude: latitude ?? this.latitude,
+    );
+  }
+}

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -40,35 +40,36 @@ import 'database/filter/filter_constraint_type.dart' as _i28;
 import 'database/foreign_key_action.dart' as _i29;
 import 'database/foreign_key_definition.dart' as _i30;
 import 'database/foreign_key_match_type.dart' as _i31;
-import 'database/index_definition.dart' as _i32;
-import 'database/index_element_definition.dart' as _i33;
-import 'database/index_element_definition_type.dart' as _i34;
-import 'database/table_definition.dart' as _i35;
-import 'database/table_migration.dart' as _i36;
-import 'distributed_cache_entry.dart' as _i37;
-import 'exceptions/access_denied.dart' as _i38;
-import 'exceptions/file_not_found.dart' as _i39;
-import 'future_call_entry.dart' as _i40;
-import 'log_entry.dart' as _i41;
-import 'log_level.dart' as _i42;
-import 'log_result.dart' as _i43;
-import 'log_settings.dart' as _i44;
-import 'log_settings_override.dart' as _i45;
-import 'message_log_entry.dart' as _i46;
-import 'method_info.dart' as _i47;
-import 'query_log_entry.dart' as _i48;
-import 'readwrite_test.dart' as _i49;
-import 'runtime_settings.dart' as _i50;
-import 'server_health_connection_info.dart' as _i51;
-import 'server_health_metric.dart' as _i52;
-import 'server_health_result.dart' as _i53;
-import 'serverpod_sql_exception.dart' as _i54;
-import 'session_log_entry.dart' as _i55;
-import 'session_log_filter.dart' as _i56;
-import 'session_log_info.dart' as _i57;
-import 'session_log_result.dart' as _i58;
-import 'protocol.dart' as _i59;
-import 'package:serverpod/src/generated/database/table_definition.dart' as _i60;
+import 'database/geography_point.dart' as _i32;
+import 'database/index_definition.dart' as _i33;
+import 'database/index_element_definition.dart' as _i34;
+import 'database/index_element_definition_type.dart' as _i35;
+import 'database/table_definition.dart' as _i36;
+import 'database/table_migration.dart' as _i37;
+import 'distributed_cache_entry.dart' as _i38;
+import 'exceptions/access_denied.dart' as _i39;
+import 'exceptions/file_not_found.dart' as _i40;
+import 'future_call_entry.dart' as _i41;
+import 'log_entry.dart' as _i42;
+import 'log_level.dart' as _i43;
+import 'log_result.dart' as _i44;
+import 'log_settings.dart' as _i45;
+import 'log_settings_override.dart' as _i46;
+import 'message_log_entry.dart' as _i47;
+import 'method_info.dart' as _i48;
+import 'query_log_entry.dart' as _i49;
+import 'readwrite_test.dart' as _i50;
+import 'runtime_settings.dart' as _i51;
+import 'server_health_connection_info.dart' as _i52;
+import 'server_health_metric.dart' as _i53;
+import 'server_health_result.dart' as _i54;
+import 'serverpod_sql_exception.dart' as _i55;
+import 'session_log_entry.dart' as _i56;
+import 'session_log_filter.dart' as _i57;
+import 'session_log_info.dart' as _i58;
+import 'session_log_result.dart' as _i59;
+import 'protocol.dart' as _i60;
+import 'package:serverpod/src/generated/database/table_definition.dart' as _i61;
 export 'auth_key.dart';
 export 'cache_info.dart';
 export 'caches_info.dart';
@@ -98,6 +99,7 @@ export 'database/filter/filter_constraint_type.dart';
 export 'database/foreign_key_action.dart';
 export 'database/foreign_key_definition.dart';
 export 'database/foreign_key_match_type.dart';
+export 'database/geography_point.dart';
 export 'database/index_definition.dart';
 export 'database/index_element_definition.dart';
 export 'database/index_element_definition_type.dart';
@@ -1465,86 +1467,89 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i31.ForeignKeyMatchType) {
       return _i31.ForeignKeyMatchType.fromJson(data) as T;
     }
-    if (t == _i32.IndexDefinition) {
-      return _i32.IndexDefinition.fromJson(data, this) as T;
+    if (t == _i32.GeographyPoint) {
+      return _i32.GeographyPoint.fromJson(data, this) as T;
     }
-    if (t == _i33.IndexElementDefinition) {
-      return _i33.IndexElementDefinition.fromJson(data, this) as T;
+    if (t == _i33.IndexDefinition) {
+      return _i33.IndexDefinition.fromJson(data, this) as T;
     }
-    if (t == _i34.IndexElementDefinitionType) {
-      return _i34.IndexElementDefinitionType.fromJson(data) as T;
+    if (t == _i34.IndexElementDefinition) {
+      return _i34.IndexElementDefinition.fromJson(data, this) as T;
     }
-    if (t == _i35.TableDefinition) {
-      return _i35.TableDefinition.fromJson(data, this) as T;
+    if (t == _i35.IndexElementDefinitionType) {
+      return _i35.IndexElementDefinitionType.fromJson(data) as T;
     }
-    if (t == _i36.TableMigration) {
-      return _i36.TableMigration.fromJson(data, this) as T;
+    if (t == _i36.TableDefinition) {
+      return _i36.TableDefinition.fromJson(data, this) as T;
     }
-    if (t == _i37.DistributedCacheEntry) {
-      return _i37.DistributedCacheEntry.fromJson(data, this) as T;
+    if (t == _i37.TableMigration) {
+      return _i37.TableMigration.fromJson(data, this) as T;
     }
-    if (t == _i38.AccessDeniedException) {
-      return _i38.AccessDeniedException.fromJson(data, this) as T;
+    if (t == _i38.DistributedCacheEntry) {
+      return _i38.DistributedCacheEntry.fromJson(data, this) as T;
     }
-    if (t == _i39.FileNotFoundException) {
-      return _i39.FileNotFoundException.fromJson(data, this) as T;
+    if (t == _i39.AccessDeniedException) {
+      return _i39.AccessDeniedException.fromJson(data, this) as T;
     }
-    if (t == _i40.FutureCallEntry) {
-      return _i40.FutureCallEntry.fromJson(data, this) as T;
+    if (t == _i40.FileNotFoundException) {
+      return _i40.FileNotFoundException.fromJson(data, this) as T;
     }
-    if (t == _i41.LogEntry) {
-      return _i41.LogEntry.fromJson(data, this) as T;
+    if (t == _i41.FutureCallEntry) {
+      return _i41.FutureCallEntry.fromJson(data, this) as T;
     }
-    if (t == _i42.LogLevel) {
-      return _i42.LogLevel.fromJson(data) as T;
+    if (t == _i42.LogEntry) {
+      return _i42.LogEntry.fromJson(data, this) as T;
     }
-    if (t == _i43.LogResult) {
-      return _i43.LogResult.fromJson(data, this) as T;
+    if (t == _i43.LogLevel) {
+      return _i43.LogLevel.fromJson(data) as T;
     }
-    if (t == _i44.LogSettings) {
-      return _i44.LogSettings.fromJson(data, this) as T;
+    if (t == _i44.LogResult) {
+      return _i44.LogResult.fromJson(data, this) as T;
     }
-    if (t == _i45.LogSettingsOverride) {
-      return _i45.LogSettingsOverride.fromJson(data, this) as T;
+    if (t == _i45.LogSettings) {
+      return _i45.LogSettings.fromJson(data, this) as T;
     }
-    if (t == _i46.MessageLogEntry) {
-      return _i46.MessageLogEntry.fromJson(data, this) as T;
+    if (t == _i46.LogSettingsOverride) {
+      return _i46.LogSettingsOverride.fromJson(data, this) as T;
     }
-    if (t == _i47.MethodInfo) {
-      return _i47.MethodInfo.fromJson(data, this) as T;
+    if (t == _i47.MessageLogEntry) {
+      return _i47.MessageLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i48.QueryLogEntry) {
-      return _i48.QueryLogEntry.fromJson(data, this) as T;
+    if (t == _i48.MethodInfo) {
+      return _i48.MethodInfo.fromJson(data, this) as T;
     }
-    if (t == _i49.ReadWriteTestEntry) {
-      return _i49.ReadWriteTestEntry.fromJson(data, this) as T;
+    if (t == _i49.QueryLogEntry) {
+      return _i49.QueryLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i50.RuntimeSettings) {
-      return _i50.RuntimeSettings.fromJson(data, this) as T;
+    if (t == _i50.ReadWriteTestEntry) {
+      return _i50.ReadWriteTestEntry.fromJson(data, this) as T;
     }
-    if (t == _i51.ServerHealthConnectionInfo) {
-      return _i51.ServerHealthConnectionInfo.fromJson(data, this) as T;
+    if (t == _i51.RuntimeSettings) {
+      return _i51.RuntimeSettings.fromJson(data, this) as T;
     }
-    if (t == _i52.ServerHealthMetric) {
-      return _i52.ServerHealthMetric.fromJson(data, this) as T;
+    if (t == _i52.ServerHealthConnectionInfo) {
+      return _i52.ServerHealthConnectionInfo.fromJson(data, this) as T;
     }
-    if (t == _i53.ServerHealthResult) {
-      return _i53.ServerHealthResult.fromJson(data, this) as T;
+    if (t == _i53.ServerHealthMetric) {
+      return _i53.ServerHealthMetric.fromJson(data, this) as T;
     }
-    if (t == _i54.ServerpodSqlException) {
-      return _i54.ServerpodSqlException.fromJson(data, this) as T;
+    if (t == _i54.ServerHealthResult) {
+      return _i54.ServerHealthResult.fromJson(data, this) as T;
     }
-    if (t == _i55.SessionLogEntry) {
-      return _i55.SessionLogEntry.fromJson(data, this) as T;
+    if (t == _i55.ServerpodSqlException) {
+      return _i55.ServerpodSqlException.fromJson(data, this) as T;
     }
-    if (t == _i56.SessionLogFilter) {
-      return _i56.SessionLogFilter.fromJson(data, this) as T;
+    if (t == _i56.SessionLogEntry) {
+      return _i56.SessionLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i57.SessionLogInfo) {
-      return _i57.SessionLogInfo.fromJson(data, this) as T;
+    if (t == _i57.SessionLogFilter) {
+      return _i57.SessionLogFilter.fromJson(data, this) as T;
     }
-    if (t == _i58.SessionLogResult) {
-      return _i58.SessionLogResult.fromJson(data, this) as T;
+    if (t == _i58.SessionLogInfo) {
+      return _i58.SessionLogInfo.fromJson(data, this) as T;
+    }
+    if (t == _i59.SessionLogResult) {
+      return _i59.SessionLogResult.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i3.AuthKey?>()) {
       return (data != null ? _i3.AuthKey.fromJson(data, this) : null) as T;
@@ -1663,118 +1668,122 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i31.ForeignKeyMatchType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i32.IndexDefinition?>()) {
-      return (data != null ? _i32.IndexDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i32.GeographyPoint?>()) {
+      return (data != null ? _i32.GeographyPoint.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i33.IndexElementDefinition?>()) {
-      return (data != null
-          ? _i33.IndexElementDefinition.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i34.IndexElementDefinitionType?>()) {
-      return (data != null
-          ? _i34.IndexElementDefinitionType.fromJson(data)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i35.TableDefinition?>()) {
-      return (data != null ? _i35.TableDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i33.IndexDefinition?>()) {
+      return (data != null ? _i33.IndexDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i36.TableMigration?>()) {
-      return (data != null ? _i36.TableMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i34.IndexElementDefinition?>()) {
+      return (data != null
+          ? _i34.IndexElementDefinition.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i35.IndexElementDefinitionType?>()) {
+      return (data != null
+          ? _i35.IndexElementDefinitionType.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i36.TableDefinition?>()) {
+      return (data != null ? _i36.TableDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i37.DistributedCacheEntry?>()) {
-      return (data != null
-          ? _i37.DistributedCacheEntry.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i38.AccessDeniedException?>()) {
-      return (data != null
-          ? _i38.AccessDeniedException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i39.FileNotFoundException?>()) {
-      return (data != null
-          ? _i39.FileNotFoundException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i40.FutureCallEntry?>()) {
-      return (data != null ? _i40.FutureCallEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i37.TableMigration?>()) {
+      return (data != null ? _i37.TableMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i41.LogEntry?>()) {
-      return (data != null ? _i41.LogEntry.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i42.LogLevel?>()) {
-      return (data != null ? _i42.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.LogResult?>()) {
-      return (data != null ? _i43.LogResult.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i44.LogSettings?>()) {
-      return (data != null ? _i44.LogSettings.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i45.LogSettingsOverride?>()) {
+    if (t == _i1.getType<_i38.DistributedCacheEntry?>()) {
       return (data != null
-          ? _i45.LogSettingsOverride.fromJson(data, this)
+          ? _i38.DistributedCacheEntry.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i46.MessageLogEntry?>()) {
-      return (data != null ? _i46.MessageLogEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i47.MethodInfo?>()) {
-      return (data != null ? _i47.MethodInfo.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i48.QueryLogEntry?>()) {
-      return (data != null ? _i48.QueryLogEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i49.ReadWriteTestEntry?>()) {
+    if (t == _i1.getType<_i39.AccessDeniedException?>()) {
       return (data != null
-          ? _i49.ReadWriteTestEntry.fromJson(data, this)
+          ? _i39.AccessDeniedException.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i50.RuntimeSettings?>()) {
-      return (data != null ? _i50.RuntimeSettings.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i51.ServerHealthConnectionInfo?>()) {
+    if (t == _i1.getType<_i40.FileNotFoundException?>()) {
       return (data != null
-          ? _i51.ServerHealthConnectionInfo.fromJson(data, this)
+          ? _i40.FileNotFoundException.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i52.ServerHealthMetric?>()) {
-      return (data != null
-          ? _i52.ServerHealthMetric.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i53.ServerHealthResult?>()) {
-      return (data != null
-          ? _i53.ServerHealthResult.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i54.ServerpodSqlException?>()) {
-      return (data != null
-          ? _i54.ServerpodSqlException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i55.SessionLogEntry?>()) {
-      return (data != null ? _i55.SessionLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i41.FutureCallEntry?>()) {
+      return (data != null ? _i41.FutureCallEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i56.SessionLogFilter?>()) {
-      return (data != null ? _i56.SessionLogFilter.fromJson(data, this) : null)
+    if (t == _i1.getType<_i42.LogEntry?>()) {
+      return (data != null ? _i42.LogEntry.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i43.LogLevel?>()) {
+      return (data != null ? _i43.LogLevel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i44.LogResult?>()) {
+      return (data != null ? _i44.LogResult.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i45.LogSettings?>()) {
+      return (data != null ? _i45.LogSettings.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i46.LogSettingsOverride?>()) {
+      return (data != null
+          ? _i46.LogSettingsOverride.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i47.MessageLogEntry?>()) {
+      return (data != null ? _i47.MessageLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i57.SessionLogInfo?>()) {
-      return (data != null ? _i57.SessionLogInfo.fromJson(data, this) : null)
+    if (t == _i1.getType<_i48.MethodInfo?>()) {
+      return (data != null ? _i48.MethodInfo.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i49.QueryLogEntry?>()) {
+      return (data != null ? _i49.QueryLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i58.SessionLogResult?>()) {
-      return (data != null ? _i58.SessionLogResult.fromJson(data, this) : null)
+    if (t == _i1.getType<_i50.ReadWriteTestEntry?>()) {
+      return (data != null
+          ? _i50.ReadWriteTestEntry.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i51.RuntimeSettings?>()) {
+      return (data != null ? _i51.RuntimeSettings.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i52.ServerHealthConnectionInfo?>()) {
+      return (data != null
+          ? _i52.ServerHealthConnectionInfo.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i53.ServerHealthMetric?>()) {
+      return (data != null
+          ? _i53.ServerHealthMetric.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i54.ServerHealthResult?>()) {
+      return (data != null
+          ? _i54.ServerHealthResult.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i55.ServerpodSqlException?>()) {
+      return (data != null
+          ? _i55.ServerpodSqlException.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i56.SessionLogEntry?>()) {
+      return (data != null ? _i56.SessionLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i57.SessionLogFilter?>()) {
+      return (data != null ? _i57.SessionLogFilter.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i58.SessionLogInfo?>()) {
+      return (data != null ? _i58.SessionLogInfo.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i59.SessionLogResult?>()) {
+      return (data != null ? _i59.SessionLogResult.fromJson(data, this) : null)
           as T;
     }
     if (t == List<String>) {
@@ -1786,103 +1795,103 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i59.ClusterServerInfo>) {
+    if (t == List<_i60.ClusterServerInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i59.ClusterServerInfo>(e))
+          .map((e) => deserialize<_i60.ClusterServerInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i59.BulkQueryColumnDescription>) {
+    if (t == List<_i60.BulkQueryColumnDescription>) {
       return (data as List)
-          .map((e) => deserialize<_i59.BulkQueryColumnDescription>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.TableDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.TableDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.DatabaseMigrationVersion>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.DatabaseMigrationVersion>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.DatabaseMigrationAction>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.DatabaseMigrationAction>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.DatabaseMigrationWarning>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.DatabaseMigrationWarning>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.FilterConstraint>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.FilterConstraint>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.IndexElementDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.IndexElementDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.ColumnDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.ColumnDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.ForeignKeyDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.ForeignKeyDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.IndexDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.IndexDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.ColumnMigration>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.ColumnMigration>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i59.LogEntry>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i59.LogSettingsOverride>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.LogSettingsOverride>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.ServerHealthMetric>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.ServerHealthMetric>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.ServerHealthConnectionInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.ServerHealthConnectionInfo>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.QueryLogEntry>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.QueryLogEntry>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.MessageLogEntry>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.MessageLogEntry>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.SessionLogInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.SessionLogInfo>(e))
+          .map((e) => deserialize<_i60.BulkQueryColumnDescription>(e))
           .toList() as dynamic;
     }
     if (t == List<_i60.TableDefinition>) {
       return (data as List)
           .map((e) => deserialize<_i60.TableDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.DatabaseMigrationVersion>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.DatabaseMigrationVersion>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.DatabaseMigrationAction>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.DatabaseMigrationAction>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.DatabaseMigrationWarning>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.DatabaseMigrationWarning>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.FilterConstraint>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.FilterConstraint>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.IndexElementDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.IndexElementDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.ColumnDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.ColumnDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.ForeignKeyDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.ForeignKeyDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.IndexDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.IndexDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.ColumnMigration>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.ColumnMigration>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.LogEntry>) {
+      return (data as List).map((e) => deserialize<_i60.LogEntry>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i60.LogSettingsOverride>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.LogSettingsOverride>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.ServerHealthMetric>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.ServerHealthMetric>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.ServerHealthConnectionInfo>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.ServerHealthConnectionInfo>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.QueryLogEntry>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.QueryLogEntry>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.MessageLogEntry>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.MessageLogEntry>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.SessionLogInfo>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.SessionLogInfo>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i61.TableDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i61.TableDefinition>(e))
           .toList() as dynamic;
     }
     if (t == List<String>) {
@@ -1981,85 +1990,88 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i31.ForeignKeyMatchType) {
       return 'ForeignKeyMatchType';
     }
-    if (data is _i32.IndexDefinition) {
+    if (data is _i32.GeographyPoint) {
+      return 'GeographyPoint';
+    }
+    if (data is _i33.IndexDefinition) {
       return 'IndexDefinition';
     }
-    if (data is _i33.IndexElementDefinition) {
+    if (data is _i34.IndexElementDefinition) {
       return 'IndexElementDefinition';
     }
-    if (data is _i34.IndexElementDefinitionType) {
+    if (data is _i35.IndexElementDefinitionType) {
       return 'IndexElementDefinitionType';
     }
-    if (data is _i35.TableDefinition) {
+    if (data is _i36.TableDefinition) {
       return 'TableDefinition';
     }
-    if (data is _i36.TableMigration) {
+    if (data is _i37.TableMigration) {
       return 'TableMigration';
     }
-    if (data is _i37.DistributedCacheEntry) {
+    if (data is _i38.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i38.AccessDeniedException) {
+    if (data is _i39.AccessDeniedException) {
       return 'AccessDeniedException';
     }
-    if (data is _i39.FileNotFoundException) {
+    if (data is _i40.FileNotFoundException) {
       return 'FileNotFoundException';
     }
-    if (data is _i40.FutureCallEntry) {
+    if (data is _i41.FutureCallEntry) {
       return 'FutureCallEntry';
     }
-    if (data is _i41.LogEntry) {
+    if (data is _i42.LogEntry) {
       return 'LogEntry';
     }
-    if (data is _i42.LogLevel) {
+    if (data is _i43.LogLevel) {
       return 'LogLevel';
     }
-    if (data is _i43.LogResult) {
+    if (data is _i44.LogResult) {
       return 'LogResult';
     }
-    if (data is _i44.LogSettings) {
+    if (data is _i45.LogSettings) {
       return 'LogSettings';
     }
-    if (data is _i45.LogSettingsOverride) {
+    if (data is _i46.LogSettingsOverride) {
       return 'LogSettingsOverride';
     }
-    if (data is _i46.MessageLogEntry) {
+    if (data is _i47.MessageLogEntry) {
       return 'MessageLogEntry';
     }
-    if (data is _i47.MethodInfo) {
+    if (data is _i48.MethodInfo) {
       return 'MethodInfo';
     }
-    if (data is _i48.QueryLogEntry) {
+    if (data is _i49.QueryLogEntry) {
       return 'QueryLogEntry';
     }
-    if (data is _i49.ReadWriteTestEntry) {
+    if (data is _i50.ReadWriteTestEntry) {
       return 'ReadWriteTestEntry';
     }
-    if (data is _i50.RuntimeSettings) {
+    if (data is _i51.RuntimeSettings) {
       return 'RuntimeSettings';
     }
-    if (data is _i51.ServerHealthConnectionInfo) {
+    if (data is _i52.ServerHealthConnectionInfo) {
       return 'ServerHealthConnectionInfo';
     }
-    if (data is _i52.ServerHealthMetric) {
+    if (data is _i53.ServerHealthMetric) {
       return 'ServerHealthMetric';
     }
-    if (data is _i53.ServerHealthResult) {
+    if (data is _i54.ServerHealthResult) {
       return 'ServerHealthResult';
     }
-    if (data is _i54.ServerpodSqlException) {
+    if (data is _i55.ServerpodSqlException) {
       return 'ServerpodSqlException';
     }
-    if (data is _i55.SessionLogEntry) {
+    if (data is _i56.SessionLogEntry) {
       return 'SessionLogEntry';
     }
-    if (data is _i56.SessionLogFilter) {
+    if (data is _i57.SessionLogFilter) {
       return 'SessionLogFilter';
     }
-    if (data is _i57.SessionLogInfo) {
+    if (data is _i58.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i58.SessionLogResult) {
+    if (data is _i59.SessionLogResult) {
       return 'SessionLogResult';
     }
     return super.getClassNameForObject(data);
@@ -2154,86 +2166,89 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'ForeignKeyMatchType') {
       return deserialize<_i31.ForeignKeyMatchType>(data['data']);
     }
+    if (data['className'] == 'GeographyPoint') {
+      return deserialize<_i32.GeographyPoint>(data['data']);
+    }
     if (data['className'] == 'IndexDefinition') {
-      return deserialize<_i32.IndexDefinition>(data['data']);
+      return deserialize<_i33.IndexDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinition') {
-      return deserialize<_i33.IndexElementDefinition>(data['data']);
+      return deserialize<_i34.IndexElementDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinitionType') {
-      return deserialize<_i34.IndexElementDefinitionType>(data['data']);
+      return deserialize<_i35.IndexElementDefinitionType>(data['data']);
     }
     if (data['className'] == 'TableDefinition') {
-      return deserialize<_i35.TableDefinition>(data['data']);
+      return deserialize<_i36.TableDefinition>(data['data']);
     }
     if (data['className'] == 'TableMigration') {
-      return deserialize<_i36.TableMigration>(data['data']);
+      return deserialize<_i37.TableMigration>(data['data']);
     }
     if (data['className'] == 'DistributedCacheEntry') {
-      return deserialize<_i37.DistributedCacheEntry>(data['data']);
+      return deserialize<_i38.DistributedCacheEntry>(data['data']);
     }
     if (data['className'] == 'AccessDeniedException') {
-      return deserialize<_i38.AccessDeniedException>(data['data']);
+      return deserialize<_i39.AccessDeniedException>(data['data']);
     }
     if (data['className'] == 'FileNotFoundException') {
-      return deserialize<_i39.FileNotFoundException>(data['data']);
+      return deserialize<_i40.FileNotFoundException>(data['data']);
     }
     if (data['className'] == 'FutureCallEntry') {
-      return deserialize<_i40.FutureCallEntry>(data['data']);
+      return deserialize<_i41.FutureCallEntry>(data['data']);
     }
     if (data['className'] == 'LogEntry') {
-      return deserialize<_i41.LogEntry>(data['data']);
+      return deserialize<_i42.LogEntry>(data['data']);
     }
     if (data['className'] == 'LogLevel') {
-      return deserialize<_i42.LogLevel>(data['data']);
+      return deserialize<_i43.LogLevel>(data['data']);
     }
     if (data['className'] == 'LogResult') {
-      return deserialize<_i43.LogResult>(data['data']);
+      return deserialize<_i44.LogResult>(data['data']);
     }
     if (data['className'] == 'LogSettings') {
-      return deserialize<_i44.LogSettings>(data['data']);
+      return deserialize<_i45.LogSettings>(data['data']);
     }
     if (data['className'] == 'LogSettingsOverride') {
-      return deserialize<_i45.LogSettingsOverride>(data['data']);
+      return deserialize<_i46.LogSettingsOverride>(data['data']);
     }
     if (data['className'] == 'MessageLogEntry') {
-      return deserialize<_i46.MessageLogEntry>(data['data']);
+      return deserialize<_i47.MessageLogEntry>(data['data']);
     }
     if (data['className'] == 'MethodInfo') {
-      return deserialize<_i47.MethodInfo>(data['data']);
+      return deserialize<_i48.MethodInfo>(data['data']);
     }
     if (data['className'] == 'QueryLogEntry') {
-      return deserialize<_i48.QueryLogEntry>(data['data']);
+      return deserialize<_i49.QueryLogEntry>(data['data']);
     }
     if (data['className'] == 'ReadWriteTestEntry') {
-      return deserialize<_i49.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i50.ReadWriteTestEntry>(data['data']);
     }
     if (data['className'] == 'RuntimeSettings') {
-      return deserialize<_i50.RuntimeSettings>(data['data']);
+      return deserialize<_i51.RuntimeSettings>(data['data']);
     }
     if (data['className'] == 'ServerHealthConnectionInfo') {
-      return deserialize<_i51.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i52.ServerHealthConnectionInfo>(data['data']);
     }
     if (data['className'] == 'ServerHealthMetric') {
-      return deserialize<_i52.ServerHealthMetric>(data['data']);
+      return deserialize<_i53.ServerHealthMetric>(data['data']);
     }
     if (data['className'] == 'ServerHealthResult') {
-      return deserialize<_i53.ServerHealthResult>(data['data']);
+      return deserialize<_i54.ServerHealthResult>(data['data']);
     }
     if (data['className'] == 'ServerpodSqlException') {
-      return deserialize<_i54.ServerpodSqlException>(data['data']);
+      return deserialize<_i55.ServerpodSqlException>(data['data']);
     }
     if (data['className'] == 'SessionLogEntry') {
-      return deserialize<_i55.SessionLogEntry>(data['data']);
+      return deserialize<_i56.SessionLogEntry>(data['data']);
     }
     if (data['className'] == 'SessionLogFilter') {
-      return deserialize<_i56.SessionLogFilter>(data['data']);
+      return deserialize<_i57.SessionLogFilter>(data['data']);
     }
     if (data['className'] == 'SessionLogInfo') {
-      return deserialize<_i57.SessionLogInfo>(data['data']);
+      return deserialize<_i58.SessionLogInfo>(data['data']);
     }
     if (data['className'] == 'SessionLogResult') {
-      return deserialize<_i58.SessionLogResult>(data['data']);
+      return deserialize<_i59.SessionLogResult>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -2249,26 +2264,26 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i7.CloudStorageDirectUploadEntry.t;
       case _i22.DatabaseMigrationVersion:
         return _i22.DatabaseMigrationVersion.t;
-      case _i40.FutureCallEntry:
-        return _i40.FutureCallEntry.t;
-      case _i41.LogEntry:
-        return _i41.LogEntry.t;
-      case _i46.MessageLogEntry:
-        return _i46.MessageLogEntry.t;
-      case _i47.MethodInfo:
-        return _i47.MethodInfo.t;
-      case _i48.QueryLogEntry:
-        return _i48.QueryLogEntry.t;
-      case _i49.ReadWriteTestEntry:
-        return _i49.ReadWriteTestEntry.t;
-      case _i50.RuntimeSettings:
-        return _i50.RuntimeSettings.t;
-      case _i51.ServerHealthConnectionInfo:
-        return _i51.ServerHealthConnectionInfo.t;
-      case _i52.ServerHealthMetric:
-        return _i52.ServerHealthMetric.t;
-      case _i55.SessionLogEntry:
-        return _i55.SessionLogEntry.t;
+      case _i41.FutureCallEntry:
+        return _i41.FutureCallEntry.t;
+      case _i42.LogEntry:
+        return _i42.LogEntry.t;
+      case _i47.MessageLogEntry:
+        return _i47.MessageLogEntry.t;
+      case _i48.MethodInfo:
+        return _i48.MethodInfo.t;
+      case _i49.QueryLogEntry:
+        return _i49.QueryLogEntry.t;
+      case _i50.ReadWriteTestEntry:
+        return _i50.ReadWriteTestEntry.t;
+      case _i51.RuntimeSettings:
+        return _i51.RuntimeSettings.t;
+      case _i52.ServerHealthConnectionInfo:
+        return _i52.ServerHealthConnectionInfo.t;
+      case _i53.ServerHealthMetric:
+        return _i53.ServerHealthMetric.t;
+      case _i56.SessionLogEntry:
+        return _i56.SessionLogEntry.t;
     }
     return null;
   }

--- a/packages/serverpod/lib/src/model/database/column_type.spy.yaml
+++ b/packages/serverpod/lib/src/model/database/column_type.spy.yaml
@@ -12,6 +12,8 @@ values:
   - doublePrecision
   ### Dart type: [DateTime]
   - timestampWithoutTimeZone
+  ### Dart type: [GeographyPoint]
+  - geographyPoint
   ### Dart type: [ByteData]
   - bytea
   ### Dart type: [Duration]

--- a/packages/serverpod/lib/src/model/database/geography_point.spy.yaml
+++ b/packages/serverpod/lib/src/model/database/geography_point.spy.yaml
@@ -1,0 +1,7 @@
+### A GeographyPoint is a point on the surface of the earth.
+class: GeographyPoint
+fields:
+  ### Longitude
+  longitude: double
+  ### Latitude
+  latitude: double

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_type.dart
@@ -28,6 +28,9 @@ enum ColumnType with _i1.SerializableEntity {
   /// Dart type: [DateTime]
   timestampWithoutTimeZone,
 
+  /// Dart type: [GeographyPoint]
+  geographyPoint,
+
   /// Dart type: [ByteData]
   bytea,
 
@@ -57,14 +60,16 @@ enum ColumnType with _i1.SerializableEntity {
       case 4:
         return timestampWithoutTimeZone;
       case 5:
-        return bytea;
+        return geographyPoint;
       case 6:
-        return bigint;
+        return bytea;
       case 7:
-        return uuid;
+        return bigint;
       case 8:
-        return json;
+        return uuid;
       case 9:
+        return json;
+      case 10:
         return unknown;
       default:
         return null;

--- a/packages/serverpod_service_client/lib/src/protocol/database/geography_point.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/geography_point.dart
@@ -1,0 +1,75 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+/// A GeographyPoint is a point on the surface of the earth.
+abstract class GeographyPoint extends _i1.SerializableEntity {
+  GeographyPoint._({
+    required this.longitude,
+    required this.latitude,
+  });
+
+  factory GeographyPoint({
+    required double longitude,
+    required double latitude,
+  }) = _GeographyPointImpl;
+
+  factory GeographyPoint.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return GeographyPoint(
+      longitude: serializationManager
+          .deserialize<double>(jsonSerialization['longitude']),
+      latitude: serializationManager
+          .deserialize<double>(jsonSerialization['latitude']),
+    );
+  }
+
+  /// Longitude
+  double longitude;
+
+  /// Latitude
+  double latitude;
+
+  GeographyPoint copyWith({
+    double? longitude,
+    double? latitude,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'longitude': longitude,
+      'latitude': latitude,
+    };
+  }
+}
+
+class _GeographyPointImpl extends GeographyPoint {
+  _GeographyPointImpl({
+    required double longitude,
+    required double latitude,
+  }) : super._(
+          longitude: longitude,
+          latitude: latitude,
+        );
+
+  @override
+  GeographyPoint copyWith({
+    double? longitude,
+    double? latitude,
+  }) {
+    return GeographyPoint(
+      longitude: longitude ?? this.longitude,
+      latitude: latitude ?? this.latitude,
+    );
+  }
+}

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -39,36 +39,37 @@ import 'database/filter/filter_constraint_type.dart' as _i27;
 import 'database/foreign_key_action.dart' as _i28;
 import 'database/foreign_key_definition.dart' as _i29;
 import 'database/foreign_key_match_type.dart' as _i30;
-import 'database/index_definition.dart' as _i31;
-import 'database/index_element_definition.dart' as _i32;
-import 'database/index_element_definition_type.dart' as _i33;
-import 'database/table_definition.dart' as _i34;
-import 'database/table_migration.dart' as _i35;
-import 'distributed_cache_entry.dart' as _i36;
-import 'exceptions/access_denied.dart' as _i37;
-import 'exceptions/file_not_found.dart' as _i38;
-import 'future_call_entry.dart' as _i39;
-import 'log_entry.dart' as _i40;
-import 'log_level.dart' as _i41;
-import 'log_result.dart' as _i42;
-import 'log_settings.dart' as _i43;
-import 'log_settings_override.dart' as _i44;
-import 'message_log_entry.dart' as _i45;
-import 'method_info.dart' as _i46;
-import 'query_log_entry.dart' as _i47;
-import 'readwrite_test.dart' as _i48;
-import 'runtime_settings.dart' as _i49;
-import 'server_health_connection_info.dart' as _i50;
-import 'server_health_metric.dart' as _i51;
-import 'server_health_result.dart' as _i52;
-import 'serverpod_sql_exception.dart' as _i53;
-import 'session_log_entry.dart' as _i54;
-import 'session_log_filter.dart' as _i55;
-import 'session_log_info.dart' as _i56;
-import 'session_log_result.dart' as _i57;
-import 'protocol.dart' as _i58;
+import 'database/geography_point.dart' as _i31;
+import 'database/index_definition.dart' as _i32;
+import 'database/index_element_definition.dart' as _i33;
+import 'database/index_element_definition_type.dart' as _i34;
+import 'database/table_definition.dart' as _i35;
+import 'database/table_migration.dart' as _i36;
+import 'distributed_cache_entry.dart' as _i37;
+import 'exceptions/access_denied.dart' as _i38;
+import 'exceptions/file_not_found.dart' as _i39;
+import 'future_call_entry.dart' as _i40;
+import 'log_entry.dart' as _i41;
+import 'log_level.dart' as _i42;
+import 'log_result.dart' as _i43;
+import 'log_settings.dart' as _i44;
+import 'log_settings_override.dart' as _i45;
+import 'message_log_entry.dart' as _i46;
+import 'method_info.dart' as _i47;
+import 'query_log_entry.dart' as _i48;
+import 'readwrite_test.dart' as _i49;
+import 'runtime_settings.dart' as _i50;
+import 'server_health_connection_info.dart' as _i51;
+import 'server_health_metric.dart' as _i52;
+import 'server_health_result.dart' as _i53;
+import 'serverpod_sql_exception.dart' as _i54;
+import 'session_log_entry.dart' as _i55;
+import 'session_log_filter.dart' as _i56;
+import 'session_log_info.dart' as _i57;
+import 'session_log_result.dart' as _i58;
+import 'protocol.dart' as _i59;
 import 'package:serverpod_service_client/src/protocol/database/table_definition.dart'
-    as _i59;
+    as _i60;
 export 'auth_key.dart';
 export 'cache_info.dart';
 export 'caches_info.dart';
@@ -98,6 +99,7 @@ export 'database/filter/filter_constraint_type.dart';
 export 'database/foreign_key_action.dart';
 export 'database/foreign_key_definition.dart';
 export 'database/foreign_key_match_type.dart';
+export 'database/geography_point.dart';
 export 'database/index_definition.dart';
 export 'database/index_element_definition.dart';
 export 'database/index_element_definition_type.dart';
@@ -232,86 +234,89 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i30.ForeignKeyMatchType) {
       return _i30.ForeignKeyMatchType.fromJson(data) as T;
     }
-    if (t == _i31.IndexDefinition) {
-      return _i31.IndexDefinition.fromJson(data, this) as T;
+    if (t == _i31.GeographyPoint) {
+      return _i31.GeographyPoint.fromJson(data, this) as T;
     }
-    if (t == _i32.IndexElementDefinition) {
-      return _i32.IndexElementDefinition.fromJson(data, this) as T;
+    if (t == _i32.IndexDefinition) {
+      return _i32.IndexDefinition.fromJson(data, this) as T;
     }
-    if (t == _i33.IndexElementDefinitionType) {
-      return _i33.IndexElementDefinitionType.fromJson(data) as T;
+    if (t == _i33.IndexElementDefinition) {
+      return _i33.IndexElementDefinition.fromJson(data, this) as T;
     }
-    if (t == _i34.TableDefinition) {
-      return _i34.TableDefinition.fromJson(data, this) as T;
+    if (t == _i34.IndexElementDefinitionType) {
+      return _i34.IndexElementDefinitionType.fromJson(data) as T;
     }
-    if (t == _i35.TableMigration) {
-      return _i35.TableMigration.fromJson(data, this) as T;
+    if (t == _i35.TableDefinition) {
+      return _i35.TableDefinition.fromJson(data, this) as T;
     }
-    if (t == _i36.DistributedCacheEntry) {
-      return _i36.DistributedCacheEntry.fromJson(data, this) as T;
+    if (t == _i36.TableMigration) {
+      return _i36.TableMigration.fromJson(data, this) as T;
     }
-    if (t == _i37.AccessDeniedException) {
-      return _i37.AccessDeniedException.fromJson(data, this) as T;
+    if (t == _i37.DistributedCacheEntry) {
+      return _i37.DistributedCacheEntry.fromJson(data, this) as T;
     }
-    if (t == _i38.FileNotFoundException) {
-      return _i38.FileNotFoundException.fromJson(data, this) as T;
+    if (t == _i38.AccessDeniedException) {
+      return _i38.AccessDeniedException.fromJson(data, this) as T;
     }
-    if (t == _i39.FutureCallEntry) {
-      return _i39.FutureCallEntry.fromJson(data, this) as T;
+    if (t == _i39.FileNotFoundException) {
+      return _i39.FileNotFoundException.fromJson(data, this) as T;
     }
-    if (t == _i40.LogEntry) {
-      return _i40.LogEntry.fromJson(data, this) as T;
+    if (t == _i40.FutureCallEntry) {
+      return _i40.FutureCallEntry.fromJson(data, this) as T;
     }
-    if (t == _i41.LogLevel) {
-      return _i41.LogLevel.fromJson(data) as T;
+    if (t == _i41.LogEntry) {
+      return _i41.LogEntry.fromJson(data, this) as T;
     }
-    if (t == _i42.LogResult) {
-      return _i42.LogResult.fromJson(data, this) as T;
+    if (t == _i42.LogLevel) {
+      return _i42.LogLevel.fromJson(data) as T;
     }
-    if (t == _i43.LogSettings) {
-      return _i43.LogSettings.fromJson(data, this) as T;
+    if (t == _i43.LogResult) {
+      return _i43.LogResult.fromJson(data, this) as T;
     }
-    if (t == _i44.LogSettingsOverride) {
-      return _i44.LogSettingsOverride.fromJson(data, this) as T;
+    if (t == _i44.LogSettings) {
+      return _i44.LogSettings.fromJson(data, this) as T;
     }
-    if (t == _i45.MessageLogEntry) {
-      return _i45.MessageLogEntry.fromJson(data, this) as T;
+    if (t == _i45.LogSettingsOverride) {
+      return _i45.LogSettingsOverride.fromJson(data, this) as T;
     }
-    if (t == _i46.MethodInfo) {
-      return _i46.MethodInfo.fromJson(data, this) as T;
+    if (t == _i46.MessageLogEntry) {
+      return _i46.MessageLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i47.QueryLogEntry) {
-      return _i47.QueryLogEntry.fromJson(data, this) as T;
+    if (t == _i47.MethodInfo) {
+      return _i47.MethodInfo.fromJson(data, this) as T;
     }
-    if (t == _i48.ReadWriteTestEntry) {
-      return _i48.ReadWriteTestEntry.fromJson(data, this) as T;
+    if (t == _i48.QueryLogEntry) {
+      return _i48.QueryLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i49.RuntimeSettings) {
-      return _i49.RuntimeSettings.fromJson(data, this) as T;
+    if (t == _i49.ReadWriteTestEntry) {
+      return _i49.ReadWriteTestEntry.fromJson(data, this) as T;
     }
-    if (t == _i50.ServerHealthConnectionInfo) {
-      return _i50.ServerHealthConnectionInfo.fromJson(data, this) as T;
+    if (t == _i50.RuntimeSettings) {
+      return _i50.RuntimeSettings.fromJson(data, this) as T;
     }
-    if (t == _i51.ServerHealthMetric) {
-      return _i51.ServerHealthMetric.fromJson(data, this) as T;
+    if (t == _i51.ServerHealthConnectionInfo) {
+      return _i51.ServerHealthConnectionInfo.fromJson(data, this) as T;
     }
-    if (t == _i52.ServerHealthResult) {
-      return _i52.ServerHealthResult.fromJson(data, this) as T;
+    if (t == _i52.ServerHealthMetric) {
+      return _i52.ServerHealthMetric.fromJson(data, this) as T;
     }
-    if (t == _i53.ServerpodSqlException) {
-      return _i53.ServerpodSqlException.fromJson(data, this) as T;
+    if (t == _i53.ServerHealthResult) {
+      return _i53.ServerHealthResult.fromJson(data, this) as T;
     }
-    if (t == _i54.SessionLogEntry) {
-      return _i54.SessionLogEntry.fromJson(data, this) as T;
+    if (t == _i54.ServerpodSqlException) {
+      return _i54.ServerpodSqlException.fromJson(data, this) as T;
     }
-    if (t == _i55.SessionLogFilter) {
-      return _i55.SessionLogFilter.fromJson(data, this) as T;
+    if (t == _i55.SessionLogEntry) {
+      return _i55.SessionLogEntry.fromJson(data, this) as T;
     }
-    if (t == _i56.SessionLogInfo) {
-      return _i56.SessionLogInfo.fromJson(data, this) as T;
+    if (t == _i56.SessionLogFilter) {
+      return _i56.SessionLogFilter.fromJson(data, this) as T;
     }
-    if (t == _i57.SessionLogResult) {
-      return _i57.SessionLogResult.fromJson(data, this) as T;
+    if (t == _i57.SessionLogInfo) {
+      return _i57.SessionLogInfo.fromJson(data, this) as T;
+    }
+    if (t == _i58.SessionLogResult) {
+      return _i58.SessionLogResult.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.AuthKey?>()) {
       return (data != null ? _i2.AuthKey.fromJson(data, this) : null) as T;
@@ -430,118 +435,122 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i30.ForeignKeyMatchType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i31.IndexDefinition?>()) {
-      return (data != null ? _i31.IndexDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i31.GeographyPoint?>()) {
+      return (data != null ? _i31.GeographyPoint.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i32.IndexElementDefinition?>()) {
-      return (data != null
-          ? _i32.IndexElementDefinition.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i33.IndexElementDefinitionType?>()) {
-      return (data != null
-          ? _i33.IndexElementDefinitionType.fromJson(data)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i34.TableDefinition?>()) {
-      return (data != null ? _i34.TableDefinition.fromJson(data, this) : null)
+    if (t == _i1.getType<_i32.IndexDefinition?>()) {
+      return (data != null ? _i32.IndexDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i35.TableMigration?>()) {
-      return (data != null ? _i35.TableMigration.fromJson(data, this) : null)
+    if (t == _i1.getType<_i33.IndexElementDefinition?>()) {
+      return (data != null
+          ? _i33.IndexElementDefinition.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i34.IndexElementDefinitionType?>()) {
+      return (data != null
+          ? _i34.IndexElementDefinitionType.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i35.TableDefinition?>()) {
+      return (data != null ? _i35.TableDefinition.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i36.DistributedCacheEntry?>()) {
-      return (data != null
-          ? _i36.DistributedCacheEntry.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i37.AccessDeniedException?>()) {
-      return (data != null
-          ? _i37.AccessDeniedException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i38.FileNotFoundException?>()) {
-      return (data != null
-          ? _i38.FileNotFoundException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i39.FutureCallEntry?>()) {
-      return (data != null ? _i39.FutureCallEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i36.TableMigration?>()) {
+      return (data != null ? _i36.TableMigration.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i40.LogEntry?>()) {
-      return (data != null ? _i40.LogEntry.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i41.LogLevel?>()) {
-      return (data != null ? _i41.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i42.LogResult?>()) {
-      return (data != null ? _i42.LogResult.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i43.LogSettings?>()) {
-      return (data != null ? _i43.LogSettings.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i44.LogSettingsOverride?>()) {
+    if (t == _i1.getType<_i37.DistributedCacheEntry?>()) {
       return (data != null
-          ? _i44.LogSettingsOverride.fromJson(data, this)
+          ? _i37.DistributedCacheEntry.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i45.MessageLogEntry?>()) {
-      return (data != null ? _i45.MessageLogEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i46.MethodInfo?>()) {
-      return (data != null ? _i46.MethodInfo.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i47.QueryLogEntry?>()) {
-      return (data != null ? _i47.QueryLogEntry.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i48.ReadWriteTestEntry?>()) {
+    if (t == _i1.getType<_i38.AccessDeniedException?>()) {
       return (data != null
-          ? _i48.ReadWriteTestEntry.fromJson(data, this)
+          ? _i38.AccessDeniedException.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i49.RuntimeSettings?>()) {
-      return (data != null ? _i49.RuntimeSettings.fromJson(data, this) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i50.ServerHealthConnectionInfo?>()) {
+    if (t == _i1.getType<_i39.FileNotFoundException?>()) {
       return (data != null
-          ? _i50.ServerHealthConnectionInfo.fromJson(data, this)
+          ? _i39.FileNotFoundException.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i51.ServerHealthMetric?>()) {
-      return (data != null
-          ? _i51.ServerHealthMetric.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i52.ServerHealthResult?>()) {
-      return (data != null
-          ? _i52.ServerHealthResult.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i53.ServerpodSqlException?>()) {
-      return (data != null
-          ? _i53.ServerpodSqlException.fromJson(data, this)
-          : null) as T;
-    }
-    if (t == _i1.getType<_i54.SessionLogEntry?>()) {
-      return (data != null ? _i54.SessionLogEntry.fromJson(data, this) : null)
+    if (t == _i1.getType<_i40.FutureCallEntry?>()) {
+      return (data != null ? _i40.FutureCallEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i55.SessionLogFilter?>()) {
-      return (data != null ? _i55.SessionLogFilter.fromJson(data, this) : null)
+    if (t == _i1.getType<_i41.LogEntry?>()) {
+      return (data != null ? _i41.LogEntry.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i42.LogLevel?>()) {
+      return (data != null ? _i42.LogLevel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i43.LogResult?>()) {
+      return (data != null ? _i43.LogResult.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i44.LogSettings?>()) {
+      return (data != null ? _i44.LogSettings.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i45.LogSettingsOverride?>()) {
+      return (data != null
+          ? _i45.LogSettingsOverride.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i46.MessageLogEntry?>()) {
+      return (data != null ? _i46.MessageLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i56.SessionLogInfo?>()) {
-      return (data != null ? _i56.SessionLogInfo.fromJson(data, this) : null)
+    if (t == _i1.getType<_i47.MethodInfo?>()) {
+      return (data != null ? _i47.MethodInfo.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i48.QueryLogEntry?>()) {
+      return (data != null ? _i48.QueryLogEntry.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i57.SessionLogResult?>()) {
-      return (data != null ? _i57.SessionLogResult.fromJson(data, this) : null)
+    if (t == _i1.getType<_i49.ReadWriteTestEntry?>()) {
+      return (data != null
+          ? _i49.ReadWriteTestEntry.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i50.RuntimeSettings?>()) {
+      return (data != null ? _i50.RuntimeSettings.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i51.ServerHealthConnectionInfo?>()) {
+      return (data != null
+          ? _i51.ServerHealthConnectionInfo.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i52.ServerHealthMetric?>()) {
+      return (data != null
+          ? _i52.ServerHealthMetric.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i53.ServerHealthResult?>()) {
+      return (data != null
+          ? _i53.ServerHealthResult.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i54.ServerpodSqlException?>()) {
+      return (data != null
+          ? _i54.ServerpodSqlException.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i55.SessionLogEntry?>()) {
+      return (data != null ? _i55.SessionLogEntry.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i56.SessionLogFilter?>()) {
+      return (data != null ? _i56.SessionLogFilter.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i57.SessionLogInfo?>()) {
+      return (data != null ? _i57.SessionLogInfo.fromJson(data, this) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i58.SessionLogResult?>()) {
+      return (data != null ? _i58.SessionLogResult.fromJson(data, this) : null)
           as T;
     }
     if (t == List<String>) {
@@ -553,103 +562,103 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i58.ClusterServerInfo>) {
+    if (t == List<_i59.ClusterServerInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i58.ClusterServerInfo>(e))
+          .map((e) => deserialize<_i59.ClusterServerInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.BulkQueryColumnDescription>) {
+    if (t == List<_i59.BulkQueryColumnDescription>) {
       return (data as List)
-          .map((e) => deserialize<_i58.BulkQueryColumnDescription>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.TableDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.TableDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.DatabaseMigrationVersion>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.DatabaseMigrationVersion>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.DatabaseMigrationAction>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.DatabaseMigrationAction>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.DatabaseMigrationWarning>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.DatabaseMigrationWarning>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.FilterConstraint>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.FilterConstraint>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.IndexElementDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.IndexElementDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.ColumnDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.ColumnDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.ForeignKeyDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.ForeignKeyDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.IndexDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.IndexDefinition>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.ColumnMigration>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.ColumnMigration>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i58.LogEntry>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i58.LogSettingsOverride>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.LogSettingsOverride>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.ServerHealthMetric>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.ServerHealthMetric>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.ServerHealthConnectionInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.ServerHealthConnectionInfo>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.QueryLogEntry>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.QueryLogEntry>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.MessageLogEntry>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.MessageLogEntry>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.SessionLogInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.SessionLogInfo>(e))
+          .map((e) => deserialize<_i59.BulkQueryColumnDescription>(e))
           .toList() as dynamic;
     }
     if (t == List<_i59.TableDefinition>) {
       return (data as List)
           .map((e) => deserialize<_i59.TableDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.DatabaseMigrationVersion>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.DatabaseMigrationVersion>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.DatabaseMigrationAction>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.DatabaseMigrationAction>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.DatabaseMigrationWarning>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.DatabaseMigrationWarning>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.FilterConstraint>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.FilterConstraint>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.IndexElementDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.IndexElementDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.ColumnDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.ColumnDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.ForeignKeyDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.ForeignKeyDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.IndexDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.IndexDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.ColumnMigration>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.ColumnMigration>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.LogEntry>) {
+      return (data as List).map((e) => deserialize<_i59.LogEntry>(e)).toList()
+          as dynamic;
+    }
+    if (t == List<_i59.LogSettingsOverride>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.LogSettingsOverride>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.ServerHealthMetric>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.ServerHealthMetric>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.ServerHealthConnectionInfo>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.ServerHealthConnectionInfo>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.QueryLogEntry>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.QueryLogEntry>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.MessageLogEntry>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.MessageLogEntry>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i59.SessionLogInfo>) {
+      return (data as List)
+          .map((e) => deserialize<_i59.SessionLogInfo>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i60.TableDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i60.TableDefinition>(e))
           .toList() as dynamic;
     }
     if (t == List<String>) {
@@ -748,85 +757,88 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i30.ForeignKeyMatchType) {
       return 'ForeignKeyMatchType';
     }
-    if (data is _i31.IndexDefinition) {
+    if (data is _i31.GeographyPoint) {
+      return 'GeographyPoint';
+    }
+    if (data is _i32.IndexDefinition) {
       return 'IndexDefinition';
     }
-    if (data is _i32.IndexElementDefinition) {
+    if (data is _i33.IndexElementDefinition) {
       return 'IndexElementDefinition';
     }
-    if (data is _i33.IndexElementDefinitionType) {
+    if (data is _i34.IndexElementDefinitionType) {
       return 'IndexElementDefinitionType';
     }
-    if (data is _i34.TableDefinition) {
+    if (data is _i35.TableDefinition) {
       return 'TableDefinition';
     }
-    if (data is _i35.TableMigration) {
+    if (data is _i36.TableMigration) {
       return 'TableMigration';
     }
-    if (data is _i36.DistributedCacheEntry) {
+    if (data is _i37.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i37.AccessDeniedException) {
+    if (data is _i38.AccessDeniedException) {
       return 'AccessDeniedException';
     }
-    if (data is _i38.FileNotFoundException) {
+    if (data is _i39.FileNotFoundException) {
       return 'FileNotFoundException';
     }
-    if (data is _i39.FutureCallEntry) {
+    if (data is _i40.FutureCallEntry) {
       return 'FutureCallEntry';
     }
-    if (data is _i40.LogEntry) {
+    if (data is _i41.LogEntry) {
       return 'LogEntry';
     }
-    if (data is _i41.LogLevel) {
+    if (data is _i42.LogLevel) {
       return 'LogLevel';
     }
-    if (data is _i42.LogResult) {
+    if (data is _i43.LogResult) {
       return 'LogResult';
     }
-    if (data is _i43.LogSettings) {
+    if (data is _i44.LogSettings) {
       return 'LogSettings';
     }
-    if (data is _i44.LogSettingsOverride) {
+    if (data is _i45.LogSettingsOverride) {
       return 'LogSettingsOverride';
     }
-    if (data is _i45.MessageLogEntry) {
+    if (data is _i46.MessageLogEntry) {
       return 'MessageLogEntry';
     }
-    if (data is _i46.MethodInfo) {
+    if (data is _i47.MethodInfo) {
       return 'MethodInfo';
     }
-    if (data is _i47.QueryLogEntry) {
+    if (data is _i48.QueryLogEntry) {
       return 'QueryLogEntry';
     }
-    if (data is _i48.ReadWriteTestEntry) {
+    if (data is _i49.ReadWriteTestEntry) {
       return 'ReadWriteTestEntry';
     }
-    if (data is _i49.RuntimeSettings) {
+    if (data is _i50.RuntimeSettings) {
       return 'RuntimeSettings';
     }
-    if (data is _i50.ServerHealthConnectionInfo) {
+    if (data is _i51.ServerHealthConnectionInfo) {
       return 'ServerHealthConnectionInfo';
     }
-    if (data is _i51.ServerHealthMetric) {
+    if (data is _i52.ServerHealthMetric) {
       return 'ServerHealthMetric';
     }
-    if (data is _i52.ServerHealthResult) {
+    if (data is _i53.ServerHealthResult) {
       return 'ServerHealthResult';
     }
-    if (data is _i53.ServerpodSqlException) {
+    if (data is _i54.ServerpodSqlException) {
       return 'ServerpodSqlException';
     }
-    if (data is _i54.SessionLogEntry) {
+    if (data is _i55.SessionLogEntry) {
       return 'SessionLogEntry';
     }
-    if (data is _i55.SessionLogFilter) {
+    if (data is _i56.SessionLogFilter) {
       return 'SessionLogFilter';
     }
-    if (data is _i56.SessionLogInfo) {
+    if (data is _i57.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i57.SessionLogResult) {
+    if (data is _i58.SessionLogResult) {
       return 'SessionLogResult';
     }
     return super.getClassNameForObject(data);
@@ -921,86 +933,89 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'ForeignKeyMatchType') {
       return deserialize<_i30.ForeignKeyMatchType>(data['data']);
     }
+    if (data['className'] == 'GeographyPoint') {
+      return deserialize<_i31.GeographyPoint>(data['data']);
+    }
     if (data['className'] == 'IndexDefinition') {
-      return deserialize<_i31.IndexDefinition>(data['data']);
+      return deserialize<_i32.IndexDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinition') {
-      return deserialize<_i32.IndexElementDefinition>(data['data']);
+      return deserialize<_i33.IndexElementDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinitionType') {
-      return deserialize<_i33.IndexElementDefinitionType>(data['data']);
+      return deserialize<_i34.IndexElementDefinitionType>(data['data']);
     }
     if (data['className'] == 'TableDefinition') {
-      return deserialize<_i34.TableDefinition>(data['data']);
+      return deserialize<_i35.TableDefinition>(data['data']);
     }
     if (data['className'] == 'TableMigration') {
-      return deserialize<_i35.TableMigration>(data['data']);
+      return deserialize<_i36.TableMigration>(data['data']);
     }
     if (data['className'] == 'DistributedCacheEntry') {
-      return deserialize<_i36.DistributedCacheEntry>(data['data']);
+      return deserialize<_i37.DistributedCacheEntry>(data['data']);
     }
     if (data['className'] == 'AccessDeniedException') {
-      return deserialize<_i37.AccessDeniedException>(data['data']);
+      return deserialize<_i38.AccessDeniedException>(data['data']);
     }
     if (data['className'] == 'FileNotFoundException') {
-      return deserialize<_i38.FileNotFoundException>(data['data']);
+      return deserialize<_i39.FileNotFoundException>(data['data']);
     }
     if (data['className'] == 'FutureCallEntry') {
-      return deserialize<_i39.FutureCallEntry>(data['data']);
+      return deserialize<_i40.FutureCallEntry>(data['data']);
     }
     if (data['className'] == 'LogEntry') {
-      return deserialize<_i40.LogEntry>(data['data']);
+      return deserialize<_i41.LogEntry>(data['data']);
     }
     if (data['className'] == 'LogLevel') {
-      return deserialize<_i41.LogLevel>(data['data']);
+      return deserialize<_i42.LogLevel>(data['data']);
     }
     if (data['className'] == 'LogResult') {
-      return deserialize<_i42.LogResult>(data['data']);
+      return deserialize<_i43.LogResult>(data['data']);
     }
     if (data['className'] == 'LogSettings') {
-      return deserialize<_i43.LogSettings>(data['data']);
+      return deserialize<_i44.LogSettings>(data['data']);
     }
     if (data['className'] == 'LogSettingsOverride') {
-      return deserialize<_i44.LogSettingsOverride>(data['data']);
+      return deserialize<_i45.LogSettingsOverride>(data['data']);
     }
     if (data['className'] == 'MessageLogEntry') {
-      return deserialize<_i45.MessageLogEntry>(data['data']);
+      return deserialize<_i46.MessageLogEntry>(data['data']);
     }
     if (data['className'] == 'MethodInfo') {
-      return deserialize<_i46.MethodInfo>(data['data']);
+      return deserialize<_i47.MethodInfo>(data['data']);
     }
     if (data['className'] == 'QueryLogEntry') {
-      return deserialize<_i47.QueryLogEntry>(data['data']);
+      return deserialize<_i48.QueryLogEntry>(data['data']);
     }
     if (data['className'] == 'ReadWriteTestEntry') {
-      return deserialize<_i48.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i49.ReadWriteTestEntry>(data['data']);
     }
     if (data['className'] == 'RuntimeSettings') {
-      return deserialize<_i49.RuntimeSettings>(data['data']);
+      return deserialize<_i50.RuntimeSettings>(data['data']);
     }
     if (data['className'] == 'ServerHealthConnectionInfo') {
-      return deserialize<_i50.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i51.ServerHealthConnectionInfo>(data['data']);
     }
     if (data['className'] == 'ServerHealthMetric') {
-      return deserialize<_i51.ServerHealthMetric>(data['data']);
+      return deserialize<_i52.ServerHealthMetric>(data['data']);
     }
     if (data['className'] == 'ServerHealthResult') {
-      return deserialize<_i52.ServerHealthResult>(data['data']);
+      return deserialize<_i53.ServerHealthResult>(data['data']);
     }
     if (data['className'] == 'ServerpodSqlException') {
-      return deserialize<_i53.ServerpodSqlException>(data['data']);
+      return deserialize<_i54.ServerpodSqlException>(data['data']);
     }
     if (data['className'] == 'SessionLogEntry') {
-      return deserialize<_i54.SessionLogEntry>(data['data']);
+      return deserialize<_i55.SessionLogEntry>(data['data']);
     }
     if (data['className'] == 'SessionLogFilter') {
-      return deserialize<_i55.SessionLogFilter>(data['data']);
+      return deserialize<_i56.SessionLogFilter>(data['data']);
     }
     if (data['className'] == 'SessionLogInfo') {
-      return deserialize<_i56.SessionLogInfo>(data['data']);
+      return deserialize<_i57.SessionLogInfo>(data['data']);
     }
     if (data['className'] == 'SessionLogResult') {
-      return deserialize<_i57.SessionLogResult>(data['data']);
+      return deserialize<_i58.SessionLogResult>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -342,6 +342,8 @@ extension ColumnDefinitionPgSqlGeneration on ColumnDefinition {
         break;
       case ColumnType.unknown:
         throw (const FormatException('Unknown column type'));
+      case ColumnType.geographyPoint:
+        type = 'geog geography(point,4269)';
     }
 
     out += '"$name" $type$nullable';


### PR DESCRIPTION
I started working on #460, adding geolocation point support to Serverpod.

I got this partially implemented, but then ran into problems, and I had too many unanswered questions about how Serverpod is currently implemented, or how it would need to be changed to finish this PR. I don't have enough time to finish this, so I'll submit this here in the hopes somebody else will finish it (and I'll have to just use manual SQL queries for now, yet again!).

The questions I ran up against:
1. How should the `toString` method in `_GeographyDistanceColumnExpression` work, given this is not a simple case of an `operator`?
2. How do I make a `FilterConstraint` which takes two parameters, not just one `value`? (I need to be able to filter using "where distance from point X is less than Y km"), whereas FilterConstraint seems to only take one parameter)
3. How do I get `orderBy` to take a parameter? (I need "order by distance from point X", whereas the current `orderBy` API lets you specify just a column, and then ascending or descending, but not an additional parameter)

Considerations for use:

* You have to index `GeographyDistance` columns using index type `type: gist`
* You have to upgrade the Postgres Docker version to one that has the postgis extension, using:

```
  postgres:
    image: postgis/postgis:16-3.4
```