### PR TITLE
fix: Generate output from models from hints and into level errors.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/code_analysis_collector.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/code_analysis_collector.dart
@@ -4,13 +4,17 @@ import 'package:super_string/super_string.dart';
 abstract class CodeAnalysisCollector {
   List<SourceSpanException> get errors;
 
-  bool get hasSeverErrors => errors.where(
-        (error) {
-          return error is! SourceSpanSeverityException ||
-              error.severity == SourceSpanSeverity.error ||
-              error.severity == SourceSpanSeverity.warning;
-        },
-      ).isNotEmpty;
+  static bool containsSeverErrors(List<SourceSpanException> errors) {
+    return errors.where(
+      (error) {
+        return error is! SourceSpanSeverityException ||
+            error.severity == SourceSpanSeverity.error ||
+            error.severity == SourceSpanSeverity.warning;
+      },
+    ).isNotEmpty;
+  }
+
+  bool get hasSeverErrors => containsSeverErrors(errors);
 
   void addError(SourceSpanException error);
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -1,5 +1,4 @@
 import 'package:serverpod_cli/analyzer.dart';
-import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 
@@ -29,7 +30,8 @@ class StatefulAnalyzer {
 
   /// Returns all valid models in the state.
   List<SerializableModelDefinition> get _validModels => _modelStates.values
-      .where((state) => state.errors.isEmpty)
+      .where(
+          (state) => !CodeAnalysisCollector.containsSeverErrors(state.errors))
       .map((state) => state.model)
       .whereType<SerializableModelDefinition>()
       .toList();

--- a/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
+++ b/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
@@ -27,7 +27,7 @@ class CodeGenerationCollector extends CodeAnalysisCollector {
   String toString() {
     var out = '';
 
-    out += 'Found ${errors.length} error${errors.length == 1 ? '' : 's'}.\n';
+    out += 'Found ${errors.length} issue${errors.length == 1 ? '' : 's'}.\n';
     out += '\n';
 
     for (var error in errors) {
@@ -43,10 +43,26 @@ class CodeGenerationCollector extends CodeAnalysisCollector {
       return;
     }
 
-    log.error(
-      'Found ${errors.length} error${errors.length == 1 ? '' : 's'}.',
-      newParagraph: true,
-    );
+    var logMessage =
+        'Found ${errors.length} issue${errors.length == 1 ? '' : 's'}.';
+
+    var severityErrors = errors.whereType<SourceSpanSeverityException>();
+
+    var hasErrors = severityErrors.isEmpty ||
+        severityErrors
+            .where((error) => error.severity == SourceSpanSeverity.error)
+            .isNotEmpty;
+    var hasWarnings = severityErrors
+        .where((error) => error.severity == SourceSpanSeverity.warning)
+        .isNotEmpty;
+
+    if (hasErrors) {
+      log.error(logMessage, newParagraph: true);
+    } else if (hasWarnings) {
+      log.warning(logMessage, newParagraph: true);
+    } else {
+      log.info(logMessage, newParagraph: true);
+    }
 
     for (var error in errors) {
       log.sourceSpanException(error);

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field_validation_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
@@ -293,7 +294,10 @@ void main() {
         expect(collector.errors, isNotEmpty,
             reason: 'Expected an error but none was generated.');
 
-        var error = collector.errors.first;
+        var error = collector.errors.first as SourceSpanSeverityException;
+
+        expect(error.severity, SourceSpanSeverity.info);
+
         expect(
           error.message,
           'Field names should be valid Dart variable names (e.g. camelCaseString).',


### PR DESCRIPTION
# Changes

- Fixes a bug where we would ignore a model regardless of error level reported.
- Changes the output when errors are found to write "issue(s)" instead and color the output based on the existing error levels, see screenshot.
- Generate command reports as succeeded if only info / hint level errors are created. 

<img width="353" alt="Screenshot 2023-12-27 at 11 45 13" src="https://github.com/serverpod/serverpod/assets/7395515/73fe7edc-80af-4c26-82b2-ccdbafa8b036">

Closes: #1682 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
