### PR TITLE
fix: Support all serverpod types in Map keys. 

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -67,7 +67,7 @@ abstract class Channel extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
       'channel': channel,
     };

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_response.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_response.dart
@@ -76,8 +76,8 @@ abstract class AuthenticationResponse extends _i1.SerializableEntity {
       'success': success,
       if (key != null) 'key': key,
       if (keyId != null) 'keyId': keyId,
-      if (userInfo != null) 'userInfo': userInfo,
-      if (failReason != null) 'failReason': failReason,
+      if (userInfo != null) 'userInfo': userInfo?.toJson(),
+      if (failReason != null) 'failReason': failReason?.toJson(),
     };
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Database table for tracking failed email sign-ins. Saves IP-address, time,
 /// and email to be prevent brute force attacks.
@@ -67,7 +68,7 @@ abstract class EmailFailedSignIn extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'email': email,
-      'time': time,
+      'time': time.toJson(),
       'ipAddress': ipAddress,
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Database table for tracking failed email sign-ins. Saves IP-address, time,
 /// and email to be prevent brute force attacks.

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Database bindings for an email reset.
 abstract class EmailReset extends _i1.SerializableEntity {

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Database bindings for an email reset.
 abstract class EmailReset extends _i1.SerializableEntity {
@@ -67,7 +68,7 @@ abstract class EmailReset extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'userId': userId,
       'verificationCode': verificationCode,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
     };
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a user. The [UserInfo] should only be shared with the user
 /// itself as it may contain sensative information, such as the users email.

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a user. The [UserInfo] should only be shared with the user
 /// itself as it may contain sensative information, such as the users email.
@@ -114,9 +115,9 @@ abstract class UserInfo extends _i1.SerializableEntity {
       'userName': userName,
       if (fullName != null) 'fullName': fullName,
       if (email != null) 'email': email,
-      'created': created,
+      'created': created.toJson(),
       if (imageUrl != null) 'imageUrl': imageUrl,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'blocked': blocked,
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a user that can safely be publically accessible.
 abstract class UserInfoPublic extends _i1.SerializableEntity {
@@ -73,7 +74,7 @@ abstract class UserInfoPublic extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'userName': userName,
       if (fullName != null) 'fullName': fullName,
-      'created': created,
+      'created': created.toJson(),
       if (imageUrl != null) 'imageUrl': imageUrl,
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a user that can safely be publically accessible.
 abstract class UserInfoPublic extends _i1.SerializableEntity {

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
@@ -87,7 +87,7 @@ abstract class AuthenticationResponse extends _i1.SerializableEntity {
       'success': success,
       if (key != null) 'key': key,
       if (keyId != null) 'keyId': keyId,
-      if (userInfo != null) 'userInfo': userInfo?.toJson(),
+      if (userInfo != null) 'userInfo': userInfo?.allToJson(),
       if (failReason != null) 'failReason': failReason?.toJson(),
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
@@ -76,8 +76,8 @@ abstract class AuthenticationResponse extends _i1.SerializableEntity {
       'success': success,
       if (key != null) 'key': key,
       if (keyId != null) 'keyId': keyId,
-      if (userInfo != null) 'userInfo': userInfo,
-      if (failReason != null) 'failReason': failReason,
+      if (userInfo != null) 'userInfo': userInfo?.toJson(),
+      if (failReason != null) 'failReason': failReason?.toJson(),
     };
   }
 
@@ -87,8 +87,8 @@ abstract class AuthenticationResponse extends _i1.SerializableEntity {
       'success': success,
       if (key != null) 'key': key,
       if (keyId != null) 'keyId': keyId,
-      if (userInfo != null) 'userInfo': userInfo,
-      if (failReason != null) 'failReason': failReason,
+      if (userInfo != null) 'userInfo': userInfo?.toJson(),
+      if (failReason != null) 'failReason': failReason?.toJson(),
     };
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -76,7 +76,7 @@ abstract class EmailAuth extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'userId': userId,
       'email': email,
       'hash': hash,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -86,7 +86,7 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'userName': userName,
       'email': email,
       'hash': hash,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Database table for tracking failed email sign-ins. Saves IP-address, time,
 /// and email to be prevent brute force attacks.
@@ -69,7 +70,7 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'email': email,
-      'time': time,
+      'time': time.toJson(),
       'ipAddress': ipAddress,
     };
   }
@@ -80,7 +81,7 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'email': email,
-      'time': time,
+      'time': time.toJson(),
       'ipAddress': ipAddress,
     };
   }
@@ -90,7 +91,7 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'email': email,
-      'time': time,
+      'time': time.toJson(),
       'ipAddress': ipAddress,
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -79,9 +79,9 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'email': email,
-      'time': time.toJson(),
+      'time': time,
       'ipAddress': ipAddress,
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Database bindings for an email reset.
 abstract class EmailReset extends _i1.TableRow {
@@ -69,7 +70,7 @@ abstract class EmailReset extends _i1.TableRow {
       if (id != null) 'id': id,
       'userId': userId,
       'verificationCode': verificationCode,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
     };
   }
 
@@ -80,7 +81,7 @@ abstract class EmailReset extends _i1.TableRow {
       if (id != null) 'id': id,
       'userId': userId,
       'verificationCode': verificationCode,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
     };
   }
 
@@ -90,7 +91,7 @@ abstract class EmailReset extends _i1.TableRow {
       if (id != null) 'id': id,
       'userId': userId,
       'verificationCode': verificationCode,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
     };
   }
 

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -78,10 +78,10 @@ abstract class EmailReset extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'userId': userId,
       'verificationCode': verificationCode,
-      'expiration': expiration.toJson(),
+      'expiration': expiration,
     };
   }
 

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -68,7 +68,7 @@ abstract class GoogleRefreshToken extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'userId': userId,
       'refreshToken': refreshToken,
     };

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -76,7 +76,7 @@ abstract class UserImage extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'userId': userId,
       'version': version,
       'url': url,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a user. The [UserInfo] should only be shared with the user
 /// itself as it may contain sensative information, such as the users email.
@@ -116,9 +117,9 @@ abstract class UserInfo extends _i1.TableRow {
       'userName': userName,
       if (fullName != null) 'fullName': fullName,
       if (email != null) 'email': email,
-      'created': created,
+      'created': created.toJson(),
       if (imageUrl != null) 'imageUrl': imageUrl,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'blocked': blocked,
     };
   }
@@ -132,9 +133,9 @@ abstract class UserInfo extends _i1.TableRow {
       'userName': userName,
       if (fullName != null) 'fullName': fullName,
       if (email != null) 'email': email,
-      'created': created,
+      'created': created.toJson(),
       if (imageUrl != null) 'imageUrl': imageUrl,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'blocked': blocked,
     };
   }
@@ -147,9 +148,9 @@ abstract class UserInfo extends _i1.TableRow {
       'userName': userName,
       if (fullName != null) 'fullName': fullName,
       if (email != null) 'email': email,
-      'created': created,
+      'created': created.toJson(),
       if (imageUrl != null) 'imageUrl': imageUrl,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'blocked': blocked,
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -128,14 +128,14 @@ abstract class UserInfo extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'userIdentifier': userIdentifier,
       'userName': userName,
-      if (fullName != null) 'fullName': fullName,
-      if (email != null) 'email': email,
-      'created': created.toJson(),
-      if (imageUrl != null) 'imageUrl': imageUrl,
-      'scopeNames': scopeNames.toJson(),
+      'fullName': fullName,
+      'email': email,
+      'created': created,
+      'imageUrl': imageUrl,
+      'scopeNames': scopeNames,
       'blocked': blocked,
     };
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a user that can safely be publically accessible.
 abstract class UserInfoPublic extends _i1.SerializableEntity {
@@ -73,7 +74,7 @@ abstract class UserInfoPublic extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'userName': userName,
       if (fullName != null) 'fullName': fullName,
-      'created': created,
+      'created': created.toJson(),
       if (imageUrl != null) 'imageUrl': imageUrl,
     };
   }
@@ -84,7 +85,7 @@ abstract class UserInfoPublic extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'userName': userName,
       if (fullName != null) 'fullName': fullName,
-      'created': created,
+      'created': created.toJson(),
       if (imageUrl != null) 'imageUrl': imageUrl,
     };
   }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_joined_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_joined_channel.dart
@@ -67,9 +67,9 @@ abstract class ChatJoinedChannel extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'channel': channel,
-      'initialMessageChunk': initialMessageChunk,
+      'initialMessageChunk': initialMessageChunk.toJson(),
       'lastReadMessageId': lastReadMessageId,
-      'userInfo': userInfo,
+      'userInfo': userInfo.toJson(),
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
@@ -11,7 +11,6 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_auth_client/module.dart' as _i2;
 import 'protocol.dart' as _i3;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chat message.
 abstract class ChatMessage extends _i1.SerializableEntity {

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_auth_client/module.dart' as _i2;
 import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chat message.
 abstract class ChatMessage extends _i1.SerializableEntity {
@@ -117,13 +118,14 @@ abstract class ChatMessage extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'channel': channel,
       'message': message,
-      'time': time,
+      'time': time.toJson(),
       'sender': sender,
-      if (senderInfo != null) 'senderInfo': senderInfo,
+      if (senderInfo != null) 'senderInfo': senderInfo?.toJson(),
       'removed': removed,
       if (clientMessageId != null) 'clientMessageId': clientMessageId,
       if (sent != null) 'sent': sent,
-      if (attachments != null) 'attachments': attachments,
+      if (attachments != null)
+        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_chunk.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chunk of chat messages.
 abstract class ChatMessageChunk extends _i1.SerializableEntity {

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_chunk.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chunk of chat messages.
 abstract class ChatMessageChunk extends _i1.SerializableEntity {
@@ -57,7 +58,7 @@ abstract class ChatMessageChunk extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'channel': channel,
-      'messages': messages,
+      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
       'hasOlderMessages': hasOlderMessages,
     };
   }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chat message post request.
 abstract class ChatMessagePost extends _i1.SerializableEntity {
@@ -68,7 +69,8 @@ abstract class ChatMessagePost extends _i1.SerializableEntity {
       'channel': channel,
       'message': message,
       'clientMessageId': clientMessageId,
-      if (attachments != null) 'attachments': attachments,
+      if (attachments != null)
+        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chat message post request.
 abstract class ChatMessagePost extends _i1.SerializableEntity {

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_joined_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_joined_channel.dart
@@ -67,9 +67,9 @@ abstract class ChatJoinedChannel extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'channel': channel,
-      'initialMessageChunk': initialMessageChunk,
+      'initialMessageChunk': initialMessageChunk.toJson(),
       'lastReadMessageId': lastReadMessageId,
-      'userInfo': userInfo,
+      'userInfo': userInfo.toJson(),
     };
   }
 
@@ -77,9 +77,9 @@ abstract class ChatJoinedChannel extends _i1.SerializableEntity {
   Map<String, dynamic> allToJson() {
     return {
       'channel': channel,
-      'initialMessageChunk': initialMessageChunk,
+      'initialMessageChunk': initialMessageChunk.toJson(),
       'lastReadMessageId': lastReadMessageId,
-      'userInfo': userInfo,
+      'userInfo': userInfo.toJson(),
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_joined_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_joined_channel.dart
@@ -77,9 +77,9 @@ abstract class ChatJoinedChannel extends _i1.SerializableEntity {
   Map<String, dynamic> allToJson() {
     return {
       'channel': channel,
-      'initialMessageChunk': initialMessageChunk.toJson(),
+      'initialMessageChunk': initialMessageChunk.allToJson(),
       'lastReadMessageId': lastReadMessageId,
-      'userInfo': userInfo.toJson(),
+      'userInfo': userInfo.allToJson(),
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/module.dart' as _i2;
 import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chat message.
 abstract class ChatMessage extends _i1.TableRow {
@@ -119,13 +120,14 @@ abstract class ChatMessage extends _i1.TableRow {
       if (id != null) 'id': id,
       'channel': channel,
       'message': message,
-      'time': time,
+      'time': time.toJson(),
       'sender': sender,
-      if (senderInfo != null) 'senderInfo': senderInfo,
+      if (senderInfo != null) 'senderInfo': senderInfo?.toJson(),
       'removed': removed,
       if (clientMessageId != null) 'clientMessageId': clientMessageId,
       if (sent != null) 'sent': sent,
-      if (attachments != null) 'attachments': attachments,
+      if (attachments != null)
+        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -136,10 +138,11 @@ abstract class ChatMessage extends _i1.TableRow {
       if (id != null) 'id': id,
       'channel': channel,
       'message': message,
-      'time': time,
+      'time': time.toJson(),
       'sender': sender,
       'removed': removed,
-      if (attachments != null) 'attachments': attachments,
+      if (attachments != null)
+        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -149,13 +152,14 @@ abstract class ChatMessage extends _i1.TableRow {
       if (id != null) 'id': id,
       'channel': channel,
       'message': message,
-      'time': time,
+      'time': time.toJson(),
       'sender': sender,
-      if (senderInfo != null) 'senderInfo': senderInfo,
+      if (senderInfo != null) 'senderInfo': senderInfo?.toJson(),
       'removed': removed,
       if (clientMessageId != null) 'clientMessageId': clientMessageId,
       if (sent != null) 'sent': sent,
-      if (attachments != null) 'attachments': attachments,
+      if (attachments != null)
+        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -135,14 +135,13 @@ abstract class ChatMessage extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'channel': channel,
       'message': message,
-      'time': time.toJson(),
+      'time': time,
       'sender': sender,
       'removed': removed,
-      if (attachments != null)
-        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
+      'attachments': attachments,
     };
   }
 
@@ -154,12 +153,12 @@ abstract class ChatMessage extends _i1.TableRow {
       'message': message,
       'time': time.toJson(),
       'sender': sender,
-      if (senderInfo != null) 'senderInfo': senderInfo?.toJson(),
+      if (senderInfo != null) 'senderInfo': senderInfo?.allToJson(),
       'removed': removed,
       if (clientMessageId != null) 'clientMessageId': clientMessageId,
       if (sent != null) 'sent': sent,
       if (attachments != null)
-        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
+        'attachments': attachments?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_chunk.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chunk of chat messages.
 abstract class ChatMessageChunk extends _i1.SerializableEntity {
@@ -57,7 +58,7 @@ abstract class ChatMessageChunk extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'channel': channel,
-      'messages': messages,
+      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
       'hasOlderMessages': hasOlderMessages,
     };
   }
@@ -66,7 +67,7 @@ abstract class ChatMessageChunk extends _i1.SerializableEntity {
   Map<String, dynamic> allToJson() {
     return {
       'channel': channel,
-      'messages': messages,
+      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
       'hasOlderMessages': hasOlderMessages,
     };
   }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_chunk.dart
@@ -67,7 +67,7 @@ abstract class ChatMessageChunk extends _i1.SerializableEntity {
   Map<String, dynamic> allToJson() {
     return {
       'channel': channel,
-      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
+      'messages': messages.toJson(valueToJson: (v) => v.allToJson()),
       'hasOlderMessages': hasOlderMessages,
     };
   }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A chat message post request.
 abstract class ChatMessagePost extends _i1.SerializableEntity {
@@ -68,7 +69,8 @@ abstract class ChatMessagePost extends _i1.SerializableEntity {
       'channel': channel,
       'message': message,
       'clientMessageId': clientMessageId,
-      if (attachments != null) 'attachments': attachments,
+      if (attachments != null)
+        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -78,7 +80,8 @@ abstract class ChatMessagePost extends _i1.SerializableEntity {
       'channel': channel,
       'message': message,
       'clientMessageId': clientMessageId,
-      if (attachments != null) 'attachments': attachments,
+      if (attachments != null)
+        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
@@ -81,7 +81,7 @@ abstract class ChatMessagePost extends _i1.SerializableEntity {
       'message': message,
       'clientMessageId': clientMessageId,
       if (attachments != null)
-        'attachments': attachments?.toJson(valueToJson: (v) => v.toJson()),
+        'attachments': attachments?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -77,7 +77,7 @@ abstract class ChatReadMessage extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'channel': channel,
       'userId': userId,
       'lastReadMessageId': lastReadMessageId,

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -95,10 +95,10 @@ abstract class AuthKey extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'userId': userId,
       'hash': hash,
-      'scopeNames': scopeNames.toJson(),
+      'scopeNames': scopeNames,
       'method': method,
     };
   }

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides a method of access for a user to authenticate with the server.
 abstract class AuthKey extends _i1.TableRow {
@@ -85,7 +86,7 @@ abstract class AuthKey extends _i1.TableRow {
       'userId': userId,
       'hash': hash,
       if (key != null) 'key': key,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'method': method,
     };
   }
@@ -97,7 +98,7 @@ abstract class AuthKey extends _i1.TableRow {
       if (id != null) 'id': id,
       'userId': userId,
       'hash': hash,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'method': method,
     };
   }
@@ -109,7 +110,7 @@ abstract class AuthKey extends _i1.TableRow {
       'userId': userId,
       'hash': hash,
       if (key != null) 'key': key,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'method': method,
     };
   }

--- a/packages/serverpod/lib/src/generated/cache_info.dart
+++ b/packages/serverpod/lib/src/generated/cache_info.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides high level information about a cache.
 abstract class CacheInfo extends _i1.SerializableEntity {
@@ -57,7 +58,7 @@ abstract class CacheInfo extends _i1.SerializableEntity {
     return {
       'numEntries': numEntries,
       'maxEntries': maxEntries,
-      if (keys != null) 'keys': keys,
+      if (keys != null) 'keys': keys?.toJson(),
     };
   }
 
@@ -66,7 +67,7 @@ abstract class CacheInfo extends _i1.SerializableEntity {
     return {
       'numEntries': numEntries,
       'maxEntries': maxEntries,
-      if (keys != null) 'keys': keys,
+      if (keys != null) 'keys': keys?.toJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/caches_info.dart
+++ b/packages/serverpod/lib/src/generated/caches_info.dart
@@ -65,9 +65,9 @@ abstract class CachesInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'local': local.toJson(),
-      'localPrio': localPrio.toJson(),
-      'global': global.toJson(),
+      'local': local.allToJson(),
+      'localPrio': localPrio.allToJson(),
+      'global': global.allToJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/caches_info.dart
+++ b/packages/serverpod/lib/src/generated/caches_info.dart
@@ -56,18 +56,18 @@ abstract class CachesInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'local': local,
-      'localPrio': localPrio,
-      'global': global,
+      'local': local.toJson(),
+      'localPrio': localPrio.toJson(),
+      'global': global.toJson(),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'local': local,
-      'localPrio': localPrio,
-      'global': global,
+      'local': local.toJson(),
+      'localPrio': localPrio.toJson(),
+      'global': global.toJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// An entry in the database for an uploaded file.
 abstract class CloudStorageEntry extends _i1.TableRow {
@@ -93,9 +94,9 @@ abstract class CloudStorageEntry extends _i1.TableRow {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'addedTime': addedTime,
-      if (expiration != null) 'expiration': expiration,
-      'byteData': byteData,
+      'addedTime': addedTime.toJson(),
+      if (expiration != null) 'expiration': expiration?.toJson(),
+      'byteData': byteData.toJson(),
       'verified': verified,
     };
   }
@@ -107,9 +108,9 @@ abstract class CloudStorageEntry extends _i1.TableRow {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'addedTime': addedTime,
-      if (expiration != null) 'expiration': expiration,
-      'byteData': byteData,
+      'addedTime': addedTime.toJson(),
+      if (expiration != null) 'expiration': expiration?.toJson(),
+      'byteData': byteData.toJson(),
       'verified': verified,
     };
   }
@@ -120,9 +121,9 @@ abstract class CloudStorageEntry extends _i1.TableRow {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'addedTime': addedTime,
-      if (expiration != null) 'expiration': expiration,
-      'byteData': byteData,
+      'addedTime': addedTime.toJson(),
+      if (expiration != null) 'expiration': expiration?.toJson(),
+      'byteData': byteData.toJson(),
       'verified': verified,
     };
   }

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -105,12 +105,12 @@ abstract class CloudStorageEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'storageId': storageId,
       'path': path,
-      'addedTime': addedTime.toJson(),
-      if (expiration != null) 'expiration': expiration?.toJson(),
-      'byteData': byteData.toJson(),
+      'addedTime': addedTime,
+      'expiration': expiration,
+      'byteData': byteData,
       'verified': verified,
     };
   }

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -86,10 +86,10 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'storageId': storageId,
       'path': path,
-      'expiration': expiration.toJson(),
+      'expiration': expiration,
       'authKey': authKey,
     };
   }

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Connects a table for handling uploading of files.
 abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
@@ -76,7 +77,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
       'authKey': authKey,
     };
   }
@@ -88,7 +89,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
       'authKey': authKey,
     };
   }
@@ -99,7 +100,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
       'authKey': authKey,
     };
   }

--- a/packages/serverpod/lib/src/generated/cluster_info.dart
+++ b/packages/serverpod/lib/src/generated/cluster_info.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a cluster of servers.
 abstract class ClusterInfo extends _i1.SerializableEntity {
@@ -33,12 +34,12 @@ abstract class ClusterInfo extends _i1.SerializableEntity {
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers});
   @override
   Map<String, dynamic> toJson() {
-    return {'servers': servers};
+    return {'servers': servers.toJson(valueToJson: (v) => v.toJson())};
   }
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'servers': servers};
+    return {'servers': servers.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/packages/serverpod/lib/src/generated/cluster_info.dart
+++ b/packages/serverpod/lib/src/generated/cluster_info.dart
@@ -39,7 +39,7 @@ abstract class ClusterInfo extends _i1.SerializableEntity {
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'servers': servers.toJson(valueToJson: (v) => v.toJson())};
+    return {'servers': servers.toJson(valueToJson: (v) => v.allToJson())};
   }
 }
 

--- a/packages/serverpod/lib/src/generated/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data.dart
@@ -52,7 +52,7 @@ abstract class BulkData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'tableDefinition': tableDefinition.toJson(),
+      'tableDefinition': tableDefinition.allToJson(),
       'data': data,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data.dart
@@ -44,7 +44,7 @@ abstract class BulkData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'tableDefinition': tableDefinition,
+      'tableDefinition': tableDefinition.toJson(),
       'data': data,
     };
   }
@@ -52,7 +52,7 @@ abstract class BulkData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'tableDefinition': tableDefinition,
+      'tableDefinition': tableDefinition.toJson(),
       'data': data,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/bulk_query_result.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_query_result.dart
@@ -69,7 +69,7 @@ abstract class BulkQueryResult extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'headers': headers.toJson(valueToJson: (v) => v.toJson()),
+      'headers': headers.toJson(valueToJson: (v) => v.allToJson()),
       'data': data,
       'numAffectedRows': numAffectedRows,
       'duration': duration.toJson(),

--- a/packages/serverpod/lib/src/generated/database/bulk_query_result.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_query_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class BulkQueryResult extends _i1.SerializableEntity {
   BulkQueryResult._({
@@ -58,20 +59,20 @@ abstract class BulkQueryResult extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'headers': headers,
+      'headers': headers.toJson(valueToJson: (v) => v.toJson()),
       'data': data,
       'numAffectedRows': numAffectedRows,
-      'duration': duration,
+      'duration': duration.toJson(),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'headers': headers,
+      'headers': headers.toJson(valueToJson: (v) => v.toJson()),
       'data': data,
       'numAffectedRows': numAffectedRows,
-      'duration': duration,
+      'duration': duration.toJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/column_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/column_definition.dart
@@ -74,7 +74,7 @@ abstract class ColumnDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'columnType': columnType,
+      'columnType': columnType.toJson(),
       'isNullable': isNullable,
       if (columnDefault != null) 'columnDefault': columnDefault,
       if (dartType != null) 'dartType': dartType,
@@ -85,7 +85,7 @@ abstract class ColumnDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> allToJson() {
     return {
       'name': name,
-      'columnType': columnType,
+      'columnType': columnType.toJson(),
       'isNullable': isNullable,
       if (columnDefault != null) 'columnDefault': columnDefault,
       if (dartType != null) 'dartType': dartType,

--- a/packages/serverpod/lib/src/generated/database/database_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Defines the structure of the database used by Serverpod.
 abstract class DatabaseDefinition extends _i1.SerializableEntity {
@@ -77,8 +78,9 @@ abstract class DatabaseDefinition extends _i1.SerializableEntity {
     return {
       if (name != null) 'name': name,
       'moduleName': moduleName,
-      'tables': tables,
-      'installedModules': installedModules,
+      'tables': tables.toJson(valueToJson: (v) => v.toJson()),
+      'installedModules':
+          installedModules.toJson(valueToJson: (v) => v.toJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }
@@ -88,8 +90,9 @@ abstract class DatabaseDefinition extends _i1.SerializableEntity {
     return {
       if (name != null) 'name': name,
       'moduleName': moduleName,
-      'tables': tables,
-      'installedModules': installedModules,
+      'tables': tables.toJson(valueToJson: (v) => v.toJson()),
+      'installedModules':
+          installedModules.toJson(valueToJson: (v) => v.toJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/database_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definition.dart
@@ -90,9 +90,9 @@ abstract class DatabaseDefinition extends _i1.SerializableEntity {
     return {
       if (name != null) 'name': name,
       'moduleName': moduleName,
-      'tables': tables.toJson(valueToJson: (v) => v.toJson()),
+      'tables': tables.toJson(valueToJson: (v) => v.allToJson()),
       'installedModules':
-          installedModules.toJson(valueToJson: (v) => v.toJson()),
+          installedModules.toJson(valueToJson: (v) => v.allToJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/database_definitions.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definitions.dart
@@ -80,12 +80,12 @@ abstract class DatabaseDefinitions extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'target': target.toJson(valueToJson: (v) => v.toJson()),
-      'live': live.toJson(valueToJson: (v) => v.toJson()),
+      'target': target.toJson(valueToJson: (v) => v.allToJson()),
+      'live': live.toJson(valueToJson: (v) => v.allToJson()),
       'installedMigrations':
-          installedMigrations.toJson(valueToJson: (v) => v.toJson()),
+          installedMigrations.toJson(valueToJson: (v) => v.allToJson()),
       'latestAvailableMigrations':
-          latestAvailableMigrations.toJson(valueToJson: (v) => v.toJson()),
+          latestAvailableMigrations.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/database_definitions.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definitions.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Defines the current state of the database, including information about
 /// installed modules and migrations.
@@ -67,20 +68,24 @@ abstract class DatabaseDefinitions extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'target': target,
-      'live': live,
-      'installedMigrations': installedMigrations,
-      'latestAvailableMigrations': latestAvailableMigrations,
+      'target': target.toJson(valueToJson: (v) => v.toJson()),
+      'live': live.toJson(valueToJson: (v) => v.toJson()),
+      'installedMigrations':
+          installedMigrations.toJson(valueToJson: (v) => v.toJson()),
+      'latestAvailableMigrations':
+          latestAvailableMigrations.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'target': target,
-      'live': live,
-      'installedMigrations': installedMigrations,
-      'latestAvailableMigrations': latestAvailableMigrations,
+      'target': target.toJson(valueToJson: (v) => v.toJson()),
+      'live': live.toJson(valueToJson: (v) => v.toJson()),
+      'installedMigrations':
+          installedMigrations.toJson(valueToJson: (v) => v.toJson()),
+      'latestAvailableMigrations':
+          latestAvailableMigrations.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/database_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class DatabaseMigration extends _i1.SerializableEntity {
   DatabaseMigration._({
@@ -54,8 +55,8 @@ abstract class DatabaseMigration extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'actions': actions,
-      'warnings': warnings,
+      'actions': actions.toJson(valueToJson: (v) => v.toJson()),
+      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }
@@ -63,8 +64,8 @@ abstract class DatabaseMigration extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'actions': actions,
-      'warnings': warnings,
+      'actions': actions.toJson(valueToJson: (v) => v.toJson()),
+      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/database_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration.dart
@@ -64,8 +64,8 @@ abstract class DatabaseMigration extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'actions': actions.toJson(valueToJson: (v) => v.toJson()),
-      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
+      'actions': actions.toJson(valueToJson: (v) => v.allToJson()),
+      'warnings': warnings.toJson(valueToJson: (v) => v.allToJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/database_migration_action.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_action.dart
@@ -71,8 +71,8 @@ abstract class DatabaseMigrationAction extends _i1.SerializableEntity {
     return {
       'type': type.toJson(),
       if (deleteTable != null) 'deleteTable': deleteTable,
-      if (alterTable != null) 'alterTable': alterTable?.toJson(),
-      if (createTable != null) 'createTable': createTable?.toJson(),
+      if (alterTable != null) 'alterTable': alterTable?.allToJson(),
+      if (createTable != null) 'createTable': createTable?.allToJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/database_migration_action.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_action.dart
@@ -59,20 +59,20 @@ abstract class DatabaseMigrationAction extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       if (deleteTable != null) 'deleteTable': deleteTable,
-      if (alterTable != null) 'alterTable': alterTable,
-      if (createTable != null) 'createTable': createTable,
+      if (alterTable != null) 'alterTable': alterTable?.toJson(),
+      if (createTable != null) 'createTable': createTable?.toJson(),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       if (deleteTable != null) 'deleteTable': deleteTable,
-      if (alterTable != null) 'alterTable': alterTable,
-      if (createTable != null) 'createTable': createTable,
+      if (alterTable != null) 'alterTable': alterTable?.toJson(),
+      if (createTable != null) 'createTable': createTable?.toJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -78,10 +78,10 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'module': module,
       'version': version,
-      if (timestamp != null) 'timestamp': timestamp?.toJson(),
+      'timestamp': timestamp,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a version of a database migration.
 abstract class DatabaseMigrationVersion extends _i1.TableRow {
@@ -69,7 +70,7 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow {
       if (id != null) 'id': id,
       'module': module,
       'version': version,
-      if (timestamp != null) 'timestamp': timestamp,
+      if (timestamp != null) 'timestamp': timestamp?.toJson(),
     };
   }
 
@@ -80,7 +81,7 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow {
       if (id != null) 'id': id,
       'module': module,
       'version': version,
-      if (timestamp != null) 'timestamp': timestamp,
+      if (timestamp != null) 'timestamp': timestamp?.toJson(),
     };
   }
 
@@ -90,7 +91,7 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow {
       if (id != null) 'id': id,
       'module': module,
       'version': version,
-      if (timestamp != null) 'timestamp': timestamp,
+      if (timestamp != null) 'timestamp': timestamp?.toJson(),
     };
   }
 

--- a/packages/serverpod/lib/src/generated/database/database_migration_warning.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_warning.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class DatabaseMigrationWarning extends _i1.SerializableEntity {
   DatabaseMigrationWarning._({
@@ -66,10 +67,10 @@ abstract class DatabaseMigrationWarning extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'message': message,
       'table': table,
-      'columns': columns,
+      'columns': columns.toJson(),
       'destrucive': destrucive,
     };
   }
@@ -77,10 +78,10 @@ abstract class DatabaseMigrationWarning extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'message': message,
       'table': table,
-      'columns': columns,
+      'columns': columns.toJson(),
       'destrucive': destrucive,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/filter/filter.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter.dart
@@ -63,7 +63,7 @@ abstract class Filter extends _i1.SerializableEntity {
     return {
       'name': name,
       'table': table,
-      'constraints': constraints.toJson(valueToJson: (v) => v.toJson()),
+      'constraints': constraints.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/filter/filter.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Filter extends _i1.SerializableEntity {
   Filter._({
@@ -53,7 +54,7 @@ abstract class Filter extends _i1.SerializableEntity {
     return {
       'name': name,
       'table': table,
-      'constraints': constraints,
+      'constraints': constraints.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -62,7 +63,7 @@ abstract class Filter extends _i1.SerializableEntity {
     return {
       'name': name,
       'table': table,
-      'constraints': constraints,
+      'constraints': constraints.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
@@ -59,7 +59,7 @@ abstract class FilterConstraint extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'column': column,
       'value': value,
       if (value2 != null) 'value2': value2,
@@ -69,7 +69,7 @@ abstract class FilterConstraint extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'column': column,
       'value': value,
       if (value2 != null) 'value2': value2,

--- a/packages/serverpod/lib/src/generated/database/foreign_key_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/foreign_key_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a foreign key.
 abstract class ForeignKeyDefinition extends _i1.SerializableEntity {
@@ -97,13 +98,13 @@ abstract class ForeignKeyDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'constraintName': constraintName,
-      'columns': columns,
+      'columns': columns.toJson(),
       'referenceTable': referenceTable,
       'referenceTableSchema': referenceTableSchema,
-      'referenceColumns': referenceColumns,
-      if (onUpdate != null) 'onUpdate': onUpdate,
-      if (onDelete != null) 'onDelete': onDelete,
-      if (matchType != null) 'matchType': matchType,
+      'referenceColumns': referenceColumns.toJson(),
+      if (onUpdate != null) 'onUpdate': onUpdate?.toJson(),
+      if (onDelete != null) 'onDelete': onDelete?.toJson(),
+      if (matchType != null) 'matchType': matchType?.toJson(),
     };
   }
 
@@ -111,13 +112,13 @@ abstract class ForeignKeyDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> allToJson() {
     return {
       'constraintName': constraintName,
-      'columns': columns,
+      'columns': columns.toJson(),
       'referenceTable': referenceTable,
       'referenceTableSchema': referenceTableSchema,
-      'referenceColumns': referenceColumns,
-      if (onUpdate != null) 'onUpdate': onUpdate,
-      if (onDelete != null) 'onDelete': onDelete,
-      if (matchType != null) 'matchType': matchType,
+      'referenceColumns': referenceColumns.toJson(),
+      if (onUpdate != null) 'onUpdate': onUpdate?.toJson(),
+      if (onDelete != null) 'onDelete': onDelete?.toJson(),
+      if (matchType != null) 'matchType': matchType?.toJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/index_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/index_definition.dart
@@ -105,7 +105,7 @@ abstract class IndexDefinition extends _i1.SerializableEntity {
     return {
       'indexName': indexName,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'elements': elements.toJson(valueToJson: (v) => v.toJson()),
+      'elements': elements.toJson(valueToJson: (v) => v.allToJson()),
       'type': type,
       'isUnique': isUnique,
       'isPrimary': isPrimary,

--- a/packages/serverpod/lib/src/generated/database/index_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/index_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// The definition of a (desired) index in the database.
 abstract class IndexDefinition extends _i1.SerializableEntity {
@@ -91,7 +92,7 @@ abstract class IndexDefinition extends _i1.SerializableEntity {
     return {
       'indexName': indexName,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'elements': elements,
+      'elements': elements.toJson(valueToJson: (v) => v.toJson()),
       'type': type,
       'isUnique': isUnique,
       'isPrimary': isPrimary,
@@ -104,7 +105,7 @@ abstract class IndexDefinition extends _i1.SerializableEntity {
     return {
       'indexName': indexName,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'elements': elements,
+      'elements': elements.toJson(valueToJson: (v) => v.toJson()),
       'type': type,
       'isUnique': isUnique,
       'isPrimary': isPrimary,

--- a/packages/serverpod/lib/src/generated/database/index_element_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/index_element_definition.dart
@@ -48,7 +48,7 @@ abstract class IndexElementDefinition extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'definition': definition,
     };
   }
@@ -56,7 +56,7 @@ abstract class IndexElementDefinition extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'definition': definition,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/table_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/table_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// The definition of a (desired) table in the database.
 abstract class TableDefinition extends _i1.SerializableEntity {
@@ -111,9 +112,9 @@ abstract class TableDefinition extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       'schema': schema,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'columns': columns,
-      'foreignKeys': foreignKeys,
-      'indexes': indexes,
+      'columns': columns.toJson(valueToJson: (v) => v.toJson()),
+      'foreignKeys': foreignKeys.toJson(valueToJson: (v) => v.toJson()),
+      'indexes': indexes.toJson(valueToJson: (v) => v.toJson()),
       if (managed != null) 'managed': managed,
     };
   }
@@ -126,9 +127,9 @@ abstract class TableDefinition extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       'schema': schema,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'columns': columns,
-      'foreignKeys': foreignKeys,
-      'indexes': indexes,
+      'columns': columns.toJson(valueToJson: (v) => v.toJson()),
+      'foreignKeys': foreignKeys.toJson(valueToJson: (v) => v.toJson()),
+      'indexes': indexes.toJson(valueToJson: (v) => v.toJson()),
       if (managed != null) 'managed': managed,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/table_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/table_definition.dart
@@ -127,9 +127,9 @@ abstract class TableDefinition extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       'schema': schema,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'columns': columns.toJson(valueToJson: (v) => v.toJson()),
-      'foreignKeys': foreignKeys.toJson(valueToJson: (v) => v.toJson()),
-      'indexes': indexes.toJson(valueToJson: (v) => v.toJson()),
+      'columns': columns.toJson(valueToJson: (v) => v.allToJson()),
+      'foreignKeys': foreignKeys.toJson(valueToJson: (v) => v.allToJson()),
+      'indexes': indexes.toJson(valueToJson: (v) => v.allToJson()),
       if (managed != null) 'managed': managed,
     };
   }

--- a/packages/serverpod/lib/src/generated/database/table_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/table_migration.dart
@@ -140,14 +140,15 @@ abstract class TableMigration extends _i1.SerializableEntity {
       if (dartName != null) 'dartName': dartName,
       if (module != null) 'module': module,
       'schema': schema,
-      'addColumns': addColumns.toJson(valueToJson: (v) => v.toJson()),
+      'addColumns': addColumns.toJson(valueToJson: (v) => v.allToJson()),
       'deleteColumns': deleteColumns.toJson(),
-      'modifyColumns': modifyColumns.toJson(valueToJson: (v) => v.toJson()),
-      'addIndexes': addIndexes.toJson(valueToJson: (v) => v.toJson()),
+      'modifyColumns': modifyColumns.toJson(valueToJson: (v) => v.allToJson()),
+      'addIndexes': addIndexes.toJson(valueToJson: (v) => v.allToJson()),
       'deleteIndexes': deleteIndexes.toJson(),
-      'addForeignKeys': addForeignKeys.toJson(valueToJson: (v) => v.toJson()),
+      'addForeignKeys':
+          addForeignKeys.toJson(valueToJson: (v) => v.allToJson()),
       'deleteForeignKeys': deleteForeignKeys.toJson(),
-      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
+      'warnings': warnings.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/database/table_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/table_migration.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class TableMigration extends _i1.SerializableEntity {
   TableMigration._({
@@ -121,14 +122,14 @@ abstract class TableMigration extends _i1.SerializableEntity {
       if (dartName != null) 'dartName': dartName,
       if (module != null) 'module': module,
       'schema': schema,
-      'addColumns': addColumns,
-      'deleteColumns': deleteColumns,
-      'modifyColumns': modifyColumns,
-      'addIndexes': addIndexes,
-      'deleteIndexes': deleteIndexes,
-      'addForeignKeys': addForeignKeys,
-      'deleteForeignKeys': deleteForeignKeys,
-      'warnings': warnings,
+      'addColumns': addColumns.toJson(valueToJson: (v) => v.toJson()),
+      'deleteColumns': deleteColumns.toJson(),
+      'modifyColumns': modifyColumns.toJson(valueToJson: (v) => v.toJson()),
+      'addIndexes': addIndexes.toJson(valueToJson: (v) => v.toJson()),
+      'deleteIndexes': deleteIndexes.toJson(),
+      'addForeignKeys': addForeignKeys.toJson(valueToJson: (v) => v.toJson()),
+      'deleteForeignKeys': deleteForeignKeys.toJson(),
+      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -139,14 +140,14 @@ abstract class TableMigration extends _i1.SerializableEntity {
       if (dartName != null) 'dartName': dartName,
       if (module != null) 'module': module,
       'schema': schema,
-      'addColumns': addColumns,
-      'deleteColumns': deleteColumns,
-      'modifyColumns': modifyColumns,
-      'addIndexes': addIndexes,
-      'deleteIndexes': deleteIndexes,
-      'addForeignKeys': addForeignKeys,
-      'deleteForeignKeys': deleteForeignKeys,
-      'warnings': warnings,
+      'addColumns': addColumns.toJson(valueToJson: (v) => v.toJson()),
+      'deleteColumns': deleteColumns.toJson(),
+      'modifyColumns': modifyColumns.toJson(valueToJson: (v) => v.toJson()),
+      'addIndexes': addIndexes.toJson(valueToJson: (v) => v.toJson()),
+      'deleteIndexes': deleteIndexes.toJson(),
+      'addForeignKeys': addForeignKeys.toJson(valueToJson: (v) => v.toJson()),
+      'deleteForeignKeys': deleteForeignKeys.toJson(),
+      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -95,12 +95,12 @@ abstract class FutureCallEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      'time': time.toJson(),
-      if (serializedObject != null) 'serializedObject': serializedObject,
+      'time': time,
+      'serializedObject': serializedObject,
       'serverId': serverId,
-      if (identifier != null) 'identifier': identifier,
+      'identifier': identifier,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A serialized future call with bindings to the database.
 abstract class FutureCallEntry extends _i1.TableRow {
@@ -83,7 +84,7 @@ abstract class FutureCallEntry extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      'time': time,
+      'time': time.toJson(),
       if (serializedObject != null) 'serializedObject': serializedObject,
       'serverId': serverId,
       if (identifier != null) 'identifier': identifier,
@@ -96,7 +97,7 @@ abstract class FutureCallEntry extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      'time': time,
+      'time': time.toJson(),
       if (serializedObject != null) 'serializedObject': serializedObject,
       'serverId': serverId,
       if (identifier != null) 'identifier': identifier,
@@ -108,7 +109,7 @@ abstract class FutureCallEntry extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      'time': time,
+      'time': time.toJson(),
       if (serializedObject != null) 'serializedObject': serializedObject,
       'serverId': serverId,
       if (identifier != null) 'identifier': identifier,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Bindings to a log entry in the database.
 abstract class LogEntry extends _i1.TableRow {
@@ -127,8 +128,8 @@ abstract class LogEntry extends _i1.TableRow {
       if (messageId != null) 'messageId': messageId,
       if (reference != null) 'reference': reference,
       'serverId': serverId,
-      'time': time,
-      'logLevel': logLevel,
+      'time': time.toJson(),
+      'logLevel': logLevel.toJson(),
       'message': message,
       if (error != null) 'error': error,
       if (stackTrace != null) 'stackTrace': stackTrace,
@@ -145,8 +146,8 @@ abstract class LogEntry extends _i1.TableRow {
       if (messageId != null) 'messageId': messageId,
       if (reference != null) 'reference': reference,
       'serverId': serverId,
-      'time': time,
-      'logLevel': logLevel,
+      'time': time.toJson(),
+      'logLevel': logLevel.toJson(),
       'message': message,
       if (error != null) 'error': error,
       if (stackTrace != null) 'stackTrace': stackTrace,
@@ -162,8 +163,8 @@ abstract class LogEntry extends _i1.TableRow {
       if (messageId != null) 'messageId': messageId,
       if (reference != null) 'reference': reference,
       'serverId': serverId,
-      'time': time,
-      'logLevel': logLevel,
+      'time': time.toJson(),
+      'logLevel': logLevel.toJson(),
       'message': message,
       if (error != null) 'error': error,
       if (stackTrace != null) 'stackTrace': stackTrace,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -141,16 +141,16 @@ abstract class LogEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'sessionLogId': sessionLogId,
-      if (messageId != null) 'messageId': messageId,
-      if (reference != null) 'reference': reference,
+      'messageId': messageId,
+      'reference': reference,
       'serverId': serverId,
-      'time': time.toJson(),
-      'logLevel': logLevel.toJson(),
+      'time': time,
+      'logLevel': logLevel,
       'message': message,
-      if (error != null) 'error': error,
-      if (stackTrace != null) 'stackTrace': stackTrace,
+      'error': error,
+      'stackTrace': stackTrace,
       'order': order,
     };
   }

--- a/packages/serverpod/lib/src/generated/log_result.dart
+++ b/packages/serverpod/lib/src/generated/log_result.dart
@@ -38,7 +38,7 @@ abstract class LogResult extends _i1.SerializableEntity {
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'entries': entries.toJson(valueToJson: (v) => v.toJson())};
+    return {'entries': entries.toJson(valueToJson: (v) => v.allToJson())};
   }
 }
 

--- a/packages/serverpod/lib/src/generated/log_result.dart
+++ b/packages/serverpod/lib/src/generated/log_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A list of log entries, used to return logging data.
 abstract class LogResult extends _i1.SerializableEntity {
@@ -32,12 +33,12 @@ abstract class LogResult extends _i1.SerializableEntity {
   LogResult copyWith({List<_i2.LogEntry>? entries});
   @override
   Map<String, dynamic> toJson() {
-    return {'entries': entries};
+    return {'entries': entries.toJson(valueToJson: (v) => v.toJson())};
   }
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'entries': entries};
+    return {'entries': entries.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/packages/serverpod/lib/src/generated/log_settings.dart
+++ b/packages/serverpod/lib/src/generated/log_settings.dart
@@ -113,7 +113,7 @@ abstract class LogSettings extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'logLevel': logLevel,
+      'logLevel': logLevel.toJson(),
       'logAllSessions': logAllSessions,
       'logAllQueries': logAllQueries,
       'logSlowSessions': logSlowSessions,
@@ -129,7 +129,7 @@ abstract class LogSettings extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'logLevel': logLevel,
+      'logLevel': logLevel.toJson(),
       'logAllSessions': logAllSessions,
       'logAllQueries': logAllQueries,
       'logSlowSessions': logSlowSessions,

--- a/packages/serverpod/lib/src/generated/log_settings_override.dart
+++ b/packages/serverpod/lib/src/generated/log_settings_override.dart
@@ -68,7 +68,7 @@ abstract class LogSettingsOverride extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
-      'logSettings': logSettings,
+      'logSettings': logSettings.toJson(),
     };
   }
 
@@ -78,7 +78,7 @@ abstract class LogSettingsOverride extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
-      'logSettings': logSettings,
+      'logSettings': logSettings.toJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/log_settings_override.dart
+++ b/packages/serverpod/lib/src/generated/log_settings_override.dart
@@ -78,7 +78,7 @@ abstract class LogSettingsOverride extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
-      'logSettings': logSettings.toJson(),
+      'logSettings': logSettings.allToJson(),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -140,15 +140,15 @@ abstract class MessageLogEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'sessionLogId': sessionLogId,
       'serverId': serverId,
       'messageId': messageId,
       'endpoint': endpoint,
       'messageName': messageName,
       'duration': duration,
-      if (error != null) 'error': error,
-      if (stackTrace != null) 'stackTrace': stackTrace,
+      'error': error,
+      'stackTrace': stackTrace,
       'slow': slow,
       'order': order,
     };

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -68,7 +68,7 @@ abstract class MethodInfo extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'endpoint': endpoint,
       'method': method,
     };

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -140,15 +140,15 @@ abstract class QueryLogEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'serverId': serverId,
       'sessionLogId': sessionLogId,
-      if (messageId != null) 'messageId': messageId,
+      'messageId': messageId,
       'query': query,
       'duration': duration,
-      if (numRows != null) 'numRows': numRows,
-      if (error != null) 'error': error,
-      if (stackTrace != null) 'stackTrace': stackTrace,
+      'numRows': numRows,
+      'error': error,
+      'stackTrace': stackTrace,
       'slow': slow,
       'order': order,
     };

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -60,7 +60,7 @@ abstract class ReadWriteTestEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'number': number,
     };
   }

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Runtime settings of the server.
 abstract class RuntimeSettings extends _i1.TableRow {
@@ -77,8 +78,9 @@ abstract class RuntimeSettings extends _i1.TableRow {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'logSettings': logSettings,
-      'logSettingsOverrides': logSettingsOverrides,
+      'logSettings': logSettings.toJson(),
+      'logSettingsOverrides':
+          logSettingsOverrides.toJson(valueToJson: (v) => v.toJson()),
       'logServiceCalls': logServiceCalls,
       'logMalformedCalls': logMalformedCalls,
     };
@@ -89,8 +91,9 @@ abstract class RuntimeSettings extends _i1.TableRow {
   Map<String, dynamic> toJsonForDatabase() {
     return {
       if (id != null) 'id': id,
-      'logSettings': logSettings,
-      'logSettingsOverrides': logSettingsOverrides,
+      'logSettings': logSettings.toJson(),
+      'logSettingsOverrides':
+          logSettingsOverrides.toJson(valueToJson: (v) => v.toJson()),
       'logServiceCalls': logServiceCalls,
       'logMalformedCalls': logMalformedCalls,
     };
@@ -100,8 +103,9 @@ abstract class RuntimeSettings extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'logSettings': logSettings,
-      'logSettingsOverrides': logSettingsOverrides,
+      'logSettings': logSettings.toJson(),
+      'logSettingsOverrides':
+          logSettingsOverrides.toJson(valueToJson: (v) => v.toJson()),
       'logServiceCalls': logServiceCalls,
       'logMalformedCalls': logMalformedCalls,
     };

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -90,10 +90,9 @@ abstract class RuntimeSettings extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      'logSettings': logSettings.toJson(),
-      'logSettingsOverrides':
-          logSettingsOverrides.toJson(valueToJson: (v) => v.toJson()),
+      'id': id,
+      'logSettings': logSettings,
+      'logSettingsOverrides': logSettingsOverrides,
       'logServiceCalls': logServiceCalls,
       'logMalformedCalls': logMalformedCalls,
     };
@@ -103,9 +102,9 @@ abstract class RuntimeSettings extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'logSettings': logSettings.toJson(),
+      'logSettings': logSettings.allToJson(),
       'logSettingsOverrides':
-          logSettingsOverrides.toJson(valueToJson: (v) => v.toJson()),
+          logSettingsOverrides.toJson(valueToJson: (v) => v.allToJson()),
       'logServiceCalls': logServiceCalls,
       'logMalformedCalls': logMalformedCalls,
     };

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a snapshot of the number of open connections the server currently
 /// is handling. An entry is written every minute for each server. All health
@@ -94,7 +95,7 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'active': active,
       'closing': closing,
       'idle': idle,
@@ -108,7 +109,7 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'active': active,
       'closing': closing,
       'idle': idle,
@@ -121,7 +122,7 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'active': active,
       'closing': closing,
       'idle': idle,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -107,9 +107,9 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'serverId': serverId,
-      'timestamp': timestamp.toJson(),
+      'timestamp': timestamp,
       'active': active,
       'closing': closing,
       'idle': idle,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a snapshot of a specific health metric. An entry is written every
 /// minute for each server. All health data can be accessed through Serverpod
@@ -95,7 +96,7 @@ abstract class ServerHealthMetric extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'isHealthy': isHealthy,
       'value': value,
       'granularity': granularity,
@@ -109,7 +110,7 @@ abstract class ServerHealthMetric extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'isHealthy': isHealthy,
       'value': value,
       'granularity': granularity,
@@ -122,7 +123,7 @@ abstract class ServerHealthMetric extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'isHealthy': isHealthy,
       'value': value,
       'granularity': granularity,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -107,10 +107,10 @@ abstract class ServerHealthMetric extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
       'serverId': serverId,
-      'timestamp': timestamp.toJson(),
+      'timestamp': timestamp,
       'isHealthy': isHealthy,
       'value': value,
       'granularity': granularity,

--- a/packages/serverpod/lib/src/generated/server_health_result.dart
+++ b/packages/serverpod/lib/src/generated/server_health_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about health and connection metrics.
 abstract class ServerHealthResult extends _i1.SerializableEntity {
@@ -49,16 +50,16 @@ abstract class ServerHealthResult extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'metrics': metrics,
-      'connectionInfos': connectionInfos,
+      'metrics': metrics.toJson(valueToJson: (v) => v.toJson()),
+      'connectionInfos': connectionInfos.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'metrics': metrics,
-      'connectionInfos': connectionInfos,
+      'metrics': metrics.toJson(valueToJson: (v) => v.toJson()),
+      'connectionInfos': connectionInfos.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/server_health_result.dart
+++ b/packages/serverpod/lib/src/generated/server_health_result.dart
@@ -58,8 +58,9 @@ abstract class ServerHealthResult extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'metrics': metrics.toJson(valueToJson: (v) => v.toJson()),
-      'connectionInfos': connectionInfos.toJson(valueToJson: (v) => v.toJson()),
+      'metrics': metrics.toJson(valueToJson: (v) => v.allToJson()),
+      'connectionInfos':
+          connectionInfos.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Log entry for a session.
 abstract class SessionLogEntry extends _i1.TableRow {
@@ -151,7 +152,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'time': time,
+      'time': time.toJson(),
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
@@ -163,7 +164,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
       if (authenticatedUserId != null)
         'authenticatedUserId': authenticatedUserId,
       if (isOpen != null) 'isOpen': isOpen,
-      'touched': touched,
+      'touched': touched.toJson(),
     };
   }
 
@@ -173,7 +174,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'time': time,
+      'time': time.toJson(),
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
@@ -185,7 +186,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
       if (authenticatedUserId != null)
         'authenticatedUserId': authenticatedUserId,
       if (isOpen != null) 'isOpen': isOpen,
-      'touched': touched,
+      'touched': touched.toJson(),
     };
   }
 
@@ -194,7 +195,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'time': time,
+      'time': time.toJson(),
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
@@ -206,7 +207,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
       if (authenticatedUserId != null)
         'authenticatedUserId': authenticatedUserId,
       if (isOpen != null) 'isOpen': isOpen,
-      'touched': touched,
+      'touched': touched.toJson(),
     };
   }
 

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -172,21 +172,20 @@ abstract class SessionLogEntry extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'serverId': serverId,
-      'time': time.toJson(),
-      if (module != null) 'module': module,
-      if (endpoint != null) 'endpoint': endpoint,
-      if (method != null) 'method': method,
-      if (duration != null) 'duration': duration,
-      if (numQueries != null) 'numQueries': numQueries,
-      if (slow != null) 'slow': slow,
-      if (error != null) 'error': error,
-      if (stackTrace != null) 'stackTrace': stackTrace,
-      if (authenticatedUserId != null)
-        'authenticatedUserId': authenticatedUserId,
-      if (isOpen != null) 'isOpen': isOpen,
-      'touched': touched.toJson(),
+      'time': time,
+      'module': module,
+      'endpoint': endpoint,
+      'method': method,
+      'duration': duration,
+      'numQueries': numQueries,
+      'slow': slow,
+      'error': error,
+      'stackTrace': stackTrace,
+      'authenticatedUserId': authenticatedUserId,
+      'isOpen': isOpen,
+      'touched': touched,
     };
   }
 

--- a/packages/serverpod/lib/src/generated/session_log_info.dart
+++ b/packages/serverpod/lib/src/generated/session_log_info.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Compounded information about a session log.
 abstract class SessionLogInfo extends _i1.SerializableEntity {
@@ -64,20 +65,20 @@ abstract class SessionLogInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'sessionLogEntry': sessionLogEntry,
-      'queries': queries,
-      'logs': logs,
-      'messages': messages,
+      'sessionLogEntry': sessionLogEntry.toJson(),
+      'queries': queries.toJson(valueToJson: (v) => v.toJson()),
+      'logs': logs.toJson(valueToJson: (v) => v.toJson()),
+      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'sessionLogEntry': sessionLogEntry,
-      'queries': queries,
-      'logs': logs,
-      'messages': messages,
+      'sessionLogEntry': sessionLogEntry.toJson(),
+      'queries': queries.toJson(valueToJson: (v) => v.toJson()),
+      'logs': logs.toJson(valueToJson: (v) => v.toJson()),
+      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/session_log_info.dart
+++ b/packages/serverpod/lib/src/generated/session_log_info.dart
@@ -75,10 +75,10 @@ abstract class SessionLogInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'sessionLogEntry': sessionLogEntry.toJson(),
-      'queries': queries.toJson(valueToJson: (v) => v.toJson()),
-      'logs': logs.toJson(valueToJson: (v) => v.toJson()),
-      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
+      'sessionLogEntry': sessionLogEntry.allToJson(),
+      'queries': queries.toJson(valueToJson: (v) => v.allToJson()),
+      'logs': logs.toJson(valueToJson: (v) => v.allToJson()),
+      'messages': messages.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 }

--- a/packages/serverpod/lib/src/generated/session_log_result.dart
+++ b/packages/serverpod/lib/src/generated/session_log_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A list of SessionLogInfo.
 abstract class SessionLogResult extends _i1.SerializableEntity {
@@ -33,12 +34,12 @@ abstract class SessionLogResult extends _i1.SerializableEntity {
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog});
   @override
   Map<String, dynamic> toJson() {
-    return {'sessionLog': sessionLog};
+    return {'sessionLog': sessionLog.toJson(valueToJson: (v) => v.toJson())};
   }
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'sessionLog': sessionLog};
+    return {'sessionLog': sessionLog.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/packages/serverpod/lib/src/generated/session_log_result.dart
+++ b/packages/serverpod/lib/src/generated/session_log_result.dart
@@ -39,7 +39,7 @@ abstract class SessionLogResult extends _i1.SerializableEntity {
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'sessionLog': sessionLog.toJson(valueToJson: (v) => v.toJson())};
+    return {'sessionLog': sessionLog.toJson(valueToJson: (v) => v.allToJson())};
   }
 }
 

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -164,6 +164,21 @@ abstract class SerializationManager {
   }
 }
 
+/// All datatypes that are serialized by default.
+/// Used internally in Serverpod code generation.
+const autoSerializedTypes = ['int', 'bool', 'double', 'String'];
+
+/// All datatypes that has extensions to support serialization.
+/// Used internally in Serverpod code generation.
+const extensionSerializedTypes = [
+  'DateTime',
+  'ByteData',
+  'Duration',
+  'UuidValue',
+  'Map',
+  'List',
+];
+
 /// Expose toJson on DateTime
 extension DateTimeToJson on DateTime {
   /// Returns a serialized version of the [DateTime] in UTC.

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -152,29 +152,7 @@ abstract class SerializationManager {
   /// indentation.
   static String encode(Object? object, {bool formatted = false}) {
     // This is the only time [jsonEncode] should be used in the project.
-    return JsonEncoder.withIndent(
-      formatted ? '  ' : null,
-      (nonEncodable) {
-        //TODO: all the "dart native" types should be listed here
-        if (nonEncodable is DateTime) {
-          return nonEncodable.toUtc().toIso8601String();
-        } else if (nonEncodable is ByteData) {
-          return nonEncodable.base64encodedString();
-        } else if (nonEncodable is Duration) {
-          return nonEncodable.inMilliseconds;
-        } else if (nonEncodable is UuidValue) {
-          return nonEncodable.uuid;
-        } else if (nonEncodable is Map && nonEncodable.keyType != String) {
-          return nonEncodable.entries
-              .map((e) => {'k': e.key, 'v': e.value})
-              .toList();
-        } else {
-          return (nonEncodable as dynamic)?.toJson();
-        }
-      },
-    ).convert(
-      object,
-    );
+    return JsonEncoder.withIndent(formatted ? '  ' : null).convert(object);
   }
 
   /// Encode the provided [object] to a json-formatted [String], include class
@@ -186,6 +164,71 @@ abstract class SerializationManager {
   }
 }
 
-extension<K, V> on Map<K, V> {
-  Type get keyType => K;
+/// Expose toJson on DateTime
+extension DateTimeToJson on DateTime {
+  /// Returns a serialized version of the [DateTime] in UTC.
+  String toJson() => toUtc().toIso8601String();
+}
+
+/// Expose toJson on Duration
+extension DurationToJson on Duration {
+  /// Returns a serialized version of the [Duration] in milliseconds.
+  int toJson() => inMilliseconds;
+}
+
+/// Expose toJson on UuidValue
+extension UuidValueToJson on UuidValue {
+  /// Returns a serialized version of the [UuidValue] as a [String].
+  String toJson() => uuid;
+}
+
+/// Expose toJson on ByteData
+extension ByteDataToJson on ByteData {
+  /// Returns a serialized version of the [ByteData] as a base64 encoded
+  /// [String].
+  String toJson() => base64encodedString();
+}
+
+/// Expose toJson on Map
+extension MapToJson<K, V> on Map<K, V> {
+  Type get _keyType => K;
+
+  /// Returns a serialized version of the [Map] with keys and values serialized.
+  dynamic toJson({
+    dynamic Function(K)? keyToJson,
+    dynamic Function(V)? valueToJson,
+  }) {
+    if (_keyType == String && keyToJson == null && valueToJson == null) {
+      return this;
+    }
+
+    // This implementation is here to support the old decoder behavior
+    // this should not be needed if the decoder is updated to not look for a nested
+    // map with 'k' and 'v' keys. If that is done the return type can be changed
+    // to Map<dynamic, dynamic>.
+    if (_keyType != String) {
+      return entries.map((e) {
+        var serializedKey = keyToJson != null ? keyToJson(e.key) : e.key;
+        var serializedValue =
+            valueToJson != null ? valueToJson(e.value) : e.value;
+        return {'k': serializedKey, 'v': serializedValue};
+      }).toList();
+    }
+
+    return map((key, value) {
+      var serializedKey = keyToJson != null ? keyToJson(key) : key;
+      var serializedValue = valueToJson != null ? valueToJson(value) : value;
+      return MapEntry(serializedKey, serializedValue);
+    });
+  }
+}
+
+/// Expose toJson on List
+extension ListToJson<T> on List<T> {
+  /// Returns a serialized version of the [List] with values serialized.
+  List<dynamic> toJson({dynamic Function(T)? valueToJson}) {
+    if (valueToJson == null) return this;
+
+    return map<dynamic>(valueToJson).toList();
+  }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/auth_key.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/auth_key.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides a method of access for a user to authenticate with the server.
 abstract class AuthKey extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/auth_key.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/auth_key.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides a method of access for a user to authenticate with the server.
 abstract class AuthKey extends _i1.SerializableEntity {
@@ -83,7 +84,7 @@ abstract class AuthKey extends _i1.SerializableEntity {
       'userId': userId,
       'hash': hash,
       if (key != null) 'key': key,
-      'scopeNames': scopeNames,
+      'scopeNames': scopeNames.toJson(),
       'method': method,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides high level information about a cache.
 abstract class CacheInfo extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides high level information about a cache.
 abstract class CacheInfo extends _i1.SerializableEntity {
@@ -57,7 +58,7 @@ abstract class CacheInfo extends _i1.SerializableEntity {
     return {
       'numEntries': numEntries,
       'maxEntries': maxEntries,
-      if (keys != null) 'keys': keys,
+      if (keys != null) 'keys': keys?.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/caches_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/caches_info.dart
@@ -56,9 +56,9 @@ abstract class CachesInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'local': local,
-      'localPrio': localPrio,
-      'global': global,
+      'local': local.toJson(),
+      'localPrio': localPrio.toJson(),
+      'global': global.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// An entry in the database for an uploaded file.
 abstract class CloudStorageEntry extends _i1.SerializableEntity {
@@ -91,9 +92,9 @@ abstract class CloudStorageEntry extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'addedTime': addedTime,
-      if (expiration != null) 'expiration': expiration,
-      'byteData': byteData,
+      'addedTime': addedTime.toJson(),
+      if (expiration != null) 'expiration': expiration?.toJson(),
+      'byteData': byteData.toJson(),
       'verified': verified,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// An entry in the database for an uploaded file.
 abstract class CloudStorageEntry extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Connects a table for handling uploading of files.
 abstract class CloudStorageDirectUploadEntry extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Connects a table for handling uploading of files.
 abstract class CloudStorageDirectUploadEntry extends _i1.SerializableEntity {
@@ -74,7 +75,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'storageId': storageId,
       'path': path,
-      'expiration': expiration,
+      'expiration': expiration.toJson(),
       'authKey': authKey,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a cluster of servers.
 abstract class ClusterInfo extends _i1.SerializableEntity {
@@ -33,7 +34,7 @@ abstract class ClusterInfo extends _i1.SerializableEntity {
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers});
   @override
   Map<String, dynamic> toJson() {
-    return {'servers': servers};
+    return {'servers': servers.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about a cluster of servers.
 abstract class ClusterInfo extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_data.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_data.dart
@@ -44,7 +44,7 @@ abstract class BulkData extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'tableDefinition': tableDefinition,
+      'tableDefinition': tableDefinition.toJson(),
       'data': data,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class BulkQueryResult extends _i1.SerializableEntity {
   BulkQueryResult._({
@@ -58,10 +59,10 @@ abstract class BulkQueryResult extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'headers': headers,
+      'headers': headers.toJson(valueToJson: (v) => v.toJson()),
       'data': data,
       'numAffectedRows': numAffectedRows,
-      'duration': duration,
+      'duration': duration.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_result.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class BulkQueryResult extends _i1.SerializableEntity {
   BulkQueryResult._({

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_definition.dart
@@ -74,7 +74,7 @@ abstract class ColumnDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
-      'columnType': columnType,
+      'columnType': columnType.toJson(),
       'isNullable': isNullable,
       if (columnDefault != null) 'columnDefault': columnDefault,
       if (dartType != null) 'dartType': dartType,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Defines the structure of the database used by Serverpod.
 abstract class DatabaseDefinition extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Defines the structure of the database used by Serverpod.
 abstract class DatabaseDefinition extends _i1.SerializableEntity {
@@ -77,8 +78,9 @@ abstract class DatabaseDefinition extends _i1.SerializableEntity {
     return {
       if (name != null) 'name': name,
       'moduleName': moduleName,
-      'tables': tables,
-      'installedModules': installedModules,
+      'tables': tables.toJson(valueToJson: (v) => v.toJson()),
+      'installedModules':
+          installedModules.toJson(valueToJson: (v) => v.toJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definitions.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definitions.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Defines the current state of the database, including information about
 /// installed modules and migrations.

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definitions.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definitions.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Defines the current state of the database, including information about
 /// installed modules and migrations.
@@ -67,10 +68,12 @@ abstract class DatabaseDefinitions extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'target': target,
-      'live': live,
-      'installedMigrations': installedMigrations,
-      'latestAvailableMigrations': latestAvailableMigrations,
+      'target': target.toJson(valueToJson: (v) => v.toJson()),
+      'live': live.toJson(valueToJson: (v) => v.toJson()),
+      'installedMigrations':
+          installedMigrations.toJson(valueToJson: (v) => v.toJson()),
+      'latestAvailableMigrations':
+          latestAvailableMigrations.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class DatabaseMigration extends _i1.SerializableEntity {
   DatabaseMigration._({
@@ -54,8 +55,8 @@ abstract class DatabaseMigration extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'actions': actions,
-      'warnings': warnings,
+      'actions': actions.toJson(valueToJson: (v) => v.toJson()),
+      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
       'migrationApiVersion': migrationApiVersion,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class DatabaseMigration extends _i1.SerializableEntity {
   DatabaseMigration._({

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action.dart
@@ -59,10 +59,10 @@ abstract class DatabaseMigrationAction extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       if (deleteTable != null) 'deleteTable': deleteTable,
-      if (alterTable != null) 'alterTable': alterTable,
-      if (createTable != null) 'createTable': createTable,
+      if (alterTable != null) 'alterTable': alterTable?.toJson(),
+      if (createTable != null) 'createTable': createTable?.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a version of a database migration.
 abstract class DatabaseMigrationVersion extends _i1.SerializableEntity {
@@ -67,7 +68,7 @@ abstract class DatabaseMigrationVersion extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'module': module,
       'version': version,
-      if (timestamp != null) 'timestamp': timestamp,
+      if (timestamp != null) 'timestamp': timestamp?.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a version of a database migration.
 abstract class DatabaseMigrationVersion extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class DatabaseMigrationWarning extends _i1.SerializableEntity {
   DatabaseMigrationWarning._({

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class DatabaseMigrationWarning extends _i1.SerializableEntity {
   DatabaseMigrationWarning._({
@@ -66,10 +67,10 @@ abstract class DatabaseMigrationWarning extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'message': message,
       'table': table,
-      'columns': columns,
+      'columns': columns.toJson(),
       'destrucive': destrucive,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Filter extends _i1.SerializableEntity {
   Filter._({

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Filter extends _i1.SerializableEntity {
   Filter._({
@@ -53,7 +54,7 @@ abstract class Filter extends _i1.SerializableEntity {
     return {
       'name': name,
       'table': table,
-      'constraints': constraints,
+      'constraints': constraints.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
@@ -59,7 +59,7 @@ abstract class FilterConstraint extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'column': column,
       'value': value,
       if (value2 != null) 'value2': value2,

--- a/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a foreign key.
 abstract class ForeignKeyDefinition extends _i1.SerializableEntity {
@@ -97,13 +98,13 @@ abstract class ForeignKeyDefinition extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       'constraintName': constraintName,
-      'columns': columns,
+      'columns': columns.toJson(),
       'referenceTable': referenceTable,
       'referenceTableSchema': referenceTableSchema,
-      'referenceColumns': referenceColumns,
-      if (onUpdate != null) 'onUpdate': onUpdate,
-      if (onDelete != null) 'onDelete': onDelete,
-      if (matchType != null) 'matchType': matchType,
+      'referenceColumns': referenceColumns.toJson(),
+      if (onUpdate != null) 'onUpdate': onUpdate?.toJson(),
+      if (onDelete != null) 'onDelete': onDelete?.toJson(),
+      if (matchType != null) 'matchType': matchType?.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a foreign key.
 abstract class ForeignKeyDefinition extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// The definition of a (desired) index in the database.
 abstract class IndexDefinition extends _i1.SerializableEntity {
@@ -91,7 +92,7 @@ abstract class IndexDefinition extends _i1.SerializableEntity {
     return {
       'indexName': indexName,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'elements': elements,
+      'elements': elements.toJson(valueToJson: (v) => v.toJson()),
       'type': type,
       'isUnique': isUnique,
       'isPrimary': isPrimary,

--- a/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// The definition of a (desired) index in the database.
 abstract class IndexDefinition extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/database/index_element_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/index_element_definition.dart
@@ -48,7 +48,7 @@ abstract class IndexElementDefinition extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'type': type,
+      'type': type.toJson(),
       'definition': definition,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// The definition of a (desired) table in the database.
 abstract class TableDefinition extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// The definition of a (desired) table in the database.
 abstract class TableDefinition extends _i1.SerializableEntity {
@@ -111,9 +112,9 @@ abstract class TableDefinition extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       'schema': schema,
       if (tableSpace != null) 'tableSpace': tableSpace,
-      'columns': columns,
-      'foreignKeys': foreignKeys,
-      'indexes': indexes,
+      'columns': columns.toJson(valueToJson: (v) => v.toJson()),
+      'foreignKeys': foreignKeys.toJson(valueToJson: (v) => v.toJson()),
+      'indexes': indexes.toJson(valueToJson: (v) => v.toJson()),
       if (managed != null) 'managed': managed,
     };
   }

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class TableMigration extends _i1.SerializableEntity {
   TableMigration._({

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class TableMigration extends _i1.SerializableEntity {
   TableMigration._({
@@ -121,14 +122,14 @@ abstract class TableMigration extends _i1.SerializableEntity {
       if (dartName != null) 'dartName': dartName,
       if (module != null) 'module': module,
       'schema': schema,
-      'addColumns': addColumns,
-      'deleteColumns': deleteColumns,
-      'modifyColumns': modifyColumns,
-      'addIndexes': addIndexes,
-      'deleteIndexes': deleteIndexes,
-      'addForeignKeys': addForeignKeys,
-      'deleteForeignKeys': deleteForeignKeys,
-      'warnings': warnings,
+      'addColumns': addColumns.toJson(valueToJson: (v) => v.toJson()),
+      'deleteColumns': deleteColumns.toJson(),
+      'modifyColumns': modifyColumns.toJson(valueToJson: (v) => v.toJson()),
+      'addIndexes': addIndexes.toJson(valueToJson: (v) => v.toJson()),
+      'deleteIndexes': deleteIndexes.toJson(),
+      'addForeignKeys': addForeignKeys.toJson(valueToJson: (v) => v.toJson()),
+      'deleteForeignKeys': deleteForeignKeys.toJson(),
+      'warnings': warnings.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A serialized future call with bindings to the database.
 abstract class FutureCallEntry extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A serialized future call with bindings to the database.
 abstract class FutureCallEntry extends _i1.SerializableEntity {
@@ -81,7 +82,7 @@ abstract class FutureCallEntry extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      'time': time,
+      'time': time.toJson(),
       if (serializedObject != null) 'serializedObject': serializedObject,
       'serverId': serverId,
       if (identifier != null) 'identifier': identifier,

--- a/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Bindings to a log entry in the database.
 abstract class LogEntry extends _i1.SerializableEntity {
@@ -125,8 +126,8 @@ abstract class LogEntry extends _i1.SerializableEntity {
       if (messageId != null) 'messageId': messageId,
       if (reference != null) 'reference': reference,
       'serverId': serverId,
-      'time': time,
-      'logLevel': logLevel,
+      'time': time.toJson(),
+      'logLevel': logLevel.toJson(),
       'message': message,
       if (error != null) 'error': error,
       if (stackTrace != null) 'stackTrace': stackTrace,

--- a/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Bindings to a log entry in the database.
 abstract class LogEntry extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_result.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A list of log entries, used to return logging data.
 abstract class LogResult extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A list of log entries, used to return logging data.
 abstract class LogResult extends _i1.SerializableEntity {
@@ -32,7 +33,7 @@ abstract class LogResult extends _i1.SerializableEntity {
   LogResult copyWith({List<_i2.LogEntry>? entries});
   @override
   Map<String, dynamic> toJson() {
-    return {'entries': entries};
+    return {'entries': entries.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/packages/serverpod_service_client/lib/src/protocol/log_settings.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_settings.dart
@@ -113,7 +113,7 @@ abstract class LogSettings extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'logLevel': logLevel,
+      'logLevel': logLevel.toJson(),
       'logAllSessions': logAllSessions,
       'logAllQueries': logAllQueries,
       'logSlowSessions': logSlowSessions,

--- a/packages/serverpod_service_client/lib/src/protocol/log_settings_override.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_settings_override.dart
@@ -68,7 +68,7 @@ abstract class LogSettingsOverride extends _i1.SerializableEntity {
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
-      'logSettings': logSettings,
+      'logSettings': logSettings.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Runtime settings of the server.
 abstract class RuntimeSettings extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Runtime settings of the server.
 abstract class RuntimeSettings extends _i1.SerializableEntity {
@@ -75,8 +76,9 @@ abstract class RuntimeSettings extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'logSettings': logSettings,
-      'logSettingsOverrides': logSettingsOverrides,
+      'logSettings': logSettings.toJson(),
+      'logSettingsOverrides':
+          logSettingsOverrides.toJson(valueToJson: (v) => v.toJson()),
       'logServiceCalls': logServiceCalls,
       'logMalformedCalls': logMalformedCalls,
     };

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a snapshot of the number of open connections the server currently
 /// is handling. An entry is written every minute for each server. All health

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a snapshot of the number of open connections the server currently
 /// is handling. An entry is written every minute for each server. All health
@@ -92,7 +93,7 @@ abstract class ServerHealthConnectionInfo extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'active': active,
       'closing': closing,
       'idle': idle,

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a snapshot of a specific health metric. An entry is written every
 /// minute for each server. All health data can be accessed through Serverpod
@@ -93,7 +94,7 @@ abstract class ServerHealthMetric extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       'serverId': serverId,
-      'timestamp': timestamp,
+      'timestamp': timestamp.toJson(),
       'isHealthy': isHealthy,
       'value': value,
       'granularity': granularity,

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Represents a snapshot of a specific health metric. An entry is written every
 /// minute for each server. All health data can be accessed through Serverpod

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_result.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about health and connection metrics.
 abstract class ServerHealthResult extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Information about health and connection metrics.
 abstract class ServerHealthResult extends _i1.SerializableEntity {
@@ -49,8 +50,8 @@ abstract class ServerHealthResult extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'metrics': metrics,
-      'connectionInfos': connectionInfos,
+      'metrics': metrics.toJson(valueToJson: (v) => v.toJson()),
+      'connectionInfos': connectionInfos.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Log entry for a session.
 abstract class SessionLogEntry extends _i1.SerializableEntity {
@@ -149,7 +150,7 @@ abstract class SessionLogEntry extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'serverId': serverId,
-      'time': time,
+      'time': time.toJson(),
       if (module != null) 'module': module,
       if (endpoint != null) 'endpoint': endpoint,
       if (method != null) 'method': method,
@@ -161,7 +162,7 @@ abstract class SessionLogEntry extends _i1.SerializableEntity {
       if (authenticatedUserId != null)
         'authenticatedUserId': authenticatedUserId,
       if (isOpen != null) 'isOpen': isOpen,
-      'touched': touched,
+      'touched': touched.toJson(),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Log entry for a session.
 abstract class SessionLogEntry extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_info.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Compounded information about a session log.
 abstract class SessionLogInfo extends _i1.SerializableEntity {
@@ -64,10 +65,10 @@ abstract class SessionLogInfo extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'sessionLogEntry': sessionLogEntry,
-      'queries': queries,
-      'logs': logs,
-      'messages': messages,
+      'sessionLogEntry': sessionLogEntry.toJson(),
+      'queries': queries.toJson(valueToJson: (v) => v.toJson()),
+      'logs': logs.toJson(valueToJson: (v) => v.toJson()),
+      'messages': messages.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_info.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Compounded information about a session log.
 abstract class SessionLogInfo extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A list of SessionLogInfo.
 abstract class SessionLogResult extends _i1.SerializableEntity {

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// A list of SessionLogInfo.
 abstract class SessionLogResult extends _i1.SerializableEntity {
@@ -33,7 +34,7 @@ abstract class SessionLogResult extends _i1.SerializableEntity {
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog});
   @override
   Map<String, dynamic> toJson() {
-    return {'sessionLog': sessionLog};
+    return {'sessionLog': sessionLog.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ExceptionWithData extends _i1.SerializableEntity
     implements _i1.SerializableException {

--- a/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ExceptionWithData extends _i1.SerializableEntity
     implements _i1.SerializableException {
@@ -60,8 +61,8 @@ abstract class ExceptionWithData extends _i1.SerializableEntity
   Map<String, dynamic> toJson() {
     return {
       'message': message,
-      'creationDate': creationDate,
-      'errorFields': errorFields,
+      'creationDate': creationDate.toJson(),
+      'errorFields': errorFields.toJson(),
       if (someNullableField != null) 'someNullableField': someNullableField,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class LongImplicitIdFieldCollection extends _i1.SerializableEntity {
   LongImplicitIdFieldCollection._({
@@ -63,7 +64,8 @@ abstract class LongImplicitIdFieldCollection extends _i1.SerializableEntity {
       'name': name,
       if (thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa != null)
         'thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa':
-            thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa,
+            thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa
+                ?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class LongImplicitIdFieldCollection extends _i1.SerializableEntity {
   LongImplicitIdFieldCollection._({

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class RelationToMultipleMaxFieldName extends _i1.SerializableEntity {
   RelationToMultipleMaxFieldName._({
@@ -57,7 +58,8 @@ abstract class RelationToMultipleMaxFieldName extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       if (multipleMaxFieldNames != null)
-        'multipleMaxFieldNames': multipleMaxFieldNames,
+        'multipleMaxFieldNames':
+            multipleMaxFieldNames?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class RelationToMultipleMaxFieldName extends _i1.SerializableEntity {
   RelationToMultipleMaxFieldName._({

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class UserNoteCollection extends _i1.SerializableEntity {
   UserNoteCollection._({
@@ -57,7 +58,8 @@ abstract class UserNoteCollection extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       if (userNotesPropertyName != null)
-        'userNotesPropertyName': userNotesPropertyName,
+        'userNotesPropertyName':
+            userNotesPropertyName?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class UserNoteCollection extends _i1.SerializableEntity {
   UserNoteCollection._({

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class UserNoteCollectionWithALongName extends _i1.SerializableEntity {
   UserNoteCollectionWithALongName._({
@@ -55,7 +56,7 @@ abstract class UserNoteCollectionWithALongName extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (notes != null) 'notes': notes,
+      if (notes != null) 'notes': notes?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class UserNoteCollectionWithALongName extends _i1.SerializableEntity {
   UserNoteCollectionWithALongName._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class City extends _i1.SerializableEntity {
   City._({
@@ -62,8 +63,10 @@ abstract class City extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (citizens != null) 'citizens': citizens,
-      if (organizations != null) 'organizations': organizations,
+      if (citizens != null)
+        'citizens': citizens?.toJson(valueToJson: (v) => v.toJson()),
+      if (organizations != null)
+        'organizations': organizations?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class City extends _i1.SerializableEntity {
   City._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Organization extends _i1.SerializableEntity {
   Organization._({
@@ -69,9 +70,10 @@ abstract class Organization extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (people != null) 'people': people,
+      if (people != null)
+        'people': people?.toJson(valueToJson: (v) => v.toJson()),
       if (cityId != null) 'cityId': cityId,
-      if (city != null) 'city': city,
+      if (city != null) 'city': city?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Organization extends _i1.SerializableEntity {
   Organization._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/person.dart
@@ -63,7 +63,7 @@ abstract class Person extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       if (organizationId != null) 'organizationId': organizationId,
-      if (organization != null) 'organization': organization,
+      if (organization != null) 'organization': organization?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Course extends _i1.SerializableEntity {
   Course._({
@@ -55,7 +56,8 @@ abstract class Course extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (enrollments != null) 'enrollments': enrollments,
+      if (enrollments != null)
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Course extends _i1.SerializableEntity {
   Course._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
@@ -70,9 +70,9 @@ abstract class Enrollment extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'studentId': studentId,
-      if (student != null) 'student': student,
+      if (student != null) 'student': student?.toJson(),
       'courseId': courseId,
-      if (course != null) 'course': course,
+      if (course != null) 'course': course?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Student extends _i1.SerializableEntity {
   Student._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Student extends _i1.SerializableEntity {
   Student._({
@@ -55,7 +56,8 @@ abstract class Student extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (enrollments != null) 'enrollments': enrollments,
+      if (enrollments != null)
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/module/object_user.dart
@@ -64,7 +64,7 @@ abstract class ObjectUser extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       if (name != null) 'name': name,
       'userInfoId': userInfoId,
-      if (userInfo != null) 'userInfo': userInfo,
+      if (userInfo != null) 'userInfo': userInfo?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
@@ -55,7 +55,7 @@ abstract class Arena extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (team != null) 'team': team,
+      if (team != null) 'team': team?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
@@ -63,7 +63,7 @@ abstract class Player extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       if (teamId != null) 'teamId': teamId,
-      if (team != null) 'team': team,
+      if (team != null) 'team': team?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Team extends _i1.SerializableEntity {
   Team._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Team extends _i1.SerializableEntity {
   Team._({
@@ -70,8 +71,9 @@ abstract class Team extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       if (arenaId != null) 'arenaId': arenaId,
-      if (arena != null) 'arena': arena,
-      if (players != null) 'players': players,
+      if (arena != null) 'arena': arena?.toJson(),
+      if (players != null)
+        'players': players?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
@@ -64,7 +64,7 @@ abstract class Comment extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'description': description,
       'orderId': orderId,
-      if (order != null) 'order': order,
+      if (order != null) 'order': order?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Customer extends _i1.SerializableEntity {
   Customer._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Customer extends _i1.SerializableEntity {
   Customer._({
@@ -55,7 +56,8 @@ abstract class Customer extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (orders != null) 'orders': orders,
+      if (orders != null)
+        'orders': orders?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Order extends _i1.SerializableEntity {
   Order._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Order extends _i1.SerializableEntity {
   Order._({
@@ -71,8 +72,9 @@ abstract class Order extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'description': description,
       'customerId': customerId,
-      if (customer != null) 'customer': customer,
-      if (comments != null) 'comments': comments,
+      if (customer != null) 'customer': customer?.toJson(),
+      if (comments != null)
+        'comments': comments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
@@ -64,7 +64,7 @@ abstract class Address extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'street': street,
       if (inhabitantId != null) 'inhabitantId': inhabitantId,
-      if (inhabitant != null) 'inhabitant': inhabitant,
+      if (inhabitant != null) 'inhabitant': inhabitant?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
@@ -83,11 +83,11 @@ abstract class Citizen extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (address != null) 'address': address,
+      if (address != null) 'address': address?.toJson(),
       'companyId': companyId,
-      if (company != null) 'company': company,
+      if (company != null) 'company': company?.toJson(),
       if (oldCompanyId != null) 'oldCompanyId': oldCompanyId,
-      if (oldCompany != null) 'oldCompany': oldCompany,
+      if (oldCompany != null) 'oldCompany': oldCompany?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
@@ -63,7 +63,7 @@ abstract class Company extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       'townId': townId,
-      if (town != null) 'town': town,
+      if (town != null) 'town': town?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
@@ -63,7 +63,7 @@ abstract class Town extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       if (mayorId != null) 'mayorId': mayorId,
-      if (mayor != null) 'mayor': mayor,
+      if (mayor != null) 'mayor': mayor?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -70,9 +70,9 @@ abstract class Blocking extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'blockedId': blockedId,
-      if (blocked != null) 'blocked': blocked,
+      if (blocked != null) 'blocked': blocked?.toJson(),
       'blockedById': blockedById,
-      if (blockedBy != null) 'blockedBy': blockedBy,
+      if (blockedBy != null) 'blockedBy': blockedBy?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Member extends _i1.SerializableEntity {
   Member._({
@@ -62,8 +63,10 @@ abstract class Member extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (blocking != null) 'blocking': blocking,
-      if (blockedBy != null) 'blockedBy': blockedBy,
+      if (blocking != null)
+        'blocking': blocking?.toJson(valueToJson: (v) => v.toJson()),
+      if (blockedBy != null)
+        'blockedBy': blockedBy?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Member extends _i1.SerializableEntity {
   Member._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Cat extends _i1.SerializableEntity {
   Cat._({
@@ -70,8 +71,9 @@ abstract class Cat extends _i1.SerializableEntity {
       if (id != null) 'id': id,
       'name': name,
       if (motherId != null) 'motherId': motherId,
-      if (mother != null) 'mother': mother,
-      if (kittens != null) 'kittens': kittens,
+      if (mother != null) 'mother': mother?.toJson(),
+      if (kittens != null)
+        'kittens': kittens?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Cat extends _i1.SerializableEntity {
   Cat._({

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
@@ -70,9 +70,9 @@ abstract class Post extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'content': content,
-      if (previous != null) 'previous': previous,
+      if (previous != null) 'previous': previous?.toJson(),
       if (nextId != null) 'nextId': nextId,
-      if (next != null) 'next': next,
+      if (next != null) 'next': next?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/module_datatype.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/module_datatype.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_test_module_client/module.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ModuleDatatype extends _i1.SerializableEntity {
   ModuleDatatype._({

--- a/tests/serverpod_test_client/lib/src/protocol/module_datatype.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/module_datatype.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_test_module_client/module.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ModuleDatatype extends _i1.SerializableEntity {
   ModuleDatatype._({
@@ -52,9 +53,9 @@ abstract class ModuleDatatype extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'model': model,
-      'list': list,
-      'map': map,
+      'model': model.toJson(),
+      'list': list.toJson(valueToJson: (v) => v.toJson()),
+      'map': map.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/nullability.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/nullability.dart
@@ -11,7 +11,6 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Nullability extends _i1.SerializableEntity {
   Nullability._({

--- a/tests/serverpod_test_client/lib/src/protocol/nullability.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/nullability.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Nullability extends _i1.SerializableEntity {
   Nullability._({
@@ -374,58 +375,76 @@ abstract class Nullability extends _i1.SerializableEntity {
       if (aNullableBool != null) 'aNullableBool': aNullableBool,
       'aString': aString,
       if (aNullableString != null) 'aNullableString': aNullableString,
-      'aDateTime': aDateTime,
-      if (aNullableDateTime != null) 'aNullableDateTime': aNullableDateTime,
-      'aByteData': aByteData,
-      if (aNullableByteData != null) 'aNullableByteData': aNullableByteData,
-      'aDuration': aDuration,
-      if (aNullableDuration != null) 'aNullableDuration': aNullableDuration,
-      'aUuid': aUuid,
-      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid,
-      'anObject': anObject,
-      if (aNullableObject != null) 'aNullableObject': aNullableObject,
-      'anIntList': anIntList,
-      if (aNullableIntList != null) 'aNullableIntList': aNullableIntList,
-      'aListWithNullableInts': aListWithNullableInts,
+      'aDateTime': aDateTime.toJson(),
+      if (aNullableDateTime != null)
+        'aNullableDateTime': aNullableDateTime?.toJson(),
+      'aByteData': aByteData.toJson(),
+      if (aNullableByteData != null)
+        'aNullableByteData': aNullableByteData?.toJson(),
+      'aDuration': aDuration.toJson(),
+      if (aNullableDuration != null)
+        'aNullableDuration': aNullableDuration?.toJson(),
+      'aUuid': aUuid.toJson(),
+      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid?.toJson(),
+      'anObject': anObject.toJson(),
+      if (aNullableObject != null) 'aNullableObject': aNullableObject?.toJson(),
+      'anIntList': anIntList.toJson(),
+      if (aNullableIntList != null)
+        'aNullableIntList': aNullableIntList?.toJson(),
+      'aListWithNullableInts': aListWithNullableInts.toJson(),
       if (aNullableListWithNullableInts != null)
-        'aNullableListWithNullableInts': aNullableListWithNullableInts,
-      'anObjectList': anObjectList,
+        'aNullableListWithNullableInts':
+            aNullableListWithNullableInts?.toJson(),
+      'anObjectList': anObjectList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableObjectList != null)
-        'aNullableObjectList': aNullableObjectList,
-      'aListWithNullableObjects': aListWithNullableObjects,
+        'aNullableObjectList':
+            aNullableObjectList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableObjects':
+          aListWithNullableObjects.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableObjects != null)
-        'aNullableListWithNullableObjects': aNullableListWithNullableObjects,
-      'aDateTimeList': aDateTimeList,
+        'aNullableListWithNullableObjects': aNullableListWithNullableObjects
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aDateTimeList': aDateTimeList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableDateTimeList != null)
-        'aNullableDateTimeList': aNullableDateTimeList,
-      'aListWithNullableDateTimes': aListWithNullableDateTimes,
+        'aNullableDateTimeList':
+            aNullableDateTimeList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableDateTimes':
+          aListWithNullableDateTimes.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableDateTimes != null)
-        'aNullableListWithNullableDateTimes':
-            aNullableListWithNullableDateTimes,
-      'aByteDataList': aByteDataList,
+        'aNullableListWithNullableDateTimes': aNullableListWithNullableDateTimes
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aByteDataList': aByteDataList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableByteDataList != null)
-        'aNullableByteDataList': aNullableByteDataList,
-      'aListWithNullableByteDatas': aListWithNullableByteDatas,
+        'aNullableByteDataList':
+            aNullableByteDataList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableByteDatas':
+          aListWithNullableByteDatas.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableByteDatas != null)
-        'aNullableListWithNullableByteDatas':
-            aNullableListWithNullableByteDatas,
-      'aDurationList': aDurationList,
+        'aNullableListWithNullableByteDatas': aNullableListWithNullableByteDatas
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aDurationList': aDurationList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableDurationList != null)
-        'aNullableDurationList': aNullableDurationList,
-      'aListWithNullableDurations': aListWithNullableDurations,
+        'aNullableDurationList':
+            aNullableDurationList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableDurations':
+          aListWithNullableDurations.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableDurations != null)
-        'aNullableListWithNullableDurations':
-            aNullableListWithNullableDurations,
-      'aUuidList': aUuidList,
-      if (aNullableUuidList != null) 'aNullableUuidList': aNullableUuidList,
-      'aListWithNullableUuids': aListWithNullableUuids,
+        'aNullableListWithNullableDurations': aNullableListWithNullableDurations
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aUuidList': aUuidList.toJson(valueToJson: (v) => v.toJson()),
+      if (aNullableUuidList != null)
+        'aNullableUuidList':
+            aNullableUuidList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableUuids':
+          aListWithNullableUuids.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableUuids != null)
-        'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
-      'anIntMap': anIntMap,
-      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap,
-      'aMapWithNullableInts': aMapWithNullableInts,
+        'aNullableListWithNullableUuids': aNullableListWithNullableUuids
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'anIntMap': anIntMap.toJson(),
+      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap?.toJson(),
+      'aMapWithNullableInts': aMapWithNullableInts.toJson(),
       if (aNullableMapWithNullableInts != null)
-        'aNullableMapWithNullableInts': aNullableMapWithNullableInts,
+        'aNullableMapWithNullableInts': aNullableMapWithNullableInts?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithByteData extends _i1.SerializableEntity {
   ObjectWithByteData._({

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithByteData extends _i1.SerializableEntity {
   ObjectWithByteData._({
@@ -48,7 +49,7 @@ abstract class ObjectWithByteData extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'byteData': byteData,
+      'byteData': byteData.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithDuration extends _i1.SerializableEntity {
   ObjectWithDuration._({

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithDuration extends _i1.SerializableEntity {
   ObjectWithDuration._({
@@ -47,7 +48,7 @@ abstract class ObjectWithDuration extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'duration': duration,
+      'duration': duration.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithEnum extends _i1.SerializableEntity {
   ObjectWithEnum._({

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithEnum extends _i1.SerializableEntity {
   ObjectWithEnum._({
@@ -76,11 +77,13 @@ abstract class ObjectWithEnum extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'testEnum': testEnum,
-      if (nullableEnum != null) 'nullableEnum': nullableEnum,
-      'enumList': enumList,
-      'nullableEnumList': nullableEnumList,
-      'enumListList': enumListList,
+      'testEnum': testEnum.toJson(),
+      if (nullableEnum != null) 'nullableEnum': nullableEnum?.toJson(),
+      'enumList': enumList.toJson(valueToJson: (v) => v.toJson()),
+      'nullableEnumList':
+          nullableEnumList.toJson(valueToJson: (v) => v?.toJson()),
+      'enumListList': enumListList.toJson(
+          valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
 import 'dart:typed_data' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithMaps extends _i1.SerializableEntity {
   ObjectWithMaps._({
@@ -142,21 +143,26 @@ abstract class ObjectWithMaps extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'dataMap': dataMap,
-      'intMap': intMap,
-      'stringMap': stringMap,
-      'dateTimeMap': dateTimeMap,
-      'byteDataMap': byteDataMap,
-      'durationMap': durationMap,
-      'uuidMap': uuidMap,
-      'nullableDataMap': nullableDataMap,
-      'nullableIntMap': nullableIntMap,
-      'nullableStringMap': nullableStringMap,
-      'nullableDateTimeMap': nullableDateTimeMap,
-      'nullableByteDataMap': nullableByteDataMap,
-      'nullableDurationMap': nullableDurationMap,
-      'nullableUuidMap': nullableUuidMap,
-      'intIntMap': intIntMap,
+      'dataMap': dataMap.toJson(valueToJson: (v) => v.toJson()),
+      'intMap': intMap.toJson(),
+      'stringMap': stringMap.toJson(),
+      'dateTimeMap': dateTimeMap.toJson(valueToJson: (v) => v.toJson()),
+      'byteDataMap': byteDataMap.toJson(valueToJson: (v) => v.toJson()),
+      'durationMap': durationMap.toJson(valueToJson: (v) => v.toJson()),
+      'uuidMap': uuidMap.toJson(valueToJson: (v) => v.toJson()),
+      'nullableDataMap':
+          nullableDataMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableIntMap': nullableIntMap.toJson(),
+      'nullableStringMap': nullableStringMap.toJson(),
+      'nullableDateTimeMap':
+          nullableDateTimeMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableByteDataMap':
+          nullableByteDataMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableDurationMap':
+          nullableDurationMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableUuidMap':
+          nullableUuidMap.toJson(valueToJson: (v) => v?.toJson()),
+      'intIntMap': intIntMap.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
@@ -11,7 +11,6 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
 import 'dart:typed_data' as _i3;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithMaps extends _i1.SerializableEntity {
   ObjectWithMaps._({

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithObject extends _i1.SerializableEntity {
   ObjectWithObject._({
@@ -85,13 +86,17 @@ abstract class ObjectWithObject extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'data': data,
-      if (nullableData != null) 'nullableData': nullableData,
-      'dataList': dataList,
-      if (nullableDataList != null) 'nullableDataList': nullableDataList,
-      'listWithNullableData': listWithNullableData,
+      'data': data.toJson(),
+      if (nullableData != null) 'nullableData': nullableData?.toJson(),
+      'dataList': dataList.toJson(valueToJson: (v) => v.toJson()),
+      if (nullableDataList != null)
+        'nullableDataList':
+            nullableDataList?.toJson(valueToJson: (v) => v.toJson()),
+      'listWithNullableData':
+          listWithNullableData.toJson(valueToJson: (v) => v?.toJson()),
       if (nullableListWithNullableData != null)
-        'nullableListWithNullableData': nullableListWithNullableData,
+        'nullableListWithNullableData': nullableListWithNullableData?.toJson(
+            valueToJson: (v) => v?.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithObject extends _i1.SerializableEntity {
   ObjectWithObject._({

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithUuid extends _i1.SerializableEntity {
   ObjectWithUuid._({
@@ -54,8 +55,8 @@ abstract class ObjectWithUuid extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'uuid': uuid,
-      if (uuidNullable != null) 'uuidNullable': uuidNullable,
+      'uuid': uuid.toJson(),
+      if (uuidNullable != null) 'uuidNullable': uuidNullable?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithUuid extends _i1.SerializableEntity {
   ObjectWithUuid._({

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -69,38 +69,41 @@ import 'serverOnly/not_server_only_enum.dart' as _i51;
 import 'simple_data.dart' as _i52;
 import 'simple_data_list.dart' as _i53;
 import 'simple_data_map.dart' as _i54;
-import 'simple_date_time.dart' as _i55;
-import 'test_enum.dart' as _i56;
-import 'test_enum_stringified.dart' as _i57;
-import 'types.dart' as _i58;
-import 'unique_data.dart' as _i59;
-import 'protocol.dart' as _i60;
-import 'package:serverpod_test_module_client/module.dart' as _i61;
-import 'dart:typed_data' as _i62;
-import 'package:serverpod_test_client/src/protocol/types.dart' as _i63;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i64;
-import 'package:uuid/uuid_value.dart' as _i65;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i66;
-import 'package:serverpod_test_client/src/protocol/unique_data.dart' as _i67;
+import 'simple_data_object.dart' as _i55;
+import 'simple_date_time.dart' as _i56;
+import 'test_enum.dart' as _i57;
+import 'test_enum_stringified.dart' as _i58;
+import 'types.dart' as _i59;
+import 'types_list.dart' as _i60;
+import 'types_map.dart' as _i61;
+import 'unique_data.dart' as _i62;
+import 'protocol.dart' as _i63;
+import 'package:serverpod_test_module_client/module.dart' as _i64;
+import 'dart:typed_data' as _i65;
+import 'package:serverpod_test_client/src/protocol/types.dart' as _i66;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i67;
+import 'package:uuid/uuid_value.dart' as _i68;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i69;
+import 'package:serverpod_test_client/src/protocol/unique_data.dart' as _i70;
 import 'package:serverpod_test_client/src/protocol/models_with_list_relations/person.dart'
-    as _i68;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/citizen.dart'
-    as _i69;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/address.dart'
-    as _i70;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/self_relation/one_to_one/post.dart'
     as _i71;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/company.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/citizen.dart'
     as _i72;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/customer.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/address.dart'
     as _i73;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/comment.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/self_relation/one_to_one/post.dart'
     as _i74;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/order.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/company.dart'
     as _i75;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i76;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i77;
-import 'package:serverpod_auth_client/module.dart' as _i78;
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/customer.dart'
+    as _i76;
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/comment.dart'
+    as _i77;
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/order.dart'
+    as _i78;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i79;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i80;
+import 'package:serverpod_auth_client/module.dart' as _i81;
 export 'exception_with_data.dart';
 export 'long_identifiers/max_field_name.dart';
 export 'long_identifiers/models_with_relations/long_implicit_id_field.dart';
@@ -154,10 +157,13 @@ export 'serverOnly/not_server_only_enum.dart';
 export 'simple_data.dart';
 export 'simple_data_list.dart';
 export 'simple_data_map.dart';
+export 'simple_data_object.dart';
 export 'simple_date_time.dart';
 export 'test_enum.dart';
 export 'test_enum_stringified.dart';
 export 'types.dart';
+export 'types_list.dart';
+export 'types_map.dart';
 export 'unique_data.dart';
 export 'client.dart';
 
@@ -338,20 +344,29 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i54.SimpleDataMap) {
       return _i54.SimpleDataMap.fromJson(data, this) as T;
     }
-    if (t == _i55.SimpleDateTime) {
-      return _i55.SimpleDateTime.fromJson(data, this) as T;
+    if (t == _i55.SimpleDataObject) {
+      return _i55.SimpleDataObject.fromJson(data, this) as T;
     }
-    if (t == _i56.TestEnum) {
-      return _i56.TestEnum.fromJson(data) as T;
+    if (t == _i56.SimpleDateTime) {
+      return _i56.SimpleDateTime.fromJson(data, this) as T;
     }
-    if (t == _i57.TestEnumStringified) {
-      return _i57.TestEnumStringified.fromJson(data) as T;
+    if (t == _i57.TestEnum) {
+      return _i57.TestEnum.fromJson(data) as T;
     }
-    if (t == _i58.Types) {
-      return _i58.Types.fromJson(data, this) as T;
+    if (t == _i58.TestEnumStringified) {
+      return _i58.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i59.UniqueData) {
-      return _i59.UniqueData.fromJson(data, this) as T;
+    if (t == _i59.Types) {
+      return _i59.Types.fromJson(data, this) as T;
+    }
+    if (t == _i60.TypesList) {
+      return _i60.TypesList.fromJson(data, this) as T;
+    }
+    if (t == _i61.TypesMap) {
+      return _i61.TypesMap.fromJson(data, this) as T;
+    }
+    if (t == _i62.UniqueData) {
+      return _i62.UniqueData.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.ExceptionWithData?>()) {
       return (data != null ? _i2.ExceptionWithData.fromJson(data, this) : null)
@@ -550,118 +565,128 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i54.SimpleDataMap.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i55.SimpleDateTime?>()) {
-      return (data != null ? _i55.SimpleDateTime.fromJson(data, this) : null)
+    if (t == _i1.getType<_i55.SimpleDataObject?>()) {
+      return (data != null ? _i55.SimpleDataObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i56.TestEnum?>()) {
-      return (data != null ? _i56.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i57.TestEnumStringified?>()) {
-      return (data != null ? _i57.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i56.SimpleDateTime?>()) {
+      return (data != null ? _i56.SimpleDateTime.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i58.Types?>()) {
-      return (data != null ? _i58.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i57.TestEnum?>()) {
+      return (data != null ? _i57.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i59.UniqueData?>()) {
-      return (data != null ? _i59.UniqueData.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i58.TestEnumStringified?>()) {
+      return (data != null ? _i58.TestEnumStringified.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i59.Types?>()) {
+      return (data != null ? _i59.Types.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i60.TypesList?>()) {
+      return (data != null ? _i60.TypesList.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i61.TypesMap?>()) {
+      return (data != null ? _i61.TypesMap.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i62.UniqueData?>()) {
+      return (data != null ? _i62.UniqueData.fromJson(data, this) : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i60.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i63.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i63.LongImplicitIdField>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i63.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i63.MultipleMaxFieldName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.UserNote>?>()) {
+    if (t == _i1.getType<List<_i63.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.UserNote>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i63.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i63.UserNoteWithALongName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Person>?>()) {
+    if (t == _i1.getType<List<_i63.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Organization>?>()) {
+    if (t == _i1.getType<List<_i63.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.Organization>(e))
+              .map((e) => deserialize<_i63.Organization>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Person>?>()) {
+    if (t == _i1.getType<List<_i63.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i63.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i63.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Player>?>()) {
+    if (t == _i1.getType<List<_i63.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Player>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Order>?>()) {
+    if (t == _i1.getType<List<_i63.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Order>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Comment>?>()) {
+    if (t == _i1.getType<List<_i63.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Comment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Blocking>?>()) {
+    if (t == _i1.getType<List<_i63.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Blocking>?>()) {
+    if (t == _i1.getType<List<_i63.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.Cat>?>()) {
+    if (t == _i1.getType<List<_i63.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.Cat>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i61.ModuleClass>) {
+    if (t == List<_i64.ModuleClass>) {
       return (data as List)
-          .map((e) => deserialize<_i61.ModuleClass>(e))
+          .map((e) => deserialize<_i64.ModuleClass>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i61.ModuleClass>) {
+    if (t == Map<String, _i64.ModuleClass>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i61.ModuleClass>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i64.ModuleClass>(v))) as dynamic;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
@@ -680,23 +705,23 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i60.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i60.SimpleData>(e)).toList()
+    if (t == List<_i63.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i63.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i60.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i63.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i60.SimpleData?>) {
+    if (t == List<_i63.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i60.SimpleData?>(e))
+          .map((e) => deserialize<_i63.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i60.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i63.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -717,22 +742,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i62.ByteData>) {
-      return (data as List).map((e) => deserialize<_i62.ByteData>(e)).toList()
+    if (t == List<_i65.ByteData>) {
+      return (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i62.ByteData>?>()) {
+    if (t == _i1.getType<List<_i65.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i62.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i62.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i62.ByteData?>(e)).toList()
+    if (t == List<_i65.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i65.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i62.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i65.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i62.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i65.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -793,22 +818,22 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i60.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i60.TestEnum>(e)).toList()
+    if (t == List<_i63.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i63.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i60.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i60.TestEnum?>(e)).toList()
+    if (t == List<_i63.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i63.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i60.TestEnum>>) {
+    if (t == List<List<_i63.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i60.TestEnum>>(e))
+          .map((e) => deserialize<List<_i63.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i60.SimpleData>) {
+    if (t == Map<String, _i63.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i60.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i63.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -820,9 +845,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i62.ByteData>) {
+    if (t == Map<String, _i65.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i62.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -835,9 +860,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i60.SimpleData?>) {
+    if (t == Map<String, _i63.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i60.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i63.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -848,9 +873,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i62.ByteData?>) {
+    if (t == Map<String, _i65.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i62.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -868,18 +893,260 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i60.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i63.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i60.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i63.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i60.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i63.SimpleData?>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<bool>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<bool>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<double>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<double>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<DateTime>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<DateTime>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<String>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<String>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i65.ByteData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<Duration>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<Duration>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i63.TestEnum>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i63.TestEnum>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i63.TestEnumStringified>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<_i63.TestEnumStringified>(e))
+              .toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i63.Types>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i63.Types>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<Map<String, _i63.Types>>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<Map<String, _i63.Types>>(e))
+              .toList()
+          : null) as dynamic;
+    }
+    if (t == Map<String, _i63.Types>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i63.Types>(v)))
+          as dynamic;
+    }
+    if (t == _i1.getType<List<List<_i63.Types>>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<List<_i63.Types>>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<_i63.Types>) {
       return (data as List).map((e) => deserialize<_i63.Types>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<int, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) =>
+              MapEntry(deserialize<int>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<bool, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) =>
+              MapEntry(deserialize<bool>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<double, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<double>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<DateTime, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<DateTime>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, String>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<String>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i65.ByteData, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i65.ByteData>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<Duration, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<Duration>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i1.UuidValue, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i1.UuidValue>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i63.TestEnum, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i63.TestEnum>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i63.TestEnumStringified, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i63.TestEnumStringified>(e['k']),
+              deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i63.Types, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i63.Types>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<Map<_i63.Types, String>, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<Map<_i63.Types, String>>(e['k']),
+              deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == Map<_i63.Types, String>) {
+      return Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i63.Types>(e['k']), deserialize<String>(e['v']))))
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<List<_i63.Types>, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<List<_i63.Types>>(e['k']),
+              deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, bool>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, double>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<double>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, DateTime>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, String>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<String>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i65.ByteData>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, Duration>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i1.UuidValue>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i63.TestEnum>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i63.TestEnum>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i63.TestEnumStringified>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<_i63.TestEnumStringified>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i63.Types>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i63.Types>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, Map<String, _i63.Types>>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<Map<String, _i63.Types>>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, List<_i63.Types>>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<List<_i63.Types>>(v)))
+          : null) as dynamic;
+    }
+    if (t == List<_i66.Types>) {
+      return (data as List).map((e) => deserialize<_i66.Types>(e)).toList()
           as dynamic;
     }
     if (t == List<bool>) {
@@ -898,8 +1165,8 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<Duration>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i64.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i64.TestEnum>(e)).toList()
+    if (t == List<_i67.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i67.TestEnum>(e)).toList()
           as dynamic;
     }
     if (t == List<int>) {
@@ -909,36 +1176,36 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i65.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i65.UuidValue>(e)).toList()
+    if (t == List<_i68.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i68.UuidValue>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i66.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i66.SimpleData>(e)).toList()
+    if (t == List<_i69.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i67.UniqueData>) {
-      return (data as List).map((e) => deserialize<_i67.UniqueData>(e)).toList()
+    if (t == List<_i70.UniqueData>) {
+      return (data as List).map((e) => deserialize<_i70.UniqueData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i68.Person>) {
-      return (data as List).map((e) => deserialize<_i68.Person>(e)).toList()
+    if (t == List<_i71.Person>) {
+      return (data as List).map((e) => deserialize<_i71.Person>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i69.Citizen>) {
-      return (data as List).map((e) => deserialize<_i69.Citizen>(e)).toList()
+    if (t == List<_i72.Citizen>) {
+      return (data as List).map((e) => deserialize<_i72.Citizen>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i70.Address>) {
-      return (data as List).map((e) => deserialize<_i70.Address>(e)).toList()
+    if (t == List<_i73.Address>) {
+      return (data as List).map((e) => deserialize<_i73.Address>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i71.Post>) {
-      return (data as List).map((e) => deserialize<_i71.Post>(e)).toList()
+    if (t == List<_i74.Post>) {
+      return (data as List).map((e) => deserialize<_i74.Post>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i72.Company>) {
-      return (data as List).map((e) => deserialize<_i72.Company>(e)).toList()
+    if (t == List<_i75.Company>) {
+      return (data as List).map((e) => deserialize<_i75.Company>(e)).toList()
           as dynamic;
     }
     if (t == List<List<int>>) {
@@ -1009,37 +1276,37 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i62.ByteData>) {
-      return (data as List).map((e) => deserialize<_i62.ByteData>(e)).toList()
+    if (t == List<_i65.ByteData>) {
+      return (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i62.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i62.ByteData?>(e)).toList()
+    if (t == List<_i65.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i65.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i66.SimpleData?>) {
+    if (t == List<_i69.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i66.SimpleData?>(e))
+          .map((e) => deserialize<_i69.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration?>) {
@@ -1089,14 +1356,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i64.TestEnum, int>) {
+    if (t == Map<_i67.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i64.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i67.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i64.TestEnum>) {
+    if (t == Map<String, _i67.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i64.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i67.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -1135,47 +1402,47 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i62.ByteData>) {
+    if (t == Map<String, _i65.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i62.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i62.ByteData?>) {
+    if (t == Map<String, _i65.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i62.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i66.SimpleData>) {
+    if (t == Map<String, _i69.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i66.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i66.SimpleData?>) {
+    if (t == Map<String, _i69.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i66.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i69.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i66.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i69.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i66.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i66.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i69.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i66.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i66.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i69.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i66.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i69.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i66.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i69.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i66.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i69.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -1188,45 +1455,45 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == List<_i73.Customer>) {
-      return (data as List).map((e) => deserialize<_i73.Customer>(e)).toList()
+    if (t == List<_i76.Customer>) {
+      return (data as List).map((e) => deserialize<_i76.Customer>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i74.Comment>) {
-      return (data as List).map((e) => deserialize<_i74.Comment>(e)).toList()
+    if (t == List<_i77.Comment>) {
+      return (data as List).map((e) => deserialize<_i77.Comment>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i75.Order>) {
-      return (data as List).map((e) => deserialize<_i75.Order>(e)).toList()
+    if (t == List<_i78.Order>) {
+      return (data as List).map((e) => deserialize<_i78.Order>(e)).toList()
           as dynamic;
     }
-    if (t == _i76.CustomClass) {
-      return _i76.CustomClass.fromJson(data, this) as T;
+    if (t == _i79.CustomClass) {
+      return _i79.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i77.ExternalCustomClass) {
-      return _i77.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i80.ExternalCustomClass) {
+      return _i80.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i77.FreezedCustomClass) {
-      return _i77.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i80.FreezedCustomClass) {
+      return _i80.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i76.CustomClass?>()) {
-      return (data != null ? _i76.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i79.CustomClass?>()) {
+      return (data != null ? _i79.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i77.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i80.ExternalCustomClass?>()) {
       return (data != null
-          ? _i77.ExternalCustomClass.fromJson(data, this)
+          ? _i80.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i77.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i80.FreezedCustomClass?>()) {
       return (data != null
-          ? _i77.FreezedCustomClass.fromJson(data, this)
+          ? _i80.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
-      return _i78.Protocol().deserialize<T>(data, t);
+      return _i81.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     try {
-      return _i61.Protocol().deserialize<T>(data, t);
+      return _i64.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -1234,21 +1501,21 @@ class Protocol extends _i1.SerializationManager {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i78.Protocol().getClassNameForObject(data);
+    className = _i81.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    className = _i61.Protocol().getClassNameForObject(data);
+    className = _i64.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    if (data is _i76.CustomClass) {
+    if (data is _i79.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i77.ExternalCustomClass) {
+    if (data is _i80.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i77.FreezedCustomClass) {
+    if (data is _i80.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.ExceptionWithData) {
@@ -1410,19 +1677,28 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i54.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i55.SimpleDateTime) {
+    if (data is _i55.SimpleDataObject) {
+      return 'SimpleDataObject';
+    }
+    if (data is _i56.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i56.TestEnum) {
+    if (data is _i57.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i57.TestEnumStringified) {
+    if (data is _i58.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i58.Types) {
+    if (data is _i59.Types) {
       return 'Types';
     }
-    if (data is _i59.UniqueData) {
+    if (data is _i60.TypesList) {
+      return 'TypesList';
+    }
+    if (data is _i61.TypesMap) {
+      return 'TypesMap';
+    }
+    if (data is _i62.UniqueData) {
       return 'UniqueData';
     }
     return super.getClassNameForObject(data);
@@ -1432,20 +1708,20 @@ class Protocol extends _i1.SerializationManager {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i78.Protocol().deserializeByClassName(data);
+      return _i81.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i61.Protocol().deserializeByClassName(data);
+      return _i64.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i76.CustomClass>(data['data']);
+      return deserialize<_i79.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i77.ExternalCustomClass>(data['data']);
+      return deserialize<_i80.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i77.FreezedCustomClass>(data['data']);
+      return deserialize<_i80.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i2.ExceptionWithData>(data['data']);
@@ -1606,20 +1882,29 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'SimpleDataMap') {
       return deserialize<_i54.SimpleDataMap>(data['data']);
     }
+    if (data['className'] == 'SimpleDataObject') {
+      return deserialize<_i55.SimpleDataObject>(data['data']);
+    }
     if (data['className'] == 'SimpleDateTime') {
-      return deserialize<_i55.SimpleDateTime>(data['data']);
+      return deserialize<_i56.SimpleDateTime>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i56.TestEnum>(data['data']);
+      return deserialize<_i57.TestEnum>(data['data']);
     }
     if (data['className'] == 'TestEnumStringified') {
-      return deserialize<_i57.TestEnumStringified>(data['data']);
+      return deserialize<_i58.TestEnumStringified>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i58.Types>(data['data']);
+      return deserialize<_i59.Types>(data['data']);
+    }
+    if (data['className'] == 'TypesList') {
+      return deserialize<_i60.TypesList>(data['data']);
+    }
+    if (data['className'] == 'TypesMap') {
+      return deserialize<_i61.TypesMap>(data['data']);
     }
     if (data['className'] == 'UniqueData') {
-      return deserialize<_i59.UniqueData>(data['data']);
+      return deserialize<_i62.UniqueData>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -62,48 +62,49 @@ import 'object_with_self_parent.dart' as _i44;
 import 'object_with_uuid.dart' as _i45;
 import 'related_unique_data.dart' as _i46;
 import 'scopes/scope_none_fields.dart' as _i47;
-import 'serverOnly/default_server_only_class.dart' as _i48;
-import 'serverOnly/default_server_only_enum.dart' as _i49;
-import 'serverOnly/not_server_only_class.dart' as _i50;
-import 'serverOnly/not_server_only_enum.dart' as _i51;
-import 'simple_data.dart' as _i52;
-import 'simple_data_list.dart' as _i53;
-import 'simple_data_map.dart' as _i54;
-import 'simple_data_object.dart' as _i55;
-import 'simple_date_time.dart' as _i56;
-import 'test_enum.dart' as _i57;
-import 'test_enum_stringified.dart' as _i58;
-import 'types.dart' as _i59;
-import 'types_list.dart' as _i60;
-import 'types_map.dart' as _i61;
-import 'unique_data.dart' as _i62;
-import 'protocol.dart' as _i63;
-import 'package:serverpod_test_module_client/module.dart' as _i64;
-import 'dart:typed_data' as _i65;
-import 'package:serverpod_test_client/src/protocol/types.dart' as _i66;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i67;
-import 'package:uuid/uuid_value.dart' as _i68;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i69;
-import 'package:serverpod_test_client/src/protocol/unique_data.dart' as _i70;
+import 'scopes/scope_server_only_field.dart' as _i48;
+import 'serverOnly/default_server_only_class.dart' as _i49;
+import 'serverOnly/default_server_only_enum.dart' as _i50;
+import 'serverOnly/not_server_only_class.dart' as _i51;
+import 'serverOnly/not_server_only_enum.dart' as _i52;
+import 'simple_data.dart' as _i53;
+import 'simple_data_list.dart' as _i54;
+import 'simple_data_map.dart' as _i55;
+import 'simple_data_object.dart' as _i56;
+import 'simple_date_time.dart' as _i57;
+import 'test_enum.dart' as _i58;
+import 'test_enum_stringified.dart' as _i59;
+import 'types.dart' as _i60;
+import 'types_list.dart' as _i61;
+import 'types_map.dart' as _i62;
+import 'unique_data.dart' as _i63;
+import 'protocol.dart' as _i64;
+import 'package:serverpod_test_module_client/module.dart' as _i65;
+import 'dart:typed_data' as _i66;
+import 'package:serverpod_test_client/src/protocol/types.dart' as _i67;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i68;
+import 'package:uuid/uuid_value.dart' as _i69;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i70;
+import 'package:serverpod_test_client/src/protocol/unique_data.dart' as _i71;
 import 'package:serverpod_test_client/src/protocol/models_with_list_relations/person.dart'
-    as _i71;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/citizen.dart'
     as _i72;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/address.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/citizen.dart'
     as _i73;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/self_relation/one_to_one/post.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/address.dart'
     as _i74;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/company.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/self_relation/one_to_one/post.dart'
     as _i75;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/customer.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_one/company.dart'
     as _i76;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/comment.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/customer.dart'
     as _i77;
-import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/order.dart'
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/comment.dart'
     as _i78;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i79;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i80;
-import 'package:serverpod_auth_client/module.dart' as _i81;
+import 'package:serverpod_test_client/src/protocol/models_with_relations/one_to_many/order.dart'
+    as _i79;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i80;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i81;
+import 'package:serverpod_auth_client/module.dart' as _i82;
 export 'exception_with_data.dart';
 export 'long_identifiers/max_field_name.dart';
 export 'long_identifiers/models_with_relations/long_implicit_id_field.dart';
@@ -150,6 +151,7 @@ export 'object_with_self_parent.dart';
 export 'object_with_uuid.dart';
 export 'related_unique_data.dart';
 export 'scopes/scope_none_fields.dart';
+export 'scopes/scope_server_only_field.dart';
 export 'serverOnly/default_server_only_class.dart';
 export 'serverOnly/default_server_only_enum.dart';
 export 'serverOnly/not_server_only_class.dart';
@@ -323,50 +325,53 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i47.ScopeNoneFields) {
       return _i47.ScopeNoneFields.fromJson(data, this) as T;
     }
-    if (t == _i48.DefaultServerOnlyClass) {
-      return _i48.DefaultServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i48.ScopeServerOnlyField) {
+      return _i48.ScopeServerOnlyField.fromJson(data, this) as T;
     }
-    if (t == _i49.DefaultServerOnlyEnum) {
-      return _i49.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i49.DefaultServerOnlyClass) {
+      return _i49.DefaultServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i50.NotServerOnlyClass) {
-      return _i50.NotServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i50.DefaultServerOnlyEnum) {
+      return _i50.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i51.NotServerOnlyEnum) {
-      return _i51.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i51.NotServerOnlyClass) {
+      return _i51.NotServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i52.SimpleData) {
-      return _i52.SimpleData.fromJson(data, this) as T;
+    if (t == _i52.NotServerOnlyEnum) {
+      return _i52.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i53.SimpleDataList) {
-      return _i53.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i53.SimpleData) {
+      return _i53.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i54.SimpleDataMap) {
-      return _i54.SimpleDataMap.fromJson(data, this) as T;
+    if (t == _i54.SimpleDataList) {
+      return _i54.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i55.SimpleDataObject) {
-      return _i55.SimpleDataObject.fromJson(data, this) as T;
+    if (t == _i55.SimpleDataMap) {
+      return _i55.SimpleDataMap.fromJson(data, this) as T;
     }
-    if (t == _i56.SimpleDateTime) {
-      return _i56.SimpleDateTime.fromJson(data, this) as T;
+    if (t == _i56.SimpleDataObject) {
+      return _i56.SimpleDataObject.fromJson(data, this) as T;
     }
-    if (t == _i57.TestEnum) {
-      return _i57.TestEnum.fromJson(data) as T;
+    if (t == _i57.SimpleDateTime) {
+      return _i57.SimpleDateTime.fromJson(data, this) as T;
     }
-    if (t == _i58.TestEnumStringified) {
-      return _i58.TestEnumStringified.fromJson(data) as T;
+    if (t == _i58.TestEnum) {
+      return _i58.TestEnum.fromJson(data) as T;
     }
-    if (t == _i59.Types) {
-      return _i59.Types.fromJson(data, this) as T;
+    if (t == _i59.TestEnumStringified) {
+      return _i59.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i60.TypesList) {
-      return _i60.TypesList.fromJson(data, this) as T;
+    if (t == _i60.Types) {
+      return _i60.Types.fromJson(data, this) as T;
     }
-    if (t == _i61.TypesMap) {
-      return _i61.TypesMap.fromJson(data, this) as T;
+    if (t == _i61.TypesList) {
+      return _i61.TypesList.fromJson(data, this) as T;
     }
-    if (t == _i62.UniqueData) {
-      return _i62.UniqueData.fromJson(data, this) as T;
+    if (t == _i62.TypesMap) {
+      return _i62.TypesMap.fromJson(data, this) as T;
+    }
+    if (t == _i63.UniqueData) {
+      return _i63.UniqueData.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i2.ExceptionWithData?>()) {
       return (data != null ? _i2.ExceptionWithData.fromJson(data, this) : null)
@@ -537,156 +542,161 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i47.ScopeNoneFields.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i48.DefaultServerOnlyClass?>()) {
+    if (t == _i1.getType<_i48.ScopeServerOnlyField?>()) {
       return (data != null
-          ? _i48.DefaultServerOnlyClass.fromJson(data, this)
+          ? _i48.ScopeServerOnlyField.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i49.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i49.DefaultServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i50.NotServerOnlyClass?>()) {
+    if (t == _i1.getType<_i49.DefaultServerOnlyClass?>()) {
       return (data != null
-          ? _i50.NotServerOnlyClass.fromJson(data, this)
+          ? _i49.DefaultServerOnlyClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i51.NotServerOnlyEnum?>()) {
-      return (data != null ? _i51.NotServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i52.SimpleData?>()) {
-      return (data != null ? _i52.SimpleData.fromJson(data, this) : null) as T;
-    }
-    if (t == _i1.getType<_i53.SimpleDataList?>()) {
-      return (data != null ? _i53.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i50.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i50.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i54.SimpleDataMap?>()) {
-      return (data != null ? _i54.SimpleDataMap.fromJson(data, this) : null)
+    if (t == _i1.getType<_i51.NotServerOnlyClass?>()) {
+      return (data != null
+          ? _i51.NotServerOnlyClass.fromJson(data, this)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i52.NotServerOnlyEnum?>()) {
+      return (data != null ? _i52.NotServerOnlyEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i53.SimpleData?>()) {
+      return (data != null ? _i53.SimpleData.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i54.SimpleDataList?>()) {
+      return (data != null ? _i54.SimpleDataList.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i55.SimpleDataObject?>()) {
-      return (data != null ? _i55.SimpleDataObject.fromJson(data, this) : null)
+    if (t == _i1.getType<_i55.SimpleDataMap?>()) {
+      return (data != null ? _i55.SimpleDataMap.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i56.SimpleDateTime?>()) {
-      return (data != null ? _i56.SimpleDateTime.fromJson(data, this) : null)
+    if (t == _i1.getType<_i56.SimpleDataObject?>()) {
+      return (data != null ? _i56.SimpleDataObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i57.TestEnum?>()) {
-      return (data != null ? _i57.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i58.TestEnumStringified?>()) {
-      return (data != null ? _i58.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i57.SimpleDateTime?>()) {
+      return (data != null ? _i57.SimpleDateTime.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i59.Types?>()) {
-      return (data != null ? _i59.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i58.TestEnum?>()) {
+      return (data != null ? _i58.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i60.TypesList?>()) {
-      return (data != null ? _i60.TypesList.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i59.TestEnumStringified?>()) {
+      return (data != null ? _i59.TestEnumStringified.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i61.TypesMap?>()) {
-      return (data != null ? _i61.TypesMap.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i60.Types?>()) {
+      return (data != null ? _i60.Types.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i62.UniqueData?>()) {
-      return (data != null ? _i62.UniqueData.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i61.TypesList?>()) {
+      return (data != null ? _i61.TypesList.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i62.TypesMap?>()) {
+      return (data != null ? _i62.TypesMap.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i63.UniqueData?>()) {
+      return (data != null ? _i63.UniqueData.fromJson(data, this) : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i63.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i64.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i64.LongImplicitIdField>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i64.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i64.MultipleMaxFieldName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.UserNote>?>()) {
+    if (t == _i1.getType<List<_i64.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.UserNote>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i64.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i64.UserNoteWithALongName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Person>?>()) {
+    if (t == _i1.getType<List<_i64.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Organization>?>()) {
+    if (t == _i1.getType<List<_i64.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.Organization>(e))
+              .map((e) => deserialize<_i64.Organization>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Person>?>()) {
+    if (t == _i1.getType<List<_i64.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i64.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i64.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Player>?>()) {
+    if (t == _i1.getType<List<_i64.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Player>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Order>?>()) {
+    if (t == _i1.getType<List<_i64.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Order>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Comment>?>()) {
+    if (t == _i1.getType<List<_i64.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Comment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Blocking>?>()) {
+    if (t == _i1.getType<List<_i64.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Blocking>?>()) {
+    if (t == _i1.getType<List<_i64.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Cat>?>()) {
+    if (t == _i1.getType<List<_i64.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Cat>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i64.ModuleClass>) {
+    if (t == List<_i65.ModuleClass>) {
       return (data as List)
-          .map((e) => deserialize<_i64.ModuleClass>(e))
+          .map((e) => deserialize<_i65.ModuleClass>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i64.ModuleClass>) {
+    if (t == Map<String, _i65.ModuleClass>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i64.ModuleClass>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i65.ModuleClass>(v))) as dynamic;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as dynamic;
@@ -705,23 +715,23 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i63.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i63.SimpleData>(e)).toList()
+    if (t == List<_i64.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i64.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i63.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i64.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i63.SimpleData?>) {
+    if (t == List<_i64.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i63.SimpleData?>(e))
+          .map((e) => deserialize<_i64.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i63.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i64.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -742,22 +752,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i65.ByteData>) {
-      return (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
+    if (t == List<_i66.ByteData>) {
+      return (data as List).map((e) => deserialize<_i66.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i65.ByteData>?>()) {
+    if (t == _i1.getType<List<_i66.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i66.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i65.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i65.ByteData?>(e)).toList()
+    if (t == List<_i66.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i66.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i65.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i66.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i65.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i66.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -818,22 +828,22 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i63.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i63.TestEnum>(e)).toList()
+    if (t == List<_i64.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i64.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i63.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i63.TestEnum?>(e)).toList()
+    if (t == List<_i64.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i64.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i63.TestEnum>>) {
+    if (t == List<List<_i64.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i63.TestEnum>>(e))
+          .map((e) => deserialize<List<_i64.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i63.SimpleData>) {
+    if (t == Map<String, _i64.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i63.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i64.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -845,9 +855,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i65.ByteData>) {
+    if (t == Map<String, _i66.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i66.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -860,9 +870,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i63.SimpleData?>) {
+    if (t == Map<String, _i64.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i63.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i64.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -873,9 +883,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i65.ByteData?>) {
+    if (t == Map<String, _i66.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i66.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -893,14 +903,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i63.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i64.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i64.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -928,9 +938,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i65.ByteData>?>()) {
+    if (t == _i1.getType<List<_i66.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i66.ByteData>(e)).toList()
           : null) as dynamic;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -943,42 +953,42 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i64.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.TestEnum>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i64.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.TestEnumStringified>(e))
+              .map((e) => deserialize<_i64.TestEnumStringified>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i63.Types>?>()) {
+    if (t == _i1.getType<List<_i64.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i63.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i64.Types>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<Map<String, _i63.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i64.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i63.Types>>(e))
+              .map((e) => deserialize<Map<String, _i64.Types>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == Map<String, _i63.Types>) {
+    if (t == Map<String, _i64.Types>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i63.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i64.Types>(v)))
           as dynamic;
     }
-    if (t == _i1.getType<List<List<_i63.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i64.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i63.Types>>(e)).toList()
+          ? (data as List).map((e) => deserialize<List<_i64.Types>>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i63.Types>) {
-      return (data as List).map((e) => deserialize<_i63.Types>(e)).toList()
+    if (t == List<_i64.Types>) {
+      return (data as List).map((e) => deserialize<_i64.Types>(e)).toList()
           as dynamic;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -1011,10 +1021,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i65.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i66.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i65.ByteData>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i66.ByteData>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
     if (t == _i1.getType<Map<Duration, String>?>()) {
@@ -1029,41 +1039,41 @@ class Protocol extends _i1.SerializationManager {
               deserialize<_i1.UuidValue>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i63.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i64.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i63.TestEnum>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i64.TestEnum>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i63.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i64.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i63.TestEnumStringified>(e['k']),
+              deserialize<_i64.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i63.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i64.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i63.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i64.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<Map<_i63.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i64.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i63.Types, String>>(e['k']),
+              deserialize<Map<_i64.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == Map<_i63.Types, String>) {
+    if (t == Map<_i64.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i63.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i64.Types>(e['k']), deserialize<String>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<Map<List<_i63.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i64.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i63.Types>>(e['k']),
+              deserialize<List<_i64.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
@@ -1097,10 +1107,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i65.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i66.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i66.ByteData>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -1115,38 +1125,38 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i63.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i64.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i63.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i64.TestEnum>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i63.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i64.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i63.TestEnumStringified>(v)))
+              deserialize<String>(k), deserialize<_i64.TestEnumStringified>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i63.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i64.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i63.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i64.Types>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i63.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i64.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i63.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i64.Types>>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, List<_i63.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i64.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i63.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i64.Types>>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i66.Types>) {
-      return (data as List).map((e) => deserialize<_i66.Types>(e)).toList()
+    if (t == List<_i67.Types>) {
+      return (data as List).map((e) => deserialize<_i67.Types>(e)).toList()
           as dynamic;
     }
     if (t == List<bool>) {
@@ -1165,8 +1175,8 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<Duration>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i67.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i67.TestEnum>(e)).toList()
+    if (t == List<_i68.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i68.TestEnum>(e)).toList()
           as dynamic;
     }
     if (t == List<int>) {
@@ -1176,36 +1186,36 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i68.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i68.UuidValue>(e)).toList()
+    if (t == List<_i69.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i69.UuidValue>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i69.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
+    if (t == List<_i70.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i70.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i70.UniqueData>) {
-      return (data as List).map((e) => deserialize<_i70.UniqueData>(e)).toList()
+    if (t == List<_i71.UniqueData>) {
+      return (data as List).map((e) => deserialize<_i71.UniqueData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i71.Person>) {
-      return (data as List).map((e) => deserialize<_i71.Person>(e)).toList()
+    if (t == List<_i72.Person>) {
+      return (data as List).map((e) => deserialize<_i72.Person>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i72.Citizen>) {
-      return (data as List).map((e) => deserialize<_i72.Citizen>(e)).toList()
+    if (t == List<_i73.Citizen>) {
+      return (data as List).map((e) => deserialize<_i73.Citizen>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i73.Address>) {
-      return (data as List).map((e) => deserialize<_i73.Address>(e)).toList()
+    if (t == List<_i74.Address>) {
+      return (data as List).map((e) => deserialize<_i74.Address>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i74.Post>) {
-      return (data as List).map((e) => deserialize<_i74.Post>(e)).toList()
+    if (t == List<_i75.Post>) {
+      return (data as List).map((e) => deserialize<_i75.Post>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i75.Company>) {
-      return (data as List).map((e) => deserialize<_i75.Company>(e)).toList()
+    if (t == List<_i76.Company>) {
+      return (data as List).map((e) => deserialize<_i76.Company>(e)).toList()
           as dynamic;
     }
     if (t == List<List<int>>) {
@@ -1276,37 +1286,37 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i65.ByteData>) {
-      return (data as List).map((e) => deserialize<_i65.ByteData>(e)).toList()
+    if (t == List<_i66.ByteData>) {
+      return (data as List).map((e) => deserialize<_i66.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i65.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i65.ByteData?>(e)).toList()
+    if (t == List<_i66.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i66.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i69.SimpleData?>) {
+    if (t == List<_i70.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i69.SimpleData?>(e))
+          .map((e) => deserialize<_i70.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration?>) {
@@ -1356,14 +1366,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i67.TestEnum, int>) {
+    if (t == Map<_i68.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i67.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i68.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i67.TestEnum>) {
+    if (t == Map<String, _i68.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i67.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i68.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -1402,47 +1412,47 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i65.ByteData>) {
+    if (t == Map<String, _i66.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i66.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i65.ByteData?>) {
+    if (t == Map<String, _i66.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i65.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i66.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i69.SimpleData>) {
+    if (t == Map<String, _i70.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i69.SimpleData?>) {
+    if (t == Map<String, _i70.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i69.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i70.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i69.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i70.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i69.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i70.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i69.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i70.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i69.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i70.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i69.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i70.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i69.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i70.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -1455,45 +1465,45 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == List<_i76.Customer>) {
-      return (data as List).map((e) => deserialize<_i76.Customer>(e)).toList()
+    if (t == List<_i77.Customer>) {
+      return (data as List).map((e) => deserialize<_i77.Customer>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i77.Comment>) {
-      return (data as List).map((e) => deserialize<_i77.Comment>(e)).toList()
+    if (t == List<_i78.Comment>) {
+      return (data as List).map((e) => deserialize<_i78.Comment>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i78.Order>) {
-      return (data as List).map((e) => deserialize<_i78.Order>(e)).toList()
+    if (t == List<_i79.Order>) {
+      return (data as List).map((e) => deserialize<_i79.Order>(e)).toList()
           as dynamic;
     }
-    if (t == _i79.CustomClass) {
-      return _i79.CustomClass.fromJson(data, this) as T;
+    if (t == _i80.CustomClass) {
+      return _i80.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i80.ExternalCustomClass) {
-      return _i80.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i81.ExternalCustomClass) {
+      return _i81.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i80.FreezedCustomClass) {
-      return _i80.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i81.FreezedCustomClass) {
+      return _i81.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i79.CustomClass?>()) {
-      return (data != null ? _i79.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i80.CustomClass?>()) {
+      return (data != null ? _i80.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i80.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i81.ExternalCustomClass?>()) {
       return (data != null
-          ? _i80.ExternalCustomClass.fromJson(data, this)
+          ? _i81.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i80.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i81.FreezedCustomClass?>()) {
       return (data != null
-          ? _i80.FreezedCustomClass.fromJson(data, this)
+          ? _i81.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
-      return _i81.Protocol().deserialize<T>(data, t);
+      return _i82.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     try {
-      return _i64.Protocol().deserialize<T>(data, t);
+      return _i65.Protocol().deserialize<T>(data, t);
     } catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -1501,21 +1511,21 @@ class Protocol extends _i1.SerializationManager {
   @override
   String? getClassNameForObject(Object data) {
     String? className;
-    className = _i81.Protocol().getClassNameForObject(data);
+    className = _i82.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    className = _i64.Protocol().getClassNameForObject(data);
+    className = _i65.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    if (data is _i79.CustomClass) {
+    if (data is _i80.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i80.ExternalCustomClass) {
+    if (data is _i81.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i80.FreezedCustomClass) {
+    if (data is _i81.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.ExceptionWithData) {
@@ -1656,49 +1666,52 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i47.ScopeNoneFields) {
       return 'ScopeNoneFields';
     }
-    if (data is _i48.DefaultServerOnlyClass) {
+    if (data is _i48.ScopeServerOnlyField) {
+      return 'ScopeServerOnlyField';
+    }
+    if (data is _i49.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i49.DefaultServerOnlyEnum) {
+    if (data is _i50.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i50.NotServerOnlyClass) {
+    if (data is _i51.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i51.NotServerOnlyEnum) {
+    if (data is _i52.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i52.SimpleData) {
+    if (data is _i53.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i53.SimpleDataList) {
+    if (data is _i54.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i54.SimpleDataMap) {
+    if (data is _i55.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i55.SimpleDataObject) {
+    if (data is _i56.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i56.SimpleDateTime) {
+    if (data is _i57.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i57.TestEnum) {
+    if (data is _i58.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i58.TestEnumStringified) {
+    if (data is _i59.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i59.Types) {
+    if (data is _i60.Types) {
       return 'Types';
     }
-    if (data is _i60.TypesList) {
+    if (data is _i61.TypesList) {
       return 'TypesList';
     }
-    if (data is _i61.TypesMap) {
+    if (data is _i62.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i62.UniqueData) {
+    if (data is _i63.UniqueData) {
       return 'UniqueData';
     }
     return super.getClassNameForObject(data);
@@ -1708,20 +1721,20 @@ class Protocol extends _i1.SerializationManager {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i81.Protocol().deserializeByClassName(data);
+      return _i82.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i64.Protocol().deserializeByClassName(data);
+      return _i65.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i79.CustomClass>(data['data']);
+      return deserialize<_i80.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i80.ExternalCustomClass>(data['data']);
+      return deserialize<_i81.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i80.FreezedCustomClass>(data['data']);
+      return deserialize<_i81.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i2.ExceptionWithData>(data['data']);
@@ -1861,50 +1874,53 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'ScopeNoneFields') {
       return deserialize<_i47.ScopeNoneFields>(data['data']);
     }
+    if (data['className'] == 'ScopeServerOnlyField') {
+      return deserialize<_i48.ScopeServerOnlyField>(data['data']);
+    }
     if (data['className'] == 'DefaultServerOnlyClass') {
-      return deserialize<_i48.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i49.DefaultServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyEnum') {
-      return deserialize<_i49.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i50.DefaultServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyClass') {
-      return deserialize<_i50.NotServerOnlyClass>(data['data']);
+      return deserialize<_i51.NotServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyEnum') {
-      return deserialize<_i51.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i52.NotServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i52.SimpleData>(data['data']);
+      return deserialize<_i53.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i53.SimpleDataList>(data['data']);
+      return deserialize<_i54.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'SimpleDataMap') {
-      return deserialize<_i54.SimpleDataMap>(data['data']);
+      return deserialize<_i55.SimpleDataMap>(data['data']);
     }
     if (data['className'] == 'SimpleDataObject') {
-      return deserialize<_i55.SimpleDataObject>(data['data']);
+      return deserialize<_i56.SimpleDataObject>(data['data']);
     }
     if (data['className'] == 'SimpleDateTime') {
-      return deserialize<_i56.SimpleDateTime>(data['data']);
+      return deserialize<_i57.SimpleDateTime>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i57.TestEnum>(data['data']);
+      return deserialize<_i58.TestEnum>(data['data']);
     }
     if (data['className'] == 'TestEnumStringified') {
-      return deserialize<_i58.TestEnumStringified>(data['data']);
+      return deserialize<_i59.TestEnumStringified>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i59.Types>(data['data']);
+      return deserialize<_i60.Types>(data['data']);
     }
     if (data['className'] == 'TypesList') {
-      return deserialize<_i60.TypesList>(data['data']);
+      return deserialize<_i61.TypesList>(data['data']);
     }
     if (data['className'] == 'TypesMap') {
-      return deserialize<_i61.TypesMap>(data['data']);
+      return deserialize<_i62.TypesMap>(data['data']);
     }
     if (data['className'] == 'UniqueData') {
-      return deserialize<_i62.UniqueData>(data['data']);
+      return deserialize<_i63.UniqueData>(data['data']);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/related_unique_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/related_unique_data.dart
@@ -63,7 +63,7 @@ abstract class RelatedUniqueData extends _i1.SerializableEntity {
     return {
       if (id != null) 'id': id,
       'uniqueDataId': uniqueDataId,
-      if (uniqueData != null) 'uniqueData': uniqueData,
+      if (uniqueData != null) 'uniqueData': uniqueData?.toJson(),
       'number': number,
     };
   }

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field.dart
@@ -1,0 +1,77 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ScopeServerOnlyField extends _i1.SerializableEntity {
+  ScopeServerOnlyField._({
+    this.allScope,
+    this.nested,
+  });
+
+  factory ScopeServerOnlyField({
+    _i2.Types? allScope,
+    _i2.ScopeServerOnlyField? nested,
+  }) = _ScopeServerOnlyFieldImpl;
+
+  factory ScopeServerOnlyField.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ScopeServerOnlyField(
+      allScope: serializationManager
+          .deserialize<_i2.Types?>(jsonSerialization['allScope']),
+      nested: serializationManager
+          .deserialize<_i2.ScopeServerOnlyField?>(jsonSerialization['nested']),
+    );
+  }
+
+  _i2.Types? allScope;
+
+  _i2.ScopeServerOnlyField? nested;
+
+  ScopeServerOnlyField copyWith({
+    _i2.Types? allScope,
+    _i2.ScopeServerOnlyField? nested,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (allScope != null) 'allScope': allScope?.toJson(),
+      if (nested != null) 'nested': nested?.toJson(),
+    };
+  }
+}
+
+class _Undefined {}
+
+class _ScopeServerOnlyFieldImpl extends ScopeServerOnlyField {
+  _ScopeServerOnlyFieldImpl({
+    _i2.Types? allScope,
+    _i2.ScopeServerOnlyField? nested,
+  }) : super._(
+          allScope: allScope,
+          nested: nested,
+        );
+
+  @override
+  ScopeServerOnlyField copyWith({
+    Object? allScope = _Undefined,
+    Object? nested = _Undefined,
+  }) {
+    return ScopeServerOnlyField(
+      allScope: allScope is _i2.Types? ? allScope : this.allScope?.copyWith(),
+      nested: nested is _i2.ScopeServerOnlyField?
+          ? nested
+          : this.nested?.copyWith(),
+    );
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataList extends _i1.SerializableEntity {
   SimpleDataList._({required this.rows});
@@ -31,7 +32,7 @@ abstract class SimpleDataList extends _i1.SerializableEntity {
   SimpleDataList copyWith({List<_i2.SimpleData>? rows});
   @override
   Map<String, dynamic> toJson() {
-    return {'rows': rows};
+    return {'rows': rows.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataList extends _i1.SerializableEntity {
   SimpleDataList._({required this.rows});

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataMap extends _i1.SerializableEntity {
   SimpleDataMap._({required this.data});
@@ -31,7 +32,7 @@ abstract class SimpleDataMap extends _i1.SerializableEntity {
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data});
   @override
   Map<String, dynamic> toJson() {
-    return {'data': data};
+    return {'data': data.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataMap extends _i1.SerializableEntity {
   SimpleDataMap._({required this.data});

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_object.dart
@@ -1,0 +1,47 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+abstract class SimpleDataObject extends _i1.SerializableEntity {
+  SimpleDataObject._({required this.object});
+
+  factory SimpleDataObject({required _i2.SimpleData object}) =
+      _SimpleDataObjectImpl;
+
+  factory SimpleDataObject.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return SimpleDataObject(
+        object: serializationManager
+            .deserialize<_i2.SimpleData>(jsonSerialization['object']));
+  }
+
+  _i2.SimpleData object;
+
+  SimpleDataObject copyWith({_i2.SimpleData? object});
+  @override
+  Map<String, dynamic> toJson() {
+    return {'object': object.toJson()};
+  }
+}
+
+class _SimpleDataObjectImpl extends SimpleDataObject {
+  _SimpleDataObjectImpl({required _i2.SimpleData object})
+      : super._(object: object);
+
+  @override
+  SimpleDataObject copyWith({_i2.SimpleData? object}) {
+    return SimpleDataObject(object: object ?? this.object.copyWith());
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_object.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataObject extends _i1.SerializableEntity {
   SimpleDataObject._({required this.object});

--- a/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Just some simple data.
 abstract class SimpleDateTime extends _i1.SerializableEntity {
@@ -49,7 +50,7 @@ abstract class SimpleDateTime extends _i1.SerializableEntity {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'dateTime': dateTime,
+      'dateTime': dateTime.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
@@ -9,7 +9,6 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Just some simple data.
 abstract class SimpleDateTime extends _i1.SerializableEntity {

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Types extends _i1.SerializableEntity {
   Types._({
@@ -115,13 +116,14 @@ abstract class Types extends _i1.SerializableEntity {
       if (anInt != null) 'anInt': anInt,
       if (aBool != null) 'aBool': aBool,
       if (aDouble != null) 'aDouble': aDouble,
-      if (aDateTime != null) 'aDateTime': aDateTime,
+      if (aDateTime != null) 'aDateTime': aDateTime?.toJson(),
       if (aString != null) 'aString': aString,
-      if (aByteData != null) 'aByteData': aByteData,
-      if (aDuration != null) 'aDuration': aDuration,
-      if (aUuid != null) 'aUuid': aUuid,
-      if (anEnum != null) 'anEnum': anEnum,
-      if (aStringifiedEnum != null) 'aStringifiedEnum': aStringifiedEnum,
+      if (aByteData != null) 'aByteData': aByteData?.toJson(),
+      if (aDuration != null) 'aDuration': aDuration?.toJson(),
+      if (aUuid != null) 'aUuid': aUuid?.toJson(),
+      if (anEnum != null) 'anEnum': anEnum?.toJson(),
+      if (aStringifiedEnum != null)
+        'aStringifiedEnum': aStringifiedEnum?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -11,7 +11,6 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Types extends _i1.SerializableEntity {
   Types._({

--- a/tests/serverpod_test_client/lib/src/protocol/types_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types_list.dart
@@ -11,7 +11,6 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class TypesList extends _i1.SerializableEntity {
   TypesList._({

--- a/tests/serverpod_test_client/lib/src/protocol/types_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types_list.dart
@@ -1,0 +1,228 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'dart:typed_data' as _i2;
+import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+abstract class TypesList extends _i1.SerializableEntity {
+  TypesList._({
+    this.anInt,
+    this.aBool,
+    this.aDouble,
+    this.aDateTime,
+    this.aString,
+    this.aByteData,
+    this.aDuration,
+    this.aUuid,
+    this.anEnum,
+    this.aStringifiedEnum,
+    this.anObject,
+    this.aMap,
+    this.aList,
+  });
+
+  factory TypesList({
+    List<int>? anInt,
+    List<bool>? aBool,
+    List<double>? aDouble,
+    List<DateTime>? aDateTime,
+    List<String>? aString,
+    List<_i2.ByteData>? aByteData,
+    List<Duration>? aDuration,
+    List<_i1.UuidValue>? aUuid,
+    List<_i3.TestEnum>? anEnum,
+    List<_i3.TestEnumStringified>? aStringifiedEnum,
+    List<_i3.Types>? anObject,
+    List<Map<String, _i3.Types>>? aMap,
+    List<List<_i3.Types>>? aList,
+  }) = _TypesListImpl;
+
+  factory TypesList.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return TypesList(
+      anInt: serializationManager
+          .deserialize<List<int>?>(jsonSerialization['anInt']),
+      aBool: serializationManager
+          .deserialize<List<bool>?>(jsonSerialization['aBool']),
+      aDouble: serializationManager
+          .deserialize<List<double>?>(jsonSerialization['aDouble']),
+      aDateTime: serializationManager
+          .deserialize<List<DateTime>?>(jsonSerialization['aDateTime']),
+      aString: serializationManager
+          .deserialize<List<String>?>(jsonSerialization['aString']),
+      aByteData: serializationManager
+          .deserialize<List<_i2.ByteData>?>(jsonSerialization['aByteData']),
+      aDuration: serializationManager
+          .deserialize<List<Duration>?>(jsonSerialization['aDuration']),
+      aUuid: serializationManager
+          .deserialize<List<_i1.UuidValue>?>(jsonSerialization['aUuid']),
+      anEnum: serializationManager
+          .deserialize<List<_i3.TestEnum>?>(jsonSerialization['anEnum']),
+      aStringifiedEnum:
+          serializationManager.deserialize<List<_i3.TestEnumStringified>?>(
+              jsonSerialization['aStringifiedEnum']),
+      anObject: serializationManager
+          .deserialize<List<_i3.Types>?>(jsonSerialization['anObject']),
+      aMap: serializationManager.deserialize<List<Map<String, _i3.Types>>?>(
+          jsonSerialization['aMap']),
+      aList: serializationManager
+          .deserialize<List<List<_i3.Types>>?>(jsonSerialization['aList']),
+    );
+  }
+
+  List<int>? anInt;
+
+  List<bool>? aBool;
+
+  List<double>? aDouble;
+
+  List<DateTime>? aDateTime;
+
+  List<String>? aString;
+
+  List<_i2.ByteData>? aByteData;
+
+  List<Duration>? aDuration;
+
+  List<_i1.UuidValue>? aUuid;
+
+  List<_i3.TestEnum>? anEnum;
+
+  List<_i3.TestEnumStringified>? aStringifiedEnum;
+
+  List<_i3.Types>? anObject;
+
+  List<Map<String, _i3.Types>>? aMap;
+
+  List<List<_i3.Types>>? aList;
+
+  TypesList copyWith({
+    List<int>? anInt,
+    List<bool>? aBool,
+    List<double>? aDouble,
+    List<DateTime>? aDateTime,
+    List<String>? aString,
+    List<_i2.ByteData>? aByteData,
+    List<Duration>? aDuration,
+    List<_i1.UuidValue>? aUuid,
+    List<_i3.TestEnum>? anEnum,
+    List<_i3.TestEnumStringified>? aStringifiedEnum,
+    List<_i3.Types>? anObject,
+    List<Map<String, _i3.Types>>? aMap,
+    List<List<_i3.Types>>? aList,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (anInt != null) 'anInt': anInt?.toJson(),
+      if (aBool != null) 'aBool': aBool?.toJson(),
+      if (aDouble != null) 'aDouble': aDouble?.toJson(),
+      if (aDateTime != null)
+        'aDateTime': aDateTime?.toJson(valueToJson: (v) => v.toJson()),
+      if (aString != null) 'aString': aString?.toJson(),
+      if (aByteData != null)
+        'aByteData': aByteData?.toJson(valueToJson: (v) => v.toJson()),
+      if (aDuration != null)
+        'aDuration': aDuration?.toJson(valueToJson: (v) => v.toJson()),
+      if (aUuid != null) 'aUuid': aUuid?.toJson(valueToJson: (v) => v.toJson()),
+      if (anEnum != null)
+        'anEnum': anEnum?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringifiedEnum != null)
+        'aStringifiedEnum':
+            aStringifiedEnum?.toJson(valueToJson: (v) => v.toJson()),
+      if (anObject != null)
+        'anObject': anObject?.toJson(valueToJson: (v) => v.toJson()),
+      if (aMap != null)
+        'aMap': aMap?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+      if (aList != null)
+        'aList': aList?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+    };
+  }
+}
+
+class _Undefined {}
+
+class _TypesListImpl extends TypesList {
+  _TypesListImpl({
+    List<int>? anInt,
+    List<bool>? aBool,
+    List<double>? aDouble,
+    List<DateTime>? aDateTime,
+    List<String>? aString,
+    List<_i2.ByteData>? aByteData,
+    List<Duration>? aDuration,
+    List<_i1.UuidValue>? aUuid,
+    List<_i3.TestEnum>? anEnum,
+    List<_i3.TestEnumStringified>? aStringifiedEnum,
+    List<_i3.Types>? anObject,
+    List<Map<String, _i3.Types>>? aMap,
+    List<List<_i3.Types>>? aList,
+  }) : super._(
+          anInt: anInt,
+          aBool: aBool,
+          aDouble: aDouble,
+          aDateTime: aDateTime,
+          aString: aString,
+          aByteData: aByteData,
+          aDuration: aDuration,
+          aUuid: aUuid,
+          anEnum: anEnum,
+          aStringifiedEnum: aStringifiedEnum,
+          anObject: anObject,
+          aMap: aMap,
+          aList: aList,
+        );
+
+  @override
+  TypesList copyWith({
+    Object? anInt = _Undefined,
+    Object? aBool = _Undefined,
+    Object? aDouble = _Undefined,
+    Object? aDateTime = _Undefined,
+    Object? aString = _Undefined,
+    Object? aByteData = _Undefined,
+    Object? aDuration = _Undefined,
+    Object? aUuid = _Undefined,
+    Object? anEnum = _Undefined,
+    Object? aStringifiedEnum = _Undefined,
+    Object? anObject = _Undefined,
+    Object? aMap = _Undefined,
+    Object? aList = _Undefined,
+  }) {
+    return TypesList(
+      anInt: anInt is List<int>? ? anInt : this.anInt?.clone(),
+      aBool: aBool is List<bool>? ? aBool : this.aBool?.clone(),
+      aDouble: aDouble is List<double>? ? aDouble : this.aDouble?.clone(),
+      aDateTime:
+          aDateTime is List<DateTime>? ? aDateTime : this.aDateTime?.clone(),
+      aString: aString is List<String>? ? aString : this.aString?.clone(),
+      aByteData: aByteData is List<_i2.ByteData>?
+          ? aByteData
+          : this.aByteData?.clone(),
+      aDuration:
+          aDuration is List<Duration>? ? aDuration : this.aDuration?.clone(),
+      aUuid: aUuid is List<_i1.UuidValue>? ? aUuid : this.aUuid?.clone(),
+      anEnum: anEnum is List<_i3.TestEnum>? ? anEnum : this.anEnum?.clone(),
+      aStringifiedEnum: aStringifiedEnum is List<_i3.TestEnumStringified>?
+          ? aStringifiedEnum
+          : this.aStringifiedEnum?.clone(),
+      anObject:
+          anObject is List<_i3.Types>? ? anObject : this.anObject?.clone(),
+      aMap: aMap is List<Map<String, _i3.Types>>? ? aMap : this.aMap?.clone(),
+      aList: aList is List<List<_i3.Types>>? ? aList : this.aList?.clone(),
+    );
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/types_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types_map.dart
@@ -11,7 +11,6 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class TypesMap extends _i1.SerializableEntity {
   TypesMap._({

--- a/tests/serverpod_test_client/lib/src/protocol/types_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types_map.dart
@@ -1,0 +1,449 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'dart:typed_data' as _i2;
+import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+abstract class TypesMap extends _i1.SerializableEntity {
+  TypesMap._({
+    this.anIntKey,
+    this.aBoolKey,
+    this.aDoubleKey,
+    this.aDateTimeKey,
+    this.aStringKey,
+    this.aByteDataKey,
+    this.aDurationKey,
+    this.aUuidKey,
+    this.anEnumKey,
+    this.aStringifiedEnumKey,
+    this.anObjectKey,
+    this.aMapKey,
+    this.aListKey,
+    this.anIntValue,
+    this.aBoolValue,
+    this.aDoubleValue,
+    this.aDateTimeValue,
+    this.aStringValue,
+    this.aByteDataValue,
+    this.aDurationValue,
+    this.aUuidValue,
+    this.anEnumValue,
+    this.aStringifiedEnumValue,
+    this.anObjectValue,
+    this.aMapValue,
+    this.aListValue,
+  });
+
+  factory TypesMap({
+    Map<int, String>? anIntKey,
+    Map<bool, String>? aBoolKey,
+    Map<double, String>? aDoubleKey,
+    Map<DateTime, String>? aDateTimeKey,
+    Map<String, String>? aStringKey,
+    Map<_i2.ByteData, String>? aByteDataKey,
+    Map<Duration, String>? aDurationKey,
+    Map<_i1.UuidValue, String>? aUuidKey,
+    Map<_i3.TestEnum, String>? anEnumKey,
+    Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey,
+    Map<_i3.Types, String>? anObjectKey,
+    Map<Map<_i3.Types, String>, String>? aMapKey,
+    Map<List<_i3.Types>, String>? aListKey,
+    Map<String, int>? anIntValue,
+    Map<String, bool>? aBoolValue,
+    Map<String, double>? aDoubleValue,
+    Map<String, DateTime>? aDateTimeValue,
+    Map<String, String>? aStringValue,
+    Map<String, _i2.ByteData>? aByteDataValue,
+    Map<String, Duration>? aDurationValue,
+    Map<String, _i1.UuidValue>? aUuidValue,
+    Map<String, _i3.TestEnum>? anEnumValue,
+    Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue,
+    Map<String, _i3.Types>? anObjectValue,
+    Map<String, Map<String, _i3.Types>>? aMapValue,
+    Map<String, List<_i3.Types>>? aListValue,
+  }) = _TypesMapImpl;
+
+  factory TypesMap.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return TypesMap(
+      anIntKey: serializationManager
+          .deserialize<Map<int, String>?>(jsonSerialization['anIntKey']),
+      aBoolKey: serializationManager
+          .deserialize<Map<bool, String>?>(jsonSerialization['aBoolKey']),
+      aDoubleKey: serializationManager
+          .deserialize<Map<double, String>?>(jsonSerialization['aDoubleKey']),
+      aDateTimeKey: serializationManager.deserialize<Map<DateTime, String>?>(
+          jsonSerialization['aDateTimeKey']),
+      aStringKey: serializationManager
+          .deserialize<Map<String, String>?>(jsonSerialization['aStringKey']),
+      aByteDataKey:
+          serializationManager.deserialize<Map<_i2.ByteData, String>?>(
+              jsonSerialization['aByteDataKey']),
+      aDurationKey: serializationManager.deserialize<Map<Duration, String>?>(
+          jsonSerialization['aDurationKey']),
+      aUuidKey: serializationManager.deserialize<Map<_i1.UuidValue, String>?>(
+          jsonSerialization['aUuidKey']),
+      anEnumKey: serializationManager.deserialize<Map<_i3.TestEnum, String>?>(
+          jsonSerialization['anEnumKey']),
+      aStringifiedEnumKey: serializationManager
+          .deserialize<Map<_i3.TestEnumStringified, String>?>(
+              jsonSerialization['aStringifiedEnumKey']),
+      anObjectKey: serializationManager.deserialize<Map<_i3.Types, String>?>(
+          jsonSerialization['anObjectKey']),
+      aMapKey: serializationManager.deserialize<
+          Map<Map<_i3.Types, String>, String>?>(jsonSerialization['aMapKey']),
+      aListKey: serializationManager.deserialize<Map<List<_i3.Types>, String>?>(
+          jsonSerialization['aListKey']),
+      anIntValue: serializationManager
+          .deserialize<Map<String, int>?>(jsonSerialization['anIntValue']),
+      aBoolValue: serializationManager
+          .deserialize<Map<String, bool>?>(jsonSerialization['aBoolValue']),
+      aDoubleValue: serializationManager
+          .deserialize<Map<String, double>?>(jsonSerialization['aDoubleValue']),
+      aDateTimeValue: serializationManager.deserialize<Map<String, DateTime>?>(
+          jsonSerialization['aDateTimeValue']),
+      aStringValue: serializationManager
+          .deserialize<Map<String, String>?>(jsonSerialization['aStringValue']),
+      aByteDataValue:
+          serializationManager.deserialize<Map<String, _i2.ByteData>?>(
+              jsonSerialization['aByteDataValue']),
+      aDurationValue: serializationManager.deserialize<Map<String, Duration>?>(
+          jsonSerialization['aDurationValue']),
+      aUuidValue: serializationManager.deserialize<Map<String, _i1.UuidValue>?>(
+          jsonSerialization['aUuidValue']),
+      anEnumValue: serializationManager.deserialize<Map<String, _i3.TestEnum>?>(
+          jsonSerialization['anEnumValue']),
+      aStringifiedEnumValue: serializationManager
+          .deserialize<Map<String, _i3.TestEnumStringified>?>(
+              jsonSerialization['aStringifiedEnumValue']),
+      anObjectValue: serializationManager.deserialize<Map<String, _i3.Types>?>(
+          jsonSerialization['anObjectValue']),
+      aMapValue: serializationManager.deserialize<
+          Map<String, Map<String, _i3.Types>>?>(jsonSerialization['aMapValue']),
+      aListValue:
+          serializationManager.deserialize<Map<String, List<_i3.Types>>?>(
+              jsonSerialization['aListValue']),
+    );
+  }
+
+  Map<int, String>? anIntKey;
+
+  Map<bool, String>? aBoolKey;
+
+  Map<double, String>? aDoubleKey;
+
+  Map<DateTime, String>? aDateTimeKey;
+
+  Map<String, String>? aStringKey;
+
+  Map<_i2.ByteData, String>? aByteDataKey;
+
+  Map<Duration, String>? aDurationKey;
+
+  Map<_i1.UuidValue, String>? aUuidKey;
+
+  Map<_i3.TestEnum, String>? anEnumKey;
+
+  Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey;
+
+  Map<_i3.Types, String>? anObjectKey;
+
+  Map<Map<_i3.Types, String>, String>? aMapKey;
+
+  Map<List<_i3.Types>, String>? aListKey;
+
+  Map<String, int>? anIntValue;
+
+  Map<String, bool>? aBoolValue;
+
+  Map<String, double>? aDoubleValue;
+
+  Map<String, DateTime>? aDateTimeValue;
+
+  Map<String, String>? aStringValue;
+
+  Map<String, _i2.ByteData>? aByteDataValue;
+
+  Map<String, Duration>? aDurationValue;
+
+  Map<String, _i1.UuidValue>? aUuidValue;
+
+  Map<String, _i3.TestEnum>? anEnumValue;
+
+  Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue;
+
+  Map<String, _i3.Types>? anObjectValue;
+
+  Map<String, Map<String, _i3.Types>>? aMapValue;
+
+  Map<String, List<_i3.Types>>? aListValue;
+
+  TypesMap copyWith({
+    Map<int, String>? anIntKey,
+    Map<bool, String>? aBoolKey,
+    Map<double, String>? aDoubleKey,
+    Map<DateTime, String>? aDateTimeKey,
+    Map<String, String>? aStringKey,
+    Map<_i2.ByteData, String>? aByteDataKey,
+    Map<Duration, String>? aDurationKey,
+    Map<_i1.UuidValue, String>? aUuidKey,
+    Map<_i3.TestEnum, String>? anEnumKey,
+    Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey,
+    Map<_i3.Types, String>? anObjectKey,
+    Map<Map<_i3.Types, String>, String>? aMapKey,
+    Map<List<_i3.Types>, String>? aListKey,
+    Map<String, int>? anIntValue,
+    Map<String, bool>? aBoolValue,
+    Map<String, double>? aDoubleValue,
+    Map<String, DateTime>? aDateTimeValue,
+    Map<String, String>? aStringValue,
+    Map<String, _i2.ByteData>? aByteDataValue,
+    Map<String, Duration>? aDurationValue,
+    Map<String, _i1.UuidValue>? aUuidValue,
+    Map<String, _i3.TestEnum>? anEnumValue,
+    Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue,
+    Map<String, _i3.Types>? anObjectValue,
+    Map<String, Map<String, _i3.Types>>? aMapValue,
+    Map<String, List<_i3.Types>>? aListValue,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (anIntKey != null) 'anIntKey': anIntKey?.toJson(),
+      if (aBoolKey != null) 'aBoolKey': aBoolKey?.toJson(),
+      if (aDoubleKey != null) 'aDoubleKey': aDoubleKey?.toJson(),
+      if (aDateTimeKey != null)
+        'aDateTimeKey': aDateTimeKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aStringKey != null) 'aStringKey': aStringKey?.toJson(),
+      if (aByteDataKey != null)
+        'aByteDataKey': aByteDataKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aDurationKey != null)
+        'aDurationKey': aDurationKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aUuidKey != null)
+        'aUuidKey': aUuidKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (anEnumKey != null)
+        'anEnumKey': anEnumKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aStringifiedEnumKey != null)
+        'aStringifiedEnumKey':
+            aStringifiedEnumKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (anObjectKey != null)
+        'anObjectKey': anObjectKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aMapKey != null)
+        'aMapKey': aMapKey?.toJson(
+            keyToJson: (k) => k.toJson(keyToJson: (k) => k.toJson())),
+      if (aListKey != null)
+        'aListKey': aListKey?.toJson(
+            keyToJson: (k) => k.toJson(valueToJson: (v) => v.toJson())),
+      if (anIntValue != null) 'anIntValue': anIntValue?.toJson(),
+      if (aBoolValue != null) 'aBoolValue': aBoolValue?.toJson(),
+      if (aDoubleValue != null) 'aDoubleValue': aDoubleValue?.toJson(),
+      if (aDateTimeValue != null)
+        'aDateTimeValue':
+            aDateTimeValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringValue != null) 'aStringValue': aStringValue?.toJson(),
+      if (aByteDataValue != null)
+        'aByteDataValue':
+            aByteDataValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aDurationValue != null)
+        'aDurationValue':
+            aDurationValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aUuidValue != null)
+        'aUuidValue': aUuidValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (anEnumValue != null)
+        'anEnumValue': anEnumValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringifiedEnumValue != null)
+        'aStringifiedEnumValue':
+            aStringifiedEnumValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (anObjectValue != null)
+        'anObjectValue': anObjectValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aMapValue != null)
+        'aMapValue': aMapValue?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+      if (aListValue != null)
+        'aListValue': aListValue?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+    };
+  }
+}
+
+class _Undefined {}
+
+class _TypesMapImpl extends TypesMap {
+  _TypesMapImpl({
+    Map<int, String>? anIntKey,
+    Map<bool, String>? aBoolKey,
+    Map<double, String>? aDoubleKey,
+    Map<DateTime, String>? aDateTimeKey,
+    Map<String, String>? aStringKey,
+    Map<_i2.ByteData, String>? aByteDataKey,
+    Map<Duration, String>? aDurationKey,
+    Map<_i1.UuidValue, String>? aUuidKey,
+    Map<_i3.TestEnum, String>? anEnumKey,
+    Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey,
+    Map<_i3.Types, String>? anObjectKey,
+    Map<Map<_i3.Types, String>, String>? aMapKey,
+    Map<List<_i3.Types>, String>? aListKey,
+    Map<String, int>? anIntValue,
+    Map<String, bool>? aBoolValue,
+    Map<String, double>? aDoubleValue,
+    Map<String, DateTime>? aDateTimeValue,
+    Map<String, String>? aStringValue,
+    Map<String, _i2.ByteData>? aByteDataValue,
+    Map<String, Duration>? aDurationValue,
+    Map<String, _i1.UuidValue>? aUuidValue,
+    Map<String, _i3.TestEnum>? anEnumValue,
+    Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue,
+    Map<String, _i3.Types>? anObjectValue,
+    Map<String, Map<String, _i3.Types>>? aMapValue,
+    Map<String, List<_i3.Types>>? aListValue,
+  }) : super._(
+          anIntKey: anIntKey,
+          aBoolKey: aBoolKey,
+          aDoubleKey: aDoubleKey,
+          aDateTimeKey: aDateTimeKey,
+          aStringKey: aStringKey,
+          aByteDataKey: aByteDataKey,
+          aDurationKey: aDurationKey,
+          aUuidKey: aUuidKey,
+          anEnumKey: anEnumKey,
+          aStringifiedEnumKey: aStringifiedEnumKey,
+          anObjectKey: anObjectKey,
+          aMapKey: aMapKey,
+          aListKey: aListKey,
+          anIntValue: anIntValue,
+          aBoolValue: aBoolValue,
+          aDoubleValue: aDoubleValue,
+          aDateTimeValue: aDateTimeValue,
+          aStringValue: aStringValue,
+          aByteDataValue: aByteDataValue,
+          aDurationValue: aDurationValue,
+          aUuidValue: aUuidValue,
+          anEnumValue: anEnumValue,
+          aStringifiedEnumValue: aStringifiedEnumValue,
+          anObjectValue: anObjectValue,
+          aMapValue: aMapValue,
+          aListValue: aListValue,
+        );
+
+  @override
+  TypesMap copyWith({
+    Object? anIntKey = _Undefined,
+    Object? aBoolKey = _Undefined,
+    Object? aDoubleKey = _Undefined,
+    Object? aDateTimeKey = _Undefined,
+    Object? aStringKey = _Undefined,
+    Object? aByteDataKey = _Undefined,
+    Object? aDurationKey = _Undefined,
+    Object? aUuidKey = _Undefined,
+    Object? anEnumKey = _Undefined,
+    Object? aStringifiedEnumKey = _Undefined,
+    Object? anObjectKey = _Undefined,
+    Object? aMapKey = _Undefined,
+    Object? aListKey = _Undefined,
+    Object? anIntValue = _Undefined,
+    Object? aBoolValue = _Undefined,
+    Object? aDoubleValue = _Undefined,
+    Object? aDateTimeValue = _Undefined,
+    Object? aStringValue = _Undefined,
+    Object? aByteDataValue = _Undefined,
+    Object? aDurationValue = _Undefined,
+    Object? aUuidValue = _Undefined,
+    Object? anEnumValue = _Undefined,
+    Object? aStringifiedEnumValue = _Undefined,
+    Object? anObjectValue = _Undefined,
+    Object? aMapValue = _Undefined,
+    Object? aListValue = _Undefined,
+  }) {
+    return TypesMap(
+      anIntKey:
+          anIntKey is Map<int, String>? ? anIntKey : this.anIntKey?.clone(),
+      aBoolKey:
+          aBoolKey is Map<bool, String>? ? aBoolKey : this.aBoolKey?.clone(),
+      aDoubleKey: aDoubleKey is Map<double, String>?
+          ? aDoubleKey
+          : this.aDoubleKey?.clone(),
+      aDateTimeKey: aDateTimeKey is Map<DateTime, String>?
+          ? aDateTimeKey
+          : this.aDateTimeKey?.clone(),
+      aStringKey: aStringKey is Map<String, String>?
+          ? aStringKey
+          : this.aStringKey?.clone(),
+      aByteDataKey: aByteDataKey is Map<_i2.ByteData, String>?
+          ? aByteDataKey
+          : this.aByteDataKey?.clone(),
+      aDurationKey: aDurationKey is Map<Duration, String>?
+          ? aDurationKey
+          : this.aDurationKey?.clone(),
+      aUuidKey: aUuidKey is Map<_i1.UuidValue, String>?
+          ? aUuidKey
+          : this.aUuidKey?.clone(),
+      anEnumKey: anEnumKey is Map<_i3.TestEnum, String>?
+          ? anEnumKey
+          : this.anEnumKey?.clone(),
+      aStringifiedEnumKey:
+          aStringifiedEnumKey is Map<_i3.TestEnumStringified, String>?
+              ? aStringifiedEnumKey
+              : this.aStringifiedEnumKey?.clone(),
+      anObjectKey: anObjectKey is Map<_i3.Types, String>?
+          ? anObjectKey
+          : this.anObjectKey?.clone(),
+      aMapKey: aMapKey is Map<Map<_i3.Types, String>, String>?
+          ? aMapKey
+          : this.aMapKey?.clone(),
+      aListKey: aListKey is Map<List<_i3.Types>, String>?
+          ? aListKey
+          : this.aListKey?.clone(),
+      anIntValue: anIntValue is Map<String, int>?
+          ? anIntValue
+          : this.anIntValue?.clone(),
+      aBoolValue: aBoolValue is Map<String, bool>?
+          ? aBoolValue
+          : this.aBoolValue?.clone(),
+      aDoubleValue: aDoubleValue is Map<String, double>?
+          ? aDoubleValue
+          : this.aDoubleValue?.clone(),
+      aDateTimeValue: aDateTimeValue is Map<String, DateTime>?
+          ? aDateTimeValue
+          : this.aDateTimeValue?.clone(),
+      aStringValue: aStringValue is Map<String, String>?
+          ? aStringValue
+          : this.aStringValue?.clone(),
+      aByteDataValue: aByteDataValue is Map<String, _i2.ByteData>?
+          ? aByteDataValue
+          : this.aByteDataValue?.clone(),
+      aDurationValue: aDurationValue is Map<String, Duration>?
+          ? aDurationValue
+          : this.aDurationValue?.clone(),
+      aUuidValue: aUuidValue is Map<String, _i1.UuidValue>?
+          ? aUuidValue
+          : this.aUuidValue?.clone(),
+      anEnumValue: anEnumValue is Map<String, _i3.TestEnum>?
+          ? anEnumValue
+          : this.anEnumValue?.clone(),
+      aStringifiedEnumValue:
+          aStringifiedEnumValue is Map<String, _i3.TestEnumStringified>?
+              ? aStringifiedEnumValue
+              : this.aStringifiedEnumValue?.clone(),
+      anObjectValue: anObjectValue is Map<String, _i3.Types>?
+          ? anObjectValue
+          : this.anObjectValue?.clone(),
+      aMapValue: aMapValue is Map<String, Map<String, _i3.Types>>?
+          ? aMapValue
+          : this.aMapValue?.clone(),
+      aListValue: aListValue is Map<String, List<_i3.Types>>?
+          ? aListValue
+          : this.aListValue?.clone(),
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ExceptionWithData extends _i1.SerializableEntity
     implements _i1.SerializableException {
@@ -60,8 +61,8 @@ abstract class ExceptionWithData extends _i1.SerializableEntity
   Map<String, dynamic> toJson() {
     return {
       'message': message,
-      'creationDate': creationDate,
-      'errorFields': errorFields,
+      'creationDate': creationDate.toJson(),
+      'errorFields': errorFields.toJson(),
       if (someNullableField != null) 'someNullableField': someNullableField,
     };
   }
@@ -70,8 +71,8 @@ abstract class ExceptionWithData extends _i1.SerializableEntity
   Map<String, dynamic> allToJson() {
     return {
       'message': message,
-      'creationDate': creationDate,
-      'errorFields': errorFields,
+      'creationDate': creationDate.toJson(),
+      'errorFields': errorFields.toJson(),
       if (someNullableField != null) 'someNullableField': someNullableField,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -60,7 +60,7 @@ abstract class MaxFieldName extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo':
           thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo,
     };

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -58,12 +58,10 @@ abstract class LongImplicitIdField extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id !=
-          null)
-        '_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id':
-            _longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id,
+      '_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id':
+          _longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -75,7 +75,7 @@ abstract class LongImplicitIdFieldCollection extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -88,7 +88,7 @@ abstract class LongImplicitIdFieldCollection extends _i1.TableRow {
       if (thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa != null)
         'thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa':
             thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa
-                ?.toJson(valueToJson: (v) => v.toJson()),
+                ?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class LongImplicitIdFieldCollection extends _i1.TableRow {
   LongImplicitIdFieldCollection._({
@@ -65,7 +66,8 @@ abstract class LongImplicitIdFieldCollection extends _i1.TableRow {
       'name': name,
       if (thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa != null)
         'thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa':
-            thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa,
+            thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa
+                ?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -85,7 +87,8 @@ abstract class LongImplicitIdFieldCollection extends _i1.TableRow {
       'name': name,
       if (thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa != null)
         'thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa':
-            thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa,
+            thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa
+                ?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class RelationToMultipleMaxFieldName extends _i1.TableRow {
   RelationToMultipleMaxFieldName._({
@@ -59,7 +60,8 @@ abstract class RelationToMultipleMaxFieldName extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (multipleMaxFieldNames != null)
-        'multipleMaxFieldNames': multipleMaxFieldNames,
+        'multipleMaxFieldNames':
+            multipleMaxFieldNames?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -78,7 +80,8 @@ abstract class RelationToMultipleMaxFieldName extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (multipleMaxFieldNames != null)
-        'multipleMaxFieldNames': multipleMaxFieldNames,
+        'multipleMaxFieldNames':
+            multipleMaxFieldNames?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -69,7 +69,7 @@ abstract class RelationToMultipleMaxFieldName extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -81,7 +81,7 @@ abstract class RelationToMultipleMaxFieldName extends _i1.TableRow {
       'name': name,
       if (multipleMaxFieldNames != null)
         'multipleMaxFieldNames':
-            multipleMaxFieldNames?.toJson(valueToJson: (v) => v.toJson()),
+            multipleMaxFieldNames?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -58,12 +58,10 @@ abstract class UserNote extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId !=
-          null)
-        '_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId':
-            _userNoteCollectionsUsernotespropertynameUserNoteCollectionsId,
+      '_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId':
+          _userNoteCollectionsUsernotespropertynameUserNoteCollectionsId,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -69,7 +69,7 @@ abstract class UserNoteCollection extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -81,7 +81,7 @@ abstract class UserNoteCollection extends _i1.TableRow {
       'name': name,
       if (userNotesPropertyName != null)
         'userNotesPropertyName':
-            userNotesPropertyName?.toJson(valueToJson: (v) => v.toJson()),
+            userNotesPropertyName?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class UserNoteCollection extends _i1.TableRow {
   UserNoteCollection._({
@@ -59,7 +60,8 @@ abstract class UserNoteCollection extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (userNotesPropertyName != null)
-        'userNotesPropertyName': userNotesPropertyName,
+        'userNotesPropertyName':
+            userNotesPropertyName?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -78,7 +80,8 @@ abstract class UserNoteCollection extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (userNotesPropertyName != null)
-        'userNotesPropertyName': userNotesPropertyName,
+        'userNotesPropertyName':
+            userNotesPropertyName?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class UserNoteCollectionWithALongName extends _i1.TableRow {
   UserNoteCollectionWithALongName._({
@@ -57,7 +58,7 @@ abstract class UserNoteCollectionWithALongName extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (notes != null) 'notes': notes,
+      if (notes != null) 'notes': notes?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -75,7 +76,7 @@ abstract class UserNoteCollectionWithALongName extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (notes != null) 'notes': notes,
+      if (notes != null) 'notes': notes?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -66,7 +66,7 @@ abstract class UserNoteCollectionWithALongName extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -76,7 +76,8 @@ abstract class UserNoteCollectionWithALongName extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (notes != null) 'notes': notes?.toJson(valueToJson: (v) => v.toJson()),
+      if (notes != null)
+        'notes': notes?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -58,12 +58,10 @@ abstract class UserNoteWithALongName extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId !=
-          null)
-        '_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId':
-            _userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId,
+      '_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId':
+          _userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -73,15 +73,13 @@ abstract class MultipleMaxFieldName extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1':
           thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1,
       'thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2':
           thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2,
-      if (_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId !=
-          null)
-        '_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId':
-            _relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId,
+      '_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId':
+          _relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/model_types/object_with_serverpod_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/model_types/object_with_serverpod_object.dart
@@ -44,16 +44,16 @@ abstract class ObjectWithServerpodObject extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'logLevel1': logLevel1,
-      'logLevel2': logLevel2,
+      'logLevel1': logLevel1.toJson(),
+      'logLevel2': logLevel2.toJson(),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'logLevel1': logLevel1,
-      'logLevel2': logLevel2,
+      'logLevel1': logLevel1.toJson(),
+      'logLevel2': logLevel2.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -76,7 +76,7 @@ abstract class City extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -87,9 +87,10 @@ abstract class City extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (citizens != null)
-        'citizens': citizens?.toJson(valueToJson: (v) => v.toJson()),
+        'citizens': citizens?.toJson(valueToJson: (v) => v.allToJson()),
       if (organizations != null)
-        'organizations': organizations?.toJson(valueToJson: (v) => v.toJson()),
+        'organizations':
+            organizations?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class City extends _i1.TableRow {
   City._({
@@ -64,8 +65,10 @@ abstract class City extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (citizens != null) 'citizens': citizens,
-      if (organizations != null) 'organizations': organizations,
+      if (citizens != null)
+        'citizens': citizens?.toJson(valueToJson: (v) => v.toJson()),
+      if (organizations != null)
+        'organizations': organizations?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -83,8 +86,10 @@ abstract class City extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (citizens != null) 'citizens': citizens,
-      if (organizations != null) 'organizations': organizations,
+      if (citizens != null)
+        'citizens': citizens?.toJson(valueToJson: (v) => v.toJson()),
+      if (organizations != null)
+        'organizations': organizations?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -83,9 +83,9 @@ abstract class Organization extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (cityId != null) 'cityId': cityId,
+      'cityId': cityId,
     };
   }
 
@@ -95,9 +95,9 @@ abstract class Organization extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (people != null)
-        'people': people?.toJson(valueToJson: (v) => v.toJson()),
+        'people': people?.toJson(valueToJson: (v) => v.allToJson()),
       if (cityId != null) 'cityId': cityId,
-      if (city != null) 'city': city?.toJson(),
+      if (city != null) 'city': city?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Organization extends _i1.TableRow {
   Organization._({
@@ -71,9 +72,10 @@ abstract class Organization extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (people != null) 'people': people,
+      if (people != null)
+        'people': people?.toJson(valueToJson: (v) => v.toJson()),
       if (cityId != null) 'cityId': cityId,
-      if (city != null) 'city': city,
+      if (city != null) 'city': city?.toJson(),
     };
   }
 
@@ -92,9 +94,10 @@ abstract class Organization extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (people != null) 'people': people,
+      if (people != null)
+        'people': people?.toJson(valueToJson: (v) => v.toJson()),
       if (cityId != null) 'cityId': cityId,
-      if (city != null) 'city': city,
+      if (city != null) 'city': city?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -75,11 +75,10 @@ abstract class Person extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (organizationId != null) 'organizationId': organizationId,
-      if (_cityCitizensCityId != null)
-        '_cityCitizensCityId': _cityCitizensCityId,
+      'organizationId': organizationId,
+      '_cityCitizensCityId': _cityCitizensCityId,
     };
   }
 
@@ -89,7 +88,7 @@ abstract class Person extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (organizationId != null) 'organizationId': organizationId,
-      if (organization != null) 'organization': organization?.toJson(),
+      if (organization != null) 'organization': organization?.allToJson(),
       if (_cityCitizensCityId != null)
         '_cityCitizensCityId': _cityCitizensCityId,
     };

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -67,7 +67,7 @@ abstract class Person extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (organizationId != null) 'organizationId': organizationId,
-      if (organization != null) 'organization': organization,
+      if (organization != null) 'organization': organization?.toJson(),
     };
   }
 
@@ -89,7 +89,7 @@ abstract class Person extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (organizationId != null) 'organizationId': organizationId,
-      if (organization != null) 'organization': organization,
+      if (organization != null) 'organization': organization?.toJson(),
       if (_cityCitizensCityId != null)
         '_cityCitizensCityId': _cityCitizensCityId,
     };

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -67,7 +67,7 @@ abstract class Course extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -78,7 +78,7 @@ abstract class Course extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (enrollments != null)
-        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Course extends _i1.TableRow {
   Course._({
@@ -57,7 +58,8 @@ abstract class Course extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (enrollments != null) 'enrollments': enrollments,
+      if (enrollments != null)
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -75,7 +77,8 @@ abstract class Course extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (enrollments != null) 'enrollments': enrollments,
+      if (enrollments != null)
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -82,7 +82,7 @@ abstract class Enrollment extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'studentId': studentId,
       'courseId': courseId,
     };
@@ -93,9 +93,9 @@ abstract class Enrollment extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'studentId': studentId,
-      if (student != null) 'student': student?.toJson(),
+      if (student != null) 'student': student?.allToJson(),
       'courseId': courseId,
-      if (course != null) 'course': course?.toJson(),
+      if (course != null) 'course': course?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -72,9 +72,9 @@ abstract class Enrollment extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'studentId': studentId,
-      if (student != null) 'student': student,
+      if (student != null) 'student': student?.toJson(),
       'courseId': courseId,
-      if (course != null) 'course': course,
+      if (course != null) 'course': course?.toJson(),
     };
   }
 
@@ -93,9 +93,9 @@ abstract class Enrollment extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'studentId': studentId,
-      if (student != null) 'student': student,
+      if (student != null) 'student': student?.toJson(),
       'courseId': courseId,
-      if (course != null) 'course': course,
+      if (course != null) 'course': course?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -67,7 +67,7 @@ abstract class Student extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -78,7 +78,7 @@ abstract class Student extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (enrollments != null)
-        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Student extends _i1.TableRow {
   Student._({
@@ -57,7 +58,8 @@ abstract class Student extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (enrollments != null) 'enrollments': enrollments,
+      if (enrollments != null)
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -75,7 +77,8 @@ abstract class Student extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (enrollments != null) 'enrollments': enrollments,
+      if (enrollments != null)
+        'enrollments': enrollments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -74,8 +74,8 @@ abstract class ObjectUser extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      if (name != null) 'name': name,
+      'id': id,
+      'name': name,
       'userInfoId': userInfoId,
     };
   }
@@ -86,7 +86,7 @@ abstract class ObjectUser extends _i1.TableRow {
       if (id != null) 'id': id,
       if (name != null) 'name': name,
       'userInfoId': userInfoId,
-      if (userInfo != null) 'userInfo': userInfo?.toJson(),
+      if (userInfo != null) 'userInfo': userInfo?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -66,7 +66,7 @@ abstract class ObjectUser extends _i1.TableRow {
       if (id != null) 'id': id,
       if (name != null) 'name': name,
       'userInfoId': userInfoId,
-      if (userInfo != null) 'userInfo': userInfo,
+      if (userInfo != null) 'userInfo': userInfo?.toJson(),
     };
   }
 
@@ -86,7 +86,7 @@ abstract class ObjectUser extends _i1.TableRow {
       if (id != null) 'id': id,
       if (name != null) 'name': name,
       'userInfoId': userInfoId,
-      if (userInfo != null) 'userInfo': userInfo,
+      if (userInfo != null) 'userInfo': userInfo?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -65,9 +65,9 @@ abstract class ParentUser extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      if (name != null) 'name': name,
-      if (userInfoId != null) 'userInfoId': userInfoId,
+      'id': id,
+      'name': name,
+      'userInfoId': userInfoId,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -57,7 +57,7 @@ abstract class Arena extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (team != null) 'team': team,
+      if (team != null) 'team': team?.toJson(),
     };
   }
 
@@ -75,7 +75,7 @@ abstract class Arena extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (team != null) 'team': team,
+      if (team != null) 'team': team?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -65,7 +65,7 @@ abstract class Arena extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -75,7 +75,7 @@ abstract class Arena extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (team != null) 'team': team?.toJson(),
+      if (team != null) 'team': team?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -65,7 +65,7 @@ abstract class Player extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (teamId != null) 'teamId': teamId,
-      if (team != null) 'team': team,
+      if (team != null) 'team': team?.toJson(),
     };
   }
 
@@ -85,7 +85,7 @@ abstract class Player extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (teamId != null) 'teamId': teamId,
-      if (team != null) 'team': team,
+      if (team != null) 'team': team?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -73,9 +73,9 @@ abstract class Player extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (teamId != null) 'teamId': teamId,
+      'teamId': teamId,
     };
   }
 
@@ -85,7 +85,7 @@ abstract class Player extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (teamId != null) 'teamId': teamId,
-      if (team != null) 'team': team?.toJson(),
+      if (team != null) 'team': team?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -83,9 +83,9 @@ abstract class Team extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (arenaId != null) 'arenaId': arenaId,
+      'arenaId': arenaId,
     };
   }
 
@@ -95,9 +95,9 @@ abstract class Team extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (arenaId != null) 'arenaId': arenaId,
-      if (arena != null) 'arena': arena?.toJson(),
+      if (arena != null) 'arena': arena?.allToJson(),
       if (players != null)
-        'players': players?.toJson(valueToJson: (v) => v.toJson()),
+        'players': players?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Team extends _i1.TableRow {
   Team._({
@@ -72,8 +73,9 @@ abstract class Team extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (arenaId != null) 'arenaId': arenaId,
-      if (arena != null) 'arena': arena,
-      if (players != null) 'players': players,
+      if (arena != null) 'arena': arena?.toJson(),
+      if (players != null)
+        'players': players?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -93,8 +95,9 @@ abstract class Team extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (arenaId != null) 'arenaId': arenaId,
-      if (arena != null) 'arena': arena,
-      if (players != null) 'players': players,
+      if (arena != null) 'arena': arena?.toJson(),
+      if (players != null)
+        'players': players?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -74,7 +74,7 @@ abstract class Comment extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'description': description,
       'orderId': orderId,
     };
@@ -86,7 +86,7 @@ abstract class Comment extends _i1.TableRow {
       if (id != null) 'id': id,
       'description': description,
       'orderId': orderId,
-      if (order != null) 'order': order?.toJson(),
+      if (order != null) 'order': order?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -66,7 +66,7 @@ abstract class Comment extends _i1.TableRow {
       if (id != null) 'id': id,
       'description': description,
       'orderId': orderId,
-      if (order != null) 'order': order,
+      if (order != null) 'order': order?.toJson(),
     };
   }
 
@@ -86,7 +86,7 @@ abstract class Comment extends _i1.TableRow {
       if (id != null) 'id': id,
       'description': description,
       'orderId': orderId,
-      if (order != null) 'order': order,
+      if (order != null) 'order': order?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Customer extends _i1.TableRow {
   Customer._({
@@ -57,7 +58,8 @@ abstract class Customer extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (orders != null) 'orders': orders,
+      if (orders != null)
+        'orders': orders?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -75,7 +77,8 @@ abstract class Customer extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (orders != null) 'orders': orders,
+      if (orders != null)
+        'orders': orders?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -67,7 +67,7 @@ abstract class Customer extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -78,7 +78,7 @@ abstract class Customer extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (orders != null)
-        'orders': orders?.toJson(valueToJson: (v) => v.toJson()),
+        'orders': orders?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -84,7 +84,7 @@ abstract class Order extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'description': description,
       'customerId': customerId,
     };
@@ -96,9 +96,9 @@ abstract class Order extends _i1.TableRow {
       if (id != null) 'id': id,
       'description': description,
       'customerId': customerId,
-      if (customer != null) 'customer': customer?.toJson(),
+      if (customer != null) 'customer': customer?.allToJson(),
       if (comments != null)
-        'comments': comments?.toJson(valueToJson: (v) => v.toJson()),
+        'comments': comments?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Order extends _i1.TableRow {
   Order._({
@@ -73,8 +74,9 @@ abstract class Order extends _i1.TableRow {
       if (id != null) 'id': id,
       'description': description,
       'customerId': customerId,
-      if (customer != null) 'customer': customer,
-      if (comments != null) 'comments': comments,
+      if (customer != null) 'customer': customer?.toJson(),
+      if (comments != null)
+        'comments': comments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -94,8 +96,9 @@ abstract class Order extends _i1.TableRow {
       if (id != null) 'id': id,
       'description': description,
       'customerId': customerId,
-      if (customer != null) 'customer': customer,
-      if (comments != null) 'comments': comments,
+      if (customer != null) 'customer': customer?.toJson(),
+      if (comments != null)
+        'comments': comments?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -74,9 +74,9 @@ abstract class Address extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'street': street,
-      if (inhabitantId != null) 'inhabitantId': inhabitantId,
+      'inhabitantId': inhabitantId,
     };
   }
 
@@ -86,7 +86,7 @@ abstract class Address extends _i1.TableRow {
       if (id != null) 'id': id,
       'street': street,
       if (inhabitantId != null) 'inhabitantId': inhabitantId,
-      if (inhabitant != null) 'inhabitant': inhabitant?.toJson(),
+      if (inhabitant != null) 'inhabitant': inhabitant?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -66,7 +66,7 @@ abstract class Address extends _i1.TableRow {
       if (id != null) 'id': id,
       'street': street,
       if (inhabitantId != null) 'inhabitantId': inhabitantId,
-      if (inhabitant != null) 'inhabitant': inhabitant,
+      if (inhabitant != null) 'inhabitant': inhabitant?.toJson(),
     };
   }
 
@@ -86,7 +86,7 @@ abstract class Address extends _i1.TableRow {
       if (id != null) 'id': id,
       'street': street,
       if (inhabitantId != null) 'inhabitantId': inhabitantId,
-      if (inhabitant != null) 'inhabitant': inhabitant,
+      if (inhabitant != null) 'inhabitant': inhabitant?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -97,10 +97,10 @@ abstract class Citizen extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
       'companyId': companyId,
-      if (oldCompanyId != null) 'oldCompanyId': oldCompanyId,
+      'oldCompanyId': oldCompanyId,
     };
   }
 
@@ -109,11 +109,11 @@ abstract class Citizen extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (address != null) 'address': address?.toJson(),
+      if (address != null) 'address': address?.allToJson(),
       'companyId': companyId,
-      if (company != null) 'company': company?.toJson(),
+      if (company != null) 'company': company?.allToJson(),
       if (oldCompanyId != null) 'oldCompanyId': oldCompanyId,
-      if (oldCompany != null) 'oldCompany': oldCompany?.toJson(),
+      if (oldCompany != null) 'oldCompany': oldCompany?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -85,11 +85,11 @@ abstract class Citizen extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (address != null) 'address': address,
+      if (address != null) 'address': address?.toJson(),
       'companyId': companyId,
-      if (company != null) 'company': company,
+      if (company != null) 'company': company?.toJson(),
       if (oldCompanyId != null) 'oldCompanyId': oldCompanyId,
-      if (oldCompany != null) 'oldCompany': oldCompany,
+      if (oldCompany != null) 'oldCompany': oldCompany?.toJson(),
     };
   }
 
@@ -109,11 +109,11 @@ abstract class Citizen extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (address != null) 'address': address,
+      if (address != null) 'address': address?.toJson(),
       'companyId': companyId,
-      if (company != null) 'company': company,
+      if (company != null) 'company': company?.toJson(),
       if (oldCompanyId != null) 'oldCompanyId': oldCompanyId,
-      if (oldCompany != null) 'oldCompany': oldCompany,
+      if (oldCompany != null) 'oldCompany': oldCompany?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -73,7 +73,7 @@ abstract class Company extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
       'townId': townId,
     };
@@ -85,7 +85,7 @@ abstract class Company extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       'townId': townId,
-      if (town != null) 'town': town?.toJson(),
+      if (town != null) 'town': town?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -65,7 +65,7 @@ abstract class Company extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       'townId': townId,
-      if (town != null) 'town': town,
+      if (town != null) 'town': town?.toJson(),
     };
   }
 
@@ -85,7 +85,7 @@ abstract class Company extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       'townId': townId,
-      if (town != null) 'town': town,
+      if (town != null) 'town': town?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -65,7 +65,7 @@ abstract class Town extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (mayorId != null) 'mayorId': mayorId,
-      if (mayor != null) 'mayor': mayor,
+      if (mayor != null) 'mayor': mayor?.toJson(),
     };
   }
 
@@ -85,7 +85,7 @@ abstract class Town extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (mayorId != null) 'mayorId': mayorId,
-      if (mayor != null) 'mayor': mayor,
+      if (mayor != null) 'mayor': mayor?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -73,9 +73,9 @@ abstract class Town extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (mayorId != null) 'mayorId': mayorId,
+      'mayorId': mayorId,
     };
   }
 
@@ -85,7 +85,7 @@ abstract class Town extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (mayorId != null) 'mayorId': mayorId,
-      if (mayor != null) 'mayor': mayor?.toJson(),
+      if (mayor != null) 'mayor': mayor?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -82,7 +82,7 @@ abstract class Blocking extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'blockedId': blockedId,
       'blockedById': blockedById,
     };
@@ -93,9 +93,9 @@ abstract class Blocking extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'blockedId': blockedId,
-      if (blocked != null) 'blocked': blocked?.toJson(),
+      if (blocked != null) 'blocked': blocked?.allToJson(),
       'blockedById': blockedById,
-      if (blockedBy != null) 'blockedBy': blockedBy?.toJson(),
+      if (blockedBy != null) 'blockedBy': blockedBy?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -72,9 +72,9 @@ abstract class Blocking extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'blockedId': blockedId,
-      if (blocked != null) 'blocked': blocked,
+      if (blocked != null) 'blocked': blocked?.toJson(),
       'blockedById': blockedById,
-      if (blockedBy != null) 'blockedBy': blockedBy,
+      if (blockedBy != null) 'blockedBy': blockedBy?.toJson(),
     };
   }
 
@@ -93,9 +93,9 @@ abstract class Blocking extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'blockedId': blockedId,
-      if (blocked != null) 'blocked': blocked,
+      if (blocked != null) 'blocked': blocked?.toJson(),
       'blockedById': blockedById,
-      if (blockedBy != null) 'blockedBy': blockedBy,
+      if (blockedBy != null) 'blockedBy': blockedBy?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Member extends _i1.TableRow {
   Member._({
@@ -64,8 +65,10 @@ abstract class Member extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (blocking != null) 'blocking': blocking,
-      if (blockedBy != null) 'blockedBy': blockedBy,
+      if (blocking != null)
+        'blocking': blocking?.toJson(valueToJson: (v) => v.toJson()),
+      if (blockedBy != null)
+        'blockedBy': blockedBy?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -83,8 +86,10 @@ abstract class Member extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'name': name,
-      if (blocking != null) 'blocking': blocking,
-      if (blockedBy != null) 'blockedBy': blockedBy,
+      if (blocking != null)
+        'blocking': blocking?.toJson(valueToJson: (v) => v.toJson()),
+      if (blockedBy != null)
+        'blockedBy': blockedBy?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -76,7 +76,7 @@ abstract class Member extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
     };
   }
@@ -87,9 +87,9 @@ abstract class Member extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (blocking != null)
-        'blocking': blocking?.toJson(valueToJson: (v) => v.toJson()),
+        'blocking': blocking?.toJson(valueToJson: (v) => v.allToJson()),
       if (blockedBy != null)
-        'blockedBy': blockedBy?.toJson(valueToJson: (v) => v.toJson()),
+        'blockedBy': blockedBy?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Cat extends _i1.TableRow {
   Cat._({
@@ -72,8 +73,9 @@ abstract class Cat extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (motherId != null) 'motherId': motherId,
-      if (mother != null) 'mother': mother,
-      if (kittens != null) 'kittens': kittens,
+      if (mother != null) 'mother': mother?.toJson(),
+      if (kittens != null)
+        'kittens': kittens?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
@@ -93,8 +95,9 @@ abstract class Cat extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (motherId != null) 'motherId': motherId,
-      if (mother != null) 'mother': mother,
-      if (kittens != null) 'kittens': kittens,
+      if (mother != null) 'mother': mother?.toJson(),
+      if (kittens != null)
+        'kittens': kittens?.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -83,9 +83,9 @@ abstract class Cat extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'name': name,
-      if (motherId != null) 'motherId': motherId,
+      'motherId': motherId,
     };
   }
 
@@ -95,9 +95,9 @@ abstract class Cat extends _i1.TableRow {
       if (id != null) 'id': id,
       'name': name,
       if (motherId != null) 'motherId': motherId,
-      if (mother != null) 'mother': mother?.toJson(),
+      if (mother != null) 'mother': mother?.allToJson(),
       if (kittens != null)
-        'kittens': kittens?.toJson(valueToJson: (v) => v.toJson()),
+        'kittens': kittens?.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -82,9 +82,9 @@ abstract class Post extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'content': content,
-      if (nextId != null) 'nextId': nextId,
+      'nextId': nextId,
     };
   }
 
@@ -93,9 +93,9 @@ abstract class Post extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'content': content,
-      if (previous != null) 'previous': previous?.toJson(),
+      if (previous != null) 'previous': previous?.allToJson(),
       if (nextId != null) 'nextId': nextId,
-      if (next != null) 'next': next?.toJson(),
+      if (next != null) 'next': next?.allToJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -72,9 +72,9 @@ abstract class Post extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'content': content,
-      if (previous != null) 'previous': previous,
+      if (previous != null) 'previous': previous?.toJson(),
       if (nextId != null) 'nextId': nextId,
-      if (next != null) 'next': next,
+      if (next != null) 'next': next?.toJson(),
     };
   }
 
@@ -93,9 +93,9 @@ abstract class Post extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'content': content,
-      if (previous != null) 'previous': previous,
+      if (previous != null) 'previous': previous?.toJson(),
       if (nextId != null) 'nextId': nextId,
-      if (next != null) 'next': next,
+      if (next != null) 'next': next?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/module_datatype.dart
+++ b/tests/serverpod_test_server/lib/src/generated/module_datatype.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_test_module_server/module.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ModuleDatatype extends _i1.SerializableEntity {
   ModuleDatatype._({
@@ -52,18 +53,18 @@ abstract class ModuleDatatype extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'model': model,
-      'list': list,
-      'map': map,
+      'model': model.toJson(),
+      'list': list.toJson(valueToJson: (v) => v.toJson()),
+      'map': map.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'model': model,
-      'list': list,
-      'map': map,
+      'model': model.toJson(),
+      'list': list.toJson(valueToJson: (v) => v.toJson()),
+      'map': map.toJson(valueToJson: (v) => v.toJson()),
     };
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/module_datatype.dart
+++ b/tests/serverpod_test_server/lib/src/generated/module_datatype.dart
@@ -62,9 +62,9 @@ abstract class ModuleDatatype extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'model': model.toJson(),
-      'list': list.toJson(valueToJson: (v) => v.toJson()),
-      'map': map.toJson(valueToJson: (v) => v.toJson()),
+      'model': model.allToJson(),
+      'list': list.toJson(valueToJson: (v) => v.allToJson()),
+      'map': map.toJson(valueToJson: (v) => v.allToJson()),
     };
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/nullability.dart
+++ b/tests/serverpod_test_server/lib/src/generated/nullability.dart
@@ -470,8 +470,9 @@ abstract class Nullability extends _i1.SerializableEntity {
         'aNullableDuration': aNullableDuration?.toJson(),
       'aUuid': aUuid.toJson(),
       if (aNullableUuid != null) 'aNullableUuid': aNullableUuid?.toJson(),
-      'anObject': anObject.toJson(),
-      if (aNullableObject != null) 'aNullableObject': aNullableObject?.toJson(),
+      'anObject': anObject.allToJson(),
+      if (aNullableObject != null)
+        'aNullableObject': aNullableObject?.allToJson(),
       'anIntList': anIntList.toJson(),
       if (aNullableIntList != null)
         'aNullableIntList': aNullableIntList?.toJson(),
@@ -479,15 +480,15 @@ abstract class Nullability extends _i1.SerializableEntity {
       if (aNullableListWithNullableInts != null)
         'aNullableListWithNullableInts':
             aNullableListWithNullableInts?.toJson(),
-      'anObjectList': anObjectList.toJson(valueToJson: (v) => v.toJson()),
+      'anObjectList': anObjectList.toJson(valueToJson: (v) => v.allToJson()),
       if (aNullableObjectList != null)
         'aNullableObjectList':
-            aNullableObjectList?.toJson(valueToJson: (v) => v.toJson()),
+            aNullableObjectList?.toJson(valueToJson: (v) => v.allToJson()),
       'aListWithNullableObjects':
-          aListWithNullableObjects.toJson(valueToJson: (v) => v?.toJson()),
+          aListWithNullableObjects.toJson(valueToJson: (v) => v?.allToJson()),
       if (aNullableListWithNullableObjects != null)
         'aNullableListWithNullableObjects': aNullableListWithNullableObjects
-            ?.toJson(valueToJson: (v) => v?.toJson()),
+            ?.toJson(valueToJson: (v) => v?.allToJson()),
       'aDateTimeList': aDateTimeList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableDateTimeList != null)
         'aNullableDateTimeList':

--- a/tests/serverpod_test_server/lib/src/generated/nullability.dart
+++ b/tests/serverpod_test_server/lib/src/generated/nullability.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Nullability extends _i1.SerializableEntity {
   Nullability._({
@@ -374,58 +375,76 @@ abstract class Nullability extends _i1.SerializableEntity {
       if (aNullableBool != null) 'aNullableBool': aNullableBool,
       'aString': aString,
       if (aNullableString != null) 'aNullableString': aNullableString,
-      'aDateTime': aDateTime,
-      if (aNullableDateTime != null) 'aNullableDateTime': aNullableDateTime,
-      'aByteData': aByteData,
-      if (aNullableByteData != null) 'aNullableByteData': aNullableByteData,
-      'aDuration': aDuration,
-      if (aNullableDuration != null) 'aNullableDuration': aNullableDuration,
-      'aUuid': aUuid,
-      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid,
-      'anObject': anObject,
-      if (aNullableObject != null) 'aNullableObject': aNullableObject,
-      'anIntList': anIntList,
-      if (aNullableIntList != null) 'aNullableIntList': aNullableIntList,
-      'aListWithNullableInts': aListWithNullableInts,
+      'aDateTime': aDateTime.toJson(),
+      if (aNullableDateTime != null)
+        'aNullableDateTime': aNullableDateTime?.toJson(),
+      'aByteData': aByteData.toJson(),
+      if (aNullableByteData != null)
+        'aNullableByteData': aNullableByteData?.toJson(),
+      'aDuration': aDuration.toJson(),
+      if (aNullableDuration != null)
+        'aNullableDuration': aNullableDuration?.toJson(),
+      'aUuid': aUuid.toJson(),
+      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid?.toJson(),
+      'anObject': anObject.toJson(),
+      if (aNullableObject != null) 'aNullableObject': aNullableObject?.toJson(),
+      'anIntList': anIntList.toJson(),
+      if (aNullableIntList != null)
+        'aNullableIntList': aNullableIntList?.toJson(),
+      'aListWithNullableInts': aListWithNullableInts.toJson(),
       if (aNullableListWithNullableInts != null)
-        'aNullableListWithNullableInts': aNullableListWithNullableInts,
-      'anObjectList': anObjectList,
+        'aNullableListWithNullableInts':
+            aNullableListWithNullableInts?.toJson(),
+      'anObjectList': anObjectList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableObjectList != null)
-        'aNullableObjectList': aNullableObjectList,
-      'aListWithNullableObjects': aListWithNullableObjects,
+        'aNullableObjectList':
+            aNullableObjectList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableObjects':
+          aListWithNullableObjects.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableObjects != null)
-        'aNullableListWithNullableObjects': aNullableListWithNullableObjects,
-      'aDateTimeList': aDateTimeList,
+        'aNullableListWithNullableObjects': aNullableListWithNullableObjects
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aDateTimeList': aDateTimeList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableDateTimeList != null)
-        'aNullableDateTimeList': aNullableDateTimeList,
-      'aListWithNullableDateTimes': aListWithNullableDateTimes,
+        'aNullableDateTimeList':
+            aNullableDateTimeList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableDateTimes':
+          aListWithNullableDateTimes.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableDateTimes != null)
-        'aNullableListWithNullableDateTimes':
-            aNullableListWithNullableDateTimes,
-      'aByteDataList': aByteDataList,
+        'aNullableListWithNullableDateTimes': aNullableListWithNullableDateTimes
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aByteDataList': aByteDataList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableByteDataList != null)
-        'aNullableByteDataList': aNullableByteDataList,
-      'aListWithNullableByteDatas': aListWithNullableByteDatas,
+        'aNullableByteDataList':
+            aNullableByteDataList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableByteDatas':
+          aListWithNullableByteDatas.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableByteDatas != null)
-        'aNullableListWithNullableByteDatas':
-            aNullableListWithNullableByteDatas,
-      'aDurationList': aDurationList,
+        'aNullableListWithNullableByteDatas': aNullableListWithNullableByteDatas
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aDurationList': aDurationList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableDurationList != null)
-        'aNullableDurationList': aNullableDurationList,
-      'aListWithNullableDurations': aListWithNullableDurations,
+        'aNullableDurationList':
+            aNullableDurationList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableDurations':
+          aListWithNullableDurations.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableDurations != null)
-        'aNullableListWithNullableDurations':
-            aNullableListWithNullableDurations,
-      'aUuidList': aUuidList,
-      if (aNullableUuidList != null) 'aNullableUuidList': aNullableUuidList,
-      'aListWithNullableUuids': aListWithNullableUuids,
+        'aNullableListWithNullableDurations': aNullableListWithNullableDurations
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aUuidList': aUuidList.toJson(valueToJson: (v) => v.toJson()),
+      if (aNullableUuidList != null)
+        'aNullableUuidList':
+            aNullableUuidList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableUuids':
+          aListWithNullableUuids.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableUuids != null)
-        'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
-      'anIntMap': anIntMap,
-      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap,
-      'aMapWithNullableInts': aMapWithNullableInts,
+        'aNullableListWithNullableUuids': aNullableListWithNullableUuids
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'anIntMap': anIntMap.toJson(),
+      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap?.toJson(),
+      'aMapWithNullableInts': aMapWithNullableInts.toJson(),
       if (aNullableMapWithNullableInts != null)
-        'aNullableMapWithNullableInts': aNullableMapWithNullableInts,
+        'aNullableMapWithNullableInts': aNullableMapWithNullableInts?.toJson(),
     };
   }
 
@@ -440,58 +459,76 @@ abstract class Nullability extends _i1.SerializableEntity {
       if (aNullableBool != null) 'aNullableBool': aNullableBool,
       'aString': aString,
       if (aNullableString != null) 'aNullableString': aNullableString,
-      'aDateTime': aDateTime,
-      if (aNullableDateTime != null) 'aNullableDateTime': aNullableDateTime,
-      'aByteData': aByteData,
-      if (aNullableByteData != null) 'aNullableByteData': aNullableByteData,
-      'aDuration': aDuration,
-      if (aNullableDuration != null) 'aNullableDuration': aNullableDuration,
-      'aUuid': aUuid,
-      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid,
-      'anObject': anObject,
-      if (aNullableObject != null) 'aNullableObject': aNullableObject,
-      'anIntList': anIntList,
-      if (aNullableIntList != null) 'aNullableIntList': aNullableIntList,
-      'aListWithNullableInts': aListWithNullableInts,
+      'aDateTime': aDateTime.toJson(),
+      if (aNullableDateTime != null)
+        'aNullableDateTime': aNullableDateTime?.toJson(),
+      'aByteData': aByteData.toJson(),
+      if (aNullableByteData != null)
+        'aNullableByteData': aNullableByteData?.toJson(),
+      'aDuration': aDuration.toJson(),
+      if (aNullableDuration != null)
+        'aNullableDuration': aNullableDuration?.toJson(),
+      'aUuid': aUuid.toJson(),
+      if (aNullableUuid != null) 'aNullableUuid': aNullableUuid?.toJson(),
+      'anObject': anObject.toJson(),
+      if (aNullableObject != null) 'aNullableObject': aNullableObject?.toJson(),
+      'anIntList': anIntList.toJson(),
+      if (aNullableIntList != null)
+        'aNullableIntList': aNullableIntList?.toJson(),
+      'aListWithNullableInts': aListWithNullableInts.toJson(),
       if (aNullableListWithNullableInts != null)
-        'aNullableListWithNullableInts': aNullableListWithNullableInts,
-      'anObjectList': anObjectList,
+        'aNullableListWithNullableInts':
+            aNullableListWithNullableInts?.toJson(),
+      'anObjectList': anObjectList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableObjectList != null)
-        'aNullableObjectList': aNullableObjectList,
-      'aListWithNullableObjects': aListWithNullableObjects,
+        'aNullableObjectList':
+            aNullableObjectList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableObjects':
+          aListWithNullableObjects.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableObjects != null)
-        'aNullableListWithNullableObjects': aNullableListWithNullableObjects,
-      'aDateTimeList': aDateTimeList,
+        'aNullableListWithNullableObjects': aNullableListWithNullableObjects
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aDateTimeList': aDateTimeList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableDateTimeList != null)
-        'aNullableDateTimeList': aNullableDateTimeList,
-      'aListWithNullableDateTimes': aListWithNullableDateTimes,
+        'aNullableDateTimeList':
+            aNullableDateTimeList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableDateTimes':
+          aListWithNullableDateTimes.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableDateTimes != null)
-        'aNullableListWithNullableDateTimes':
-            aNullableListWithNullableDateTimes,
-      'aByteDataList': aByteDataList,
+        'aNullableListWithNullableDateTimes': aNullableListWithNullableDateTimes
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aByteDataList': aByteDataList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableByteDataList != null)
-        'aNullableByteDataList': aNullableByteDataList,
-      'aListWithNullableByteDatas': aListWithNullableByteDatas,
+        'aNullableByteDataList':
+            aNullableByteDataList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableByteDatas':
+          aListWithNullableByteDatas.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableByteDatas != null)
-        'aNullableListWithNullableByteDatas':
-            aNullableListWithNullableByteDatas,
-      'aDurationList': aDurationList,
+        'aNullableListWithNullableByteDatas': aNullableListWithNullableByteDatas
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aDurationList': aDurationList.toJson(valueToJson: (v) => v.toJson()),
       if (aNullableDurationList != null)
-        'aNullableDurationList': aNullableDurationList,
-      'aListWithNullableDurations': aListWithNullableDurations,
+        'aNullableDurationList':
+            aNullableDurationList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableDurations':
+          aListWithNullableDurations.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableDurations != null)
-        'aNullableListWithNullableDurations':
-            aNullableListWithNullableDurations,
-      'aUuidList': aUuidList,
-      if (aNullableUuidList != null) 'aNullableUuidList': aNullableUuidList,
-      'aListWithNullableUuids': aListWithNullableUuids,
+        'aNullableListWithNullableDurations': aNullableListWithNullableDurations
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'aUuidList': aUuidList.toJson(valueToJson: (v) => v.toJson()),
+      if (aNullableUuidList != null)
+        'aNullableUuidList':
+            aNullableUuidList?.toJson(valueToJson: (v) => v.toJson()),
+      'aListWithNullableUuids':
+          aListWithNullableUuids.toJson(valueToJson: (v) => v?.toJson()),
       if (aNullableListWithNullableUuids != null)
-        'aNullableListWithNullableUuids': aNullableListWithNullableUuids,
-      'anIntMap': anIntMap,
-      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap,
-      'aMapWithNullableInts': aMapWithNullableInts,
+        'aNullableListWithNullableUuids': aNullableListWithNullableUuids
+            ?.toJson(valueToJson: (v) => v?.toJson()),
+      'anIntMap': anIntMap.toJson(),
+      if (aNullableIntMap != null) 'aNullableIntMap': aNullableIntMap?.toJson(),
+      'aMapWithNullableInts': aMapWithNullableInts.toJson(),
       if (aNullableMapWithNullableInts != null)
-        'aNullableMapWithNullableInts': aNullableMapWithNullableInts,
+        'aNullableMapWithNullableInts': aNullableMapWithNullableInts?.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -71,9 +71,9 @@ abstract class ObjectFieldScopes extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'normal': normal,
-      if (database != null) 'database': database,
+      'database': database,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithByteData extends _i1.TableRow {
   ObjectWithByteData._({
@@ -50,7 +51,7 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'byteData': byteData,
+      'byteData': byteData.toJson(),
     };
   }
 
@@ -59,7 +60,7 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   Map<String, dynamic> toJsonForDatabase() {
     return {
       if (id != null) 'id': id,
-      'byteData': byteData,
+      'byteData': byteData.toJson(),
     };
   }
 
@@ -67,7 +68,7 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'byteData': byteData,
+      'byteData': byteData.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -59,8 +59,8 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      'byteData': byteData.toJson(),
+      'id': id,
+      'byteData': byteData,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -58,8 +58,8 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      'duration': duration.toJson(),
+      'id': id,
+      'duration': duration,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithDuration extends _i1.TableRow {
   ObjectWithDuration._({
@@ -49,7 +50,7 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'duration': duration,
+      'duration': duration.toJson(),
     };
   }
 
@@ -58,7 +59,7 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   Map<String, dynamic> toJsonForDatabase() {
     return {
       if (id != null) 'id': id,
-      'duration': duration,
+      'duration': duration.toJson(),
     };
   }
 
@@ -66,7 +67,7 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'duration': duration,
+      'duration': duration.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -93,14 +93,12 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      'testEnum': testEnum.toJson(),
-      if (nullableEnum != null) 'nullableEnum': nullableEnum?.toJson(),
-      'enumList': enumList.toJson(valueToJson: (v) => v.toJson()),
-      'nullableEnumList':
-          nullableEnumList.toJson(valueToJson: (v) => v?.toJson()),
-      'enumListList': enumListList.toJson(
-          valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+      'id': id,
+      'testEnum': testEnum,
+      'nullableEnum': nullableEnum,
+      'enumList': enumList,
+      'nullableEnumList': nullableEnumList,
+      'enumListList': enumListList,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithEnum extends _i1.TableRow {
   ObjectWithEnum._({
@@ -78,11 +79,13 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'testEnum': testEnum,
-      if (nullableEnum != null) 'nullableEnum': nullableEnum,
-      'enumList': enumList,
-      'nullableEnumList': nullableEnumList,
-      'enumListList': enumListList,
+      'testEnum': testEnum.toJson(),
+      if (nullableEnum != null) 'nullableEnum': nullableEnum?.toJson(),
+      'enumList': enumList.toJson(valueToJson: (v) => v.toJson()),
+      'nullableEnumList':
+          nullableEnumList.toJson(valueToJson: (v) => v?.toJson()),
+      'enumListList': enumListList.toJson(
+          valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
     };
   }
 
@@ -91,11 +94,13 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   Map<String, dynamic> toJsonForDatabase() {
     return {
       if (id != null) 'id': id,
-      'testEnum': testEnum,
-      if (nullableEnum != null) 'nullableEnum': nullableEnum,
-      'enumList': enumList,
-      'nullableEnumList': nullableEnumList,
-      'enumListList': enumListList,
+      'testEnum': testEnum.toJson(),
+      if (nullableEnum != null) 'nullableEnum': nullableEnum?.toJson(),
+      'enumList': enumList.toJson(valueToJson: (v) => v.toJson()),
+      'nullableEnumList':
+          nullableEnumList.toJson(valueToJson: (v) => v?.toJson()),
+      'enumListList': enumListList.toJson(
+          valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
     };
   }
 
@@ -103,11 +108,13 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'testEnum': testEnum,
-      if (nullableEnum != null) 'nullableEnum': nullableEnum,
-      'enumList': enumList,
-      'nullableEnumList': nullableEnumList,
-      'enumListList': enumListList,
+      'testEnum': testEnum.toJson(),
+      if (nullableEnum != null) 'nullableEnum': nullableEnum?.toJson(),
+      'enumList': enumList.toJson(valueToJson: (v) => v.toJson()),
+      'nullableEnumList':
+          nullableEnumList.toJson(valueToJson: (v) => v?.toJson()),
+      'enumListList': enumListList.toJson(
+          valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -65,7 +65,7 @@ abstract class ObjectWithIndex extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'indexed': indexed,
       'indexed2': indexed2,
     };

--- a/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
 import 'dart:typed_data' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithMaps extends _i1.SerializableEntity {
   ObjectWithMaps._({
@@ -142,42 +143,52 @@ abstract class ObjectWithMaps extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> toJson() {
     return {
-      'dataMap': dataMap,
-      'intMap': intMap,
-      'stringMap': stringMap,
-      'dateTimeMap': dateTimeMap,
-      'byteDataMap': byteDataMap,
-      'durationMap': durationMap,
-      'uuidMap': uuidMap,
-      'nullableDataMap': nullableDataMap,
-      'nullableIntMap': nullableIntMap,
-      'nullableStringMap': nullableStringMap,
-      'nullableDateTimeMap': nullableDateTimeMap,
-      'nullableByteDataMap': nullableByteDataMap,
-      'nullableDurationMap': nullableDurationMap,
-      'nullableUuidMap': nullableUuidMap,
-      'intIntMap': intIntMap,
+      'dataMap': dataMap.toJson(valueToJson: (v) => v.toJson()),
+      'intMap': intMap.toJson(),
+      'stringMap': stringMap.toJson(),
+      'dateTimeMap': dateTimeMap.toJson(valueToJson: (v) => v.toJson()),
+      'byteDataMap': byteDataMap.toJson(valueToJson: (v) => v.toJson()),
+      'durationMap': durationMap.toJson(valueToJson: (v) => v.toJson()),
+      'uuidMap': uuidMap.toJson(valueToJson: (v) => v.toJson()),
+      'nullableDataMap':
+          nullableDataMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableIntMap': nullableIntMap.toJson(),
+      'nullableStringMap': nullableStringMap.toJson(),
+      'nullableDateTimeMap':
+          nullableDateTimeMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableByteDataMap':
+          nullableByteDataMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableDurationMap':
+          nullableDurationMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableUuidMap':
+          nullableUuidMap.toJson(valueToJson: (v) => v?.toJson()),
+      'intIntMap': intIntMap.toJson(),
     };
   }
 
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'dataMap': dataMap,
-      'intMap': intMap,
-      'stringMap': stringMap,
-      'dateTimeMap': dateTimeMap,
-      'byteDataMap': byteDataMap,
-      'durationMap': durationMap,
-      'uuidMap': uuidMap,
-      'nullableDataMap': nullableDataMap,
-      'nullableIntMap': nullableIntMap,
-      'nullableStringMap': nullableStringMap,
-      'nullableDateTimeMap': nullableDateTimeMap,
-      'nullableByteDataMap': nullableByteDataMap,
-      'nullableDurationMap': nullableDurationMap,
-      'nullableUuidMap': nullableUuidMap,
-      'intIntMap': intIntMap,
+      'dataMap': dataMap.toJson(valueToJson: (v) => v.toJson()),
+      'intMap': intMap.toJson(),
+      'stringMap': stringMap.toJson(),
+      'dateTimeMap': dateTimeMap.toJson(valueToJson: (v) => v.toJson()),
+      'byteDataMap': byteDataMap.toJson(valueToJson: (v) => v.toJson()),
+      'durationMap': durationMap.toJson(valueToJson: (v) => v.toJson()),
+      'uuidMap': uuidMap.toJson(valueToJson: (v) => v.toJson()),
+      'nullableDataMap':
+          nullableDataMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableIntMap': nullableIntMap.toJson(),
+      'nullableStringMap': nullableStringMap.toJson(),
+      'nullableDateTimeMap':
+          nullableDateTimeMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableByteDataMap':
+          nullableByteDataMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableDurationMap':
+          nullableDurationMap.toJson(valueToJson: (v) => v?.toJson()),
+      'nullableUuidMap':
+          nullableUuidMap.toJson(valueToJson: (v) => v?.toJson()),
+      'intIntMap': intIntMap.toJson(),
     };
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
@@ -169,7 +169,7 @@ abstract class ObjectWithMaps extends _i1.SerializableEntity {
   @override
   Map<String, dynamic> allToJson() {
     return {
-      'dataMap': dataMap.toJson(valueToJson: (v) => v.toJson()),
+      'dataMap': dataMap.toJson(valueToJson: (v) => v.allToJson()),
       'intMap': intMap.toJson(),
       'stringMap': stringMap.toJson(),
       'dateTimeMap': dateTimeMap.toJson(valueToJson: (v) => v.toJson()),
@@ -177,7 +177,7 @@ abstract class ObjectWithMaps extends _i1.SerializableEntity {
       'durationMap': durationMap.toJson(valueToJson: (v) => v.toJson()),
       'uuidMap': uuidMap.toJson(valueToJson: (v) => v.toJson()),
       'nullableDataMap':
-          nullableDataMap.toJson(valueToJson: (v) => v?.toJson()),
+          nullableDataMap.toJson(valueToJson: (v) => v?.allToJson()),
       'nullableIntMap': nullableIntMap.toJson(),
       'nullableStringMap': nullableStringMap.toJson(),
       'nullableDateTimeMap':

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithObject extends _i1.TableRow {
   ObjectWithObject._({
@@ -87,13 +88,17 @@ abstract class ObjectWithObject extends _i1.TableRow {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'data': data,
-      if (nullableData != null) 'nullableData': nullableData,
-      'dataList': dataList,
-      if (nullableDataList != null) 'nullableDataList': nullableDataList,
-      'listWithNullableData': listWithNullableData,
+      'data': data.toJson(),
+      if (nullableData != null) 'nullableData': nullableData?.toJson(),
+      'dataList': dataList.toJson(valueToJson: (v) => v.toJson()),
+      if (nullableDataList != null)
+        'nullableDataList':
+            nullableDataList?.toJson(valueToJson: (v) => v.toJson()),
+      'listWithNullableData':
+          listWithNullableData.toJson(valueToJson: (v) => v?.toJson()),
       if (nullableListWithNullableData != null)
-        'nullableListWithNullableData': nullableListWithNullableData,
+        'nullableListWithNullableData': nullableListWithNullableData?.toJson(
+            valueToJson: (v) => v?.toJson()),
     };
   }
 
@@ -102,13 +107,17 @@ abstract class ObjectWithObject extends _i1.TableRow {
   Map<String, dynamic> toJsonForDatabase() {
     return {
       if (id != null) 'id': id,
-      'data': data,
-      if (nullableData != null) 'nullableData': nullableData,
-      'dataList': dataList,
-      if (nullableDataList != null) 'nullableDataList': nullableDataList,
-      'listWithNullableData': listWithNullableData,
+      'data': data.toJson(),
+      if (nullableData != null) 'nullableData': nullableData?.toJson(),
+      'dataList': dataList.toJson(valueToJson: (v) => v.toJson()),
+      if (nullableDataList != null)
+        'nullableDataList':
+            nullableDataList?.toJson(valueToJson: (v) => v.toJson()),
+      'listWithNullableData':
+          listWithNullableData.toJson(valueToJson: (v) => v?.toJson()),
       if (nullableListWithNullableData != null)
-        'nullableListWithNullableData': nullableListWithNullableData,
+        'nullableListWithNullableData': nullableListWithNullableData?.toJson(
+            valueToJson: (v) => v?.toJson()),
     };
   }
 
@@ -116,13 +125,17 @@ abstract class ObjectWithObject extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'data': data,
-      if (nullableData != null) 'nullableData': nullableData,
-      'dataList': dataList,
-      if (nullableDataList != null) 'nullableDataList': nullableDataList,
-      'listWithNullableData': listWithNullableData,
+      'data': data.toJson(),
+      if (nullableData != null) 'nullableData': nullableData?.toJson(),
+      'dataList': dataList.toJson(valueToJson: (v) => v.toJson()),
+      if (nullableDataList != null)
+        'nullableDataList':
+            nullableDataList?.toJson(valueToJson: (v) => v.toJson()),
+      'listWithNullableData':
+          listWithNullableData.toJson(valueToJson: (v) => v?.toJson()),
       if (nullableListWithNullableData != null)
-        'nullableListWithNullableData': nullableListWithNullableData,
+        'nullableListWithNullableData': nullableListWithNullableData?.toJson(
+            valueToJson: (v) => v?.toJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -106,18 +106,13 @@ abstract class ObjectWithObject extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      'data': data.toJson(),
-      if (nullableData != null) 'nullableData': nullableData?.toJson(),
-      'dataList': dataList.toJson(valueToJson: (v) => v.toJson()),
-      if (nullableDataList != null)
-        'nullableDataList':
-            nullableDataList?.toJson(valueToJson: (v) => v.toJson()),
-      'listWithNullableData':
-          listWithNullableData.toJson(valueToJson: (v) => v?.toJson()),
-      if (nullableListWithNullableData != null)
-        'nullableListWithNullableData': nullableListWithNullableData?.toJson(
-            valueToJson: (v) => v?.toJson()),
+      'id': id,
+      'data': data,
+      'nullableData': nullableData,
+      'dataList': dataList,
+      'nullableDataList': nullableDataList,
+      'listWithNullableData': listWithNullableData,
+      'nullableListWithNullableData': nullableListWithNullableData,
     };
   }
 
@@ -125,17 +120,17 @@ abstract class ObjectWithObject extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'data': data.toJson(),
-      if (nullableData != null) 'nullableData': nullableData?.toJson(),
-      'dataList': dataList.toJson(valueToJson: (v) => v.toJson()),
+      'data': data.allToJson(),
+      if (nullableData != null) 'nullableData': nullableData?.allToJson(),
+      'dataList': dataList.toJson(valueToJson: (v) => v.allToJson()),
       if (nullableDataList != null)
         'nullableDataList':
-            nullableDataList?.toJson(valueToJson: (v) => v.toJson()),
+            nullableDataList?.toJson(valueToJson: (v) => v.allToJson()),
       'listWithNullableData':
-          listWithNullableData.toJson(valueToJson: (v) => v?.toJson()),
+          listWithNullableData.toJson(valueToJson: (v) => v?.allToJson()),
       if (nullableListWithNullableData != null)
         'nullableListWithNullableData': nullableListWithNullableData?.toJson(
-            valueToJson: (v) => v?.toJson()),
+            valueToJson: (v) => v?.allToJson()),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -56,7 +56,7 @@ abstract class ObjectWithParent extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'other': other,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -56,8 +56,8 @@ abstract class ObjectWithSelfParent extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      if (other != null) 'other': other,
+      'id': id,
+      'other': other,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -66,9 +66,9 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      'uuid': uuid.toJson(),
-      if (uuidNullable != null) 'uuidNullable': uuidNullable?.toJson(),
+      'id': id,
+      'uuid': uuid,
+      'uuidNullable': uuidNullable,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class ObjectWithUuid extends _i1.TableRow {
   ObjectWithUuid._({
@@ -56,8 +57,8 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'uuid': uuid,
-      if (uuidNullable != null) 'uuidNullable': uuidNullable,
+      'uuid': uuid.toJson(),
+      if (uuidNullable != null) 'uuidNullable': uuidNullable?.toJson(),
     };
   }
 
@@ -66,8 +67,8 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   Map<String, dynamic> toJsonForDatabase() {
     return {
       if (id != null) 'id': id,
-      'uuid': uuid,
-      if (uuidNullable != null) 'uuidNullable': uuidNullable,
+      'uuid': uuid.toJson(),
+      if (uuidNullable != null) 'uuidNullable': uuidNullable?.toJson(),
     };
   }
 
@@ -75,8 +76,8 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'uuid': uuid,
-      if (uuidNullable != null) 'uuidNullable': uuidNullable,
+      'uuid': uuid.toJson(),
+      if (uuidNullable != null) 'uuidNullable': uuidNullable?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -66,48 +66,49 @@ import 'object_with_self_parent.dart' as _i48;
 import 'object_with_uuid.dart' as _i49;
 import 'related_unique_data.dart' as _i50;
 import 'scopes/scope_none_fields.dart' as _i51;
-import 'serverOnly/default_server_only_class.dart' as _i52;
-import 'serverOnly/default_server_only_enum.dart' as _i53;
-import 'serverOnly/not_server_only_class.dart' as _i54;
-import 'serverOnly/not_server_only_enum.dart' as _i55;
-import 'serverOnly/server_only_class.dart' as _i56;
-import 'serverOnly/server_only_enum.dart' as _i57;
-import 'simple_data.dart' as _i58;
-import 'simple_data_list.dart' as _i59;
-import 'simple_data_map.dart' as _i60;
-import 'simple_data_object.dart' as _i61;
-import 'simple_date_time.dart' as _i62;
-import 'test_enum.dart' as _i63;
-import 'test_enum_stringified.dart' as _i64;
-import 'types.dart' as _i65;
-import 'types_list.dart' as _i66;
-import 'types_map.dart' as _i67;
-import 'unique_data.dart' as _i68;
-import 'protocol.dart' as _i69;
-import 'dart:typed_data' as _i70;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i71;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i72;
-import 'package:uuid/uuid_value.dart' as _i73;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i74;
-import 'package:serverpod_test_server/src/generated/unique_data.dart' as _i75;
+import 'scopes/scope_server_only_field.dart' as _i52;
+import 'serverOnly/default_server_only_class.dart' as _i53;
+import 'serverOnly/default_server_only_enum.dart' as _i54;
+import 'serverOnly/not_server_only_class.dart' as _i55;
+import 'serverOnly/not_server_only_enum.dart' as _i56;
+import 'serverOnly/server_only_class.dart' as _i57;
+import 'serverOnly/server_only_enum.dart' as _i58;
+import 'simple_data.dart' as _i59;
+import 'simple_data_list.dart' as _i60;
+import 'simple_data_map.dart' as _i61;
+import 'simple_data_object.dart' as _i62;
+import 'simple_date_time.dart' as _i63;
+import 'test_enum.dart' as _i64;
+import 'test_enum_stringified.dart' as _i65;
+import 'types.dart' as _i66;
+import 'types_list.dart' as _i67;
+import 'types_map.dart' as _i68;
+import 'unique_data.dart' as _i69;
+import 'protocol.dart' as _i70;
+import 'dart:typed_data' as _i71;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i72;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i73;
+import 'package:uuid/uuid_value.dart' as _i74;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i75;
+import 'package:serverpod_test_server/src/generated/unique_data.dart' as _i76;
 import 'package:serverpod_test_server/src/generated/models_with_list_relations/person.dart'
-    as _i76;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/citizen.dart'
     as _i77;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/address.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/citizen.dart'
     as _i78;
-import 'package:serverpod_test_server/src/generated/models_with_relations/self_relation/one_to_one/post.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/address.dart'
     as _i79;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/company.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/self_relation/one_to_one/post.dart'
     as _i80;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/customer.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/company.dart'
     as _i81;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/comment.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/customer.dart'
     as _i82;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/order.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/comment.dart'
     as _i83;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i84;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i85;
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/order.dart'
+    as _i84;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i85;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i86;
 export 'exception_with_data.dart';
 export 'long_identifiers/max_field_name.dart';
 export 'long_identifiers/models_with_relations/long_implicit_id_field.dart';
@@ -155,6 +156,7 @@ export 'object_with_self_parent.dart';
 export 'object_with_uuid.dart';
 export 'related_unique_data.dart';
 export 'scopes/scope_none_fields.dart';
+export 'scopes/scope_server_only_field.dart';
 export 'serverOnly/default_server_only_class.dart';
 export 'serverOnly/default_server_only_enum.dart';
 export 'serverOnly/not_server_only_class.dart';
@@ -2776,56 +2778,59 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i51.ScopeNoneFields) {
       return _i51.ScopeNoneFields.fromJson(data, this) as T;
     }
-    if (t == _i52.DefaultServerOnlyClass) {
-      return _i52.DefaultServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i52.ScopeServerOnlyField) {
+      return _i52.ScopeServerOnlyField.fromJson(data, this) as T;
     }
-    if (t == _i53.DefaultServerOnlyEnum) {
-      return _i53.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i53.DefaultServerOnlyClass) {
+      return _i53.DefaultServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i54.NotServerOnlyClass) {
-      return _i54.NotServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i54.DefaultServerOnlyEnum) {
+      return _i54.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i55.NotServerOnlyEnum) {
-      return _i55.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i55.NotServerOnlyClass) {
+      return _i55.NotServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i56.ServerOnlyClass) {
-      return _i56.ServerOnlyClass.fromJson(data, this) as T;
+    if (t == _i56.NotServerOnlyEnum) {
+      return _i56.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i57.ServerOnlyEnum) {
-      return _i57.ServerOnlyEnum.fromJson(data) as T;
+    if (t == _i57.ServerOnlyClass) {
+      return _i57.ServerOnlyClass.fromJson(data, this) as T;
     }
-    if (t == _i58.SimpleData) {
-      return _i58.SimpleData.fromJson(data, this) as T;
+    if (t == _i58.ServerOnlyEnum) {
+      return _i58.ServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i59.SimpleDataList) {
-      return _i59.SimpleDataList.fromJson(data, this) as T;
+    if (t == _i59.SimpleData) {
+      return _i59.SimpleData.fromJson(data, this) as T;
     }
-    if (t == _i60.SimpleDataMap) {
-      return _i60.SimpleDataMap.fromJson(data, this) as T;
+    if (t == _i60.SimpleDataList) {
+      return _i60.SimpleDataList.fromJson(data, this) as T;
     }
-    if (t == _i61.SimpleDataObject) {
-      return _i61.SimpleDataObject.fromJson(data, this) as T;
+    if (t == _i61.SimpleDataMap) {
+      return _i61.SimpleDataMap.fromJson(data, this) as T;
     }
-    if (t == _i62.SimpleDateTime) {
-      return _i62.SimpleDateTime.fromJson(data, this) as T;
+    if (t == _i62.SimpleDataObject) {
+      return _i62.SimpleDataObject.fromJson(data, this) as T;
     }
-    if (t == _i63.TestEnum) {
-      return _i63.TestEnum.fromJson(data) as T;
+    if (t == _i63.SimpleDateTime) {
+      return _i63.SimpleDateTime.fromJson(data, this) as T;
     }
-    if (t == _i64.TestEnumStringified) {
-      return _i64.TestEnumStringified.fromJson(data) as T;
+    if (t == _i64.TestEnum) {
+      return _i64.TestEnum.fromJson(data) as T;
     }
-    if (t == _i65.Types) {
-      return _i65.Types.fromJson(data, this) as T;
+    if (t == _i65.TestEnumStringified) {
+      return _i65.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i66.TypesList) {
-      return _i66.TypesList.fromJson(data, this) as T;
+    if (t == _i66.Types) {
+      return _i66.Types.fromJson(data, this) as T;
     }
-    if (t == _i67.TypesMap) {
-      return _i67.TypesMap.fromJson(data, this) as T;
+    if (t == _i67.TypesList) {
+      return _i67.TypesList.fromJson(data, this) as T;
     }
-    if (t == _i68.UniqueData) {
-      return _i68.UniqueData.fromJson(data, this) as T;
+    if (t == _i68.TypesMap) {
+      return _i68.TypesMap.fromJson(data, this) as T;
+    }
+    if (t == _i69.UniqueData) {
+      return _i69.UniqueData.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i5.ExceptionWithData?>()) {
       return (data != null ? _i5.ExceptionWithData.fromJson(data, this) : null)
@@ -3002,153 +3007,158 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i51.ScopeNoneFields.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i52.DefaultServerOnlyClass?>()) {
+    if (t == _i1.getType<_i52.ScopeServerOnlyField?>()) {
       return (data != null
-          ? _i52.DefaultServerOnlyClass.fromJson(data, this)
+          ? _i52.ScopeServerOnlyField.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i53.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i53.DefaultServerOnlyEnum.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i54.NotServerOnlyClass?>()) {
+    if (t == _i1.getType<_i53.DefaultServerOnlyClass?>()) {
       return (data != null
-          ? _i54.NotServerOnlyClass.fromJson(data, this)
+          ? _i53.DefaultServerOnlyClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i55.NotServerOnlyEnum?>()) {
-      return (data != null ? _i55.NotServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i56.ServerOnlyClass?>()) {
-      return (data != null ? _i56.ServerOnlyClass.fromJson(data, this) : null)
+    if (t == _i1.getType<_i54.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i54.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i57.ServerOnlyEnum?>()) {
-      return (data != null ? _i57.ServerOnlyEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i55.NotServerOnlyClass?>()) {
+      return (data != null
+          ? _i55.NotServerOnlyClass.fromJson(data, this)
+          : null) as T;
     }
-    if (t == _i1.getType<_i58.SimpleData?>()) {
-      return (data != null ? _i58.SimpleData.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i56.NotServerOnlyEnum?>()) {
+      return (data != null ? _i56.NotServerOnlyEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i59.SimpleDataList?>()) {
-      return (data != null ? _i59.SimpleDataList.fromJson(data, this) : null)
+    if (t == _i1.getType<_i57.ServerOnlyClass?>()) {
+      return (data != null ? _i57.ServerOnlyClass.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i60.SimpleDataMap?>()) {
-      return (data != null ? _i60.SimpleDataMap.fromJson(data, this) : null)
+    if (t == _i1.getType<_i58.ServerOnlyEnum?>()) {
+      return (data != null ? _i58.ServerOnlyEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i59.SimpleData?>()) {
+      return (data != null ? _i59.SimpleData.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i60.SimpleDataList?>()) {
+      return (data != null ? _i60.SimpleDataList.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i61.SimpleDataObject?>()) {
-      return (data != null ? _i61.SimpleDataObject.fromJson(data, this) : null)
+    if (t == _i1.getType<_i61.SimpleDataMap?>()) {
+      return (data != null ? _i61.SimpleDataMap.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i62.SimpleDateTime?>()) {
-      return (data != null ? _i62.SimpleDateTime.fromJson(data, this) : null)
+    if (t == _i1.getType<_i62.SimpleDataObject?>()) {
+      return (data != null ? _i62.SimpleDataObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i63.TestEnum?>()) {
-      return (data != null ? _i63.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i64.TestEnumStringified?>()) {
-      return (data != null ? _i64.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i63.SimpleDateTime?>()) {
+      return (data != null ? _i63.SimpleDateTime.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i65.Types?>()) {
-      return (data != null ? _i65.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i64.TestEnum?>()) {
+      return (data != null ? _i64.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i66.TypesList?>()) {
-      return (data != null ? _i66.TypesList.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i65.TestEnumStringified?>()) {
+      return (data != null ? _i65.TestEnumStringified.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i67.TypesMap?>()) {
-      return (data != null ? _i67.TypesMap.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i66.Types?>()) {
+      return (data != null ? _i66.Types.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i68.UniqueData?>()) {
-      return (data != null ? _i68.UniqueData.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i67.TypesList?>()) {
+      return (data != null ? _i67.TypesList.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i68.TypesMap?>()) {
+      return (data != null ? _i68.TypesMap.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i69.UniqueData?>()) {
+      return (data != null ? _i69.UniqueData.fromJson(data, this) : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i69.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i70.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i69.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i70.LongImplicitIdField>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i70.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i69.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i70.MultipleMaxFieldName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.UserNote>?>()) {
+    if (t == _i1.getType<List<_i70.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.UserNote>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i70.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i69.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i70.UserNoteWithALongName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Person>?>()) {
+    if (t == _i1.getType<List<_i70.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Organization>?>()) {
+    if (t == _i1.getType<List<_i70.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i69.Organization>(e))
+              .map((e) => deserialize<_i70.Organization>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Person>?>()) {
+    if (t == _i1.getType<List<_i70.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i70.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i70.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Player>?>()) {
+    if (t == _i1.getType<List<_i70.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Player>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Order>?>()) {
+    if (t == _i1.getType<List<_i70.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Order>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Comment>?>()) {
+    if (t == _i1.getType<List<_i70.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Comment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Blocking>?>()) {
+    if (t == _i1.getType<List<_i70.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Blocking>?>()) {
+    if (t == _i1.getType<List<_i70.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Cat>?>()) {
+    if (t == _i1.getType<List<_i70.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Cat>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<_i4.ModuleClass>) {
@@ -3177,23 +3187,23 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i69.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
+    if (t == List<_i70.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i70.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i69.SimpleData?>) {
+    if (t == List<_i70.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i69.SimpleData?>(e))
+          .map((e) => deserialize<_i70.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -3214,22 +3224,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i70.ByteData>) {
-      return (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
+    if (t == List<_i71.ByteData>) {
+      return (data as List).map((e) => deserialize<_i71.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i70.ByteData>?>()) {
+    if (t == _i1.getType<List<_i71.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i71.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i70.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i70.ByteData?>(e)).toList()
+    if (t == List<_i71.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i71.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i70.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i71.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i70.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i71.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -3290,22 +3300,22 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i69.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i69.TestEnum>(e)).toList()
+    if (t == List<_i70.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i70.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i69.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i69.TestEnum?>(e)).toList()
+    if (t == List<_i70.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i70.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i69.TestEnum>>) {
+    if (t == List<List<_i70.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i69.TestEnum>>(e))
+          .map((e) => deserialize<List<_i70.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i69.SimpleData>) {
+    if (t == Map<String, _i70.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -3317,9 +3327,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i70.ByteData>) {
+    if (t == Map<String, _i71.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i71.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -3332,9 +3342,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i69.SimpleData?>) {
+    if (t == Map<String, _i70.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i69.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i70.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -3345,9 +3355,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i70.ByteData?>) {
+    if (t == Map<String, _i71.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i71.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -3365,14 +3375,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i70.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -3400,9 +3410,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i70.ByteData>?>()) {
+    if (t == _i1.getType<List<_i71.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i71.ByteData>(e)).toList()
           : null) as dynamic;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -3415,42 +3425,42 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i70.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.TestEnum>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i70.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i69.TestEnumStringified>(e))
+              .map((e) => deserialize<_i70.TestEnumStringified>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i69.Types>?>()) {
+    if (t == _i1.getType<List<_i70.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i69.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.Types>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<Map<String, _i69.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i70.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i69.Types>>(e))
+              .map((e) => deserialize<Map<String, _i70.Types>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == Map<String, _i69.Types>) {
+    if (t == Map<String, _i70.Types>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.Types>(v)))
           as dynamic;
     }
-    if (t == _i1.getType<List<List<_i69.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i70.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i69.Types>>(e)).toList()
+          ? (data as List).map((e) => deserialize<List<_i70.Types>>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i69.Types>) {
-      return (data as List).map((e) => deserialize<_i69.Types>(e)).toList()
+    if (t == List<_i70.Types>) {
+      return (data as List).map((e) => deserialize<_i70.Types>(e)).toList()
           as dynamic;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -3483,10 +3493,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i70.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i71.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i70.ByteData>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i71.ByteData>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
     if (t == _i1.getType<Map<Duration, String>?>()) {
@@ -3501,41 +3511,41 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<_i1.UuidValue>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i69.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i70.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i69.TestEnum>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i70.TestEnum>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i69.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i70.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i69.TestEnumStringified>(e['k']),
+              deserialize<_i70.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i69.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i70.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i69.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i70.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<Map<_i69.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i70.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i69.Types, String>>(e['k']),
+              deserialize<Map<_i70.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == Map<_i69.Types, String>) {
+    if (t == Map<_i70.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i69.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i70.Types>(e['k']), deserialize<String>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<Map<List<_i69.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i70.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i69.Types>>(e['k']),
+              deserialize<List<_i70.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
@@ -3569,10 +3579,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i70.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i71.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i71.ByteData>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -3587,38 +3597,38 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i69.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i70.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.TestEnum>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i69.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i70.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i69.TestEnumStringified>(v)))
+              deserialize<String>(k), deserialize<_i70.TestEnumStringified>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i69.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i70.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.Types>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i69.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i70.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i69.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i70.Types>>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, List<_i69.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i70.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i69.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i70.Types>>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i71.Types>) {
-      return (data as List).map((e) => deserialize<_i71.Types>(e)).toList()
+    if (t == List<_i72.Types>) {
+      return (data as List).map((e) => deserialize<_i72.Types>(e)).toList()
           as dynamic;
     }
     if (t == List<bool>) {
@@ -3637,8 +3647,8 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<Duration>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i72.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i72.TestEnum>(e)).toList()
+    if (t == List<_i73.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i73.TestEnum>(e)).toList()
           as dynamic;
     }
     if (t == List<int>) {
@@ -3648,36 +3658,36 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i73.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i73.UuidValue>(e)).toList()
+    if (t == List<_i74.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i74.UuidValue>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i74.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i74.SimpleData>(e)).toList()
+    if (t == List<_i75.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i75.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i75.UniqueData>) {
-      return (data as List).map((e) => deserialize<_i75.UniqueData>(e)).toList()
+    if (t == List<_i76.UniqueData>) {
+      return (data as List).map((e) => deserialize<_i76.UniqueData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i76.Person>) {
-      return (data as List).map((e) => deserialize<_i76.Person>(e)).toList()
+    if (t == List<_i77.Person>) {
+      return (data as List).map((e) => deserialize<_i77.Person>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i77.Citizen>) {
-      return (data as List).map((e) => deserialize<_i77.Citizen>(e)).toList()
+    if (t == List<_i78.Citizen>) {
+      return (data as List).map((e) => deserialize<_i78.Citizen>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i78.Address>) {
-      return (data as List).map((e) => deserialize<_i78.Address>(e)).toList()
+    if (t == List<_i79.Address>) {
+      return (data as List).map((e) => deserialize<_i79.Address>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i79.Post>) {
-      return (data as List).map((e) => deserialize<_i79.Post>(e)).toList()
+    if (t == List<_i80.Post>) {
+      return (data as List).map((e) => deserialize<_i80.Post>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i80.Company>) {
-      return (data as List).map((e) => deserialize<_i80.Company>(e)).toList()
+    if (t == List<_i81.Company>) {
+      return (data as List).map((e) => deserialize<_i81.Company>(e)).toList()
           as dynamic;
     }
     if (t == List<List<int>>) {
@@ -3748,37 +3758,37 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i70.ByteData>) {
-      return (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
+    if (t == List<_i71.ByteData>) {
+      return (data as List).map((e) => deserialize<_i71.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i70.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i70.ByteData?>(e)).toList()
+    if (t == List<_i71.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i71.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i74.SimpleData?>) {
+    if (t == List<_i75.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i74.SimpleData?>(e))
+          .map((e) => deserialize<_i75.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i74.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i75.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i74.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i75.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i74.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i75.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i74.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i75.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration?>) {
@@ -3828,14 +3838,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i72.TestEnum, int>) {
+    if (t == Map<_i73.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i72.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i73.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i72.TestEnum>) {
+    if (t == Map<String, _i73.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i72.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i73.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -3874,47 +3884,47 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i70.ByteData>) {
+    if (t == Map<String, _i71.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i71.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i70.ByteData?>) {
+    if (t == Map<String, _i71.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i71.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i74.SimpleData>) {
+    if (t == Map<String, _i75.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i74.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i75.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i74.SimpleData?>) {
+    if (t == Map<String, _i75.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i74.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i75.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i74.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i75.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i74.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i75.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i74.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i75.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i74.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i75.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i74.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i75.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i74.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i75.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i74.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i75.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i74.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i75.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -3927,38 +3937,38 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == List<_i81.Customer>) {
-      return (data as List).map((e) => deserialize<_i81.Customer>(e)).toList()
+    if (t == List<_i82.Customer>) {
+      return (data as List).map((e) => deserialize<_i82.Customer>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i82.Comment>) {
-      return (data as List).map((e) => deserialize<_i82.Comment>(e)).toList()
+    if (t == List<_i83.Comment>) {
+      return (data as List).map((e) => deserialize<_i83.Comment>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i83.Order>) {
-      return (data as List).map((e) => deserialize<_i83.Order>(e)).toList()
+    if (t == List<_i84.Order>) {
+      return (data as List).map((e) => deserialize<_i84.Order>(e)).toList()
           as dynamic;
     }
-    if (t == _i84.CustomClass) {
-      return _i84.CustomClass.fromJson(data, this) as T;
+    if (t == _i85.CustomClass) {
+      return _i85.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i85.ExternalCustomClass) {
-      return _i85.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i86.ExternalCustomClass) {
+      return _i86.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i85.FreezedCustomClass) {
-      return _i85.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i86.FreezedCustomClass) {
+      return _i86.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i84.CustomClass?>()) {
-      return (data != null ? _i84.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i85.CustomClass?>()) {
+      return (data != null ? _i85.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i85.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i86.ExternalCustomClass?>()) {
       return (data != null
-          ? _i85.ExternalCustomClass.fromJson(data, this)
+          ? _i86.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i85.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i86.FreezedCustomClass?>()) {
       return (data != null
-          ? _i85.FreezedCustomClass.fromJson(data, this)
+          ? _i86.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
@@ -3984,13 +3994,13 @@ class Protocol extends _i1.SerializationManagerServer {
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    if (data is _i84.CustomClass) {
+    if (data is _i85.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i85.ExternalCustomClass) {
+    if (data is _i86.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i85.FreezedCustomClass) {
+    if (data is _i86.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i5.ExceptionWithData) {
@@ -4134,55 +4144,58 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i51.ScopeNoneFields) {
       return 'ScopeNoneFields';
     }
-    if (data is _i52.DefaultServerOnlyClass) {
+    if (data is _i52.ScopeServerOnlyField) {
+      return 'ScopeServerOnlyField';
+    }
+    if (data is _i53.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i53.DefaultServerOnlyEnum) {
+    if (data is _i54.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i54.NotServerOnlyClass) {
+    if (data is _i55.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i55.NotServerOnlyEnum) {
+    if (data is _i56.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i56.ServerOnlyClass) {
+    if (data is _i57.ServerOnlyClass) {
       return 'ServerOnlyClass';
     }
-    if (data is _i57.ServerOnlyEnum) {
+    if (data is _i58.ServerOnlyEnum) {
       return 'ServerOnlyEnum';
     }
-    if (data is _i58.SimpleData) {
+    if (data is _i59.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i59.SimpleDataList) {
+    if (data is _i60.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i60.SimpleDataMap) {
+    if (data is _i61.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i61.SimpleDataObject) {
+    if (data is _i62.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i62.SimpleDateTime) {
+    if (data is _i63.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i63.TestEnum) {
+    if (data is _i64.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i64.TestEnumStringified) {
+    if (data is _i65.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i65.Types) {
+    if (data is _i66.Types) {
       return 'Types';
     }
-    if (data is _i66.TypesList) {
+    if (data is _i67.TypesList) {
       return 'TypesList';
     }
-    if (data is _i67.TypesMap) {
+    if (data is _i68.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i68.UniqueData) {
+    if (data is _i69.UniqueData) {
       return 'UniqueData';
     }
     return super.getClassNameForObject(data);
@@ -4199,13 +4212,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return _i4.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i84.CustomClass>(data['data']);
+      return deserialize<_i85.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i85.ExternalCustomClass>(data['data']);
+      return deserialize<_i86.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i85.FreezedCustomClass>(data['data']);
+      return deserialize<_i86.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i5.ExceptionWithData>(data['data']);
@@ -4348,56 +4361,59 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'ScopeNoneFields') {
       return deserialize<_i51.ScopeNoneFields>(data['data']);
     }
+    if (data['className'] == 'ScopeServerOnlyField') {
+      return deserialize<_i52.ScopeServerOnlyField>(data['data']);
+    }
     if (data['className'] == 'DefaultServerOnlyClass') {
-      return deserialize<_i52.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i53.DefaultServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyEnum') {
-      return deserialize<_i53.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i54.DefaultServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyClass') {
-      return deserialize<_i54.NotServerOnlyClass>(data['data']);
+      return deserialize<_i55.NotServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyEnum') {
-      return deserialize<_i55.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i56.NotServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'ServerOnlyClass') {
-      return deserialize<_i56.ServerOnlyClass>(data['data']);
+      return deserialize<_i57.ServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'ServerOnlyEnum') {
-      return deserialize<_i57.ServerOnlyEnum>(data['data']);
+      return deserialize<_i58.ServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i58.SimpleData>(data['data']);
+      return deserialize<_i59.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i59.SimpleDataList>(data['data']);
+      return deserialize<_i60.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'SimpleDataMap') {
-      return deserialize<_i60.SimpleDataMap>(data['data']);
+      return deserialize<_i61.SimpleDataMap>(data['data']);
     }
     if (data['className'] == 'SimpleDataObject') {
-      return deserialize<_i61.SimpleDataObject>(data['data']);
+      return deserialize<_i62.SimpleDataObject>(data['data']);
     }
     if (data['className'] == 'SimpleDateTime') {
-      return deserialize<_i62.SimpleDateTime>(data['data']);
+      return deserialize<_i63.SimpleDateTime>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i63.TestEnum>(data['data']);
+      return deserialize<_i64.TestEnum>(data['data']);
     }
     if (data['className'] == 'TestEnumStringified') {
-      return deserialize<_i64.TestEnumStringified>(data['data']);
+      return deserialize<_i65.TestEnumStringified>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i65.Types>(data['data']);
+      return deserialize<_i66.Types>(data['data']);
     }
     if (data['className'] == 'TypesList') {
-      return deserialize<_i66.TypesList>(data['data']);
+      return deserialize<_i67.TypesList>(data['data']);
     }
     if (data['className'] == 'TypesMap') {
-      return deserialize<_i67.TypesMap>(data['data']);
+      return deserialize<_i68.TypesMap>(data['data']);
     }
     if (data['className'] == 'UniqueData') {
-      return deserialize<_i68.UniqueData>(data['data']);
+      return deserialize<_i69.UniqueData>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -4507,14 +4523,14 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i50.RelatedUniqueData.t;
       case _i51.ScopeNoneFields:
         return _i51.ScopeNoneFields.t;
-      case _i58.SimpleData:
-        return _i58.SimpleData.t;
-      case _i62.SimpleDateTime:
-        return _i62.SimpleDateTime.t;
-      case _i65.Types:
-        return _i65.Types.t;
-      case _i68.UniqueData:
-        return _i68.UniqueData.t;
+      case _i59.SimpleData:
+        return _i59.SimpleData.t;
+      case _i63.SimpleDateTime:
+        return _i63.SimpleDateTime.t;
+      case _i66.Types:
+        return _i66.Types.t;
+      case _i69.UniqueData:
+        return _i69.UniqueData.t;
     }
     return null;
   }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -75,36 +75,39 @@ import 'serverOnly/server_only_enum.dart' as _i57;
 import 'simple_data.dart' as _i58;
 import 'simple_data_list.dart' as _i59;
 import 'simple_data_map.dart' as _i60;
-import 'simple_date_time.dart' as _i61;
-import 'test_enum.dart' as _i62;
-import 'test_enum_stringified.dart' as _i63;
-import 'types.dart' as _i64;
-import 'unique_data.dart' as _i65;
-import 'protocol.dart' as _i66;
-import 'dart:typed_data' as _i67;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i68;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i69;
-import 'package:uuid/uuid_value.dart' as _i70;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i71;
-import 'package:serverpod_test_server/src/generated/unique_data.dart' as _i72;
+import 'simple_data_object.dart' as _i61;
+import 'simple_date_time.dart' as _i62;
+import 'test_enum.dart' as _i63;
+import 'test_enum_stringified.dart' as _i64;
+import 'types.dart' as _i65;
+import 'types_list.dart' as _i66;
+import 'types_map.dart' as _i67;
+import 'unique_data.dart' as _i68;
+import 'protocol.dart' as _i69;
+import 'dart:typed_data' as _i70;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i71;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i72;
+import 'package:uuid/uuid_value.dart' as _i73;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i74;
+import 'package:serverpod_test_server/src/generated/unique_data.dart' as _i75;
 import 'package:serverpod_test_server/src/generated/models_with_list_relations/person.dart'
-    as _i73;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/citizen.dart'
-    as _i74;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/address.dart'
-    as _i75;
-import 'package:serverpod_test_server/src/generated/models_with_relations/self_relation/one_to_one/post.dart'
     as _i76;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/company.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/citizen.dart'
     as _i77;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/customer.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/address.dart'
     as _i78;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/comment.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/self_relation/one_to_one/post.dart'
     as _i79;
-import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/order.dart'
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_one/company.dart'
     as _i80;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i81;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i82;
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/customer.dart'
+    as _i81;
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/comment.dart'
+    as _i82;
+import 'package:serverpod_test_server/src/generated/models_with_relations/one_to_many/order.dart'
+    as _i83;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i84;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i85;
 export 'exception_with_data.dart';
 export 'long_identifiers/max_field_name.dart';
 export 'long_identifiers/models_with_relations/long_implicit_id_field.dart';
@@ -161,10 +164,13 @@ export 'serverOnly/server_only_enum.dart';
 export 'simple_data.dart';
 export 'simple_data_list.dart';
 export 'simple_data_map.dart';
+export 'simple_data_object.dart';
 export 'simple_date_time.dart';
 export 'test_enum.dart';
 export 'test_enum_stringified.dart';
 export 'types.dart';
+export 'types_list.dart';
+export 'types_map.dart';
 export 'unique_data.dart';
 
 class Protocol extends _i1.SerializationManagerServer {
@@ -2797,20 +2803,29 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i60.SimpleDataMap) {
       return _i60.SimpleDataMap.fromJson(data, this) as T;
     }
-    if (t == _i61.SimpleDateTime) {
-      return _i61.SimpleDateTime.fromJson(data, this) as T;
+    if (t == _i61.SimpleDataObject) {
+      return _i61.SimpleDataObject.fromJson(data, this) as T;
     }
-    if (t == _i62.TestEnum) {
-      return _i62.TestEnum.fromJson(data) as T;
+    if (t == _i62.SimpleDateTime) {
+      return _i62.SimpleDateTime.fromJson(data, this) as T;
     }
-    if (t == _i63.TestEnumStringified) {
-      return _i63.TestEnumStringified.fromJson(data) as T;
+    if (t == _i63.TestEnum) {
+      return _i63.TestEnum.fromJson(data) as T;
     }
-    if (t == _i64.Types) {
-      return _i64.Types.fromJson(data, this) as T;
+    if (t == _i64.TestEnumStringified) {
+      return _i64.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i65.UniqueData) {
-      return _i65.UniqueData.fromJson(data, this) as T;
+    if (t == _i65.Types) {
+      return _i65.Types.fromJson(data, this) as T;
+    }
+    if (t == _i66.TypesList) {
+      return _i66.TypesList.fromJson(data, this) as T;
+    }
+    if (t == _i67.TypesMap) {
+      return _i67.TypesMap.fromJson(data, this) as T;
+    }
+    if (t == _i68.UniqueData) {
+      return _i68.UniqueData.fromJson(data, this) as T;
     }
     if (t == _i1.getType<_i5.ExceptionWithData?>()) {
       return (data != null ? _i5.ExceptionWithData.fromJson(data, this) : null)
@@ -3022,108 +3037,118 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i60.SimpleDataMap.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i61.SimpleDateTime?>()) {
-      return (data != null ? _i61.SimpleDateTime.fromJson(data, this) : null)
+    if (t == _i1.getType<_i61.SimpleDataObject?>()) {
+      return (data != null ? _i61.SimpleDataObject.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i62.TestEnum?>()) {
-      return (data != null ? _i62.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i63.TestEnumStringified?>()) {
-      return (data != null ? _i63.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i62.SimpleDateTime?>()) {
+      return (data != null ? _i62.SimpleDateTime.fromJson(data, this) : null)
           as T;
     }
-    if (t == _i1.getType<_i64.Types?>()) {
-      return (data != null ? _i64.Types.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i63.TestEnum?>()) {
+      return (data != null ? _i63.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i65.UniqueData?>()) {
-      return (data != null ? _i65.UniqueData.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i64.TestEnumStringified?>()) {
+      return (data != null ? _i64.TestEnumStringified.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i65.Types?>()) {
+      return (data != null ? _i65.Types.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i66.TypesList?>()) {
+      return (data != null ? _i66.TypesList.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i67.TypesMap?>()) {
+      return (data != null ? _i67.TypesMap.fromJson(data, this) : null) as T;
+    }
+    if (t == _i1.getType<_i68.UniqueData?>()) {
+      return (data != null ? _i68.UniqueData.fromJson(data, this) : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i66.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i69.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i66.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i69.LongImplicitIdField>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i69.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i66.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i69.MultipleMaxFieldName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.UserNote>?>()) {
+    if (t == _i1.getType<List<_i69.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.UserNote>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i69.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i66.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i69.UserNoteWithALongName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Person>?>()) {
+    if (t == _i1.getType<List<_i69.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Organization>?>()) {
+    if (t == _i1.getType<List<_i69.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i66.Organization>(e))
+              .map((e) => deserialize<_i69.Organization>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Person>?>()) {
+    if (t == _i1.getType<List<_i69.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i69.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i69.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Player>?>()) {
+    if (t == _i1.getType<List<_i69.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Player>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Order>?>()) {
+    if (t == _i1.getType<List<_i69.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Order>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Comment>?>()) {
+    if (t == _i1.getType<List<_i69.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Comment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Blocking>?>()) {
+    if (t == _i1.getType<List<_i69.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Blocking>?>()) {
+    if (t == _i1.getType<List<_i69.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.Cat>?>()) {
+    if (t == _i1.getType<List<_i69.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.Cat>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<_i4.ModuleClass>) {
@@ -3152,23 +3177,23 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i66.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i66.SimpleData>(e)).toList()
+    if (t == List<_i69.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i66.SimpleData?>) {
+    if (t == List<_i69.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i66.SimpleData?>(e))
+          .map((e) => deserialize<_i69.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<DateTime>) {
@@ -3189,22 +3214,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i67.ByteData>) {
-      return (data as List).map((e) => deserialize<_i67.ByteData>(e)).toList()
+    if (t == List<_i70.ByteData>) {
+      return (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i67.ByteData>?>()) {
+    if (t == _i1.getType<List<_i70.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i67.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i67.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i67.ByteData?>(e)).toList()
+    if (t == List<_i70.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i70.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i67.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i70.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i67.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i70.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -3265,22 +3290,22 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == List<_i66.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i66.TestEnum>(e)).toList()
+    if (t == List<_i69.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i69.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i66.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i66.TestEnum?>(e)).toList()
+    if (t == List<_i69.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i69.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i66.TestEnum>>) {
+    if (t == List<List<_i69.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i66.TestEnum>>(e))
+          .map((e) => deserialize<List<_i69.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i66.SimpleData>) {
+    if (t == Map<String, _i69.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i66.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i69.SimpleData>(v)))
           as dynamic;
     }
     if (t == Map<String, String>) {
@@ -3292,9 +3317,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i67.ByteData>) {
+    if (t == Map<String, _i70.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i67.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -3307,9 +3332,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i66.SimpleData?>) {
+    if (t == Map<String, _i69.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i66.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i69.SimpleData?>(v))) as dynamic;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -3320,9 +3345,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i67.ByteData?>) {
+    if (t == Map<String, _i70.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i67.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -3340,18 +3365,260 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i66.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i69.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i66.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i68.Types>) {
-      return (data as List).map((e) => deserialize<_i68.Types>(e)).toList()
+    if (t == _i1.getType<List<int>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<int>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<bool>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<bool>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<double>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<double>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<DateTime>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<DateTime>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<String>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<String>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i70.ByteData>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<Duration>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<Duration>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i1.UuidValue>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i69.TestEnum>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i69.TestEnum>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i69.TestEnumStringified>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<_i69.TestEnumStringified>(e))
+              .toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<_i69.Types>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<_i69.Types>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<List<Map<String, _i69.Types>>?>()) {
+      return (data != null
+          ? (data as List)
+              .map((e) => deserialize<Map<String, _i69.Types>>(e))
+              .toList()
+          : null) as dynamic;
+    }
+    if (t == Map<String, _i69.Types>) {
+      return (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i69.Types>(v)))
+          as dynamic;
+    }
+    if (t == _i1.getType<List<List<_i69.Types>>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<List<_i69.Types>>(e)).toList()
+          : null) as dynamic;
+    }
+    if (t == List<_i69.Types>) {
+      return (data as List).map((e) => deserialize<_i69.Types>(e)).toList()
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<int, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) =>
+              MapEntry(deserialize<int>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<bool, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) =>
+              MapEntry(deserialize<bool>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<double, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<double>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<DateTime, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<DateTime>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, String>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<String>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i70.ByteData, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i70.ByteData>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<Duration, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<Duration>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i1.UuidValue, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i1.UuidValue>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i69.TestEnum, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i69.TestEnum>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i69.TestEnumStringified, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i69.TestEnumStringified>(e['k']),
+              deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<_i69.Types, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i69.Types>(e['k']), deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<Map<_i69.Types, String>, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<Map<_i69.Types, String>>(e['k']),
+              deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == Map<_i69.Types, String>) {
+      return Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<_i69.Types>(e['k']), deserialize<String>(e['v']))))
+          as dynamic;
+    }
+    if (t == _i1.getType<Map<List<_i69.Types>, String>?>()) {
+      return (data != null
+          ? Map.fromEntries((data as List).map((e) => MapEntry(
+              deserialize<List<_i69.Types>>(e['k']),
+              deserialize<String>(e['v']))))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, int>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<int>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, bool>?>()) {
+      return (data != null
+          ? (data as Map).map(
+              (k, v) => MapEntry(deserialize<String>(k), deserialize<bool>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, double>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<double>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, DateTime>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, String>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<String>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i70.ByteData>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, Duration>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<Duration>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i1.UuidValue>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i69.TestEnum>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i69.TestEnum>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i69.TestEnumStringified>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<_i69.TestEnumStringified>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, _i69.Types>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) =>
+              MapEntry(deserialize<String>(k), deserialize<_i69.Types>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, Map<String, _i69.Types>>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<Map<String, _i69.Types>>(v)))
+          : null) as dynamic;
+    }
+    if (t == _i1.getType<Map<String, List<_i69.Types>>?>()) {
+      return (data != null
+          ? (data as Map).map((k, v) => MapEntry(
+              deserialize<String>(k), deserialize<List<_i69.Types>>(v)))
+          : null) as dynamic;
+    }
+    if (t == List<_i71.Types>) {
+      return (data as List).map((e) => deserialize<_i71.Types>(e)).toList()
           as dynamic;
     }
     if (t == List<bool>) {
@@ -3370,8 +3637,8 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<Duration>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i69.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i69.TestEnum>(e)).toList()
+    if (t == List<_i72.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i72.TestEnum>(e)).toList()
           as dynamic;
     }
     if (t == List<int>) {
@@ -3381,36 +3648,36 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i70.UuidValue>) {
-      return (data as List).map((e) => deserialize<_i70.UuidValue>(e)).toList()
+    if (t == List<_i73.UuidValue>) {
+      return (data as List).map((e) => deserialize<_i73.UuidValue>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i71.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i71.SimpleData>(e)).toList()
+    if (t == List<_i74.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i74.SimpleData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i72.UniqueData>) {
-      return (data as List).map((e) => deserialize<_i72.UniqueData>(e)).toList()
+    if (t == List<_i75.UniqueData>) {
+      return (data as List).map((e) => deserialize<_i75.UniqueData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i73.Person>) {
-      return (data as List).map((e) => deserialize<_i73.Person>(e)).toList()
+    if (t == List<_i76.Person>) {
+      return (data as List).map((e) => deserialize<_i76.Person>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i74.Citizen>) {
-      return (data as List).map((e) => deserialize<_i74.Citizen>(e)).toList()
+    if (t == List<_i77.Citizen>) {
+      return (data as List).map((e) => deserialize<_i77.Citizen>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i75.Address>) {
-      return (data as List).map((e) => deserialize<_i75.Address>(e)).toList()
+    if (t == List<_i78.Address>) {
+      return (data as List).map((e) => deserialize<_i78.Address>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i76.Post>) {
-      return (data as List).map((e) => deserialize<_i76.Post>(e)).toList()
+    if (t == List<_i79.Post>) {
+      return (data as List).map((e) => deserialize<_i79.Post>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i77.Company>) {
-      return (data as List).map((e) => deserialize<_i77.Company>(e)).toList()
+    if (t == List<_i80.Company>) {
+      return (data as List).map((e) => deserialize<_i80.Company>(e)).toList()
           as dynamic;
     }
     if (t == List<List<int>>) {
@@ -3481,37 +3748,37 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i67.ByteData>) {
-      return (data as List).map((e) => deserialize<_i67.ByteData>(e)).toList()
+    if (t == List<_i70.ByteData>) {
+      return (data as List).map((e) => deserialize<_i70.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i67.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i67.ByteData?>(e)).toList()
+    if (t == List<_i70.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i70.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i71.SimpleData?>) {
+    if (t == List<_i74.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i71.SimpleData?>(e))
+          .map((e) => deserialize<_i74.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i71.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i74.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i71.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i74.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i71.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i74.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i71.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i74.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i71.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i74.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i71.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i74.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i71.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i74.SimpleData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i71.SimpleData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i74.SimpleData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration?>) {
@@ -3561,14 +3828,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i69.TestEnum, int>) {
+    if (t == Map<_i72.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i69.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i72.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i69.TestEnum>) {
+    if (t == Map<String, _i72.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i69.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i72.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -3607,47 +3874,47 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i67.ByteData>) {
+    if (t == Map<String, _i70.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i67.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i67.ByteData?>) {
+    if (t == Map<String, _i70.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i67.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i70.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i71.SimpleData>) {
+    if (t == Map<String, _i74.SimpleData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i71.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i74.SimpleData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i71.SimpleData?>) {
+    if (t == Map<String, _i74.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i71.SimpleData?>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i74.SimpleData?>(v))) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i71.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i74.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i71.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i74.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i71.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i74.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i71.SimpleData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i74.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i71.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i74.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i71.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i74.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i71.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i74.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i71.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i74.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -3660,38 +3927,38 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == List<_i78.Customer>) {
-      return (data as List).map((e) => deserialize<_i78.Customer>(e)).toList()
+    if (t == List<_i81.Customer>) {
+      return (data as List).map((e) => deserialize<_i81.Customer>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i79.Comment>) {
-      return (data as List).map((e) => deserialize<_i79.Comment>(e)).toList()
+    if (t == List<_i82.Comment>) {
+      return (data as List).map((e) => deserialize<_i82.Comment>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i80.Order>) {
-      return (data as List).map((e) => deserialize<_i80.Order>(e)).toList()
+    if (t == List<_i83.Order>) {
+      return (data as List).map((e) => deserialize<_i83.Order>(e)).toList()
           as dynamic;
     }
-    if (t == _i81.CustomClass) {
-      return _i81.CustomClass.fromJson(data, this) as T;
+    if (t == _i84.CustomClass) {
+      return _i84.CustomClass.fromJson(data, this) as T;
     }
-    if (t == _i82.ExternalCustomClass) {
-      return _i82.ExternalCustomClass.fromJson(data, this) as T;
+    if (t == _i85.ExternalCustomClass) {
+      return _i85.ExternalCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i82.FreezedCustomClass) {
-      return _i82.FreezedCustomClass.fromJson(data, this) as T;
+    if (t == _i85.FreezedCustomClass) {
+      return _i85.FreezedCustomClass.fromJson(data, this) as T;
     }
-    if (t == _i1.getType<_i81.CustomClass?>()) {
-      return (data != null ? _i81.CustomClass.fromJson(data, this) : null) as T;
+    if (t == _i1.getType<_i84.CustomClass?>()) {
+      return (data != null ? _i84.CustomClass.fromJson(data, this) : null) as T;
     }
-    if (t == _i1.getType<_i82.ExternalCustomClass?>()) {
+    if (t == _i1.getType<_i85.ExternalCustomClass?>()) {
       return (data != null
-          ? _i82.ExternalCustomClass.fromJson(data, this)
+          ? _i85.ExternalCustomClass.fromJson(data, this)
           : null) as T;
     }
-    if (t == _i1.getType<_i82.FreezedCustomClass?>()) {
+    if (t == _i1.getType<_i85.FreezedCustomClass?>()) {
       return (data != null
-          ? _i82.FreezedCustomClass.fromJson(data, this)
+          ? _i85.FreezedCustomClass.fromJson(data, this)
           : null) as T;
     }
     try {
@@ -3717,13 +3984,13 @@ class Protocol extends _i1.SerializationManagerServer {
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
-    if (data is _i81.CustomClass) {
+    if (data is _i84.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i82.ExternalCustomClass) {
+    if (data is _i85.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i82.FreezedCustomClass) {
+    if (data is _i85.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i5.ExceptionWithData) {
@@ -3894,19 +4161,28 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i60.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i61.SimpleDateTime) {
+    if (data is _i61.SimpleDataObject) {
+      return 'SimpleDataObject';
+    }
+    if (data is _i62.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i62.TestEnum) {
+    if (data is _i63.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i63.TestEnumStringified) {
+    if (data is _i64.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i64.Types) {
+    if (data is _i65.Types) {
       return 'Types';
     }
-    if (data is _i65.UniqueData) {
+    if (data is _i66.TypesList) {
+      return 'TypesList';
+    }
+    if (data is _i67.TypesMap) {
+      return 'TypesMap';
+    }
+    if (data is _i68.UniqueData) {
       return 'UniqueData';
     }
     return super.getClassNameForObject(data);
@@ -3923,13 +4199,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return _i4.Protocol().deserializeByClassName(data);
     }
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i81.CustomClass>(data['data']);
+      return deserialize<_i84.CustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i82.ExternalCustomClass>(data['data']);
+      return deserialize<_i85.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i82.FreezedCustomClass>(data['data']);
+      return deserialize<_i85.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'ExceptionWithData') {
       return deserialize<_i5.ExceptionWithData>(data['data']);
@@ -4099,20 +4375,29 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'SimpleDataMap') {
       return deserialize<_i60.SimpleDataMap>(data['data']);
     }
+    if (data['className'] == 'SimpleDataObject') {
+      return deserialize<_i61.SimpleDataObject>(data['data']);
+    }
     if (data['className'] == 'SimpleDateTime') {
-      return deserialize<_i61.SimpleDateTime>(data['data']);
+      return deserialize<_i62.SimpleDateTime>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i62.TestEnum>(data['data']);
+      return deserialize<_i63.TestEnum>(data['data']);
     }
     if (data['className'] == 'TestEnumStringified') {
-      return deserialize<_i63.TestEnumStringified>(data['data']);
+      return deserialize<_i64.TestEnumStringified>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i64.Types>(data['data']);
+      return deserialize<_i65.Types>(data['data']);
+    }
+    if (data['className'] == 'TypesList') {
+      return deserialize<_i66.TypesList>(data['data']);
+    }
+    if (data['className'] == 'TypesMap') {
+      return deserialize<_i67.TypesMap>(data['data']);
     }
     if (data['className'] == 'UniqueData') {
-      return deserialize<_i65.UniqueData>(data['data']);
+      return deserialize<_i68.UniqueData>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -4224,12 +4509,12 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i51.ScopeNoneFields.t;
       case _i58.SimpleData:
         return _i58.SimpleData.t;
-      case _i61.SimpleDateTime:
-        return _i61.SimpleDateTime.t;
-      case _i64.Types:
-        return _i64.Types.t;
-      case _i65.UniqueData:
-        return _i65.UniqueData.t;
+      case _i62.SimpleDateTime:
+        return _i62.SimpleDateTime.t;
+      case _i65.Types:
+        return _i65.Types.t;
+      case _i68.UniqueData:
+        return _i68.UniqueData.t;
     }
     return null;
   }

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -74,7 +74,7 @@ abstract class RelatedUniqueData extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'uniqueDataId': uniqueDataId,
       'number': number,
     };
@@ -85,7 +85,7 @@ abstract class RelatedUniqueData extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'uniqueDataId': uniqueDataId,
-      if (uniqueData != null) 'uniqueData': uniqueData?.toJson(),
+      if (uniqueData != null) 'uniqueData': uniqueData?.allToJson(),
       'number': number,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -65,7 +65,7 @@ abstract class RelatedUniqueData extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'uniqueDataId': uniqueDataId,
-      if (uniqueData != null) 'uniqueData': uniqueData,
+      if (uniqueData != null) 'uniqueData': uniqueData?.toJson(),
       'number': number,
     };
   }
@@ -85,7 +85,7 @@ abstract class RelatedUniqueData extends _i1.TableRow {
     return {
       if (id != null) 'id': id,
       'uniqueDataId': uniqueDataId,
-      if (uniqueData != null) 'uniqueData': uniqueData,
+      if (uniqueData != null) 'uniqueData': uniqueData?.toJson(),
       'number': number,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -42,8 +42,8 @@ abstract class ScopeNoneFields extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      if (_name != null) 'name': _name,
+      'id': id,
+      'name': _name,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field.dart
@@ -1,0 +1,100 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ScopeServerOnlyField extends _i1.SerializableEntity {
+  ScopeServerOnlyField._({
+    this.allScope,
+    this.serverOnlyScope,
+    this.nested,
+  });
+
+  factory ScopeServerOnlyField({
+    _i2.Types? allScope,
+    _i2.Types? serverOnlyScope,
+    _i2.ScopeServerOnlyField? nested,
+  }) = _ScopeServerOnlyFieldImpl;
+
+  factory ScopeServerOnlyField.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return ScopeServerOnlyField(
+      allScope: serializationManager
+          .deserialize<_i2.Types?>(jsonSerialization['allScope']),
+      serverOnlyScope: serializationManager
+          .deserialize<_i2.Types?>(jsonSerialization['serverOnlyScope']),
+      nested: serializationManager
+          .deserialize<_i2.ScopeServerOnlyField?>(jsonSerialization['nested']),
+    );
+  }
+
+  _i2.Types? allScope;
+
+  _i2.Types? serverOnlyScope;
+
+  _i2.ScopeServerOnlyField? nested;
+
+  ScopeServerOnlyField copyWith({
+    _i2.Types? allScope,
+    _i2.Types? serverOnlyScope,
+    _i2.ScopeServerOnlyField? nested,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (allScope != null) 'allScope': allScope?.toJson(),
+      if (nested != null) 'nested': nested?.toJson(),
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      if (allScope != null) 'allScope': allScope?.allToJson(),
+      if (serverOnlyScope != null)
+        'serverOnlyScope': serverOnlyScope?.allToJson(),
+      if (nested != null) 'nested': nested?.allToJson(),
+    };
+  }
+}
+
+class _Undefined {}
+
+class _ScopeServerOnlyFieldImpl extends ScopeServerOnlyField {
+  _ScopeServerOnlyFieldImpl({
+    _i2.Types? allScope,
+    _i2.Types? serverOnlyScope,
+    _i2.ScopeServerOnlyField? nested,
+  }) : super._(
+          allScope: allScope,
+          serverOnlyScope: serverOnlyScope,
+          nested: nested,
+        );
+
+  @override
+  ScopeServerOnlyField copyWith({
+    Object? allScope = _Undefined,
+    Object? serverOnlyScope = _Undefined,
+    Object? nested = _Undefined,
+  }) {
+    return ScopeServerOnlyField(
+      allScope: allScope is _i2.Types? ? allScope : this.allScope?.copyWith(),
+      serverOnlyScope: serverOnlyScope is _i2.Types?
+          ? serverOnlyScope
+          : this.serverOnlyScope?.copyWith(),
+      nested: nested is _i2.ScopeServerOnlyField?
+          ? nested
+          : this.nested?.copyWith(),
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -60,7 +60,7 @@ abstract class SimpleData extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'num': num,
     };
   }

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataList extends _i1.SerializableEntity {
   SimpleDataList._({required this.rows});
@@ -31,12 +32,12 @@ abstract class SimpleDataList extends _i1.SerializableEntity {
   SimpleDataList copyWith({List<_i2.SimpleData>? rows});
   @override
   Map<String, dynamic> toJson() {
-    return {'rows': rows};
+    return {'rows': rows.toJson(valueToJson: (v) => v.toJson())};
   }
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'rows': rows};
+    return {'rows': rows.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
@@ -37,7 +37,7 @@ abstract class SimpleDataList extends _i1.SerializableEntity {
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'rows': rows.toJson(valueToJson: (v) => v.toJson())};
+    return {'rows': rows.toJson(valueToJson: (v) => v.allToJson())};
   }
 }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
@@ -37,7 +37,7 @@ abstract class SimpleDataMap extends _i1.SerializableEntity {
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'data': data.toJson(valueToJson: (v) => v.toJson())};
+    return {'data': data.toJson(valueToJson: (v) => v.allToJson())};
   }
 }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
@@ -10,6 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataMap extends _i1.SerializableEntity {
   SimpleDataMap._({required this.data});
@@ -31,12 +32,12 @@ abstract class SimpleDataMap extends _i1.SerializableEntity {
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data});
   @override
   Map<String, dynamic> toJson() {
-    return {'data': data};
+    return {'data': data.toJson(valueToJson: (v) => v.toJson())};
   }
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'data': data};
+    return {'data': data.toJson(valueToJson: (v) => v.toJson())};
   }
 }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
@@ -10,7 +10,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class SimpleDataObject extends _i1.SerializableEntity {
   SimpleDataObject._({required this.object});

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
@@ -36,7 +36,7 @@ abstract class SimpleDataObject extends _i1.SerializableEntity {
 
   @override
   Map<String, dynamic> allToJson() {
-    return {'object': object.toJson()};
+    return {'object': object.allToJson()};
   }
 }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
@@ -1,0 +1,52 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+abstract class SimpleDataObject extends _i1.SerializableEntity {
+  SimpleDataObject._({required this.object});
+
+  factory SimpleDataObject({required _i2.SimpleData object}) =
+      _SimpleDataObjectImpl;
+
+  factory SimpleDataObject.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return SimpleDataObject(
+        object: serializationManager
+            .deserialize<_i2.SimpleData>(jsonSerialization['object']));
+  }
+
+  _i2.SimpleData object;
+
+  SimpleDataObject copyWith({_i2.SimpleData? object});
+  @override
+  Map<String, dynamic> toJson() {
+    return {'object': object.toJson()};
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {'object': object.toJson()};
+  }
+}
+
+class _SimpleDataObjectImpl extends SimpleDataObject {
+  _SimpleDataObjectImpl({required _i2.SimpleData object})
+      : super._(object: object);
+
+  @override
+  SimpleDataObject copyWith({_i2.SimpleData? object}) {
+    return SimpleDataObject(object: object ?? this.object.copyWith());
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -9,6 +9,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Just some simple data.
 abstract class SimpleDateTime extends _i1.TableRow {
@@ -51,7 +52,7 @@ abstract class SimpleDateTime extends _i1.TableRow {
   Map<String, dynamic> toJson() {
     return {
       if (id != null) 'id': id,
-      'dateTime': dateTime,
+      'dateTime': dateTime.toJson(),
     };
   }
 
@@ -60,7 +61,7 @@ abstract class SimpleDateTime extends _i1.TableRow {
   Map<String, dynamic> toJsonForDatabase() {
     return {
       if (id != null) 'id': id,
-      'dateTime': dateTime,
+      'dateTime': dateTime.toJson(),
     };
   }
 
@@ -68,7 +69,7 @@ abstract class SimpleDateTime extends _i1.TableRow {
   Map<String, dynamic> allToJson() {
     return {
       if (id != null) 'id': id,
-      'dateTime': dateTime,
+      'dateTime': dateTime.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -60,8 +60,8 @@ abstract class SimpleDateTime extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      'dateTime': dateTime.toJson(),
+      'id': id,
+      'dateTime': dateTime,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -11,6 +11,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 abstract class Types extends _i1.TableRow {
   Types._({
@@ -117,13 +118,14 @@ abstract class Types extends _i1.TableRow {
       if (anInt != null) 'anInt': anInt,
       if (aBool != null) 'aBool': aBool,
       if (aDouble != null) 'aDouble': aDouble,
-      if (aDateTime != null) 'aDateTime': aDateTime,
+      if (aDateTime != null) 'aDateTime': aDateTime?.toJson(),
       if (aString != null) 'aString': aString,
-      if (aByteData != null) 'aByteData': aByteData,
-      if (aDuration != null) 'aDuration': aDuration,
-      if (aUuid != null) 'aUuid': aUuid,
-      if (anEnum != null) 'anEnum': anEnum,
-      if (aStringifiedEnum != null) 'aStringifiedEnum': aStringifiedEnum,
+      if (aByteData != null) 'aByteData': aByteData?.toJson(),
+      if (aDuration != null) 'aDuration': aDuration?.toJson(),
+      if (aUuid != null) 'aUuid': aUuid?.toJson(),
+      if (anEnum != null) 'anEnum': anEnum?.toJson(),
+      if (aStringifiedEnum != null)
+        'aStringifiedEnum': aStringifiedEnum?.toJson(),
     };
   }
 
@@ -135,13 +137,14 @@ abstract class Types extends _i1.TableRow {
       if (anInt != null) 'anInt': anInt,
       if (aBool != null) 'aBool': aBool,
       if (aDouble != null) 'aDouble': aDouble,
-      if (aDateTime != null) 'aDateTime': aDateTime,
+      if (aDateTime != null) 'aDateTime': aDateTime?.toJson(),
       if (aString != null) 'aString': aString,
-      if (aByteData != null) 'aByteData': aByteData,
-      if (aDuration != null) 'aDuration': aDuration,
-      if (aUuid != null) 'aUuid': aUuid,
-      if (anEnum != null) 'anEnum': anEnum,
-      if (aStringifiedEnum != null) 'aStringifiedEnum': aStringifiedEnum,
+      if (aByteData != null) 'aByteData': aByteData?.toJson(),
+      if (aDuration != null) 'aDuration': aDuration?.toJson(),
+      if (aUuid != null) 'aUuid': aUuid?.toJson(),
+      if (anEnum != null) 'anEnum': anEnum?.toJson(),
+      if (aStringifiedEnum != null)
+        'aStringifiedEnum': aStringifiedEnum?.toJson(),
     };
   }
 
@@ -152,13 +155,14 @@ abstract class Types extends _i1.TableRow {
       if (anInt != null) 'anInt': anInt,
       if (aBool != null) 'aBool': aBool,
       if (aDouble != null) 'aDouble': aDouble,
-      if (aDateTime != null) 'aDateTime': aDateTime,
+      if (aDateTime != null) 'aDateTime': aDateTime?.toJson(),
       if (aString != null) 'aString': aString,
-      if (aByteData != null) 'aByteData': aByteData,
-      if (aDuration != null) 'aDuration': aDuration,
-      if (aUuid != null) 'aUuid': aUuid,
-      if (anEnum != null) 'anEnum': anEnum,
-      if (aStringifiedEnum != null) 'aStringifiedEnum': aStringifiedEnum,
+      if (aByteData != null) 'aByteData': aByteData?.toJson(),
+      if (aDuration != null) 'aDuration': aDuration?.toJson(),
+      if (aUuid != null) 'aUuid': aUuid?.toJson(),
+      if (anEnum != null) 'anEnum': anEnum?.toJson(),
+      if (aStringifiedEnum != null)
+        'aStringifiedEnum': aStringifiedEnum?.toJson(),
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -133,18 +133,17 @@ abstract class Types extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
-      if (anInt != null) 'anInt': anInt,
-      if (aBool != null) 'aBool': aBool,
-      if (aDouble != null) 'aDouble': aDouble,
-      if (aDateTime != null) 'aDateTime': aDateTime?.toJson(),
-      if (aString != null) 'aString': aString,
-      if (aByteData != null) 'aByteData': aByteData?.toJson(),
-      if (aDuration != null) 'aDuration': aDuration?.toJson(),
-      if (aUuid != null) 'aUuid': aUuid?.toJson(),
-      if (anEnum != null) 'anEnum': anEnum?.toJson(),
-      if (aStringifiedEnum != null)
-        'aStringifiedEnum': aStringifiedEnum?.toJson(),
+      'id': id,
+      'anInt': anInt,
+      'aBool': aBool,
+      'aDouble': aDouble,
+      'aDateTime': aDateTime,
+      'aString': aString,
+      'aByteData': aByteData,
+      'aDuration': aDuration,
+      'aUuid': aUuid,
+      'anEnum': anEnum,
+      'aStringifiedEnum': aStringifiedEnum,
     };
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/types_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types_list.dart
@@ -1,0 +1,258 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:typed_data' as _i2;
+import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+abstract class TypesList extends _i1.SerializableEntity {
+  TypesList._({
+    this.anInt,
+    this.aBool,
+    this.aDouble,
+    this.aDateTime,
+    this.aString,
+    this.aByteData,
+    this.aDuration,
+    this.aUuid,
+    this.anEnum,
+    this.aStringifiedEnum,
+    this.anObject,
+    this.aMap,
+    this.aList,
+  });
+
+  factory TypesList({
+    List<int>? anInt,
+    List<bool>? aBool,
+    List<double>? aDouble,
+    List<DateTime>? aDateTime,
+    List<String>? aString,
+    List<_i2.ByteData>? aByteData,
+    List<Duration>? aDuration,
+    List<_i1.UuidValue>? aUuid,
+    List<_i3.TestEnum>? anEnum,
+    List<_i3.TestEnumStringified>? aStringifiedEnum,
+    List<_i3.Types>? anObject,
+    List<Map<String, _i3.Types>>? aMap,
+    List<List<_i3.Types>>? aList,
+  }) = _TypesListImpl;
+
+  factory TypesList.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return TypesList(
+      anInt: serializationManager
+          .deserialize<List<int>?>(jsonSerialization['anInt']),
+      aBool: serializationManager
+          .deserialize<List<bool>?>(jsonSerialization['aBool']),
+      aDouble: serializationManager
+          .deserialize<List<double>?>(jsonSerialization['aDouble']),
+      aDateTime: serializationManager
+          .deserialize<List<DateTime>?>(jsonSerialization['aDateTime']),
+      aString: serializationManager
+          .deserialize<List<String>?>(jsonSerialization['aString']),
+      aByteData: serializationManager
+          .deserialize<List<_i2.ByteData>?>(jsonSerialization['aByteData']),
+      aDuration: serializationManager
+          .deserialize<List<Duration>?>(jsonSerialization['aDuration']),
+      aUuid: serializationManager
+          .deserialize<List<_i1.UuidValue>?>(jsonSerialization['aUuid']),
+      anEnum: serializationManager
+          .deserialize<List<_i3.TestEnum>?>(jsonSerialization['anEnum']),
+      aStringifiedEnum:
+          serializationManager.deserialize<List<_i3.TestEnumStringified>?>(
+              jsonSerialization['aStringifiedEnum']),
+      anObject: serializationManager
+          .deserialize<List<_i3.Types>?>(jsonSerialization['anObject']),
+      aMap: serializationManager.deserialize<List<Map<String, _i3.Types>>?>(
+          jsonSerialization['aMap']),
+      aList: serializationManager
+          .deserialize<List<List<_i3.Types>>?>(jsonSerialization['aList']),
+    );
+  }
+
+  List<int>? anInt;
+
+  List<bool>? aBool;
+
+  List<double>? aDouble;
+
+  List<DateTime>? aDateTime;
+
+  List<String>? aString;
+
+  List<_i2.ByteData>? aByteData;
+
+  List<Duration>? aDuration;
+
+  List<_i1.UuidValue>? aUuid;
+
+  List<_i3.TestEnum>? anEnum;
+
+  List<_i3.TestEnumStringified>? aStringifiedEnum;
+
+  List<_i3.Types>? anObject;
+
+  List<Map<String, _i3.Types>>? aMap;
+
+  List<List<_i3.Types>>? aList;
+
+  TypesList copyWith({
+    List<int>? anInt,
+    List<bool>? aBool,
+    List<double>? aDouble,
+    List<DateTime>? aDateTime,
+    List<String>? aString,
+    List<_i2.ByteData>? aByteData,
+    List<Duration>? aDuration,
+    List<_i1.UuidValue>? aUuid,
+    List<_i3.TestEnum>? anEnum,
+    List<_i3.TestEnumStringified>? aStringifiedEnum,
+    List<_i3.Types>? anObject,
+    List<Map<String, _i3.Types>>? aMap,
+    List<List<_i3.Types>>? aList,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (anInt != null) 'anInt': anInt?.toJson(),
+      if (aBool != null) 'aBool': aBool?.toJson(),
+      if (aDouble != null) 'aDouble': aDouble?.toJson(),
+      if (aDateTime != null)
+        'aDateTime': aDateTime?.toJson(valueToJson: (v) => v.toJson()),
+      if (aString != null) 'aString': aString?.toJson(),
+      if (aByteData != null)
+        'aByteData': aByteData?.toJson(valueToJson: (v) => v.toJson()),
+      if (aDuration != null)
+        'aDuration': aDuration?.toJson(valueToJson: (v) => v.toJson()),
+      if (aUuid != null) 'aUuid': aUuid?.toJson(valueToJson: (v) => v.toJson()),
+      if (anEnum != null)
+        'anEnum': anEnum?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringifiedEnum != null)
+        'aStringifiedEnum':
+            aStringifiedEnum?.toJson(valueToJson: (v) => v.toJson()),
+      if (anObject != null)
+        'anObject': anObject?.toJson(valueToJson: (v) => v.toJson()),
+      if (aMap != null)
+        'aMap': aMap?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+      if (aList != null)
+        'aList': aList?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      if (anInt != null) 'anInt': anInt?.toJson(),
+      if (aBool != null) 'aBool': aBool?.toJson(),
+      if (aDouble != null) 'aDouble': aDouble?.toJson(),
+      if (aDateTime != null)
+        'aDateTime': aDateTime?.toJson(valueToJson: (v) => v.toJson()),
+      if (aString != null) 'aString': aString?.toJson(),
+      if (aByteData != null)
+        'aByteData': aByteData?.toJson(valueToJson: (v) => v.toJson()),
+      if (aDuration != null)
+        'aDuration': aDuration?.toJson(valueToJson: (v) => v.toJson()),
+      if (aUuid != null) 'aUuid': aUuid?.toJson(valueToJson: (v) => v.toJson()),
+      if (anEnum != null)
+        'anEnum': anEnum?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringifiedEnum != null)
+        'aStringifiedEnum':
+            aStringifiedEnum?.toJson(valueToJson: (v) => v.toJson()),
+      if (anObject != null)
+        'anObject': anObject?.toJson(valueToJson: (v) => v.toJson()),
+      if (aMap != null)
+        'aMap': aMap?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+      if (aList != null)
+        'aList': aList?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+    };
+  }
+}
+
+class _Undefined {}
+
+class _TypesListImpl extends TypesList {
+  _TypesListImpl({
+    List<int>? anInt,
+    List<bool>? aBool,
+    List<double>? aDouble,
+    List<DateTime>? aDateTime,
+    List<String>? aString,
+    List<_i2.ByteData>? aByteData,
+    List<Duration>? aDuration,
+    List<_i1.UuidValue>? aUuid,
+    List<_i3.TestEnum>? anEnum,
+    List<_i3.TestEnumStringified>? aStringifiedEnum,
+    List<_i3.Types>? anObject,
+    List<Map<String, _i3.Types>>? aMap,
+    List<List<_i3.Types>>? aList,
+  }) : super._(
+          anInt: anInt,
+          aBool: aBool,
+          aDouble: aDouble,
+          aDateTime: aDateTime,
+          aString: aString,
+          aByteData: aByteData,
+          aDuration: aDuration,
+          aUuid: aUuid,
+          anEnum: anEnum,
+          aStringifiedEnum: aStringifiedEnum,
+          anObject: anObject,
+          aMap: aMap,
+          aList: aList,
+        );
+
+  @override
+  TypesList copyWith({
+    Object? anInt = _Undefined,
+    Object? aBool = _Undefined,
+    Object? aDouble = _Undefined,
+    Object? aDateTime = _Undefined,
+    Object? aString = _Undefined,
+    Object? aByteData = _Undefined,
+    Object? aDuration = _Undefined,
+    Object? aUuid = _Undefined,
+    Object? anEnum = _Undefined,
+    Object? aStringifiedEnum = _Undefined,
+    Object? anObject = _Undefined,
+    Object? aMap = _Undefined,
+    Object? aList = _Undefined,
+  }) {
+    return TypesList(
+      anInt: anInt is List<int>? ? anInt : this.anInt?.clone(),
+      aBool: aBool is List<bool>? ? aBool : this.aBool?.clone(),
+      aDouble: aDouble is List<double>? ? aDouble : this.aDouble?.clone(),
+      aDateTime:
+          aDateTime is List<DateTime>? ? aDateTime : this.aDateTime?.clone(),
+      aString: aString is List<String>? ? aString : this.aString?.clone(),
+      aByteData: aByteData is List<_i2.ByteData>?
+          ? aByteData
+          : this.aByteData?.clone(),
+      aDuration:
+          aDuration is List<Duration>? ? aDuration : this.aDuration?.clone(),
+      aUuid: aUuid is List<_i1.UuidValue>? ? aUuid : this.aUuid?.clone(),
+      anEnum: anEnum is List<_i3.TestEnum>? ? anEnum : this.anEnum?.clone(),
+      aStringifiedEnum: aStringifiedEnum is List<_i3.TestEnumStringified>?
+          ? aStringifiedEnum
+          : this.aStringifiedEnum?.clone(),
+      anObject:
+          anObject is List<_i3.Types>? ? anObject : this.anObject?.clone(),
+      aMap: aMap is List<Map<String, _i3.Types>>? ? aMap : this.aMap?.clone(),
+      aList: aList is List<List<_i3.Types>>? ? aList : this.aList?.clone(),
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/types_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types_list.dart
@@ -172,13 +172,13 @@ abstract class TypesList extends _i1.SerializableEntity {
         'aStringifiedEnum':
             aStringifiedEnum?.toJson(valueToJson: (v) => v.toJson()),
       if (anObject != null)
-        'anObject': anObject?.toJson(valueToJson: (v) => v.toJson()),
+        'anObject': anObject?.toJson(valueToJson: (v) => v.allToJson()),
       if (aMap != null)
         'aMap': aMap?.toJson(
-            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.allToJson())),
       if (aList != null)
         'aList': aList?.toJson(
-            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.allToJson())),
     };
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/types_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types_map.dart
@@ -1,0 +1,508 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:typed_data' as _i2;
+import 'protocol.dart' as _i3;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+abstract class TypesMap extends _i1.SerializableEntity {
+  TypesMap._({
+    this.anIntKey,
+    this.aBoolKey,
+    this.aDoubleKey,
+    this.aDateTimeKey,
+    this.aStringKey,
+    this.aByteDataKey,
+    this.aDurationKey,
+    this.aUuidKey,
+    this.anEnumKey,
+    this.aStringifiedEnumKey,
+    this.anObjectKey,
+    this.aMapKey,
+    this.aListKey,
+    this.anIntValue,
+    this.aBoolValue,
+    this.aDoubleValue,
+    this.aDateTimeValue,
+    this.aStringValue,
+    this.aByteDataValue,
+    this.aDurationValue,
+    this.aUuidValue,
+    this.anEnumValue,
+    this.aStringifiedEnumValue,
+    this.anObjectValue,
+    this.aMapValue,
+    this.aListValue,
+  });
+
+  factory TypesMap({
+    Map<int, String>? anIntKey,
+    Map<bool, String>? aBoolKey,
+    Map<double, String>? aDoubleKey,
+    Map<DateTime, String>? aDateTimeKey,
+    Map<String, String>? aStringKey,
+    Map<_i2.ByteData, String>? aByteDataKey,
+    Map<Duration, String>? aDurationKey,
+    Map<_i1.UuidValue, String>? aUuidKey,
+    Map<_i3.TestEnum, String>? anEnumKey,
+    Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey,
+    Map<_i3.Types, String>? anObjectKey,
+    Map<Map<_i3.Types, String>, String>? aMapKey,
+    Map<List<_i3.Types>, String>? aListKey,
+    Map<String, int>? anIntValue,
+    Map<String, bool>? aBoolValue,
+    Map<String, double>? aDoubleValue,
+    Map<String, DateTime>? aDateTimeValue,
+    Map<String, String>? aStringValue,
+    Map<String, _i2.ByteData>? aByteDataValue,
+    Map<String, Duration>? aDurationValue,
+    Map<String, _i1.UuidValue>? aUuidValue,
+    Map<String, _i3.TestEnum>? anEnumValue,
+    Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue,
+    Map<String, _i3.Types>? anObjectValue,
+    Map<String, Map<String, _i3.Types>>? aMapValue,
+    Map<String, List<_i3.Types>>? aListValue,
+  }) = _TypesMapImpl;
+
+  factory TypesMap.fromJson(
+    Map<String, dynamic> jsonSerialization,
+    _i1.SerializationManager serializationManager,
+  ) {
+    return TypesMap(
+      anIntKey: serializationManager
+          .deserialize<Map<int, String>?>(jsonSerialization['anIntKey']),
+      aBoolKey: serializationManager
+          .deserialize<Map<bool, String>?>(jsonSerialization['aBoolKey']),
+      aDoubleKey: serializationManager
+          .deserialize<Map<double, String>?>(jsonSerialization['aDoubleKey']),
+      aDateTimeKey: serializationManager.deserialize<Map<DateTime, String>?>(
+          jsonSerialization['aDateTimeKey']),
+      aStringKey: serializationManager
+          .deserialize<Map<String, String>?>(jsonSerialization['aStringKey']),
+      aByteDataKey:
+          serializationManager.deserialize<Map<_i2.ByteData, String>?>(
+              jsonSerialization['aByteDataKey']),
+      aDurationKey: serializationManager.deserialize<Map<Duration, String>?>(
+          jsonSerialization['aDurationKey']),
+      aUuidKey: serializationManager.deserialize<Map<_i1.UuidValue, String>?>(
+          jsonSerialization['aUuidKey']),
+      anEnumKey: serializationManager.deserialize<Map<_i3.TestEnum, String>?>(
+          jsonSerialization['anEnumKey']),
+      aStringifiedEnumKey: serializationManager
+          .deserialize<Map<_i3.TestEnumStringified, String>?>(
+              jsonSerialization['aStringifiedEnumKey']),
+      anObjectKey: serializationManager.deserialize<Map<_i3.Types, String>?>(
+          jsonSerialization['anObjectKey']),
+      aMapKey: serializationManager.deserialize<
+          Map<Map<_i3.Types, String>, String>?>(jsonSerialization['aMapKey']),
+      aListKey: serializationManager.deserialize<Map<List<_i3.Types>, String>?>(
+          jsonSerialization['aListKey']),
+      anIntValue: serializationManager
+          .deserialize<Map<String, int>?>(jsonSerialization['anIntValue']),
+      aBoolValue: serializationManager
+          .deserialize<Map<String, bool>?>(jsonSerialization['aBoolValue']),
+      aDoubleValue: serializationManager
+          .deserialize<Map<String, double>?>(jsonSerialization['aDoubleValue']),
+      aDateTimeValue: serializationManager.deserialize<Map<String, DateTime>?>(
+          jsonSerialization['aDateTimeValue']),
+      aStringValue: serializationManager
+          .deserialize<Map<String, String>?>(jsonSerialization['aStringValue']),
+      aByteDataValue:
+          serializationManager.deserialize<Map<String, _i2.ByteData>?>(
+              jsonSerialization['aByteDataValue']),
+      aDurationValue: serializationManager.deserialize<Map<String, Duration>?>(
+          jsonSerialization['aDurationValue']),
+      aUuidValue: serializationManager.deserialize<Map<String, _i1.UuidValue>?>(
+          jsonSerialization['aUuidValue']),
+      anEnumValue: serializationManager.deserialize<Map<String, _i3.TestEnum>?>(
+          jsonSerialization['anEnumValue']),
+      aStringifiedEnumValue: serializationManager
+          .deserialize<Map<String, _i3.TestEnumStringified>?>(
+              jsonSerialization['aStringifiedEnumValue']),
+      anObjectValue: serializationManager.deserialize<Map<String, _i3.Types>?>(
+          jsonSerialization['anObjectValue']),
+      aMapValue: serializationManager.deserialize<
+          Map<String, Map<String, _i3.Types>>?>(jsonSerialization['aMapValue']),
+      aListValue:
+          serializationManager.deserialize<Map<String, List<_i3.Types>>?>(
+              jsonSerialization['aListValue']),
+    );
+  }
+
+  Map<int, String>? anIntKey;
+
+  Map<bool, String>? aBoolKey;
+
+  Map<double, String>? aDoubleKey;
+
+  Map<DateTime, String>? aDateTimeKey;
+
+  Map<String, String>? aStringKey;
+
+  Map<_i2.ByteData, String>? aByteDataKey;
+
+  Map<Duration, String>? aDurationKey;
+
+  Map<_i1.UuidValue, String>? aUuidKey;
+
+  Map<_i3.TestEnum, String>? anEnumKey;
+
+  Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey;
+
+  Map<_i3.Types, String>? anObjectKey;
+
+  Map<Map<_i3.Types, String>, String>? aMapKey;
+
+  Map<List<_i3.Types>, String>? aListKey;
+
+  Map<String, int>? anIntValue;
+
+  Map<String, bool>? aBoolValue;
+
+  Map<String, double>? aDoubleValue;
+
+  Map<String, DateTime>? aDateTimeValue;
+
+  Map<String, String>? aStringValue;
+
+  Map<String, _i2.ByteData>? aByteDataValue;
+
+  Map<String, Duration>? aDurationValue;
+
+  Map<String, _i1.UuidValue>? aUuidValue;
+
+  Map<String, _i3.TestEnum>? anEnumValue;
+
+  Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue;
+
+  Map<String, _i3.Types>? anObjectValue;
+
+  Map<String, Map<String, _i3.Types>>? aMapValue;
+
+  Map<String, List<_i3.Types>>? aListValue;
+
+  TypesMap copyWith({
+    Map<int, String>? anIntKey,
+    Map<bool, String>? aBoolKey,
+    Map<double, String>? aDoubleKey,
+    Map<DateTime, String>? aDateTimeKey,
+    Map<String, String>? aStringKey,
+    Map<_i2.ByteData, String>? aByteDataKey,
+    Map<Duration, String>? aDurationKey,
+    Map<_i1.UuidValue, String>? aUuidKey,
+    Map<_i3.TestEnum, String>? anEnumKey,
+    Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey,
+    Map<_i3.Types, String>? anObjectKey,
+    Map<Map<_i3.Types, String>, String>? aMapKey,
+    Map<List<_i3.Types>, String>? aListKey,
+    Map<String, int>? anIntValue,
+    Map<String, bool>? aBoolValue,
+    Map<String, double>? aDoubleValue,
+    Map<String, DateTime>? aDateTimeValue,
+    Map<String, String>? aStringValue,
+    Map<String, _i2.ByteData>? aByteDataValue,
+    Map<String, Duration>? aDurationValue,
+    Map<String, _i1.UuidValue>? aUuidValue,
+    Map<String, _i3.TestEnum>? anEnumValue,
+    Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue,
+    Map<String, _i3.Types>? anObjectValue,
+    Map<String, Map<String, _i3.Types>>? aMapValue,
+    Map<String, List<_i3.Types>>? aListValue,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (anIntKey != null) 'anIntKey': anIntKey?.toJson(),
+      if (aBoolKey != null) 'aBoolKey': aBoolKey?.toJson(),
+      if (aDoubleKey != null) 'aDoubleKey': aDoubleKey?.toJson(),
+      if (aDateTimeKey != null)
+        'aDateTimeKey': aDateTimeKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aStringKey != null) 'aStringKey': aStringKey?.toJson(),
+      if (aByteDataKey != null)
+        'aByteDataKey': aByteDataKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aDurationKey != null)
+        'aDurationKey': aDurationKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aUuidKey != null)
+        'aUuidKey': aUuidKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (anEnumKey != null)
+        'anEnumKey': anEnumKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aStringifiedEnumKey != null)
+        'aStringifiedEnumKey':
+            aStringifiedEnumKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (anObjectKey != null)
+        'anObjectKey': anObjectKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aMapKey != null)
+        'aMapKey': aMapKey?.toJson(
+            keyToJson: (k) => k.toJson(keyToJson: (k) => k.toJson())),
+      if (aListKey != null)
+        'aListKey': aListKey?.toJson(
+            keyToJson: (k) => k.toJson(valueToJson: (v) => v.toJson())),
+      if (anIntValue != null) 'anIntValue': anIntValue?.toJson(),
+      if (aBoolValue != null) 'aBoolValue': aBoolValue?.toJson(),
+      if (aDoubleValue != null) 'aDoubleValue': aDoubleValue?.toJson(),
+      if (aDateTimeValue != null)
+        'aDateTimeValue':
+            aDateTimeValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringValue != null) 'aStringValue': aStringValue?.toJson(),
+      if (aByteDataValue != null)
+        'aByteDataValue':
+            aByteDataValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aDurationValue != null)
+        'aDurationValue':
+            aDurationValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aUuidValue != null)
+        'aUuidValue': aUuidValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (anEnumValue != null)
+        'anEnumValue': anEnumValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringifiedEnumValue != null)
+        'aStringifiedEnumValue':
+            aStringifiedEnumValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (anObjectValue != null)
+        'anObjectValue': anObjectValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aMapValue != null)
+        'aMapValue': aMapValue?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+      if (aListValue != null)
+        'aListValue': aListValue?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+    };
+  }
+
+  @override
+  Map<String, dynamic> allToJson() {
+    return {
+      if (anIntKey != null) 'anIntKey': anIntKey?.toJson(),
+      if (aBoolKey != null) 'aBoolKey': aBoolKey?.toJson(),
+      if (aDoubleKey != null) 'aDoubleKey': aDoubleKey?.toJson(),
+      if (aDateTimeKey != null)
+        'aDateTimeKey': aDateTimeKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aStringKey != null) 'aStringKey': aStringKey?.toJson(),
+      if (aByteDataKey != null)
+        'aByteDataKey': aByteDataKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aDurationKey != null)
+        'aDurationKey': aDurationKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aUuidKey != null)
+        'aUuidKey': aUuidKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (anEnumKey != null)
+        'anEnumKey': anEnumKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aStringifiedEnumKey != null)
+        'aStringifiedEnumKey':
+            aStringifiedEnumKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (anObjectKey != null)
+        'anObjectKey': anObjectKey?.toJson(keyToJson: (k) => k.toJson()),
+      if (aMapKey != null)
+        'aMapKey': aMapKey?.toJson(
+            keyToJson: (k) => k.toJson(keyToJson: (k) => k.toJson())),
+      if (aListKey != null)
+        'aListKey': aListKey?.toJson(
+            keyToJson: (k) => k.toJson(valueToJson: (v) => v.toJson())),
+      if (anIntValue != null) 'anIntValue': anIntValue?.toJson(),
+      if (aBoolValue != null) 'aBoolValue': aBoolValue?.toJson(),
+      if (aDoubleValue != null) 'aDoubleValue': aDoubleValue?.toJson(),
+      if (aDateTimeValue != null)
+        'aDateTimeValue':
+            aDateTimeValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringValue != null) 'aStringValue': aStringValue?.toJson(),
+      if (aByteDataValue != null)
+        'aByteDataValue':
+            aByteDataValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aDurationValue != null)
+        'aDurationValue':
+            aDurationValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aUuidValue != null)
+        'aUuidValue': aUuidValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (anEnumValue != null)
+        'anEnumValue': anEnumValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aStringifiedEnumValue != null)
+        'aStringifiedEnumValue':
+            aStringifiedEnumValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (anObjectValue != null)
+        'anObjectValue': anObjectValue?.toJson(valueToJson: (v) => v.toJson()),
+      if (aMapValue != null)
+        'aMapValue': aMapValue?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+      if (aListValue != null)
+        'aListValue': aListValue?.toJson(
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+    };
+  }
+}
+
+class _Undefined {}
+
+class _TypesMapImpl extends TypesMap {
+  _TypesMapImpl({
+    Map<int, String>? anIntKey,
+    Map<bool, String>? aBoolKey,
+    Map<double, String>? aDoubleKey,
+    Map<DateTime, String>? aDateTimeKey,
+    Map<String, String>? aStringKey,
+    Map<_i2.ByteData, String>? aByteDataKey,
+    Map<Duration, String>? aDurationKey,
+    Map<_i1.UuidValue, String>? aUuidKey,
+    Map<_i3.TestEnum, String>? anEnumKey,
+    Map<_i3.TestEnumStringified, String>? aStringifiedEnumKey,
+    Map<_i3.Types, String>? anObjectKey,
+    Map<Map<_i3.Types, String>, String>? aMapKey,
+    Map<List<_i3.Types>, String>? aListKey,
+    Map<String, int>? anIntValue,
+    Map<String, bool>? aBoolValue,
+    Map<String, double>? aDoubleValue,
+    Map<String, DateTime>? aDateTimeValue,
+    Map<String, String>? aStringValue,
+    Map<String, _i2.ByteData>? aByteDataValue,
+    Map<String, Duration>? aDurationValue,
+    Map<String, _i1.UuidValue>? aUuidValue,
+    Map<String, _i3.TestEnum>? anEnumValue,
+    Map<String, _i3.TestEnumStringified>? aStringifiedEnumValue,
+    Map<String, _i3.Types>? anObjectValue,
+    Map<String, Map<String, _i3.Types>>? aMapValue,
+    Map<String, List<_i3.Types>>? aListValue,
+  }) : super._(
+          anIntKey: anIntKey,
+          aBoolKey: aBoolKey,
+          aDoubleKey: aDoubleKey,
+          aDateTimeKey: aDateTimeKey,
+          aStringKey: aStringKey,
+          aByteDataKey: aByteDataKey,
+          aDurationKey: aDurationKey,
+          aUuidKey: aUuidKey,
+          anEnumKey: anEnumKey,
+          aStringifiedEnumKey: aStringifiedEnumKey,
+          anObjectKey: anObjectKey,
+          aMapKey: aMapKey,
+          aListKey: aListKey,
+          anIntValue: anIntValue,
+          aBoolValue: aBoolValue,
+          aDoubleValue: aDoubleValue,
+          aDateTimeValue: aDateTimeValue,
+          aStringValue: aStringValue,
+          aByteDataValue: aByteDataValue,
+          aDurationValue: aDurationValue,
+          aUuidValue: aUuidValue,
+          anEnumValue: anEnumValue,
+          aStringifiedEnumValue: aStringifiedEnumValue,
+          anObjectValue: anObjectValue,
+          aMapValue: aMapValue,
+          aListValue: aListValue,
+        );
+
+  @override
+  TypesMap copyWith({
+    Object? anIntKey = _Undefined,
+    Object? aBoolKey = _Undefined,
+    Object? aDoubleKey = _Undefined,
+    Object? aDateTimeKey = _Undefined,
+    Object? aStringKey = _Undefined,
+    Object? aByteDataKey = _Undefined,
+    Object? aDurationKey = _Undefined,
+    Object? aUuidKey = _Undefined,
+    Object? anEnumKey = _Undefined,
+    Object? aStringifiedEnumKey = _Undefined,
+    Object? anObjectKey = _Undefined,
+    Object? aMapKey = _Undefined,
+    Object? aListKey = _Undefined,
+    Object? anIntValue = _Undefined,
+    Object? aBoolValue = _Undefined,
+    Object? aDoubleValue = _Undefined,
+    Object? aDateTimeValue = _Undefined,
+    Object? aStringValue = _Undefined,
+    Object? aByteDataValue = _Undefined,
+    Object? aDurationValue = _Undefined,
+    Object? aUuidValue = _Undefined,
+    Object? anEnumValue = _Undefined,
+    Object? aStringifiedEnumValue = _Undefined,
+    Object? anObjectValue = _Undefined,
+    Object? aMapValue = _Undefined,
+    Object? aListValue = _Undefined,
+  }) {
+    return TypesMap(
+      anIntKey:
+          anIntKey is Map<int, String>? ? anIntKey : this.anIntKey?.clone(),
+      aBoolKey:
+          aBoolKey is Map<bool, String>? ? aBoolKey : this.aBoolKey?.clone(),
+      aDoubleKey: aDoubleKey is Map<double, String>?
+          ? aDoubleKey
+          : this.aDoubleKey?.clone(),
+      aDateTimeKey: aDateTimeKey is Map<DateTime, String>?
+          ? aDateTimeKey
+          : this.aDateTimeKey?.clone(),
+      aStringKey: aStringKey is Map<String, String>?
+          ? aStringKey
+          : this.aStringKey?.clone(),
+      aByteDataKey: aByteDataKey is Map<_i2.ByteData, String>?
+          ? aByteDataKey
+          : this.aByteDataKey?.clone(),
+      aDurationKey: aDurationKey is Map<Duration, String>?
+          ? aDurationKey
+          : this.aDurationKey?.clone(),
+      aUuidKey: aUuidKey is Map<_i1.UuidValue, String>?
+          ? aUuidKey
+          : this.aUuidKey?.clone(),
+      anEnumKey: anEnumKey is Map<_i3.TestEnum, String>?
+          ? anEnumKey
+          : this.anEnumKey?.clone(),
+      aStringifiedEnumKey:
+          aStringifiedEnumKey is Map<_i3.TestEnumStringified, String>?
+              ? aStringifiedEnumKey
+              : this.aStringifiedEnumKey?.clone(),
+      anObjectKey: anObjectKey is Map<_i3.Types, String>?
+          ? anObjectKey
+          : this.anObjectKey?.clone(),
+      aMapKey: aMapKey is Map<Map<_i3.Types, String>, String>?
+          ? aMapKey
+          : this.aMapKey?.clone(),
+      aListKey: aListKey is Map<List<_i3.Types>, String>?
+          ? aListKey
+          : this.aListKey?.clone(),
+      anIntValue: anIntValue is Map<String, int>?
+          ? anIntValue
+          : this.anIntValue?.clone(),
+      aBoolValue: aBoolValue is Map<String, bool>?
+          ? aBoolValue
+          : this.aBoolValue?.clone(),
+      aDoubleValue: aDoubleValue is Map<String, double>?
+          ? aDoubleValue
+          : this.aDoubleValue?.clone(),
+      aDateTimeValue: aDateTimeValue is Map<String, DateTime>?
+          ? aDateTimeValue
+          : this.aDateTimeValue?.clone(),
+      aStringValue: aStringValue is Map<String, String>?
+          ? aStringValue
+          : this.aStringValue?.clone(),
+      aByteDataValue: aByteDataValue is Map<String, _i2.ByteData>?
+          ? aByteDataValue
+          : this.aByteDataValue?.clone(),
+      aDurationValue: aDurationValue is Map<String, Duration>?
+          ? aDurationValue
+          : this.aDurationValue?.clone(),
+      aUuidValue: aUuidValue is Map<String, _i1.UuidValue>?
+          ? aUuidValue
+          : this.aUuidValue?.clone(),
+      anEnumValue: anEnumValue is Map<String, _i3.TestEnum>?
+          ? anEnumValue
+          : this.anEnumValue?.clone(),
+      aStringifiedEnumValue:
+          aStringifiedEnumValue is Map<String, _i3.TestEnumStringified>?
+              ? aStringifiedEnumValue
+              : this.aStringifiedEnumValue?.clone(),
+      anObjectValue: anObjectValue is Map<String, _i3.Types>?
+          ? anObjectValue
+          : this.anObjectValue?.clone(),
+      aMapValue: aMapValue is Map<String, Map<String, _i3.Types>>?
+          ? aMapValue
+          : this.aMapValue?.clone(),
+      aListValue: aListValue is Map<String, List<_i3.Types>>?
+          ? aListValue
+          : this.aListValue?.clone(),
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/types_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types_map.dart
@@ -297,13 +297,13 @@ abstract class TypesMap extends _i1.SerializableEntity {
         'aStringifiedEnumKey':
             aStringifiedEnumKey?.toJson(keyToJson: (k) => k.toJson()),
       if (anObjectKey != null)
-        'anObjectKey': anObjectKey?.toJson(keyToJson: (k) => k.toJson()),
+        'anObjectKey': anObjectKey?.toJson(keyToJson: (k) => k.allToJson()),
       if (aMapKey != null)
         'aMapKey': aMapKey?.toJson(
-            keyToJson: (k) => k.toJson(keyToJson: (k) => k.toJson())),
+            keyToJson: (k) => k.toJson(keyToJson: (k) => k.allToJson())),
       if (aListKey != null)
         'aListKey': aListKey?.toJson(
-            keyToJson: (k) => k.toJson(valueToJson: (v) => v.toJson())),
+            keyToJson: (k) => k.toJson(valueToJson: (v) => v.allToJson())),
       if (anIntValue != null) 'anIntValue': anIntValue?.toJson(),
       if (aBoolValue != null) 'aBoolValue': aBoolValue?.toJson(),
       if (aDoubleValue != null) 'aDoubleValue': aDoubleValue?.toJson(),
@@ -325,13 +325,14 @@ abstract class TypesMap extends _i1.SerializableEntity {
         'aStringifiedEnumValue':
             aStringifiedEnumValue?.toJson(valueToJson: (v) => v.toJson()),
       if (anObjectValue != null)
-        'anObjectValue': anObjectValue?.toJson(valueToJson: (v) => v.toJson()),
+        'anObjectValue':
+            anObjectValue?.toJson(valueToJson: (v) => v.allToJson()),
       if (aMapValue != null)
         'aMapValue': aMapValue?.toJson(
-            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.allToJson())),
       if (aListValue != null)
         'aListValue': aListValue?.toJson(
-            valueToJson: (v) => v.toJson(valueToJson: (v) => v.toJson())),
+            valueToJson: (v) => v.toJson(valueToJson: (v) => v.allToJson())),
     };
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -65,7 +65,7 @@ abstract class UniqueData extends _i1.TableRow {
   @Deprecated('Will be removed in 2.0.0')
   Map<String, dynamic> toJsonForDatabase() {
     return {
-      if (id != null) 'id': id,
+      'id': id,
       'number': number,
       'email': email,
     };

--- a/tests/serverpod_test_server/lib/src/models/scopes/scope_server_only_field.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/scopes/scope_server_only_field.spy.yaml
@@ -1,0 +1,5 @@
+class: ScopeServerOnlyField
+fields:
+  allScope: Types?
+  serverOnlyScope: Types?, scope = serverOnly
+  nested: ScopeServerOnlyField?

--- a/tests/serverpod_test_server/lib/src/models/simple_data_object.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/simple_data_object.spy.yaml
@@ -1,0 +1,3 @@
+class: SimpleDataObject
+fields:
+  object: SimpleData

--- a/tests/serverpod_test_server/lib/src/models/types_list.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/types_list.spy.yaml
@@ -1,0 +1,15 @@
+class: TypesList
+fields:
+  anInt: List<int>?
+  aBool: List<bool>?
+  aDouble: List<double>?
+  aDateTime: List<DateTime>?
+  aString: List<String>?
+  aByteData: List<ByteData>?
+  aDuration: List<Duration>?
+  aUuid: List<UuidValue>?
+  anEnum: List<TestEnum>?
+  aStringifiedEnum: List<TestEnumStringified>?
+  anObject: List<Types>?
+  aMap: List<Map<String, Types>>?
+  aList: List<List<Types>>?

--- a/tests/serverpod_test_server/lib/src/models/types_map.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/types_map.spy.yaml
@@ -1,0 +1,30 @@
+class: TypesMap
+fields:
+  # keys
+  anIntKey: Map<int, String>?
+  aBoolKey: Map<bool, String>?
+  aDoubleKey: Map<double, String>?
+  aDateTimeKey: Map<DateTime, String>?
+  aStringKey: Map<String, String>?
+  aByteDataKey: Map<ByteData, String>?
+  aDurationKey: Map<Duration, String>?
+  aUuidKey: Map<UuidValue, String>?
+  anEnumKey: Map<TestEnum, String>?
+  aStringifiedEnumKey: Map<TestEnumStringified, String>?
+  anObjectKey: Map<Types, String>?
+  aMapKey: Map<Map<Types, String>, String>?
+  aListKey: Map<List<Types>, String>?
+  # values
+  anIntValue: Map<String, int>?
+  aBoolValue: Map<String, bool>?
+  aDoubleValue: Map<String, double>?
+  aDateTimeValue: Map<String, DateTime>?
+  aStringValue: Map<String, String>?
+  aByteDataValue: Map<String, ByteData>?
+  aDurationValue: Map<String, Duration>?
+  aUuidValue: Map<String, UuidValue>?
+  anEnumValue: Map<String, TestEnum>?
+  aStringifiedEnumValue: Map<String, TestEnumStringified>?
+  anObjectValue: Map<String, Types>?
+  aMapValue: Map<String, Map<String, Types>>?
+  aListValue: Map<String, List<Types>>?

--- a/tests/serverpod_test_server/test/generated_methods/all_to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/all_to_json_test.dart
@@ -610,4 +610,23 @@ void main() {
       });
     });
   });
+
+  test('Given an object with a server only field then field is serialized.',
+      () {
+    var object = ScopeServerOnlyField(
+      nested: ScopeServerOnlyField(
+        allScope: Types(anInt: 1),
+        serverOnlyScope: Types(anInt: 2),
+      ),
+    );
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'nested': {
+        'allScope': {'anInt': 1},
+        'serverOnlyScope': {'anInt': 2},
+      },
+    });
+  });
 }

--- a/tests/serverpod_test_server/test/generated_methods/all_to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/all_to_json_test.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
+import 'package:uuid/uuid_value.dart';
 
 void main() {
   test(
@@ -20,5 +23,567 @@ void main() {
     var jsonMap = types.allToJson();
 
     expect(jsonMap, {'anInt': 1});
+  });
+
+  test(
+      'Given a class with only nullable fields with a double defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aDouble: 1.0);
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aDouble': 1.0});
+  });
+
+  test(
+      'Given a class with only nullable fields with a bool defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aBool: true);
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aBool': true});
+  });
+
+  test(
+      'Given a class with only nullable fields with a String defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aString: 'Hello world!');
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aString': 'Hello world!'});
+  });
+
+  test(
+      'Given a class with only nullable fields with an enum serialized by index defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(anEnum: TestEnum.one);
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'anEnum': 0});
+  });
+
+  test(
+      'Given a class with only nullable fields with an enum serialized by name defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aStringifiedEnum: TestEnumStringified.one);
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aStringifiedEnum': 'one'});
+  });
+
+  test(
+      'Given a class with only nullable fields with a Uuid defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aUuid: UuidValue.nil);
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aUuid': '00000000-0000-0000-0000-000000000000'});
+  });
+
+  test(
+      'Given a class with only nullable fields with a Duration defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aDuration: Duration(seconds: 1));
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aDuration': 1000});
+  });
+
+  test(
+      'Given a class with only nullable fields with a DateTime defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aDateTime: DateTime.parse('2024-01-01T00:00:00.000Z'));
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aDateTime': '2024-01-01T00:00:00.000Z'});
+  });
+
+  test(
+      'Given a class with only nullable fields with a ByteData defined when calling toJson then the key and value is set.',
+      () {
+    var intList = Uint8List(8);
+    for (var i = 0; i < intList.length; i++) {
+      intList[i] = i;
+    }
+
+    var types = Types(aByteData: ByteData.view(intList.buffer));
+
+    var jsonMap = types.allToJson();
+
+    expect(jsonMap, {'aByteData': 'decode(\'AAECAwQFBgc=\', \'base64\')'});
+  });
+
+  test(
+      'Given a class with a relation to an object when calling toJson the entire nested structure is converted.',
+      () {
+    var next = Post(content: 'next');
+    var post = Post(content: 'post', next: next);
+
+    var jsonMap = post.allToJson();
+
+    expect(jsonMap, {
+      'content': 'post',
+      'next': {'content': 'next'}
+    });
+  });
+
+  test(
+      'Given a class with a nested object when calling toJson the entire nested structure is converted.',
+      () {
+    var simpleData = SimpleData(num: 123);
+    var object = SimpleDataObject(object: simpleData);
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'object': {'num': 123}
+    });
+  });
+
+  ///----
+
+  test(
+      'Given a class with a List with a nested object when calling toJson the entire nested structure is converted.',
+      () {
+    var type = Types(anInt: 123);
+    var object = TypesList(anObject: [type]);
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'anObject': [
+        {'anInt': 123}
+      ]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested DateTime when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aDateTime: [DateTime.parse('2024-01-01T00:00:00.000Z')],
+    );
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'aDateTime': ['2024-01-01T00:00:00.000Z']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested ByteData when calling toJson the entire nested structure is converted.',
+      () {
+    var intList = Uint8List(8);
+    for (var i = 0; i < intList.length; i++) {
+      intList[i] = i;
+    }
+
+    var object = TypesList(
+      aByteData: [ByteData.view(intList.buffer)],
+    );
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'aByteData': ['decode(\'AAECAwQFBgc=\', \'base64\')']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested Duration when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aDuration: [Duration(seconds: 1)],
+    );
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'aDuration': [1000]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested Uuid when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aUuid: [UuidValue.nil],
+    );
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'aUuid': ['00000000-0000-0000-0000-000000000000']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested enum serialized by index when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      anEnum: [TestEnum.one],
+    );
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'anEnum': [0]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested enum serialized by name when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aStringifiedEnum: [TestEnumStringified.one],
+    );
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'aStringifiedEnum': ['one']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested Map serialized by name when calling toJson the entire nested structure is converted.',
+      () {
+    var type = Types(anInt: 123);
+    var object = TypesList(aMap: [
+      {'key': type}
+    ]);
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'aMap': [
+        {
+          'key': {'anInt': 123}
+        }
+      ]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested List serialized by name when calling toJson the entire nested structure is converted.',
+      () {
+    var type = Types(anInt: 123);
+    var object = TypesList(aList: [
+      [type]
+    ]);
+
+    var jsonMap = object.allToJson();
+
+    expect(jsonMap, {
+      'aList': [
+        [
+          {'anInt': 123}
+        ]
+      ]
+    });
+  });
+
+  group('Map value -', () {
+    test(
+        'Given a class with a Map with a nested object when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 123);
+      var object = TypesMap(anObjectValue: {'key': type});
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'anObjectValue': {
+          'key': {'anInt': 123}
+        }
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested DateTime when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDateTimeValue: {'key': DateTime.parse('2024-01-01T00:00:00.000Z')},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aDateTimeValue': {'key': '2024-01-01T00:00:00.000Z'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested ByteData when calling toJson the entire nested structure is converted.',
+        () {
+      var intList = Uint8List(8);
+      for (var i = 0; i < intList.length; i++) {
+        intList[i] = i;
+      }
+
+      var object = TypesMap(
+        aByteDataValue: {'key': ByteData.view(intList.buffer)},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aByteDataValue': {'key': 'decode(\'AAECAwQFBgc=\', \'base64\')'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Duration when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDurationValue: {'key': Duration(seconds: 1)},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aDurationValue': {'key': 1000}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aUuidValue: {'key': UuidValue.nil},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aUuidValue': {'key': '00000000-0000-0000-0000-000000000000'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by index when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        anEnumValue: {'key': TestEnum.one},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'anEnumValue': {'key': 0}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aStringifiedEnumValue: {'key': TestEnumStringified.one},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aStringifiedEnumValue': {'key': 'one'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Map serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aMapValue: {
+          'key': {'key': type}
+        },
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aMapValue': {
+          'key': {
+            'key': {'anInt': 1}
+          }
+        }
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested List serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aListValue: {
+          'key': [type]
+        },
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aListValue': {
+          'key': [
+            {'anInt': 1}
+          ]
+        }
+      });
+    });
+  });
+
+  group('Map key -', () {
+    test(
+        'Given a class with a Map with a nested object when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 123);
+      var object = TypesMap(anObjectKey: {type: 'value'});
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'anObjectValue': {
+          {'anInt': 123}: 'value'
+        }
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested DateTime when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDateTimeValue: {'key': DateTime.parse('2024-01-01T00:00:00.000Z')},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aDateTimeValue': {'key': '2024-01-01T00:00:00.000Z'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested ByteData when calling toJson the entire nested structure is converted.',
+        () {
+      var intList = Uint8List(8);
+      for (var i = 0; i < intList.length; i++) {
+        intList[i] = i;
+      }
+
+      var object = TypesMap(
+        aByteDataValue: {'key': ByteData.view(intList.buffer)},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aByteDataValue': {'key': 'decode(\'AAECAwQFBgc=\', \'base64\')'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Duration when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDurationValue: {'key': Duration(seconds: 1)},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aDurationValue': {'key': 1000}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aUuidValue: {'key': UuidValue.nil},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aUuidValue': {'key': '00000000-0000-0000-0000-000000000000'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by index when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        anEnumValue: {'key': TestEnum.one},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'anEnumValue': {'key': 0}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aStringifiedEnumValue: {'key': TestEnumStringified.one},
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aStringifiedEnumValue': {'key': 'one'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Map serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aMapValue: {
+          'key': {'key': type}
+        },
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aMapValue': {
+          'key': {
+            'key': {'anInt': 1}
+          }
+        }
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested List serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aListValue: {
+          'key': [type]
+        },
+      );
+
+      var jsonMap = object.allToJson();
+
+      expect(jsonMap, {
+        'aListValue': {
+          'key': [
+            {'anInt': 1}
+          ]
+        }
+      });
+    });
   });
 }

--- a/tests/serverpod_test_server/test/generated_methods/all_to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/all_to_json_test.dart
@@ -1,8 +1,8 @@
 import 'dart:typed_data';
 
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
-import 'package:uuid/uuid_value.dart';
 
 void main() {
   test(
@@ -449,9 +449,12 @@ void main() {
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'anObjectValue': {
-          {'anInt': 123}: 'value'
-        }
+        'anObjectKey': [
+          {
+            'k': {'anInt': 123},
+            'v': 'value'
+          }
+        ]
       });
     });
 
@@ -459,13 +462,15 @@ void main() {
         'Given a class with a Map with a nested DateTime when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aDateTimeValue: {'key': DateTime.parse('2024-01-01T00:00:00.000Z')},
+        aDateTimeKey: {DateTime.parse('2024-01-01T00:00:00.000Z'): 'value'},
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'aDateTimeValue': {'key': '2024-01-01T00:00:00.000Z'}
+        'aDateTimeKey': [
+          {'k': '2024-01-01T00:00:00.000Z', 'v': 'value'}
+        ]
       });
     });
 
@@ -478,13 +483,15 @@ void main() {
       }
 
       var object = TypesMap(
-        aByteDataValue: {'key': ByteData.view(intList.buffer)},
+        aByteDataKey: {ByteData.view(intList.buffer): 'value'},
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'aByteDataValue': {'key': 'decode(\'AAECAwQFBgc=\', \'base64\')'}
+        'aByteDataKey': [
+          {'k': 'decode(\'AAECAwQFBgc=\', \'base64\')', 'v': 'value'}
+        ]
       });
     });
 
@@ -492,13 +499,15 @@ void main() {
         'Given a class with a Map with a nested Duration when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aDurationValue: {'key': Duration(seconds: 1)},
+        aDurationKey: {Duration(seconds: 1): 'value'},
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'aDurationValue': {'key': 1000}
+        'aDurationKey': [
+          {'k': 1000, 'v': 'value'}
+        ]
       });
     });
 
@@ -506,13 +515,15 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidValue: {'key': UuidValue.nil},
+        aUuidKey: {UuidValue.nil: 'value'},
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'aUuidValue': {'key': '00000000-0000-0000-0000-000000000000'}
+        'aUuidKey': [
+          {'k': '00000000-0000-0000-0000-000000000000', 'v': 'value'}
+        ]
       });
     });
 
@@ -520,13 +531,15 @@ void main() {
         'Given a class with a Map with a nested enum serialized by index when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        anEnumValue: {'key': TestEnum.one},
+        anEnumKey: {TestEnum.one: 'value'},
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'anEnumValue': {'key': 0}
+        'anEnumKey': [
+          {'k': 0, 'v': 'value'}
+        ]
       });
     });
 
@@ -534,13 +547,15 @@ void main() {
         'Given a class with a Map with a nested enum serialized by name when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aStringifiedEnumValue: {'key': TestEnumStringified.one},
+        aStringifiedEnumKey: {TestEnumStringified.one: 'value'},
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'aStringifiedEnumValue': {'key': 'one'}
+        'aStringifiedEnumKey': [
+          {'k': 'one', 'v': 'value'}
+        ]
       });
     });
 
@@ -549,19 +564,25 @@ void main() {
         () {
       var type = Types(anInt: 1);
       var object = TypesMap(
-        aMapValue: {
-          'key': {'key': type}
+        aMapKey: {
+          {type: 'value'}: 'value'
         },
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'aMapValue': {
-          'key': {
-            'key': {'anInt': 1}
+        'aMapKey': [
+          {
+            'k': [
+              {
+                'k': {'anInt': 1},
+                'v': 'value'
+              }
+            ],
+            'v': 'value'
           }
-        }
+        ]
       });
     });
 
@@ -570,19 +591,22 @@ void main() {
         () {
       var type = Types(anInt: 1);
       var object = TypesMap(
-        aListValue: {
-          'key': [type]
+        aListKey: {
+          [type]: 'value'
         },
       );
 
       var jsonMap = object.allToJson();
 
       expect(jsonMap, {
-        'aListValue': {
-          'key': [
-            {'anInt': 1}
-          ]
-        }
+        'aListKey': [
+          {
+            'k': [
+              {'anInt': 1}
+            ],
+            'v': 'value'
+          }
+        ]
       });
     });
   });

--- a/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
@@ -610,4 +610,23 @@ void main() {
       });
     });
   });
+
+  test(
+      'Given an object with a server only field then that field is not serialized.',
+      () {
+    var object = ScopeServerOnlyField(
+      nested: ScopeServerOnlyField(
+        allScope: Types(anInt: 1),
+        serverOnlyScope: Types(anInt: 2),
+      ),
+    );
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'nested': {
+        'allScope': {'anInt': 1},
+      },
+    });
+  });
 }

--- a/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:test/test.dart';
 
@@ -20,5 +23,591 @@ void main() {
     var jsonMap = types.toJson();
 
     expect(jsonMap, {'anInt': 1});
+  });
+
+  test(
+      'Given a class with only nullable fields with a double defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aDouble: 1.0);
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aDouble': 1.0});
+  });
+
+  test(
+      'Given a class with only nullable fields with a bool defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aBool: true);
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aBool': true});
+  });
+
+  test(
+      'Given a class with only nullable fields with a String defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aString: 'Hello world!');
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aString': 'Hello world!'});
+  });
+
+  test(
+      'Given a class with only nullable fields with an enum serialized by index defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(anEnum: TestEnum.one);
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'anEnum': 0});
+  });
+
+  test(
+      'Given a class with only nullable fields with an enum serialized by name defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aStringifiedEnum: TestEnumStringified.one);
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aStringifiedEnum': 'one'});
+  });
+
+  test(
+      'Given a class with only nullable fields with a Uuid defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aUuid: UuidValue.nil);
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aUuid': '00000000-0000-0000-0000-000000000000'});
+  });
+
+  test(
+      'Given a class with only nullable fields with a Duration defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aDuration: Duration(seconds: 1));
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aDuration': 1000});
+  });
+
+  test(
+      'Given a class with only nullable fields with a DateTime defined when calling toJson then the key and value is set.',
+      () {
+    var types = Types(aDateTime: DateTime.parse('2024-01-01T00:00:00.000Z'));
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aDateTime': '2024-01-01T00:00:00.000Z'});
+  });
+
+  test(
+      'Given a class with only nullable fields with a ByteData defined when calling toJson then the key and value is set.',
+      () {
+    var intList = Uint8List(8);
+    for (var i = 0; i < intList.length; i++) {
+      intList[i] = i;
+    }
+
+    var types = Types(aByteData: ByteData.view(intList.buffer));
+
+    var jsonMap = types.toJson();
+
+    expect(jsonMap, {'aByteData': 'decode(\'AAECAwQFBgc=\', \'base64\')'});
+  });
+
+  test(
+      'Given a class with a relation to an object when calling toJson the entire nested structure is converted.',
+      () {
+    var next = Post(content: 'next');
+    var post = Post(content: 'post', next: next);
+
+    var jsonMap = post.toJson();
+
+    expect(jsonMap, {
+      'content': 'post',
+      'next': {'content': 'next'}
+    });
+  });
+
+  test(
+      'Given a class with a nested object when calling toJson the entire nested structure is converted.',
+      () {
+    var simpleData = SimpleData(num: 123);
+    var object = SimpleDataObject(object: simpleData);
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'object': {'num': 123}
+    });
+  });
+
+  ///----
+
+  test(
+      'Given a class with a List with a nested object when calling toJson the entire nested structure is converted.',
+      () {
+    var type = Types(anInt: 123);
+    var object = TypesList(anObject: [type]);
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'anObject': [
+        {'anInt': 123}
+      ]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested DateTime when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aDateTime: [DateTime.parse('2024-01-01T00:00:00.000Z')],
+    );
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'aDateTime': ['2024-01-01T00:00:00.000Z']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested ByteData when calling toJson the entire nested structure is converted.',
+      () {
+    var intList = Uint8List(8);
+    for (var i = 0; i < intList.length; i++) {
+      intList[i] = i;
+    }
+
+    var object = TypesList(
+      aByteData: [ByteData.view(intList.buffer)],
+    );
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'aByteData': ['decode(\'AAECAwQFBgc=\', \'base64\')']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested Duration when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aDuration: [Duration(seconds: 1)],
+    );
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'aDuration': [1000]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested Uuid when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aUuid: [UuidValue.nil],
+    );
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'aUuid': ['00000000-0000-0000-0000-000000000000']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested enum serialized by index when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      anEnum: [TestEnum.one],
+    );
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'anEnum': [0]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested enum serialized by name when calling toJson the entire nested structure is converted.',
+      () {
+    var object = TypesList(
+      aStringifiedEnum: [TestEnumStringified.one],
+    );
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'aStringifiedEnum': ['one']
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested Map serialized by name when calling toJson the entire nested structure is converted.',
+      () {
+    var type = Types(anInt: 123);
+    var object = TypesList(aMap: [
+      {'key': type}
+    ]);
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'aMap': [
+        {
+          'key': {'anInt': 123}
+        }
+      ]
+    });
+  });
+
+  test(
+      'Given a class with a List with a nested List serialized by name when calling toJson the entire nested structure is converted.',
+      () {
+    var type = Types(anInt: 123);
+    var object = TypesList(aList: [
+      [type]
+    ]);
+
+    var jsonMap = object.toJson();
+
+    expect(jsonMap, {
+      'aList': [
+        [
+          {'anInt': 123}
+        ]
+      ]
+    });
+  });
+
+  group('Map value -', () {
+    test(
+        'Given a class with a Map with a nested object when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 123);
+      var object = TypesMap(anObjectValue: {'key': type});
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'anObjectValue': {
+          'key': {'anInt': 123}
+        }
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested DateTime when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDateTimeValue: {'key': DateTime.parse('2024-01-01T00:00:00.000Z')},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aDateTimeValue': {'key': '2024-01-01T00:00:00.000Z'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested ByteData when calling toJson the entire nested structure is converted.',
+        () {
+      var intList = Uint8List(8);
+      for (var i = 0; i < intList.length; i++) {
+        intList[i] = i;
+      }
+
+      var object = TypesMap(
+        aByteDataValue: {'key': ByteData.view(intList.buffer)},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aByteDataValue': {'key': 'decode(\'AAECAwQFBgc=\', \'base64\')'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Duration when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDurationValue: {'key': Duration(seconds: 1)},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aDurationValue': {'key': 1000}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aUuidValue: {'key': UuidValue.nil},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aUuidValue': {'key': '00000000-0000-0000-0000-000000000000'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by index when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        anEnumValue: {'key': TestEnum.one},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'anEnumValue': {'key': 0}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aStringifiedEnumValue: {'key': TestEnumStringified.one},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aStringifiedEnumValue': {'key': 'one'}
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Map serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aMapValue: {
+          'key': {'key': type}
+        },
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aMapValue': {
+          'key': {
+            'key': {'anInt': 1}
+          }
+        }
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested List serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aListValue: {
+          'key': [type]
+        },
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aListValue': {
+          'key': [
+            {'anInt': 1}
+          ]
+        }
+      });
+    });
+  });
+
+  group('Map key -', () {
+    test(
+        'Given a class with a Map with a nested object when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 123);
+      var object = TypesMap(anObjectKey: {type: 'value'});
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'anObjectKey': [
+          {
+            'k': {'anInt': 123},
+            'v': 'value'
+          }
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested DateTime when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDateTimeKey: {DateTime.parse('2024-01-01T00:00:00.000Z'): 'value'},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aDateTimeKey': [
+          {'k': '2024-01-01T00:00:00.000Z', 'v': 'value'}
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested ByteData when calling toJson the entire nested structure is converted.',
+        () {
+      var intList = Uint8List(8);
+      for (var i = 0; i < intList.length; i++) {
+        intList[i] = i;
+      }
+
+      var object = TypesMap(
+        aByteDataKey: {ByteData.view(intList.buffer): 'value'},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aByteDataKey': [
+          {'k': 'decode(\'AAECAwQFBgc=\', \'base64\')', 'v': 'value'}
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Duration when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aDurationKey: {Duration(seconds: 1): 'value'},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aDurationKey': [
+          {'k': 1000, 'v': 'value'}
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aUuidKey: {UuidValue.nil: 'value'},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aUuidKey': [
+          {'k': '00000000-0000-0000-0000-000000000000', 'v': 'value'}
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by index when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        anEnumKey: {TestEnum.one: 'value'},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'anEnumKey': [
+          {'k': 0, 'v': 'value'}
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested enum serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var object = TypesMap(
+        aStringifiedEnumKey: {TestEnumStringified.one: 'value'},
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aStringifiedEnumKey': [
+          {'k': 'one', 'v': 'value'}
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested Map serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aMapKey: {
+          {type: 'value'}: 'value'
+        },
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aMapKey': [
+          {
+            'k': [
+              {
+                'k': {'anInt': 1},
+                'v': 'value'
+              }
+            ],
+            'v': 'value'
+          }
+        ]
+      });
+    });
+
+    test(
+        'Given a class with a Map with a nested List serialized by name when calling toJson the entire nested structure is converted.',
+        () {
+      var type = Types(anInt: 1);
+      var object = TypesMap(
+        aListKey: {
+          [type]: 'value'
+        },
+      );
+
+      var jsonMap = object.toJson();
+
+      expect(jsonMap, {
+        'aListKey': [
+          {
+            'k': [
+              {'anInt': 1}
+            ],
+            'v': 'value'
+          }
+        ]
+      });
+    });
   });
 }

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -70,7 +70,7 @@ void main() {
   });
 
   test(
-      'Given a serializable object as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a serializable object as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var type = Types(anInt: 123);
     var object = TypesMap(anObjectKey: {type: 'value'});
@@ -82,7 +82,7 @@ void main() {
   });
 
   test(
-      'Given a DateTime as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a DateTime as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var object = TypesMap(
       aDateTimeKey: {DateTime.parse('2024-01-01T00:00:00.000Z'): 'value'},
@@ -98,7 +98,7 @@ void main() {
   });
 
   test(
-      'Given a UuidValue as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a UuidValue as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var object = TypesMap(aUuidKey: {UuidValue.nil: 'value'});
 
@@ -112,7 +112,7 @@ void main() {
   });
 
   test(
-      'Given a ByteData as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a ByteData as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var intList = Uint8List(8);
     for (var i = 0; i < intList.length; i++) {
@@ -133,7 +133,7 @@ void main() {
   });
 
   test(
-      'Given a Duration as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a Duration as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var object = TypesMap(
       aDurationKey: {Duration(seconds: 1): 'value'},
@@ -149,7 +149,7 @@ void main() {
   });
 
   test(
-      'Given a index serialized Enum as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a index serialized Enum as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var object = TypesMap(
       anEnumKey: {TestEnum.one: 'value'},
@@ -165,7 +165,7 @@ void main() {
   });
 
   test(
-      'Given a name serialized Enum as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a name serialized Enum as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var object = TypesMap(
       aStringifiedEnumKey: {TestEnumStringified.one: 'value'},
@@ -181,7 +181,7 @@ void main() {
   });
 
   test(
-      'Given a Map as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a Map as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var object = TypesMap(
       aMapKey: {
@@ -199,7 +199,7 @@ void main() {
   });
 
   test(
-      'Given a List as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      'Given a List as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
     var type = Types(anInt: 1);
     var object = TypesMap(
@@ -215,5 +215,27 @@ void main() {
       typesMap.aListKey?.entries.first.key.first.anInt,
       1,
     );
+  });
+
+  test(
+      'Given an empty map with an int key when serializing and unpacking the empty map is preserved.',
+      () {
+    var object = TypesMap(anIntKey: {});
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(typesMap.anIntKey, {});
+  });
+
+  test(
+      'Given an empty map with an SerializedEntity key when serializing and unpacking the empty map is preserved.',
+      () {
+    var object = TypesMap(anObjectKey: {});
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(typesMap.anObjectKey, {});
   });
 }

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -1,4 +1,4 @@
-import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_client/serverpod_test_client.dart';
@@ -15,7 +15,7 @@ void main() {
     var types = Types();
 
     var encoded = SerializationManager.encode(types);
-    var unpacked = protocol.deserialize<Types>(jsonDecode(encoded));
+    var unpacked = protocol.decode<Types>(encoded);
 
     expect(unpacked.aStringifiedEnum, isNull);
   });
@@ -26,8 +26,7 @@ void main() {
     var types = server.Types(aStringifiedEnum: server.TestEnumStringified.one);
 
     var encoded = SerializationManager.encode(types);
-    var unpacked =
-        serverProtocol.deserialize<server.Types>(jsonDecode(encoded));
+    var unpacked = serverProtocol.decode<server.Types>(encoded);
 
     expect(unpacked.aStringifiedEnum, server.TestEnumStringified.one);
   });
@@ -38,8 +37,7 @@ void main() {
     var types = server.Types();
 
     var encoded = SerializationManager.encode(types);
-    var unpacked =
-        serverProtocol.deserialize<server.Types>(jsonDecode(encoded));
+    var unpacked = serverProtocol.decode<server.Types>(encoded);
 
     expect(unpacked.aStringifiedEnum, isNull);
   });
@@ -50,7 +48,7 @@ void main() {
     var types = Types(aStringifiedEnum: TestEnumStringified.one);
 
     var encoded = SerializationManager.encode(types);
-    var unpacked = protocol.deserialize<Types>(jsonDecode(encoded));
+    var unpacked = protocol.decode<Types>(encoded);
 
     expect(unpacked.aStringifiedEnum, TestEnumStringified.one);
   });
@@ -64,10 +62,158 @@ void main() {
     );
 
     var encoded = SerializationManager.encode(type);
-    var unpacked = serverProtocol
-        .deserialize<server.ObjectWithServerpodObject>(jsonDecode(encoded));
+    var unpacked =
+        serverProtocol.decode<server.ObjectWithServerpodObject>(encoded);
 
     expect(unpacked.logLevel1, LogLevel.debug);
     expect(unpacked.logLevel2, LogLevel.error);
+  });
+
+  test(
+      'Given a serializable object as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var type = Types(anInt: 123);
+    var object = TypesMap(anObjectKey: {type: 'value'});
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(typesMap.anObjectKey?.entries.first.key.anInt, 123);
+  });
+
+  test(
+      'Given a DateTime as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var object = TypesMap(
+      aDateTimeKey: {DateTime.parse('2024-01-01T00:00:00.000Z'): 'value'},
+    );
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.aDateTimeKey?.entries.first.key,
+      DateTime.parse('2024-01-01T00:00:00.000Z'),
+    );
+  });
+
+  test(
+      'Given a UuidValue as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var object = TypesMap(aUuidKey: {UuidValue.nil: 'value'});
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.aUuidKey?.entries.first.key,
+      UuidValue.nil,
+    );
+  });
+
+  test(
+      'Given a ByteData as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var intList = Uint8List(8);
+    for (var i = 0; i < intList.length; i++) {
+      intList[i] = i;
+    }
+
+    var object = TypesMap(
+      aByteDataKey: {ByteData.view(intList.buffer): 'value'},
+    );
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.aByteDataKey?.entries.first.key.buffer.asUint8List(),
+      Uint8List.fromList([0, 1, 2, 3, 4, 5, 6, 7]),
+    );
+  });
+
+  test(
+      'Given a Duration as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var object = TypesMap(
+      aDurationKey: {Duration(seconds: 1): 'value'},
+    );
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.aDurationKey?.entries.first.key.inMilliseconds,
+      Duration(seconds: 1).inMilliseconds,
+    );
+  });
+
+  test(
+      'Given a index serialized Enum as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var object = TypesMap(
+      anEnumKey: {TestEnum.one: 'value'},
+    );
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.anEnumKey?.entries.first.key,
+      TestEnum.one,
+    );
+  });
+
+  test(
+      'Given a name serialized Enum as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var object = TypesMap(
+      aStringifiedEnumKey: {TestEnumStringified.one: 'value'},
+    );
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.aStringifiedEnumKey?.entries.first.key,
+      TestEnumStringified.one,
+    );
+  });
+
+  test(
+      'Given a Map as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var object = TypesMap(
+      aMapKey: {
+        {Types(anInt: 123): 'value'}: 'value',
+      },
+    );
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.aMapKey?.entries.first.key.entries.first.key.anInt,
+      123,
+    );
+  });
+
+  test(
+      'Given a List as a key in a map then wen serializing and unpacking the original object remains unchanged.',
+      () {
+    var type = Types(anInt: 1);
+    var object = TypesMap(
+      aListKey: {
+        [type]: 'value'
+      },
+    );
+
+    var encodedString = SerializationManager.encode(object);
+    var typesMap = Protocol().decode<TypesMap>(encodedString);
+
+    expect(
+      typesMap.aListKey?.entries.first.key.first.anInt,
+      1,
+    );
   });
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -41,9 +41,16 @@ class SerializableModelLibraryGenerator {
 
     return Library(
       (libraryBuilder) {
+        var hasFieldSerializedByExtension = classDefinition.fields
+            .where((field) => field.shouldIncludeField(serverCode))
+            .any((field) => field.type.isSerializedByExtension);
+
+        if (hasFieldSerializedByExtension) {
+          libraryBuilder.directives.add(Directive.import(
+              'package:serverpod_serialization/serverpod_serialization.dart'));
+        }
+
         libraryBuilder.body.addAll([
-          const Code(
-              "import 'package:serverpod_serialization/serverpod_serialization.dart';"),
           _buildModelClass(
             className,
             classDefinition,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -45,7 +45,7 @@ class SerializableModelLibraryGenerator {
             .where((field) => field.shouldIncludeField(serverCode))
             .any((field) => field.type.isSerializedByExtension);
 
-        if (hasFieldSerializedByExtension) {
+        if (hasFieldSerializedByExtension && serverCode) {
           libraryBuilder.directives.add(Directive.import(
               'package:serverpod_serialization/serverpod_serialization.dart'));
         }

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -6,6 +6,7 @@ import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/generator/shared.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 import 'package:serverpod_cli/src/util/string_manipulation.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
@@ -43,8 +44,10 @@ class TypeDefinition {
     this.serializeEnum,
   });
 
-  bool get isSerializedValue =>
-      ['int', 'bool', 'double', 'String'].contains(className);
+  bool get isSerializedValue => autoSerializedTypes.contains(className);
+
+  bool get isSerializedByExtension =>
+      extensionSerializedTypes.contains(className);
 
   bool get isListType => className == 'List';
 

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -43,6 +43,9 @@ class TypeDefinition {
     this.serializeEnum,
   });
 
+  bool get isSerializedValue =>
+      ['int', 'bool', 'double', 'String'].contains(className);
+
   bool get isListType => className == 'List';
 
   bool get isMapType => className == 'Map';


### PR DESCRIPTION
# Changes

- Moves serialization logic into extensions rather than handling them in the encoder. This change means that the toJson methods will generate a complete Map structure n-levels deep rather than just the top level.
- Adds a big test suit for the generated toJson and allToJson methods.
- Adds additional serialization/deserialization tests
- Fixes broken serialization of map Keys that were not of type String or int, now any supported serverpod type should be handled by the serilization logic when used as a key in a Map.

Motivation: For upcoming changes to how we handle relational resolution we have to call resolve this Map for these keys. It makes the most sense to be consistent and making sure the entire tree is built the same way. This approach also aligns with how all other dart toJson implementations are done. 

Closes: #1806 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None