### PR TITLE
test: Initiate listen outside of keyword search class for test.

### DIFF
--- a/tools/serverpod_cli/test_e2e/lib/src/keyword_search_in_stream.dart
+++ b/tools/serverpod_cli/test_e2e/lib/src/keyword_search_in_stream.dart
@@ -1,27 +1,24 @@
 import 'dart:async';
 
-/// Searches for keywords in a stream of strings.
-/// The class expects a stream that is split by lines and utf8 decoded.
+/// Searches the [onData] string for the [keywords].
 ///
-/// The class will listen to the stream and set the [_found] flag to true
+/// The class will search for the keywords and set the [_found] flag to true
 /// if the keyword is found. If the keyword is not found within the timeout
 /// period, the [_found] flag will be set to false.
 ///
 /// The user can call [keywordFound] to wait for the keyword to be
 /// found or the timeout to occur.
 ///
-/// The user needs to call [startListen] to start listening to the stream.
-/// The user needs to call [close] to stop listening to the stream.
+/// The user needs to call [cancel] once search is completed to remove any
+/// active timeouts and prevent future onces from being initialized.
 class KeywordSearchInStream {
   bool? _found;
   final List<String> keywords;
-  final Stream<String> _stream;
-  late final StreamSubscription<String> _subscription;
   final Duration timeout;
   Timer? _timer;
+  bool _searching = true;
 
-  KeywordSearchInStream(
-    this._stream, {
+  KeywordSearchInStream({
     this.timeout = const Duration(seconds: 30),
     required this.keywords,
   });
@@ -39,28 +36,23 @@ class KeywordSearchInStream {
     return value;
   }
 
-  void close() {
-    _timer?.cancel();
-    _subscription.cancel();
+  void onData(String data) {
+    print(data);
+
+    if (!_searching) {
+      return;
+    }
+
+    if (keywords.contains(data.trim())) {
+      _found = true;
+    }
+
+    _scheduleTimeout();
   }
 
-  KeywordSearchInStream startListen() {
-    _subscription = _stream.listen(
-      (String output) {
-        if (keywords.contains(output.trim())) {
-          _found = true;
-        }
-
-        print(output);
-        _scheduleTimeout();
-      },
-      onError: (err) {
-        print('Error in stream: $err');
-      },
-      cancelOnError: false,
-    );
-
-    return this;
+  void cancel() {
+    _searching = false;
+    _timer?.cancel();
   }
 
   void _scheduleTimeout() {

--- a/tools/serverpod_cli/test_e2e/test/generate_watch_test.dart
+++ b/tools/serverpod_cli/test_e2e/test/generate_watch_test.dart
@@ -40,7 +40,9 @@ void main() async {
 
     late Process createProcess;
     Process? generateWatch;
-    KeywordSearchInStream? generateStreamSearch;
+    KeywordSearchInStream generateStreamSearch = KeywordSearchInStream(
+      keywords: generateWatchCompletionKeywords,
+    );
     setUp(() async {
       // Create project
       createProcess = await Process.start(
@@ -65,7 +67,7 @@ void main() async {
     tearDown(() async {
       createProcess.kill();
       generateWatch?.kill();
-      generateStreamSearch?.close();
+      generateStreamSearch.cancel();
 
       await Process.run(
         'docker',
@@ -88,21 +90,20 @@ void main() async {
         },
       );
 
-      var stdoutStream = generateWatch!.stdout
+      generateStreamSearch = KeywordSearchInStream(
+        keywords: generateWatchCompletionKeywords,
+      );
+      generateWatch!.stdout
           .transform(const Utf8Decoder())
-          .transform(const LineSplitter());
+          .transform(const LineSplitter())
+          .listen(generateStreamSearch.onData);
       generateWatch!.stderr
           .transform(const Utf8Decoder())
           .transform(const LineSplitter())
           .listen(print);
 
-      generateStreamSearch = KeywordSearchInStream(
-        stdoutStream,
-        keywords: generateWatchCompletionKeywords,
-      ).startListen();
-
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Initial code generation did not complete before timeout was reached.',
@@ -126,7 +127,7 @@ fields:
 ''', flush: true);
 
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Incremental code generation did not complete before timeout was reached.',
@@ -168,7 +169,7 @@ fields:
 ''', flush: true);
 
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Incremental code generation did not complete before timeout was reached.',
@@ -191,7 +192,7 @@ fields:
       // Remove model file
       protocolFile.deleteSync();
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Incremental code generation did not complete before timeout was reached.',
@@ -214,7 +215,9 @@ fields:
 
     late Process createProcess;
     Process? generateWatch;
-    KeywordSearchInStream? generateStreamSearch;
+    KeywordSearchInStream generateStreamSearch = KeywordSearchInStream(
+      keywords: generateWatchCompletionKeywords,
+    );
     setUp(() async {
       // Create project
       createProcess = await Process.start(
@@ -239,7 +242,7 @@ fields:
     tearDown(() async {
       createProcess.kill();
       generateWatch?.kill();
-      generateStreamSearch?.close();
+      generateStreamSearch.cancel();
 
       await Process.run(
         'docker',
@@ -261,21 +264,17 @@ fields:
         },
       );
 
-      var stdoutStream = generateWatch!.stdout
+      generateWatch!.stdout
           .transform(const Utf8Decoder())
-          .transform(const LineSplitter());
+          .transform(const LineSplitter())
+          .listen(generateStreamSearch.onData);
       generateWatch!.stderr
           .transform(const Utf8Decoder())
           .transform(const LineSplitter())
           .listen(print);
 
-      generateStreamSearch = KeywordSearchInStream(
-        stdoutStream,
-        keywords: generateWatchCompletionKeywords,
-      ).startListen();
-
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Initial code generation did not complete before timeout was reached.',
@@ -303,7 +302,7 @@ class TestEndpoint extends Endpoint {
 ''', flush: true);
 
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Incremental code generation did not complete before timeout was reached.',
@@ -351,7 +350,7 @@ class TestEndpoint extends Endpoint {
 ''', flush: true);
 
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Incremental code generation did not complete before timeout was reached.',
@@ -371,7 +370,7 @@ class TestEndpoint extends Endpoint {
       endpointFile.deleteSync();
 
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Incremental code generation did not complete before timeout was reached.',
@@ -396,7 +395,9 @@ class TestEndpoint extends Endpoint {
 
     late Process createProcess;
     Process? generateWatch;
-    KeywordSearchInStream? generateStreamSearch;
+    KeywordSearchInStream generateStreamSearch = KeywordSearchInStream(
+      keywords: generateWatchCompletionKeywords,
+    );
     setUp(() async {
       // Create project
       createProcess = await Process.start(
@@ -421,7 +422,7 @@ class TestEndpoint extends Endpoint {
     tearDown(() async {
       createProcess.kill();
       generateWatch?.kill();
-      generateStreamSearch?.close();
+      generateStreamSearch.cancel();
 
       await Process.run(
         'docker',
@@ -474,21 +475,17 @@ fields:
         },
       );
 
-      var stdoutStream = generateWatch!.stdout
+      generateWatch!.stdout
           .transform(const Utf8Decoder())
-          .transform(const LineSplitter());
+          .transform(const LineSplitter())
+          .listen(generateStreamSearch.onData);
       generateWatch!.stderr
           .transform(const Utf8Decoder())
           .transform(const LineSplitter())
           .listen(print);
 
-      generateStreamSearch = KeywordSearchInStream(
-        stdoutStream,
-        keywords: generateWatchCompletionKeywords,
-      ).startListen();
-
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Initial code generation did not complete before timeout was reached.',
@@ -541,7 +538,7 @@ fields:
       ));
 
       await expectLater(
-        generateStreamSearch?.keywordFound,
+        generateStreamSearch.keywordFound,
         completion(isTrue),
         reason:
             'Incremental code generation did not complete before timeout was reached.',


### PR DESCRIPTION
## Change:
- Moves the stream listen initialization out into the test class for hopefully a different lifecycle management.

For some reason moving the listen initialization out into the test instead of having it inside of the keyword search class seems to help to keep the stream open.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
