### PR TITLE
test: Add debug output on stream errors.

### DIFF
--- a/tools/serverpod_cli/test_e2e/lib/src/keyword_search_in_stream.dart
+++ b/tools/serverpod_cli/test_e2e/lib/src/keyword_search_in_stream.dart
@@ -45,14 +45,20 @@ class KeywordSearchInStream {
   }
 
   KeywordSearchInStream startListen() {
-    _subscription = _stream.listen((String output) {
-      if (keywords.contains(output.trim())) {
-        _found = true;
-      }
+    _subscription = _stream.listen(
+      (String output) {
+        if (keywords.contains(output.trim())) {
+          _found = true;
+        }
 
-      print(output);
-      _scheduleTimeout();
-    });
+        print(output);
+        _scheduleTimeout();
+      },
+      onError: (err) {
+        print('Error in stream: $err');
+      },
+      cancelOnError: false,
+    );
 
     return this;
   }


### PR DESCRIPTION
## Changes:
- Adds debug output and does not cancel stream if error is encountered in stream.


In an effort to debug the issues with the CLI e2e tests recently encountered we add some debug information if a steam encounters an error.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
