### PR TITLE
fix: Remove Serverpod project warning message.

### DIFF
--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -52,10 +52,10 @@ Future<void> runLanguageServer() async {
         exception is ServerpodModulesNotFoundException) {
       _sendModulesNotFoundNotification(connection);
     } else if (serverProject == null) {
-      _sendServerDisabledNotification(connection);
-    } else {
-      serverProject?.analyzer.validateAll();
+      return;
     }
+
+    serverProject?.analyzer.validateAll();
   });
 
   connection.onShutdown(() async {
@@ -129,16 +129,6 @@ void _sendModulesNotFoundNotification(Connection connection) {
       message:
           'Serverpod model validation disabled. Unable to locate necessary modules, have you run "dart pub get"?',
       type: MessageType.Warning,
-    ).toJson(),
-  );
-}
-
-void _sendServerDisabledNotification(Connection connection) {
-  connection.sendNotification(
-    'window/showMessage',
-    ShowMessageParams(
-      message: 'Serverpod model validation disabled, not a Serverpod project.',
-      type: MessageType.Info,
     ).toJson(),
   );
 }


### PR DESCRIPTION
### Change:
- Remove displaying warning when the LSP fails to resolve the Serverpod project.

When opening VSCode, currently warnings "not a serverpod project" warnings are shown as soon as a file that matches the lsp pattern I opened, such as `.yaml` files in a protocol or model folder.

We are concerned that this warning in the wrong context will drive users to disable or uninstall the plugin.
This PR removes that warning for now.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
