### PR TITLE
fix: Prevent database analyzer from crashing when missing table

### DIFF
--- a/packages/serverpod/lib/src/database/analyze.dart
+++ b/packages/serverpod/lib/src/database/analyze.dart
@@ -174,7 +174,7 @@ WHERE contype = 'f' AND t.relname = '$tableName' AND nt.nspname = '$schemaName';
     Database database,
   ) async {
     try {
-      return database.find<DatabaseMigrationVersion>();
+      return await database.find<DatabaseMigrationVersion>();
     } catch (e) {
       // Ignore if the table does not exist.
       stderr.writeln('Failed to get installed migrations: $e');
@@ -187,7 +187,7 @@ WHERE contype = 'f' AND t.relname = '$tableName' AND nt.nspname = '$schemaName';
     Session session,
   ) async {
     try {
-      return DatabaseMigrationVersion.db.find(session);
+      return await DatabaseMigrationVersion.db.find(session);
     } catch (e) {
       // Ignore if the table does not exist.
       stderr.writeln('Failed to get installed migrations: $e');


### PR DESCRIPTION
## Changes:
- Because an await was missing a future that could throw was passed out from its catch scope which caused the database analyzer to crash.

Solves the bug issue in: https://github.com/serverpod/serverpod/issues/1773

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - stabilizing fix.
