### PR TITLE
Don't serialize null map values

### DIFF
--- a/examples/chat/chat_client/lib/src/protocol/channel.dart
+++ b/examples/chat/chat_client/lib/src/protocol/channel.dart
@@ -55,7 +55,7 @@ abstract class Channel extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'channel': channel,
     };

--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -57,7 +57,7 @@ abstract class Channel extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'channel': channel,
     };

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/apple_auth_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/apple_auth_info.dart
@@ -80,7 +80,7 @@ abstract class AppleAuthInfo extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'userIdentifier': userIdentifier,
-      'email': email,
+      if (email != null) 'email': email,
       'fullName': fullName,
       'nickname': nickname,
       'identityToken': identityToken,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_response.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_response.dart
@@ -74,10 +74,10 @@ abstract class AuthenticationResponse extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'success': success,
-      'key': key,
-      'keyId': keyId,
-      'userInfo': userInfo,
-      'failReason': failReason,
+      if (key != null) 'key': key,
+      if (keyId != null) 'keyId': keyId,
+      if (userInfo != null) 'userInfo': userInfo,
+      if (failReason != null) 'failReason': failReason,
     };
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_auth.dart
@@ -63,7 +63,7 @@ abstract class EmailAuth extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'email': email,
       'hash': hash,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_create_account_request.dart
@@ -72,7 +72,7 @@ abstract class EmailCreateAccountRequest extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userName': userName,
       'email': email,
       'hash': hash,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
@@ -65,7 +65,7 @@ abstract class EmailFailedSignIn extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'email': email,
       'time': time,
       'ipAddress': ipAddress,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
@@ -64,7 +64,7 @@ abstract class EmailReset extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'verificationCode': verificationCode,
       'expiration': expiration,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/google_refresh_token.dart
@@ -56,7 +56,7 @@ abstract class GoogleRefreshToken extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'refreshToken': refreshToken,
     };

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_image.dart
@@ -63,7 +63,7 @@ abstract class UserImage extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'version': version,
       'url': url,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
@@ -109,13 +109,13 @@ abstract class UserInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userIdentifier': userIdentifier,
       'userName': userName,
-      'fullName': fullName,
-      'email': email,
+      if (fullName != null) 'fullName': fullName,
+      if (email != null) 'email': email,
       'created': created,
-      'imageUrl': imageUrl,
+      if (imageUrl != null) 'imageUrl': imageUrl,
       'scopeNames': scopeNames,
       'blocked': blocked,
     };

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
@@ -70,11 +70,11 @@ abstract class UserInfoPublic extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userName': userName,
-      'fullName': fullName,
+      if (fullName != null) 'fullName': fullName,
       'created': created,
-      'imageUrl': imageUrl,
+      if (imageUrl != null) 'imageUrl': imageUrl,
     };
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/apple_auth_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/apple_auth_info.dart
@@ -80,7 +80,7 @@ abstract class AppleAuthInfo extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'userIdentifier': userIdentifier,
-      'email': email,
+      if (email != null) 'email': email,
       'fullName': fullName,
       'nickname': nickname,
       'identityToken': identityToken,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
@@ -74,10 +74,10 @@ abstract class AuthenticationResponse extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'success': success,
-      'key': key,
-      'keyId': keyId,
-      'userInfo': userInfo,
-      'failReason': failReason,
+      if (key != null) 'key': key,
+      if (keyId != null) 'keyId': keyId,
+      if (userInfo != null) 'userInfo': userInfo,
+      if (failReason != null) 'failReason': failReason,
     };
   }
 

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -65,7 +65,7 @@ abstract class EmailAuth extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'email': email,
       'hash': hash,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -74,7 +74,7 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userName': userName,
       'email': email,
       'hash': hash,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -67,7 +67,7 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'email': email,
       'time': time,
       'ipAddress': ipAddress,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -66,7 +66,7 @@ abstract class EmailReset extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'verificationCode': verificationCode,
       'expiration': expiration,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -58,7 +58,7 @@ abstract class GoogleRefreshToken extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'refreshToken': refreshToken,
     };

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -65,7 +65,7 @@ abstract class UserImage extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'version': version,
       'url': url,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -111,13 +111,13 @@ abstract class UserInfo extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userIdentifier': userIdentifier,
       'userName': userName,
-      'fullName': fullName,
-      'email': email,
+      if (fullName != null) 'fullName': fullName,
+      if (email != null) 'email': email,
       'created': created,
-      'imageUrl': imageUrl,
+      if (imageUrl != null) 'imageUrl': imageUrl,
       'scopeNames': scopeNames,
       'blocked': blocked,
     };

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
@@ -70,11 +70,11 @@ abstract class UserInfoPublic extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userName': userName,
-      'fullName': fullName,
+      if (fullName != null) 'fullName': fullName,
       'created': created,
-      'imageUrl': imageUrl,
+      if (imageUrl != null) 'imageUrl': imageUrl,
     };
   }
 

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_join_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_join_channel.dart
@@ -48,7 +48,7 @@ abstract class ChatJoinChannel extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'channel': channel,
-      'userName': userName,
+      if (userName != null) 'userName': userName,
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_leave_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_leave_channel.dart
@@ -31,7 +31,9 @@ abstract class ChatLeaveChannel extends _i1.SerializableEntity {
   ChatLeaveChannel copyWith({String? channel});
   @override
   Map<String, dynamic> toJson() {
-    return {'channel': channel};
+    return {
+      'channel': channel,
+    };
   }
 }
 

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
@@ -114,16 +114,16 @@ abstract class ChatMessage extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'channel': channel,
       'message': message,
       'time': time,
       'sender': sender,
-      'senderInfo': senderInfo,
+      if (senderInfo != null) 'senderInfo': senderInfo,
       'removed': removed,
-      'clientMessageId': clientMessageId,
-      'sent': sent,
-      'attachments': attachments,
+      if (clientMessageId != null) 'clientMessageId': clientMessageId,
+      if (sent != null) 'sent': sent,
+      if (attachments != null) 'attachments': attachments,
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment.dart
@@ -81,9 +81,9 @@ abstract class ChatMessageAttachment extends _i1.SerializableEntity {
       'fileName': fileName,
       'url': url,
       'contentType': contentType,
-      'previewImage': previewImage,
-      'previewWidth': previewWidth,
-      'previewHeight': previewHeight,
+      if (previewImage != null) 'previewImage': previewImage,
+      if (previewWidth != null) 'previewWidth': previewWidth,
+      if (previewHeight != null) 'previewHeight': previewHeight,
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
@@ -68,7 +68,7 @@ abstract class ChatMessagePost extends _i1.SerializableEntity {
       'channel': channel,
       'message': message,
       'clientMessageId': clientMessageId,
-      'attachments': attachments,
+      if (attachments != null) 'attachments': attachments,
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_read_message.dart
@@ -64,7 +64,7 @@ abstract class ChatReadMessage extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'channel': channel,
       'userId': userId,
       'lastReadMessageId': lastReadMessageId,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_join_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_join_channel.dart
@@ -48,7 +48,7 @@ abstract class ChatJoinChannel extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'channel': channel,
-      'userName': userName,
+      if (userName != null) 'userName': userName,
     };
   }
 

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_leave_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_leave_channel.dart
@@ -31,7 +31,9 @@ abstract class ChatLeaveChannel extends _i1.SerializableEntity {
   ChatLeaveChannel copyWith({String? channel});
   @override
   Map<String, dynamic> toJson() {
-    return {'channel': channel};
+    return {
+      'channel': channel,
+    };
   }
 
   @override

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -116,16 +116,16 @@ abstract class ChatMessage extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'channel': channel,
       'message': message,
       'time': time,
       'sender': sender,
-      'senderInfo': senderInfo,
+      if (senderInfo != null) 'senderInfo': senderInfo,
       'removed': removed,
-      'clientMessageId': clientMessageId,
-      'sent': sent,
-      'attachments': attachments,
+      if (clientMessageId != null) 'clientMessageId': clientMessageId,
+      if (sent != null) 'sent': sent,
+      if (attachments != null) 'attachments': attachments,
     };
   }
 

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment.dart
@@ -81,9 +81,9 @@ abstract class ChatMessageAttachment extends _i1.SerializableEntity {
       'fileName': fileName,
       'url': url,
       'contentType': contentType,
-      'previewImage': previewImage,
-      'previewWidth': previewWidth,
-      'previewHeight': previewHeight,
+      if (previewImage != null) 'previewImage': previewImage,
+      if (previewWidth != null) 'previewWidth': previewWidth,
+      if (previewHeight != null) 'previewHeight': previewHeight,
     };
   }
 

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
@@ -68,7 +68,7 @@ abstract class ChatMessagePost extends _i1.SerializableEntity {
       'channel': channel,
       'message': message,
       'clientMessageId': clientMessageId,
-      'attachments': attachments,
+      if (attachments != null) 'attachments': attachments,
     };
   }
 

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -66,7 +66,7 @@ abstract class ChatReadMessage extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'channel': channel,
       'userId': userId,
       'lastReadMessageId': lastReadMessageId,

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -81,10 +81,10 @@ abstract class AuthKey extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'hash': hash,
-      'key': key,
+      if (key != null) 'key': key,
       'scopeNames': scopeNames,
       'method': method,
     };

--- a/packages/serverpod/lib/src/generated/cache_info.dart
+++ b/packages/serverpod/lib/src/generated/cache_info.dart
@@ -57,7 +57,7 @@ abstract class CacheInfo extends _i1.SerializableEntity {
     return {
       'numEntries': numEntries,
       'maxEntries': maxEntries,
-      'keys': keys,
+      if (keys != null) 'keys': keys,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -90,11 +90,11 @@ abstract class CloudStorageEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
       'addedTime': addedTime,
-      'expiration': expiration,
+      if (expiration != null) 'expiration': expiration,
       'byteData': byteData,
       'verified': verified,
     };

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -73,7 +73,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
       'expiration': expiration,

--- a/packages/serverpod/lib/src/generated/cluster_info.dart
+++ b/packages/serverpod/lib/src/generated/cluster_info.dart
@@ -33,7 +33,9 @@ abstract class ClusterInfo extends _i1.SerializableEntity {
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers});
   @override
   Map<String, dynamic> toJson() {
-    return {'servers': servers};
+    return {
+      'servers': servers,
+    };
   }
 
   @override

--- a/packages/serverpod/lib/src/generated/cluster_server_info.dart
+++ b/packages/serverpod/lib/src/generated/cluster_server_info.dart
@@ -32,7 +32,9 @@ abstract class ClusterServerInfo extends _i1.SerializableEntity {
   ClusterServerInfo copyWith({String? serverId});
   @override
   Map<String, dynamic> toJson() {
-    return {'serverId': serverId};
+    return {
+      'serverId': serverId,
+    };
   }
 
   @override

--- a/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
@@ -46,7 +46,7 @@ abstract class BulkDataException extends _i1.SerializableEntity
   Map<String, dynamic> toJson() {
     return {
       'message': message,
-      'query': query,
+      if (query != null) 'query': query,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/column_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/column_definition.dart
@@ -76,8 +76,8 @@ abstract class ColumnDefinition extends _i1.SerializableEntity {
       'name': name,
       'columnType': columnType,
       'isNullable': isNullable,
-      'columnDefault': columnDefault,
-      'dartType': dartType,
+      if (columnDefault != null) 'columnDefault': columnDefault,
+      if (dartType != null) 'dartType': dartType,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/column_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/column_migration.dart
@@ -69,7 +69,7 @@ abstract class ColumnMigration extends _i1.SerializableEntity {
       'addNullable': addNullable,
       'removeNullable': removeNullable,
       'changeDefault': changeDefault,
-      'newDefault': newDefault,
+      if (newDefault != null) 'newDefault': newDefault,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/database_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definition.dart
@@ -75,7 +75,7 @@ abstract class DatabaseDefinition extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'name': name,
+      if (name != null) 'name': name,
       'moduleName': moduleName,
       'tables': tables,
       'installedModules': installedModules,

--- a/packages/serverpod/lib/src/generated/database/database_migration_action.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_action.dart
@@ -60,9 +60,9 @@ abstract class DatabaseMigrationAction extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'type': type,
-      'deleteTable': deleteTable,
-      'alterTable': alterTable,
-      'createTable': createTable,
+      if (deleteTable != null) 'deleteTable': deleteTable,
+      if (alterTable != null) 'alterTable': alterTable,
+      if (createTable != null) 'createTable': createTable,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -66,10 +66,10 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'module': module,
       'version': version,
-      'timestamp': timestamp,
+      if (timestamp != null) 'timestamp': timestamp,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
@@ -62,7 +62,7 @@ abstract class FilterConstraint extends _i1.SerializableEntity {
       'type': type,
       'column': column,
       'value': value,
-      'value2': value2,
+      if (value2 != null) 'value2': value2,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/foreign_key_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/foreign_key_definition.dart
@@ -101,9 +101,9 @@ abstract class ForeignKeyDefinition extends _i1.SerializableEntity {
       'referenceTable': referenceTable,
       'referenceTableSchema': referenceTableSchema,
       'referenceColumns': referenceColumns,
-      'onUpdate': onUpdate,
-      'onDelete': onDelete,
-      'matchType': matchType,
+      if (onUpdate != null) 'onUpdate': onUpdate,
+      if (onDelete != null) 'onDelete': onDelete,
+      if (matchType != null) 'matchType': matchType,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/index_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/index_definition.dart
@@ -90,12 +90,12 @@ abstract class IndexDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'indexName': indexName,
-      'tableSpace': tableSpace,
+      if (tableSpace != null) 'tableSpace': tableSpace,
       'elements': elements,
       'type': type,
       'isUnique': isUnique,
       'isPrimary': isPrimary,
-      'predicate': predicate,
+      if (predicate != null) 'predicate': predicate,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/table_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/table_definition.dart
@@ -107,14 +107,14 @@ abstract class TableDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'dartName': dartName,
-      'module': module,
+      if (dartName != null) 'dartName': dartName,
+      if (module != null) 'module': module,
       'schema': schema,
-      'tableSpace': tableSpace,
+      if (tableSpace != null) 'tableSpace': tableSpace,
       'columns': columns,
       'foreignKeys': foreignKeys,
       'indexes': indexes,
-      'managed': managed,
+      if (managed != null) 'managed': managed,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/table_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/table_migration.dart
@@ -118,8 +118,8 @@ abstract class TableMigration extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'dartName': dartName,
-      'module': module,
+      if (dartName != null) 'dartName': dartName,
+      if (module != null) 'module': module,
       'schema': schema,
       'addColumns': addColumns,
       'deleteColumns': deleteColumns,

--- a/packages/serverpod/lib/src/generated/distributed_cache_entry.dart
+++ b/packages/serverpod/lib/src/generated/distributed_cache_entry.dart
@@ -32,7 +32,9 @@ abstract class DistributedCacheEntry extends _i1.SerializableEntity {
   DistributedCacheEntry copyWith({String? data});
   @override
   Map<String, dynamic> toJson() {
-    return {'data': data};
+    return {
+      'data': data,
+    };
   }
 
   @override

--- a/packages/serverpod/lib/src/generated/exceptions/access_denied.dart
+++ b/packages/serverpod/lib/src/generated/exceptions/access_denied.dart
@@ -31,7 +31,9 @@ abstract class AccessDeniedException extends _i1.SerializableEntity
   AccessDeniedException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
-    return {'message': message};
+    return {
+      'message': message,
+    };
   }
 
   @override

--- a/packages/serverpod/lib/src/generated/exceptions/file_not_found.dart
+++ b/packages/serverpod/lib/src/generated/exceptions/file_not_found.dart
@@ -31,7 +31,9 @@ abstract class FileNotFoundException extends _i1.SerializableEntity
   FileNotFoundException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
-    return {'message': message};
+    return {
+      'message': message,
+    };
   }
 
   @override

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -81,12 +81,12 @@ abstract class FutureCallEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'time': time,
-      'serializedObject': serializedObject,
+      if (serializedObject != null) 'serializedObject': serializedObject,
       'serverId': serverId,
-      'identifier': identifier,
+      if (identifier != null) 'identifier': identifier,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -122,16 +122,16 @@ abstract class LogEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'sessionLogId': sessionLogId,
-      'messageId': messageId,
-      'reference': reference,
+      if (messageId != null) 'messageId': messageId,
+      if (reference != null) 'reference': reference,
       'serverId': serverId,
       'time': time,
       'logLevel': logLevel,
       'message': message,
-      'error': error,
-      'stackTrace': stackTrace,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
       'order': order,
     };
   }

--- a/packages/serverpod/lib/src/generated/log_result.dart
+++ b/packages/serverpod/lib/src/generated/log_result.dart
@@ -32,7 +32,9 @@ abstract class LogResult extends _i1.SerializableEntity {
   LogResult copyWith({List<_i2.LogEntry>? entries});
   @override
   Map<String, dynamic> toJson() {
-    return {'entries': entries};
+    return {
+      'entries': entries,
+    };
   }
 
   @override

--- a/packages/serverpod/lib/src/generated/log_settings_override.dart
+++ b/packages/serverpod/lib/src/generated/log_settings_override.dart
@@ -65,9 +65,9 @@ abstract class LogSettingsOverride extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'module': module,
-      'endpoint': endpoint,
-      'method': method,
+      if (module != null) 'module': module,
+      if (endpoint != null) 'endpoint': endpoint,
+      if (method != null) 'method': method,
       'logSettings': logSettings,
     };
   }

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -122,15 +122,15 @@ abstract class MessageLogEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'sessionLogId': sessionLogId,
       'serverId': serverId,
       'messageId': messageId,
       'endpoint': endpoint,
       'messageName': messageName,
       'duration': duration,
-      'error': error,
-      'stackTrace': stackTrace,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
       'slow': slow,
       'order': order,
     };

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -58,7 +58,7 @@ abstract class MethodInfo extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'endpoint': endpoint,
       'method': method,
     };

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -122,15 +122,15 @@ abstract class QueryLogEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'serverId': serverId,
       'sessionLogId': sessionLogId,
-      'messageId': messageId,
+      if (messageId != null) 'messageId': messageId,
       'query': query,
       'duration': duration,
-      'numRows': numRows,
-      'error': error,
-      'stackTrace': stackTrace,
+      if (numRows != null) 'numRows': numRows,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
       'slow': slow,
       'order': order,
     };

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -51,7 +51,7 @@ abstract class ReadWriteTestEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'number': number,
     };
   }

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -76,7 +76,7 @@ abstract class RuntimeSettings extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'logSettings': logSettings,
       'logSettingsOverrides': logSettingsOverrides,
       'logServiceCalls': logServiceCalls,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -92,7 +92,7 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'serverId': serverId,
       'timestamp': timestamp,
       'active': active,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -92,7 +92,7 @@ abstract class ServerHealthMetric extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'serverId': serverId,
       'timestamp': timestamp,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -149,19 +149,20 @@ abstract class SessionLogEntry extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'serverId': serverId,
       'time': time,
-      'module': module,
-      'endpoint': endpoint,
-      'method': method,
-      'duration': duration,
-      'numQueries': numQueries,
-      'slow': slow,
-      'error': error,
-      'stackTrace': stackTrace,
-      'authenticatedUserId': authenticatedUserId,
-      'isOpen': isOpen,
+      if (module != null) 'module': module,
+      if (endpoint != null) 'endpoint': endpoint,
+      if (method != null) 'method': method,
+      if (duration != null) 'duration': duration,
+      if (numQueries != null) 'numQueries': numQueries,
+      if (slow != null) 'slow': slow,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
+      if (authenticatedUserId != null)
+        'authenticatedUserId': authenticatedUserId,
+      if (isOpen != null) 'isOpen': isOpen,
       'touched': touched,
     };
   }

--- a/packages/serverpod/lib/src/generated/session_log_filter.dart
+++ b/packages/serverpod/lib/src/generated/session_log_filter.dart
@@ -84,13 +84,13 @@ abstract class SessionLogFilter extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'endpoint': endpoint,
-      'method': method,
-      'futureCall': futureCall,
+      if (endpoint != null) 'endpoint': endpoint,
+      if (method != null) 'method': method,
+      if (futureCall != null) 'futureCall': futureCall,
       'slow': slow,
       'error': error,
       'open': open,
-      'lastSessionLogId': lastSessionLogId,
+      if (lastSessionLogId != null) 'lastSessionLogId': lastSessionLogId,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/session_log_result.dart
+++ b/packages/serverpod/lib/src/generated/session_log_result.dart
@@ -33,7 +33,9 @@ abstract class SessionLogResult extends _i1.SerializableEntity {
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog});
   @override
   Map<String, dynamic> toJson() {
-    return {'sessionLog': sessionLog};
+    return {
+      'sessionLog': sessionLog,
+    };
   }
 
   @override

--- a/packages/serverpod_service_client/lib/src/protocol/auth_key.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/auth_key.dart
@@ -79,10 +79,10 @@ abstract class AuthKey extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'userId': userId,
       'hash': hash,
-      'key': key,
+      if (key != null) 'key': key,
       'scopeNames': scopeNames,
       'method': method,
     };

--- a/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
@@ -57,7 +57,7 @@ abstract class CacheInfo extends _i1.SerializableEntity {
     return {
       'numEntries': numEntries,
       'maxEntries': maxEntries,
-      'keys': keys,
+      if (keys != null) 'keys': keys,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
@@ -88,11 +88,11 @@ abstract class CloudStorageEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
       'addedTime': addedTime,
-      'expiration': expiration,
+      if (expiration != null) 'expiration': expiration,
       'byteData': byteData,
       'verified': verified,
     };

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
@@ -71,7 +71,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
       'expiration': expiration,

--- a/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
@@ -33,7 +33,9 @@ abstract class ClusterInfo extends _i1.SerializableEntity {
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers});
   @override
   Map<String, dynamic> toJson() {
-    return {'servers': servers};
+    return {
+      'servers': servers,
+    };
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/cluster_server_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cluster_server_info.dart
@@ -32,7 +32,9 @@ abstract class ClusterServerInfo extends _i1.SerializableEntity {
   ClusterServerInfo copyWith({String? serverId});
   @override
   Map<String, dynamic> toJson() {
-    return {'serverId': serverId};
+    return {
+      'serverId': serverId,
+    };
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
@@ -46,7 +46,7 @@ abstract class BulkDataException extends _i1.SerializableEntity
   Map<String, dynamic> toJson() {
     return {
       'message': message,
-      'query': query,
+      if (query != null) 'query': query,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_definition.dart
@@ -76,8 +76,8 @@ abstract class ColumnDefinition extends _i1.SerializableEntity {
       'name': name,
       'columnType': columnType,
       'isNullable': isNullable,
-      'columnDefault': columnDefault,
-      'dartType': dartType,
+      if (columnDefault != null) 'columnDefault': columnDefault,
+      if (dartType != null) 'dartType': dartType,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_migration.dart
@@ -69,7 +69,7 @@ abstract class ColumnMigration extends _i1.SerializableEntity {
       'addNullable': addNullable,
       'removeNullable': removeNullable,
       'changeDefault': changeDefault,
-      'newDefault': newDefault,
+      if (newDefault != null) 'newDefault': newDefault,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
@@ -75,7 +75,7 @@ abstract class DatabaseDefinition extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'name': name,
+      if (name != null) 'name': name,
       'moduleName': moduleName,
       'tables': tables,
       'installedModules': installedModules,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action.dart
@@ -60,9 +60,9 @@ abstract class DatabaseMigrationAction extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'type': type,
-      'deleteTable': deleteTable,
-      'alterTable': alterTable,
-      'createTable': createTable,
+      if (deleteTable != null) 'deleteTable': deleteTable,
+      if (alterTable != null) 'alterTable': alterTable,
+      if (createTable != null) 'createTable': createTable,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
@@ -64,10 +64,10 @@ abstract class DatabaseMigrationVersion extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'module': module,
       'version': version,
-      'timestamp': timestamp,
+      if (timestamp != null) 'timestamp': timestamp,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
@@ -62,7 +62,7 @@ abstract class FilterConstraint extends _i1.SerializableEntity {
       'type': type,
       'column': column,
       'value': value,
-      'value2': value2,
+      if (value2 != null) 'value2': value2,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
@@ -101,9 +101,9 @@ abstract class ForeignKeyDefinition extends _i1.SerializableEntity {
       'referenceTable': referenceTable,
       'referenceTableSchema': referenceTableSchema,
       'referenceColumns': referenceColumns,
-      'onUpdate': onUpdate,
-      'onDelete': onDelete,
-      'matchType': matchType,
+      if (onUpdate != null) 'onUpdate': onUpdate,
+      if (onDelete != null) 'onDelete': onDelete,
+      if (matchType != null) 'matchType': matchType,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
@@ -90,12 +90,12 @@ abstract class IndexDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'indexName': indexName,
-      'tableSpace': tableSpace,
+      if (tableSpace != null) 'tableSpace': tableSpace,
       'elements': elements,
       'type': type,
       'isUnique': isUnique,
       'isPrimary': isPrimary,
-      'predicate': predicate,
+      if (predicate != null) 'predicate': predicate,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
@@ -107,14 +107,14 @@ abstract class TableDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'dartName': dartName,
-      'module': module,
+      if (dartName != null) 'dartName': dartName,
+      if (module != null) 'module': module,
       'schema': schema,
-      'tableSpace': tableSpace,
+      if (tableSpace != null) 'tableSpace': tableSpace,
       'columns': columns,
       'foreignKeys': foreignKeys,
       'indexes': indexes,
-      'managed': managed,
+      if (managed != null) 'managed': managed,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
@@ -118,8 +118,8 @@ abstract class TableMigration extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'dartName': dartName,
-      'module': module,
+      if (dartName != null) 'dartName': dartName,
+      if (module != null) 'module': module,
       'schema': schema,
       'addColumns': addColumns,
       'deleteColumns': deleteColumns,

--- a/packages/serverpod_service_client/lib/src/protocol/distributed_cache_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/distributed_cache_entry.dart
@@ -32,7 +32,9 @@ abstract class DistributedCacheEntry extends _i1.SerializableEntity {
   DistributedCacheEntry copyWith({String? data});
   @override
   Map<String, dynamic> toJson() {
-    return {'data': data};
+    return {
+      'data': data,
+    };
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/exceptions/access_denied.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/exceptions/access_denied.dart
@@ -31,7 +31,9 @@ abstract class AccessDeniedException extends _i1.SerializableEntity
   AccessDeniedException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
-    return {'message': message};
+    return {
+      'message': message,
+    };
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/exceptions/file_not_found.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/exceptions/file_not_found.dart
@@ -31,7 +31,9 @@ abstract class FileNotFoundException extends _i1.SerializableEntity
   FileNotFoundException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
-    return {'message': message};
+    return {
+      'message': message,
+    };
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
@@ -79,12 +79,12 @@ abstract class FutureCallEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'time': time,
-      'serializedObject': serializedObject,
+      if (serializedObject != null) 'serializedObject': serializedObject,
       'serverId': serverId,
-      'identifier': identifier,
+      if (identifier != null) 'identifier': identifier,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
@@ -120,16 +120,16 @@ abstract class LogEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'sessionLogId': sessionLogId,
-      'messageId': messageId,
-      'reference': reference,
+      if (messageId != null) 'messageId': messageId,
+      if (reference != null) 'reference': reference,
       'serverId': serverId,
       'time': time,
       'logLevel': logLevel,
       'message': message,
-      'error': error,
-      'stackTrace': stackTrace,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
       'order': order,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_result.dart
@@ -32,7 +32,9 @@ abstract class LogResult extends _i1.SerializableEntity {
   LogResult copyWith({List<_i2.LogEntry>? entries});
   @override
   Map<String, dynamic> toJson() {
-    return {'entries': entries};
+    return {
+      'entries': entries,
+    };
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/log_settings_override.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_settings_override.dart
@@ -65,9 +65,9 @@ abstract class LogSettingsOverride extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'module': module,
-      'endpoint': endpoint,
-      'method': method,
+      if (module != null) 'module': module,
+      if (endpoint != null) 'endpoint': endpoint,
+      if (method != null) 'method': method,
       'logSettings': logSettings,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/message_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/message_log_entry.dart
@@ -120,15 +120,15 @@ abstract class MessageLogEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'sessionLogId': sessionLogId,
       'serverId': serverId,
       'messageId': messageId,
       'endpoint': endpoint,
       'messageName': messageName,
       'duration': duration,
-      'error': error,
-      'stackTrace': stackTrace,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
       'slow': slow,
       'order': order,
     };

--- a/packages/serverpod_service_client/lib/src/protocol/method_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/method_info.dart
@@ -56,7 +56,7 @@ abstract class MethodInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'endpoint': endpoint,
       'method': method,
     };

--- a/packages/serverpod_service_client/lib/src/protocol/query_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/query_log_entry.dart
@@ -120,15 +120,15 @@ abstract class QueryLogEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'serverId': serverId,
       'sessionLogId': sessionLogId,
-      'messageId': messageId,
+      if (messageId != null) 'messageId': messageId,
       'query': query,
       'duration': duration,
-      'numRows': numRows,
-      'error': error,
-      'stackTrace': stackTrace,
+      if (numRows != null) 'numRows': numRows,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
       'slow': slow,
       'order': order,
     };

--- a/packages/serverpod_service_client/lib/src/protocol/readwrite_test.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/readwrite_test.dart
@@ -49,7 +49,7 @@ abstract class ReadWriteTestEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'number': number,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
@@ -74,7 +74,7 @@ abstract class RuntimeSettings extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'logSettings': logSettings,
       'logSettingsOverrides': logSettingsOverrides,
       'logServiceCalls': logServiceCalls,

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
@@ -90,7 +90,7 @@ abstract class ServerHealthConnectionInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'serverId': serverId,
       'timestamp': timestamp,
       'active': active,

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
@@ -90,7 +90,7 @@ abstract class ServerHealthMetric extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'serverId': serverId,
       'timestamp': timestamp,

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
@@ -147,19 +147,20 @@ abstract class SessionLogEntry extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'serverId': serverId,
       'time': time,
-      'module': module,
-      'endpoint': endpoint,
-      'method': method,
-      'duration': duration,
-      'numQueries': numQueries,
-      'slow': slow,
-      'error': error,
-      'stackTrace': stackTrace,
-      'authenticatedUserId': authenticatedUserId,
-      'isOpen': isOpen,
+      if (module != null) 'module': module,
+      if (endpoint != null) 'endpoint': endpoint,
+      if (method != null) 'method': method,
+      if (duration != null) 'duration': duration,
+      if (numQueries != null) 'numQueries': numQueries,
+      if (slow != null) 'slow': slow,
+      if (error != null) 'error': error,
+      if (stackTrace != null) 'stackTrace': stackTrace,
+      if (authenticatedUserId != null)
+        'authenticatedUserId': authenticatedUserId,
+      if (isOpen != null) 'isOpen': isOpen,
       'touched': touched,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_filter.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_filter.dart
@@ -84,13 +84,13 @@ abstract class SessionLogFilter extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'endpoint': endpoint,
-      'method': method,
-      'futureCall': futureCall,
+      if (endpoint != null) 'endpoint': endpoint,
+      if (method != null) 'method': method,
+      if (futureCall != null) 'futureCall': futureCall,
       'slow': slow,
       'error': error,
       'open': open,
-      'lastSessionLogId': lastSessionLogId,
+      if (lastSessionLogId != null) 'lastSessionLogId': lastSessionLogId,
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
@@ -33,7 +33,9 @@ abstract class SessionLogResult extends _i1.SerializableEntity {
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog});
   @override
   Map<String, dynamic> toJson() {
-    return {'sessionLog': sessionLog};
+    return {
+      'sessionLog': sessionLog,
+    };
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
@@ -62,7 +62,7 @@ abstract class ExceptionWithData extends _i1.SerializableEntity
       'message': message,
       'creationDate': creationDate,
       'errorFields': errorFields,
-      'someNullableField': someNullableField,
+      if (someNullableField != null) 'someNullableField': someNullableField,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
@@ -60,10 +60,10 @@ abstract class City extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'citizens': citizens,
-      'organizations': organizations,
+      if (citizens != null) 'citizens': citizens,
+      if (organizations != null) 'organizations': organizations,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
@@ -67,11 +67,11 @@ abstract class Organization extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'people': people,
-      'cityId': cityId,
-      'city': city,
+      if (people != null) 'people': people,
+      if (cityId != null) 'cityId': cityId,
+      if (city != null) 'city': city,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/person.dart
@@ -60,10 +60,10 @@ abstract class Person extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'organizationId': organizationId,
-      'organization': organization,
+      if (organizationId != null) 'organizationId': organizationId,
+      if (organization != null) 'organization': organization,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -53,9 +53,9 @@ abstract class Course extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'enrollments': enrollments,
+      if (enrollments != null) 'enrollments': enrollments,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
@@ -68,11 +68,11 @@ abstract class Enrollment extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'studentId': studentId,
-      'student': student,
+      if (student != null) 'student': student,
       'courseId': courseId,
-      'course': course,
+      if (course != null) 'course': course,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
@@ -53,9 +53,9 @@ abstract class Student extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'enrollments': enrollments,
+      if (enrollments != null) 'enrollments': enrollments,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
@@ -53,9 +53,9 @@ abstract class Arena extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'team': team,
+      if (team != null) 'team': team,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
@@ -60,10 +60,10 @@ abstract class Player extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'teamId': teamId,
-      'team': team,
+      if (teamId != null) 'teamId': teamId,
+      if (team != null) 'team': team,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
@@ -67,11 +67,11 @@ abstract class Team extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'arenaId': arenaId,
-      'arena': arena,
-      'players': players,
+      if (arenaId != null) 'arenaId': arenaId,
+      if (arena != null) 'arena': arena,
+      if (players != null) 'players': players,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
@@ -61,10 +61,10 @@ abstract class Comment extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'description': description,
       'orderId': orderId,
-      'order': order,
+      if (order != null) 'order': order,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -53,9 +53,9 @@ abstract class Customer extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'orders': orders,
+      if (orders != null) 'orders': orders,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
@@ -68,11 +68,11 @@ abstract class Order extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'description': description,
       'customerId': customerId,
-      'customer': customer,
-      'comments': comments,
+      if (customer != null) 'customer': customer,
+      if (comments != null) 'comments': comments,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
@@ -61,10 +61,10 @@ abstract class Address extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'street': street,
-      'inhabitantId': inhabitantId,
-      'inhabitant': inhabitant,
+      if (inhabitantId != null) 'inhabitantId': inhabitantId,
+      if (inhabitant != null) 'inhabitant': inhabitant,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
@@ -81,13 +81,13 @@ abstract class Citizen extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'address': address,
+      if (address != null) 'address': address,
       'companyId': companyId,
-      'company': company,
-      'oldCompanyId': oldCompanyId,
-      'oldCompany': oldCompany,
+      if (company != null) 'company': company,
+      if (oldCompanyId != null) 'oldCompanyId': oldCompanyId,
+      if (oldCompany != null) 'oldCompany': oldCompany,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
@@ -60,10 +60,10 @@ abstract class Company extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'townId': townId,
-      'town': town,
+      if (town != null) 'town': town,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
@@ -60,10 +60,10 @@ abstract class Town extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'mayorId': mayorId,
-      'mayor': mayor,
+      if (mayorId != null) 'mayorId': mayorId,
+      if (mayor != null) 'mayor': mayor,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -68,11 +68,11 @@ abstract class Blocking extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'blockedId': blockedId,
-      'blocked': blocked,
+      if (blocked != null) 'blocked': blocked,
       'blockedById': blockedById,
-      'blockedBy': blockedBy,
+      if (blockedBy != null) 'blockedBy': blockedBy,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
@@ -60,10 +60,10 @@ abstract class Member extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'blocking': blocking,
-      'blockedBy': blockedBy,
+      if (blocking != null) 'blocking': blocking,
+      if (blockedBy != null) 'blockedBy': blockedBy,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
@@ -67,11 +67,11 @@ abstract class Cat extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'motherId': motherId,
-      'mother': mother,
-      'kittens': kittens,
+      if (motherId != null) 'motherId': motherId,
+      if (mother != null) 'mother': mother,
+      if (kittens != null) 'kittens': kittens,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
@@ -68,11 +68,11 @@ abstract class Post extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'content': content,
-      'previous': previous,
-      'nextId': nextId,
-      'next': next,
+      if (previous != null) 'previous': previous,
+      if (nextId != null) 'nextId': nextId,
+      if (next != null) 'next': next,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/nullability.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/nullability.dart
@@ -367,51 +367,65 @@ abstract class Nullability extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'anInt': anInt,
-      'aNullableInt': aNullableInt,
+      if (aNullableInt != null) 'aNullableInt': aNullableInt,
       'aDouble': aDouble,
-      'aNullableDouble': aNullableDouble,
+      if (aNullableDouble != null) 'aNullableDouble': aNullableDouble,
       'aBool': aBool,
-      'aNullableBool': aNullableBool,
+      if (aNullableBool != null) 'aNullableBool': aNullableBool,
       'aString': aString,
-      'aNullableString': aNullableString,
+      if (aNullableString != null) 'aNullableString': aNullableString,
       'aDateTime': aDateTime,
-      'aNullableDateTime': aNullableDateTime,
+      if (aNullableDateTime != null) 'aNullableDateTime': aNullableDateTime,
       'aByteData': aByteData,
-      'aNullableByteData': aNullableByteData,
+      if (aNullableByteData != null) 'aNullableByteData': aNullableByteData,
       'aDuration': aDuration,
-      'aNullableDuration': aNullableDuration,
+      if (aNullableDuration != null) 'aNullableDuration': aNullableDuration,
       'aUuid': aUuid,
-      'aNullableUuid': aNullableUuid,
+      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid,
       'anObject': anObject,
-      'aNullableObject': aNullableObject,
+      if (aNullableObject != null) 'aNullableObject': aNullableObject,
       'anIntList': anIntList,
-      'aNullableIntList': aNullableIntList,
+      if (aNullableIntList != null) 'aNullableIntList': aNullableIntList,
       'aListWithNullableInts': aListWithNullableInts,
-      'aNullableListWithNullableInts': aNullableListWithNullableInts,
+      if (aNullableListWithNullableInts != null)
+        'aNullableListWithNullableInts': aNullableListWithNullableInts,
       'anObjectList': anObjectList,
-      'aNullableObjectList': aNullableObjectList,
+      if (aNullableObjectList != null)
+        'aNullableObjectList': aNullableObjectList,
       'aListWithNullableObjects': aListWithNullableObjects,
-      'aNullableListWithNullableObjects': aNullableListWithNullableObjects,
+      if (aNullableListWithNullableObjects != null)
+        'aNullableListWithNullableObjects': aNullableListWithNullableObjects,
       'aDateTimeList': aDateTimeList,
-      'aNullableDateTimeList': aNullableDateTimeList,
+      if (aNullableDateTimeList != null)
+        'aNullableDateTimeList': aNullableDateTimeList,
       'aListWithNullableDateTimes': aListWithNullableDateTimes,
-      'aNullableListWithNullableDateTimes': aNullableListWithNullableDateTimes,
+      if (aNullableListWithNullableDateTimes != null)
+        'aNullableListWithNullableDateTimes':
+            aNullableListWithNullableDateTimes,
       'aByteDataList': aByteDataList,
-      'aNullableByteDataList': aNullableByteDataList,
+      if (aNullableByteDataList != null)
+        'aNullableByteDataList': aNullableByteDataList,
       'aListWithNullableByteDatas': aListWithNullableByteDatas,
-      'aNullableListWithNullableByteDatas': aNullableListWithNullableByteDatas,
+      if (aNullableListWithNullableByteDatas != null)
+        'aNullableListWithNullableByteDatas':
+            aNullableListWithNullableByteDatas,
       'aDurationList': aDurationList,
-      'aNullableDurationList': aNullableDurationList,
+      if (aNullableDurationList != null)
+        'aNullableDurationList': aNullableDurationList,
       'aListWithNullableDurations': aListWithNullableDurations,
-      'aNullableListWithNullableDurations': aNullableListWithNullableDurations,
+      if (aNullableListWithNullableDurations != null)
+        'aNullableListWithNullableDurations':
+            aNullableListWithNullableDurations,
       'aUuidList': aUuidList,
-      'aNullableUuidList': aNullableUuidList,
+      if (aNullableUuidList != null) 'aNullableUuidList': aNullableUuidList,
       'aListWithNullableUuids': aListWithNullableUuids,
-      'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
+      if (aNullableListWithNullableUuids != null)
+        'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
       'anIntMap': anIntMap,
-      'aNullableIntMap': aNullableIntMap,
+      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap,
       'aMapWithNullableInts': aMapWithNullableInts,
-      'aNullableMapWithNullableInts': aNullableMapWithNullableInts,
+      if (aNullableMapWithNullableInts != null)
+        'aNullableMapWithNullableInts': aNullableMapWithNullableInts,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
@@ -52,9 +52,9 @@ abstract class ObjectFieldScopes extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'normal': normal,
-      'api': api,
+      if (api != null) 'api': api,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
@@ -47,7 +47,7 @@ abstract class ObjectWithByteData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'byteData': byteData,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
@@ -46,7 +46,7 @@ abstract class ObjectWithDuration extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'duration': duration,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
@@ -75,9 +75,9 @@ abstract class ObjectWithEnum extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'testEnum': testEnum,
-      'nullableEnum': nullableEnum,
+      if (nullableEnum != null) 'nullableEnum': nullableEnum,
       'enumList': enumList,
       'nullableEnumList': nullableEnumList,
       'enumListList': enumListList,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_index.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_index.dart
@@ -53,7 +53,7 @@ abstract class ObjectWithIndex extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'indexed': indexed,
       'indexed2': indexed2,
     };

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
@@ -84,13 +84,14 @@ abstract class ObjectWithObject extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'data': data,
-      'nullableData': nullableData,
+      if (nullableData != null) 'nullableData': nullableData,
       'dataList': dataList,
-      'nullableDataList': nullableDataList,
+      if (nullableDataList != null) 'nullableDataList': nullableDataList,
       'listWithNullableData': listWithNullableData,
-      'nullableListWithNullableData': nullableListWithNullableData,
+      if (nullableListWithNullableData != null)
+        'nullableListWithNullableData': nullableListWithNullableData,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_parent.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_parent.dart
@@ -45,7 +45,7 @@ abstract class ObjectWithParent extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'other': other,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
@@ -45,8 +45,8 @@ abstract class ObjectWithSelfParent extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
-      'other': other,
+      if (id != null) 'id': id,
+      if (other != null) 'other': other,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
@@ -53,9 +53,9 @@ abstract class ObjectWithUuid extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'uuid': uuid,
-      'uuidNullable': uuidNullable,
+      if (uuidNullable != null) 'uuidNullable': uuidNullable,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/related_unique_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/related_unique_data.dart
@@ -61,9 +61,9 @@ abstract class RelatedUniqueData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'uniqueDataId': uniqueDataId,
-      'uniqueData': uniqueData,
+      if (uniqueData != null) 'uniqueData': uniqueData,
       'number': number,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/serverOnly/default_server_only_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/serverOnly/default_server_only_class.dart
@@ -30,7 +30,9 @@ abstract class DefaultServerOnlyClass extends _i1.SerializableEntity {
   DefaultServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
-    return {'foo': foo};
+    return {
+      'foo': foo,
+    };
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/serverOnly/not_server_only_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/serverOnly/not_server_only_class.dart
@@ -29,7 +29,9 @@ abstract class NotServerOnlyClass extends _i1.SerializableEntity {
   NotServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
-    return {'foo': foo};
+    return {
+      'foo': foo,
+    };
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
@@ -49,7 +49,7 @@ abstract class SimpleData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'num': num,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
@@ -31,7 +31,9 @@ abstract class SimpleDataList extends _i1.SerializableEntity {
   SimpleDataList copyWith({List<_i2.SimpleData>? rows});
   @override
   Map<String, dynamic> toJson() {
-    return {'rows': rows};
+    return {
+      'rows': rows,
+    };
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
@@ -31,7 +31,9 @@ abstract class SimpleDataMap extends _i1.SerializableEntity {
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data});
   @override
   Map<String, dynamic> toJson() {
-    return {'data': data};
+    return {
+      'data': data,
+    };
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
@@ -48,7 +48,7 @@ abstract class SimpleDateTime extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'dateTime': dateTime,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -111,17 +111,17 @@ abstract class Types extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
-      'anInt': anInt,
-      'aBool': aBool,
-      'aDouble': aDouble,
-      'aDateTime': aDateTime,
-      'aString': aString,
-      'aByteData': aByteData,
-      'aDuration': aDuration,
-      'aUuid': aUuid,
-      'anEnum': anEnum,
-      'aStringifiedEnum': aStringifiedEnum,
+      if (id != null) 'id': id,
+      if (anInt != null) 'anInt': anInt,
+      if (aBool != null) 'aBool': aBool,
+      if (aDouble != null) 'aDouble': aDouble,
+      if (aDateTime != null) 'aDateTime': aDateTime,
+      if (aString != null) 'aString': aString,
+      if (aByteData != null) 'aByteData': aByteData,
+      if (aDuration != null) 'aDuration': aDuration,
+      if (aUuid != null) 'aUuid': aUuid,
+      if (anEnum != null) 'anEnum': anEnum,
+      if (aStringifiedEnum != null) 'aStringifiedEnum': aStringifiedEnum,
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/unique_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/unique_data.dart
@@ -53,7 +53,7 @@ abstract class UniqueData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'number': number,
       'email': email,
     };

--- a/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
@@ -62,7 +62,7 @@ abstract class ExceptionWithData extends _i1.SerializableEntity
       'message': message,
       'creationDate': creationDate,
       'errorFields': errorFields,
-      'someNullableField': someNullableField,
+      if (someNullableField != null) 'someNullableField': someNullableField,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -62,10 +62,10 @@ abstract class City extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'citizens': citizens,
-      'organizations': organizations,
+      if (citizens != null) 'citizens': citizens,
+      if (organizations != null) 'organizations': organizations,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -69,11 +69,11 @@ abstract class Organization extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'people': people,
-      'cityId': cityId,
-      'city': city,
+      if (people != null) 'people': people,
+      if (cityId != null) 'cityId': cityId,
+      if (city != null) 'city': city,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -64,10 +64,10 @@ abstract class Person extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'organizationId': organizationId,
-      'organization': organization,
+      if (organizationId != null) 'organizationId': organizationId,
+      if (organization != null) 'organization': organization,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -55,9 +55,9 @@ abstract class Course extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'enrollments': enrollments,
+      if (enrollments != null) 'enrollments': enrollments,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -70,11 +70,11 @@ abstract class Enrollment extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'studentId': studentId,
-      'student': student,
+      if (student != null) 'student': student,
       'courseId': courseId,
-      'course': course,
+      if (course != null) 'course': course,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -55,9 +55,9 @@ abstract class Student extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'enrollments': enrollments,
+      if (enrollments != null) 'enrollments': enrollments,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -55,9 +55,9 @@ abstract class Arena extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'team': team,
+      if (team != null) 'team': team,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -62,10 +62,10 @@ abstract class Player extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'teamId': teamId,
-      'team': team,
+      if (teamId != null) 'teamId': teamId,
+      if (team != null) 'team': team,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -69,11 +69,11 @@ abstract class Team extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'arenaId': arenaId,
-      'arena': arena,
-      'players': players,
+      if (arenaId != null) 'arenaId': arenaId,
+      if (arena != null) 'arena': arena,
+      if (players != null) 'players': players,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -63,10 +63,10 @@ abstract class Comment extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'description': description,
       'orderId': orderId,
-      'order': order,
+      if (order != null) 'order': order,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -55,9 +55,9 @@ abstract class Customer extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'orders': orders,
+      if (orders != null) 'orders': orders,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -70,11 +70,11 @@ abstract class Order extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'description': description,
       'customerId': customerId,
-      'customer': customer,
-      'comments': comments,
+      if (customer != null) 'customer': customer,
+      if (comments != null) 'comments': comments,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -63,10 +63,10 @@ abstract class Address extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'street': street,
-      'inhabitantId': inhabitantId,
-      'inhabitant': inhabitant,
+      if (inhabitantId != null) 'inhabitantId': inhabitantId,
+      if (inhabitant != null) 'inhabitant': inhabitant,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -83,13 +83,13 @@ abstract class Citizen extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'address': address,
+      if (address != null) 'address': address,
       'companyId': companyId,
-      'company': company,
-      'oldCompanyId': oldCompanyId,
-      'oldCompany': oldCompany,
+      if (company != null) 'company': company,
+      if (oldCompanyId != null) 'oldCompanyId': oldCompanyId,
+      if (oldCompany != null) 'oldCompany': oldCompany,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -62,10 +62,10 @@ abstract class Company extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
       'townId': townId,
-      'town': town,
+      if (town != null) 'town': town,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -62,10 +62,10 @@ abstract class Town extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'mayorId': mayorId,
-      'mayor': mayor,
+      if (mayorId != null) 'mayorId': mayorId,
+      if (mayor != null) 'mayor': mayor,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -70,11 +70,11 @@ abstract class Blocking extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'blockedId': blockedId,
-      'blocked': blocked,
+      if (blocked != null) 'blocked': blocked,
       'blockedById': blockedById,
-      'blockedBy': blockedBy,
+      if (blockedBy != null) 'blockedBy': blockedBy,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -62,10 +62,10 @@ abstract class Member extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'blocking': blocking,
-      'blockedBy': blockedBy,
+      if (blocking != null) 'blocking': blocking,
+      if (blockedBy != null) 'blockedBy': blockedBy,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -69,11 +69,11 @@ abstract class Cat extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'name': name,
-      'motherId': motherId,
-      'mother': mother,
-      'kittens': kittens,
+      if (motherId != null) 'motherId': motherId,
+      if (mother != null) 'mother': mother,
+      if (kittens != null) 'kittens': kittens,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -70,11 +70,11 @@ abstract class Post extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'content': content,
-      'previous': previous,
-      'nextId': nextId,
-      'next': next,
+      if (previous != null) 'previous': previous,
+      if (nextId != null) 'nextId': nextId,
+      if (next != null) 'next': next,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/nullability.dart
+++ b/tests/serverpod_test_server/lib/src/generated/nullability.dart
@@ -367,51 +367,65 @@ abstract class Nullability extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'anInt': anInt,
-      'aNullableInt': aNullableInt,
+      if (aNullableInt != null) 'aNullableInt': aNullableInt,
       'aDouble': aDouble,
-      'aNullableDouble': aNullableDouble,
+      if (aNullableDouble != null) 'aNullableDouble': aNullableDouble,
       'aBool': aBool,
-      'aNullableBool': aNullableBool,
+      if (aNullableBool != null) 'aNullableBool': aNullableBool,
       'aString': aString,
-      'aNullableString': aNullableString,
+      if (aNullableString != null) 'aNullableString': aNullableString,
       'aDateTime': aDateTime,
-      'aNullableDateTime': aNullableDateTime,
+      if (aNullableDateTime != null) 'aNullableDateTime': aNullableDateTime,
       'aByteData': aByteData,
-      'aNullableByteData': aNullableByteData,
+      if (aNullableByteData != null) 'aNullableByteData': aNullableByteData,
       'aDuration': aDuration,
-      'aNullableDuration': aNullableDuration,
+      if (aNullableDuration != null) 'aNullableDuration': aNullableDuration,
       'aUuid': aUuid,
-      'aNullableUuid': aNullableUuid,
+      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid,
       'anObject': anObject,
-      'aNullableObject': aNullableObject,
+      if (aNullableObject != null) 'aNullableObject': aNullableObject,
       'anIntList': anIntList,
-      'aNullableIntList': aNullableIntList,
+      if (aNullableIntList != null) 'aNullableIntList': aNullableIntList,
       'aListWithNullableInts': aListWithNullableInts,
-      'aNullableListWithNullableInts': aNullableListWithNullableInts,
+      if (aNullableListWithNullableInts != null)
+        'aNullableListWithNullableInts': aNullableListWithNullableInts,
       'anObjectList': anObjectList,
-      'aNullableObjectList': aNullableObjectList,
+      if (aNullableObjectList != null)
+        'aNullableObjectList': aNullableObjectList,
       'aListWithNullableObjects': aListWithNullableObjects,
-      'aNullableListWithNullableObjects': aNullableListWithNullableObjects,
+      if (aNullableListWithNullableObjects != null)
+        'aNullableListWithNullableObjects': aNullableListWithNullableObjects,
       'aDateTimeList': aDateTimeList,
-      'aNullableDateTimeList': aNullableDateTimeList,
+      if (aNullableDateTimeList != null)
+        'aNullableDateTimeList': aNullableDateTimeList,
       'aListWithNullableDateTimes': aListWithNullableDateTimes,
-      'aNullableListWithNullableDateTimes': aNullableListWithNullableDateTimes,
+      if (aNullableListWithNullableDateTimes != null)
+        'aNullableListWithNullableDateTimes':
+            aNullableListWithNullableDateTimes,
       'aByteDataList': aByteDataList,
-      'aNullableByteDataList': aNullableByteDataList,
+      if (aNullableByteDataList != null)
+        'aNullableByteDataList': aNullableByteDataList,
       'aListWithNullableByteDatas': aListWithNullableByteDatas,
-      'aNullableListWithNullableByteDatas': aNullableListWithNullableByteDatas,
+      if (aNullableListWithNullableByteDatas != null)
+        'aNullableListWithNullableByteDatas':
+            aNullableListWithNullableByteDatas,
       'aDurationList': aDurationList,
-      'aNullableDurationList': aNullableDurationList,
+      if (aNullableDurationList != null)
+        'aNullableDurationList': aNullableDurationList,
       'aListWithNullableDurations': aListWithNullableDurations,
-      'aNullableListWithNullableDurations': aNullableListWithNullableDurations,
+      if (aNullableListWithNullableDurations != null)
+        'aNullableListWithNullableDurations':
+            aNullableListWithNullableDurations,
       'aUuidList': aUuidList,
-      'aNullableUuidList': aNullableUuidList,
+      if (aNullableUuidList != null) 'aNullableUuidList': aNullableUuidList,
       'aListWithNullableUuids': aListWithNullableUuids,
-      'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
+      if (aNullableListWithNullableUuids != null)
+        'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
       'anIntMap': anIntMap,
-      'aNullableIntMap': aNullableIntMap,
+      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap,
       'aMapWithNullableInts': aMapWithNullableInts,
-      'aNullableMapWithNullableInts': aNullableMapWithNullableInts,
+      if (aNullableMapWithNullableInts != null)
+        'aNullableMapWithNullableInts': aNullableMapWithNullableInts,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -61,9 +61,9 @@ abstract class ObjectFieldScopes extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'normal': normal,
-      'api': api,
+      if (api != null) 'api': api,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -49,7 +49,7 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'byteData': byteData,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -48,7 +48,7 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'duration': duration,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -77,9 +77,9 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'testEnum': testEnum,
-      'nullableEnum': nullableEnum,
+      if (nullableEnum != null) 'nullableEnum': nullableEnum,
       'enumList': enumList,
       'nullableEnumList': nullableEnumList,
       'enumListList': enumListList,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -55,7 +55,7 @@ abstract class ObjectWithIndex extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'indexed': indexed,
       'indexed2': indexed2,
     };

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -86,13 +86,14 @@ abstract class ObjectWithObject extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'data': data,
-      'nullableData': nullableData,
+      if (nullableData != null) 'nullableData': nullableData,
       'dataList': dataList,
-      'nullableDataList': nullableDataList,
+      if (nullableDataList != null) 'nullableDataList': nullableDataList,
       'listWithNullableData': listWithNullableData,
-      'nullableListWithNullableData': nullableListWithNullableData,
+      if (nullableListWithNullableData != null)
+        'nullableListWithNullableData': nullableListWithNullableData,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -47,7 +47,7 @@ abstract class ObjectWithParent extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'other': other,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -47,8 +47,8 @@ abstract class ObjectWithSelfParent extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
-      'other': other,
+      if (id != null) 'id': id,
+      if (other != null) 'other': other,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -55,9 +55,9 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'uuid': uuid,
-      'uuidNullable': uuidNullable,
+      if (uuidNullable != null) 'uuidNullable': uuidNullable,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -63,9 +63,9 @@ abstract class RelatedUniqueData extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'uniqueDataId': uniqueDataId,
-      'uniqueData': uniqueData,
+      if (uniqueData != null) 'uniqueData': uniqueData,
       'number': number,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/serverOnly/default_server_only_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/serverOnly/default_server_only_class.dart
@@ -30,7 +30,9 @@ abstract class DefaultServerOnlyClass extends _i1.SerializableEntity {
   DefaultServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
-    return {'foo': foo};
+    return {
+      'foo': foo,
+    };
   }
 
   @override

--- a/tests/serverpod_test_server/lib/src/generated/serverOnly/not_server_only_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/serverOnly/not_server_only_class.dart
@@ -29,7 +29,9 @@ abstract class NotServerOnlyClass extends _i1.SerializableEntity {
   NotServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
-    return {'foo': foo};
+    return {
+      'foo': foo,
+    };
   }
 
   @override

--- a/tests/serverpod_test_server/lib/src/generated/serverOnly/server_only_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/serverOnly/server_only_class.dart
@@ -29,7 +29,9 @@ abstract class ServerOnlyClass extends _i1.SerializableEntity {
   ServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
-    return {'foo': foo};
+    return {
+      'foo': foo,
+    };
   }
 
   @override

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -51,7 +51,7 @@ abstract class SimpleData extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'num': num,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
@@ -31,7 +31,9 @@ abstract class SimpleDataList extends _i1.SerializableEntity {
   SimpleDataList copyWith({List<_i2.SimpleData>? rows});
   @override
   Map<String, dynamic> toJson() {
-    return {'rows': rows};
+    return {
+      'rows': rows,
+    };
   }
 
   @override

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
@@ -31,7 +31,9 @@ abstract class SimpleDataMap extends _i1.SerializableEntity {
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data});
   @override
   Map<String, dynamic> toJson() {
-    return {'data': data};
+    return {
+      'data': data,
+    };
   }
 
   @override

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -50,7 +50,7 @@ abstract class SimpleDateTime extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'dateTime': dateTime,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -113,17 +113,17 @@ abstract class Types extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
-      'anInt': anInt,
-      'aBool': aBool,
-      'aDouble': aDouble,
-      'aDateTime': aDateTime,
-      'aString': aString,
-      'aByteData': aByteData,
-      'aDuration': aDuration,
-      'aUuid': aUuid,
-      'anEnum': anEnum,
-      'aStringifiedEnum': aStringifiedEnum,
+      if (id != null) 'id': id,
+      if (anInt != null) 'anInt': anInt,
+      if (aBool != null) 'aBool': aBool,
+      if (aDouble != null) 'aDouble': aDouble,
+      if (aDateTime != null) 'aDateTime': aDateTime,
+      if (aString != null) 'aString': aString,
+      if (aByteData != null) 'aByteData': aByteData,
+      if (aDuration != null) 'aDuration': aDuration,
+      if (aUuid != null) 'aUuid': aUuid,
+      if (anEnum != null) 'anEnum': anEnum,
+      if (aStringifiedEnum != null) 'aStringifiedEnum': aStringifiedEnum,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -55,7 +55,7 @@ abstract class UniqueData extends _i1.TableRow {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'id': id,
+      if (id != null) 'id': id,
       'number': number,
       'email': email,
     };

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1203,13 +1203,15 @@ class SerializableModelLibraryGenerator {
         m.name = 'toJson';
         m.annotations.add(refer('override'));
 
-        m.body = literalMap(
-          {
-            for (var field in fields)
-              if (field.shouldSerializeField(serverCode))
-                literalString(field.name): refer(field.name)
-          },
-        ).returned.statement;
+        var fieldExprs = fields
+            .where((field) => field.shouldSerializeField(serverCode))
+            .map((field) =>
+                '${field.type.nullable ? 'if (${field.name} != null) ' : ''}'
+                '\'${field.name}\':${field.name}')
+            .join(',');
+
+        m.body =
+            Code('return { ${fieldExprs.isEmpty ? '' : '$fieldExprs,'} };');
       },
     );
   }


### PR DESCRIPTION
Adds a condition that prevents nullable fields from being serialized to a JSON map when their value is null.

Fixes #1700.

I had to implement this using a `Code` block because `code_builder` does not yet support collection-if: https://github.com/dart-lang/code_builder/issues/447

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Shouldn't break anything on deserialization, since reading a key from a map will return `null` whether the key doesn't exist in the map or the key is mapped to a `null` value.