### PR TITLE
test: Add e2e test for opting out from migrations.

### DIFF
--- a/tests/serverpod_test_server/test_e2e_migrations/migrations_roundtrip_test.dart
+++ b/tests/serverpod_test_server/test_e2e_migrations/migrations_roundtrip_test.dart
@@ -1084,4 +1084,41 @@ This is not a valid protocol file, in yaml format
       expect(migrationRegistry.versions, isNot(contains(tag)));
     });
   });
+
+  group('Given a new table that should not be managed by Serverpod', () {
+    tearDown(() async {
+      await MigrationTestUtils.migrationTestCleanup(
+        serviceClient: serviceClient,
+      );
+    });
+
+    test(
+        'when creating migration then create migration exits with error and migration is not created.',
+        () async {
+      var tag = 'managed-false';
+      var targetStateProtocols = {
+        'migrated_table': '''
+class: MigratedTable
+managedMigration: false
+table: migrated_table
+fields:
+  name: String
+'''
+      };
+
+      var createMigrationExitCode =
+          await MigrationTestUtils.createMigrationFromProtocols(
+        protocols: targetStateProtocols,
+        tag: tag,
+      );
+      expect(
+        createMigrationExitCode,
+        isNot(0),
+        reason: 'Should fail to create migration but exit code 0.',
+      );
+
+      var migrationRegistry = MigrationTestUtils.loadMigrationRegistry();
+      expect(migrationRegistry.versions, isNot(contains(tag)));
+    });
+  });
 }


### PR DESCRIPTION
# Changes

Adds an e2e test to check that we do not create a new migration if we only add a none managed table.

Related to PR: [#16](https://github.com/serverpod/serverpod/pull/1688)

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).


