### PR TITLE
fix: Only report invalid type error on list relations with an invalid type.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -851,7 +851,7 @@ class Restrictions {
           ?.findAllByClassName(field.type.generics.first.className)
           .firstOrNull;
 
-      if (referenceClass?.moduleAlias != definition.moduleAlias) {
+      if (referenceClass != null && referenceClass.moduleAlias != definition.moduleAlias) {
         return [
           SourceSpanSeverityException(
             'A List relation is not allowed on module tables.',

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_one_to_many_test.dart
@@ -74,4 +74,34 @@ void main() {
       expect((relation as ListRelationDefinition).nullableRelation, false);
     }, skip: relation is! ListRelationDefinition);
   });
+
+  test(
+      'Given a list relation with an invalid type then the only error reported is that the type is invalid.',
+      () {
+    var models = [
+      ModelSourceBuilder().withFileName('example').withYaml(
+        '''
+        class: Example
+        table: example
+        fields:
+          list: List<InvalidType>?, relation
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      models,
+      onErrorsCollector(collector),
+    );
+
+    analyzer.validateAll();
+
+    expect(collector.errors, hasLength(1));
+
+    expect(
+      collector.errors.first.message,
+      'The field has an invalid datatype "InvalidType".',
+    );
+  });
 }

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -8,7 +8,7 @@
     "color": "#020E24",
     "theme": "dark"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "vscode": "^1.75.0"
   },


### PR DESCRIPTION
# Changes

- Removes error reported for the type not being the same module if the model does not exist at all.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
