### PR TITLE
fix: Add warnings if Serverpod CLI is not found or if version is not compatible with extension.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/version.dart
+++ b/tools/serverpod_cli/lib/src/commands/version.dart
@@ -11,6 +11,8 @@ class VersionCommand extends ServerpodCommand {
 
   @override
   void run() {
+    // The format that the version is printed in is important, as it is used by
+    // the Serverpod Language Server to determine if the CLI is compatible.
     log.info('Serverpod version: $templateVersion');
   }
 }

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -67,7 +67,9 @@
     "test-compile": "tsc -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
-    "test": "node ./out/test/runTest.js"
+    "test": "node ./out/test/runTest.js",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
   },
   "dependencies": {
     "vscode-languageclient": "^8.1.0"

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -64,7 +64,6 @@
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
-    "test-compile": "tsc -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",

--- a/tools/serverpod_vscode_extension/src/extension.ts
+++ b/tools/serverpod_vscode_extension/src/extension.ts
@@ -1,5 +1,5 @@
 
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, window } from 'vscode';
 import {
 	LanguageClient,
 	LanguageClientOptions,
@@ -7,10 +7,25 @@ import {
 	ServerOptions,
 	TransportKind,
 } from 'vscode-languageclient/node';
+import { execSync } from 'child_process';
+import { satisfies, coerce } from 'semver';
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
+	let output;
+	try {
+		output = execSync('serverpod version');
+	} catch (e) {
+		window.showErrorMessage('Failed to resolve the Serverpod CLI executable. Please ensure the Serverpod CLI is installed and available on the PATH used by VS Code.');
+		return;
+	}
+
+	if (!validVersion(output.toString().trim())) {
+		window.showErrorMessage('The Serverpod CLI version is outdated. Please upgrade to the latest version (minimum required version is 1.2).');
+		return;
+	}
+
 	const serverOptions: ServerOptions = {
 		command: 'serverpod',
 		args: ['language-server'],
@@ -44,4 +59,18 @@ export function deactivate(): Thenable<void> | undefined {
 		return undefined;
 	}
 	return client.stop();
+}
+
+
+function validVersion(versionString: string): boolean {
+	console.log(versionString);
+	const versionTag = versionString.split(':')[1];
+	const versionNumber = coerce(versionTag);
+	if (versionNumber === null) {
+		// If we can't parse the version number, assume it's valid
+		// since the version format is valid for all pre 1.2 versions.
+		return true;
+	}
+
+	return satisfies(versionNumber, '>=1.2.0');
 }


### PR DESCRIPTION
## Change
- Adds a helpful warning to the user if the extension is installed together with an incompatible serverpod version or if the serverpod cli is not found.

### When serverpod is not installed
<img width="1155" alt="Screenshot 2024-01-03 at 16 40 42" src="https://github.com/serverpod/serverpod/assets/137198655/95ef903b-4ed6-40ca-977b-228812981004">

### When older version of serverpod is installed
<img width="1155" alt="Screenshot 2024-01-03 at 16 42 14" src="https://github.com/serverpod/serverpod/assets/137198655/db810849-67b2-4414-b623-699b2be28547">


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Only impacts unreleased feature.