### PR TITLE
fix: Reduce model field name max length.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -98,9 +98,13 @@ const _databaseModelReservedFieldNames = [
   'table',
 ];
 
-/// The maximum length of a identfiers and key words in Postgres.
+/// The maximum length of a identifiers and key words in Postgres.
 /// Source: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 const _pgsqlMaxNameLimitation = 63;
+
+/// We reserve 2 characters to enable implicit foreign key field generation
+/// without truncation since we append "id" as a suffix of on the field name.
+const _reservedColumnSuffixChars = 2;
 
 /// We reserve 7 characters to enable deterministic generation of the following
 /// suffixes:
@@ -110,6 +114,8 @@ const _pgsqlMaxNameLimitation = 63;
 const _reservedTableSuffixChars = 7;
 
 const _maxTableNameLength = _pgsqlMaxNameLimitation - _reservedTableSuffixChars;
+const _maxColumnNameLength =
+    _pgsqlMaxNameLimitation - _reservedColumnSuffixChars;
 
 class Restrictions {
   String documentType;
@@ -385,10 +391,10 @@ class Restrictions {
       ];
     }
 
-    if (fieldName.length > _pgsqlMaxNameLimitation) {
+    if (fieldName.length > _maxColumnNameLength) {
       return [
         SourceSpanSeverityException(
-          'The field name "$fieldName" exceeds the $_pgsqlMaxNameLimitation character field name limitation.',
+          'The field name "$fieldName" exceeds the $_maxColumnNameLength character field name limitation.',
           span,
         )
       ];

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_validation_test.dart
@@ -369,14 +369,14 @@ void main() {
   );
 
   test(
-      'Given a class with a field name longer than 63 characters, then an error is collected.',
+      'Given a class with a field name longer than 61 characters, then an error is collected.',
       () {
     var models = [
       ModelSourceBuilder().withYaml(
         '''
         class: Example
         fields:
-          thisFieldIsExactly64CharactersLongAndIsThereforeInvalidAsNameFor: String
+          thisFieldIsExactly62CharactersLongAndIsThereforeInvalidAsNameF: String
         ''',
       ).build()
     ];
@@ -398,20 +398,20 @@ void main() {
 
     expect(
       error.message,
-      'The field name "thisFieldIsExactly64CharactersLongAndIsThereforeInvalidAsNameFor" exceeds the 63 character field name limitation.',
+      'The field name "thisFieldIsExactly62CharactersLongAndIsThereforeInvalidAsNameF" exceeds the 61 character field name limitation.',
       reason: 'Expected the error message to indicate a field name too long.',
     );
   });
 
   group(
-      'Given a class with a field name that is 63 characters when analyzing models',
+      'Given a class with a field name that is 61 characters when analyzing models',
       () {
     var models = [
       ModelSourceBuilder().withYaml(
         '''
         class: Example
         fields:
-          thisFieldIsExactly63CharactersLongAndIsThereforeAValidFieldName: String
+          thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa: String
         ''',
       ).build()
     ];
@@ -433,7 +433,7 @@ void main() {
     test('then a field definition is created.', () {
       var field = definition?.fields.firstOrNull;
       expect(field?.name,
-          'thisFieldIsExactly63CharactersLongAndIsThereforeAValidFieldName');
+          'thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa');
     }, skip: errors.isNotEmpty);
   });
 }


### PR DESCRIPTION
## Change
- Reduces the max number of characters allowed for a model field to allow space for implicit id fields.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
