### PR TITLE
ci: Increase MacOS test timeout.

### DIFF
--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1,4 +1,4 @@
-@Timeout(Duration(minutes: 8))
+@Timeout(Duration(minutes: 20))
 
 import 'dart:convert';
 import 'dart:io';

--- a/tools/serverpod_cli/test_e2e/test/generate_watch_test.dart
+++ b/tools/serverpod_cli/test_e2e/test/generate_watch_test.dart
@@ -1,4 +1,4 @@
-@Timeout(Duration(minutes: 8))
+@Timeout(Duration(minutes: 20))
 
 import 'dart:async';
 import 'dart:convert';


### PR DESCRIPTION
## Changes:
- Increases the test timeout for MacOS.

MacOS runner in Github actions is notoriously slow https://github.com/actions/runner-images/issues/1336.

We currently have multiple runs that are failing because the MacOS runner times out during test execution without anything going wrong in the test giving us a false negative.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
