### PR TITLE
test: Increase timeout on integration tests.

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -131,7 +131,7 @@ jobs:
       fail-fast: false
       matrix:
         flutter-version: ['3.10.0', '3.13.0']
-        os: [ubuntu-latest, "macos-latest"]
+        os: [ubuntu-latest]
         path: ["tests/bootstrap_project"]
     steps:
       - uses: actions/checkout@v3
@@ -173,7 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         flutter-version: ['3.10.0', '3.13.0']
-        os: [ubuntu-latest, "macos-latest"]
+        os: [ubuntu-latest]
         path: ["tools/serverpod_cli/test_e2e"]
     steps:
       - uses: actions/checkout@v3

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1,4 +1,4 @@
-@Timeout(Duration(minutes: 8))
+@Timeout(Duration(minutes: 12))
 
 import 'dart:convert';
 import 'dart:io';

--- a/tools/serverpod_cli/test_e2e/test/generate_watch_test.dart
+++ b/tools/serverpod_cli/test_e2e/test/generate_watch_test.dart
@@ -1,4 +1,4 @@
-@Timeout(Duration(minutes: 8))
+@Timeout(Duration(minutes: 12))
 
 import 'dart:async';
 import 'dart:convert';


### PR DESCRIPTION
Increase the timeout on the integration test as we are hitting the limit on macOS runners.