### PR TITLE
fix: Correctly mark nested enum types in the analyzer.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -15,7 +15,7 @@ class ModelDependencyResolver {
       for (var fieldDefinition in classDefinition.fields) {
         _resolveFieldIndexes(fieldDefinition, classDefinition);
         _resolveProtocolReference(fieldDefinition, modelDefinitions);
-        _resolveEnumType(fieldDefinition, modelDefinitions);
+        _resolveEnumType(fieldDefinition.type, modelDefinitions);
         _resolveObjectRelationReference(
           classDefinition,
           fieldDefinition,
@@ -53,17 +53,23 @@ class ModelDependencyResolver {
   }
 
   static void _resolveEnumType(
-    SerializableModelFieldDefinition fieldDefinition,
+    TypeDefinition typeDefinition,
     List<SerializableModelDefinition> modelDefinitions,
   ) {
+    if (typeDefinition.generics.isNotEmpty) {
+      for (var genericType in typeDefinition.generics) {
+        _resolveEnumType(genericType, modelDefinitions);
+      }
+      return;
+    }
+
     var enumDefinitionList = modelDefinitions
         .whereType<EnumDefinition>()
-        .where((e) => e.className == fieldDefinition.type.className)
-        .toList();
+        .where((e) => e.className == typeDefinition.className);
 
     if (enumDefinitionList.isEmpty) return;
 
-    fieldDefinition.type.serializeEnum = enumDefinitionList.first.serialized;
+    typeDefinition.serializeEnum = enumDefinitionList.first.serialized;
   }
 
   static void _resolveObjectRelationReference(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
@@ -325,6 +325,81 @@ void main() {
       });
     });
 
+    test(
+        'Given a class with a field with the type List<MyEnum> then the nested type is tagged as an enum',
+        () {
+      var models = [
+        ModelSourceBuilder().withFileName('example').withYaml(
+          '''
+          class: Example
+          fields:
+            myEnum: List<MyEnum>
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('my_enum').withYaml(
+          '''
+          enum: MyEnum
+          values:
+            - first
+            - second
+          ''',
+        ).build()
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer analyzer = StatefulAnalyzer(
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+
+      var definition = definitions.first as ClassDefinition;
+      expect(
+        definition.fields.first.type.generics.first.isEnumType,
+        isTrue,
+      );
+    });
+
+    test(
+        'Given a class with a field with the type Map<MyEnum, MyEnum> then the nested type is tagged as an enum',
+        () {
+      var models = [
+        ModelSourceBuilder().withFileName('example').withYaml(
+          '''
+          class: Example
+          fields:
+            myEnum: Map<MyEnum, MyEnum>
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('my_enum').withYaml(
+          '''
+          enum: MyEnum
+          values:
+            - first
+            - second
+          ''',
+        ).build()
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer analyzer = StatefulAnalyzer(
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+
+      var definition = definitions.first as ClassDefinition;
+      expect(
+        definition.fields.first.type.generics.first.isEnumType,
+        isTrue,
+      );
+
+      expect(
+        definition.fields.first.type.generics.last.isEnumType,
+        isTrue,
+      );
+    });
+
     group('Given a class with a field with an enum type from a module', () {
       var models = [
         ModelSourceBuilder().withFileName('example').withYaml(


### PR DESCRIPTION
# Fix

- Mark enum types in generic data types in model files, E.g. on List and Map

Example:

```yaml
class: Example
fields:
  listEnum: List<MyEnum>
  mapEnum: Map<MyEnum, MyEnum>
```

Before this change the internal model did not correctly mark the enums as enums.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
