### PR TITLE
fix: Enable possiblity to create module templates in developer mode.

### DIFF
--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -120,7 +120,11 @@ Future<bool> performCreate(
     success &= await log.progress(
         'Writing project files.',
         () => Future(() {
-              _copyModuleTemplates(serverpodDirs, name: name);
+              _copyModuleTemplates(
+                serverpodDirs,
+                name: name,
+                customServerpodPath: productionMode ? null : serverpodHome,
+              );
               return true;
             }));
   }
@@ -426,6 +430,7 @@ void _copyServerTemplates(
 void _copyModuleTemplates(
   ServerpodDirectories serverpodDirs, {
   required String name,
+  String? customServerpodPath,
 }) {
   log.debug('Copying server files', newParagraph: true);
   var copier = Copier(
@@ -443,8 +448,13 @@ void _copyModuleTemplates(
       ),
       Replacement(
         slotName: 'VERSION',
-        replacement: templateVersion,
+        replacement: customServerpodPath == null ? templateVersion : '',
       ),
+      if (customServerpodPath != null)
+        Replacement(
+          slotName: 'path: ../../../packages/serverpod',
+          replacement: 'path: $customServerpodPath/packages/serverpod',
+        ),
     ],
     fileNameReplacements: [
       Replacement(
@@ -456,7 +466,9 @@ void _copyModuleTemplates(
         replacement: '.gitignore',
       ),
     ],
-    removePrefixes: ['path'],
+    removePrefixes: [
+      if (customServerpodPath == null) 'path',
+    ],
     ignoreFileNames: ['pubspec.lock'],
   );
   copier.copyFiles();
@@ -477,8 +489,13 @@ void _copyModuleTemplates(
       ),
       Replacement(
         slotName: 'VERSION',
-        replacement: templateVersion,
+        replacement: customServerpodPath == null ? templateVersion : '',
       ),
+      if (customServerpodPath != null)
+        Replacement(
+          slotName: 'path: ../../../packages/serverpod_client',
+          replacement: 'path: $customServerpodPath/packages/serverpod_client',
+        ),
     ],
     fileNameReplacements: [
       Replacement(
@@ -490,7 +507,9 @@ void _copyModuleTemplates(
         replacement: '.gitignore',
       ),
     ],
-    removePrefixes: ['path'],
+    removePrefixes: [
+      if (customServerpodPath == null) 'path',
+    ],
     ignoreFileNames: ['pubspec.lock'],
   );
   copier.copyFiles();


### PR DESCRIPTION
### Change:
- Enables the possibility to create modules in developer mode with a reference to local Serverpod project.

Part of: https://github.com/serverpod/serverpod/issues/1768

Noticed that we didn't support creating developer projects for modules.
This is just a small fix too align the implementation in order to change it later.

### After change:
<img width="971" alt="Screenshot 2024-01-23 at 16 42 36" src="https://github.com/serverpod/serverpod/assets/137198655/d73a7a86-b014-448e-ac26-206ea0f9c654">


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None: only fixes for developer mode.
