### PR TITLE
fix: Remove copy of removed generated folder

### DIFF
--- a/templates/serverpod_templates/projectname_server/Dockerfile
+++ b/templates/serverpod_templates/projectname_server/Dockerfile
@@ -16,7 +16,6 @@ ENV role=monolith
 COPY --from=build /runtime/ /
 COPY --from=build /app/bin/main /app/bin/main
 COPY --from=build /app/config/ config/
-COPY --from=build /app/generated/ generated/
 COPY --from=build /app/web/ web/
 
 EXPOSE 8080


### PR DESCRIPTION
### Change:
- Removes reference to removed folder.

When rearranging the folder structure (PR here: https://github.com/serverpod/serverpod/pull/1752) a copy in the docker file was not correctly removed preventing the docker file from being built.

Closes: #1763

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this file copied once on project creation and influenced projects don't have the generated file anymore.
