### PR TITLE
fix: Make path parsing windows compatible.

### DIFF
--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -71,7 +71,7 @@ class RouteStaticDirectory extends Route {
       // Enforce strong cache control.
       request.response.headers.set('Cache-Control', 'max-age=31536000');
 
-      var filePath = p.joinAll(path.split('/'));
+      var filePath = path.startsWith('/') ? path.substring(1) : path;
       filePath = 'web/$filePath';
 
       var fileContents = await File(filePath).readAsBytes();

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -338,7 +338,7 @@ class Server {
 
   Future<Result> _handleUriCall(
       Uri uri, String body, HttpRequest request) async {
-    var path = p.joinAll(uri.pathSegments);
+    var path = uri.pathSegments.join('/');
     return endpoints.handleUriCall(this, path, uri, body, request);
   }
 

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:path/path.dart' as p;
 import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/server/health_check.dart';


### PR DESCRIPTION
### Change
- Make path parsing windows compatible.

Recent change modified the URI path parsing, but by using the path library the paths on windows would use backslash.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
