### PR TITLE
fix: Add error validation if unable to locate modules.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -49,8 +49,10 @@ class CreateMigrationCommand extends ServerpodCommand {
       }
     }
 
-    var config = await GeneratorConfig.load();
-    if (config == null) {
+    GeneratorConfig config;
+    try {
+      config = await GeneratorConfig.load();
+    } catch (_) {
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -66,13 +66,6 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 
-    try {
-      // Todo: ask alex if we actually need this load?
-      await GeneratorConfig.load();
-    } catch (_) {
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
-    }
-
     var projectName = await getProjectName();
     if (projectName == null) {
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -66,8 +66,10 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 
-    var config = await GeneratorConfig.load();
-    if (config == null) {
+    try {
+      // Todo: ask alex if we actually need this load?
+      await GeneratorConfig.load();
+    } catch (_) {
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -33,8 +33,10 @@ class GenerateCommand extends ServerpodCommand {
     bool watch = argResults!['watch'];
 
     // TODO: add a -d option to select the directory
-    var config = await GeneratorConfig.load();
-    if (config == null) {
+    GeneratorConfig config;
+    try {
+      config = await GeneratorConfig.load();
+    } catch (_) {
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -22,6 +22,24 @@ enum PackageType {
   internal,
 }
 
+class ServerpodProjectNotFoundException implements Exception {
+  final String message;
+
+  const ServerpodProjectNotFoundException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+class ServerpodModulesNotFoundException implements Exception {
+  final String message;
+
+  const ServerpodModulesNotFoundException(this.message);
+
+  @override
+  String toString() => message;
+}
+
 /// The configuration of the generation and analyzing process.
 class GeneratorConfig {
   const GeneratorConfig({
@@ -124,7 +142,7 @@ class GeneratorConfig {
   List<ModuleConfig> get modulesAll => _modules;
 
   /// Create a new [GeneratorConfig] by loading the configuration in the [dir].
-  static Future<GeneratorConfig?> load([String dir = '']) async {
+  static Future<GeneratorConfig> load([String dir = '']) async {
     var serverPackageDirectoryPathParts = p.split(dir);
 
     Map? pubspec;
@@ -137,7 +155,10 @@ class GeneratorConfig {
         'Failed to load pubspec.yaml. Are you running serverpod from your '
         'projects root directory?',
       );
-      return null;
+
+      throw const ServerpodProjectNotFoundException(
+        'Failed to load pubspec.yaml',
+      );
     }
 
     if (pubspec!['name'] == null) {
@@ -154,7 +175,10 @@ class GeneratorConfig {
     } catch (_) {
       log.error('Failed to load config/generator.yaml. Is this a Serverpod '
           'project?');
-      return null;
+
+      throw const ServerpodProjectNotFoundException(
+        'Failed to load config/generator.yaml',
+      );
     }
 
     if (generatorConfig == null) {
@@ -190,7 +214,9 @@ class GeneratorConfig {
         'Failed to load client pubspec.yaml. Is your client_package_path set '
         'correctly?',
       );
-      return null;
+      throw const ServerpodProjectNotFoundException(
+        'Failed to load client pubspec.yaml',
+      );
     }
 
     var manualModules = <String, String?>{};
@@ -208,7 +234,9 @@ class GeneratorConfig {
     );
 
     if (modules == null) {
-      return null;
+      throw const ServerpodModulesNotFoundException(
+        'Failed to locate modules',
+      );
     }
 
     // Load extraClasses

--- a/tools/serverpod_cli/lib/src/create/database_setup.dart
+++ b/tools/serverpod_cli/lib/src/create/database_setup.dart
@@ -11,8 +11,11 @@ class DatabaseSetup {
   ) async {
     log.debug('Creating initial migration.');
 
-    var config = await GeneratorConfig.load(dir.path);
-    if (config == null) {
+    GeneratorConfig? config;
+
+    try {
+      config = await GeneratorConfig.load(dir.path);
+    } catch (error) {
       log.error('Could not load config file.');
       return false;
     }

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:lsp_server/lsp_server.dart';
-import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/language_server/diagnostics_source.dart';
 import 'package:serverpod_cli/src/util/directory.dart';
@@ -26,11 +26,18 @@ Future<void> runLanguageServer() async {
   var connection = Connection(stdin, stdout);
 
   ServerProject? serverProject;
+  Exception? exception;
 
   connection.onInitialize((params) async {
     var rootUri = params.rootUri;
     if (rootUri != null) {
-      serverProject = await _loadServerProject(rootUri, connection);
+      try {
+        serverProject = await _loadServerProject(rootUri, connection);
+      } catch (error) {
+        if (error is Exception) {
+          exception = error;
+        }
+      }
     }
 
     return InitializeResult(
@@ -41,7 +48,10 @@ Future<void> runLanguageServer() async {
   });
 
   connection.onInitialized((_) async {
-    if (serverProject == null) {
+    if (serverProject == null &&
+        exception is ServerpodModulesNotFoundException) {
+      _sendModulesNotFoundNotification(connection);
+    } else if (serverProject == null) {
       _sendServerDisabledNotification(connection);
     } else {
       serverProject?.analyzer.validateAll();
@@ -112,12 +122,22 @@ Future<void> runLanguageServer() async {
   await connection.listen();
 }
 
-void _sendServerDisabledNotification(Connection connection) {
+void _sendModulesNotFoundNotification(Connection connection) {
   connection.sendNotification(
     'window/showMessage',
     ShowMessageParams(
       message:
-          'Serverpod protocol validation disabled, not a Serverpod project.',
+          'Serverpod model validation disabled. Unable to locate necessary modules, have you run dart pub get?',
+      type: MessageType.Warning,
+    ).toJson(),
+  );
+}
+
+void _sendServerDisabledNotification(Connection connection) {
+  connection.sendNotification(
+    'window/showMessage',
+    ShowMessageParams(
+      message: 'Serverpod model validation disabled, not a Serverpod project.',
       type: MessageType.Info,
     ).toJson(),
   );
@@ -133,7 +153,6 @@ Future<ServerProject?> _loadServerProject(
   if (serverRootDir == null) return null;
 
   var config = await GeneratorConfig.load(serverRootDir.path);
-  if (config == null) return null;
 
   var yamlSources = await ModelHelper.loadProjectYamlModelsFromDisk(
     config,

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -127,7 +127,7 @@ void _sendModulesNotFoundNotification(Connection connection) {
     'window/showMessage',
     ShowMessageParams(
       message:
-          'Serverpod model validation disabled. Unable to locate necessary modules, have you run dart pub get?',
+          'Serverpod model validation disabled. Unable to locate necessary modules, have you run "dart pub get"?',
       type: MessageType.Warning,
     ).toJson(),
   );


### PR DESCRIPTION
# Changes

Report explicit errors when failing to load the config, this enable us to give better error messages when we are unable to load a project in the vscode plugin.

Report that `dart pub get` needs to be run if we are unable to locate the modules.


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
