### PR TITLE
chore: Bump vm_service version to ">=13.x.x <15.x.x".

### DIFF
--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   synchronized: ^3.1.0
   postgres_pool: ^2.1.6
   system_resources: ^1.6.0
-  vm_service: ^13.0.0
+  vm_service: ">=13.0.0 <15.0.0"
   yaml: ^3.1.1
   serverpod_shared: #1.2.0
     path: ../serverpod_shared

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   synchronized: ^3.1.0
   postgres_pool: ^2.1.6
   system_resources: ^1.6.0
-  vm_service: ^13.0.0
+  vm_service: ">=13.0.0 <15.0.0"
   yaml: ^3.1.1
   serverpod_shared: #--CONDITIONAL_COMMENT--#VERSION
     path: ../serverpod_shared


### PR DESCRIPTION
### Change
- Bumps the vm_service version from 13.x.x to the range ">=13.x.x <15.x.x".

Using the range since there seems to be some lacking support in the dart sdk for all features of the vm_service.

Since this is only used in one place in the Serverpod project it probably won't influence us but could be a transitive limitation for anyone utilizing the Serverpod package.

Thanks @yahu1031 for the heads up on the compatibility issues.
Dart thread here: https://github.com/dart-lang/sdk/issues/54483

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - backwards compatible upgrade.