### PR TITLE
fix: Less restrictive enum naming rules.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -1047,17 +1047,9 @@ class Restrictions {
         );
       }
 
-      if (StringValidators.isInvalidFieldValueInfoSeverity(node.value)) {
+      if (!StringValidators.isValidEnumName(node.value)) {
         return SourceSpanSeverityException(
-          'Enum values should be lowerCamelCase.',
-          node.span,
-          severity: SourceSpanSeverity.info,
-        );
-      }
-
-      if (!StringValidators.isValidFieldName(node.value)) {
-        return SourceSpanSeverityException(
-          'Enum values must be lowerCamelCase.',
+          'Enum values must be valid dart enums.',
           node.span,
         );
       }

--- a/tools/serverpod_cli/lib/src/util/string_validators.dart
+++ b/tools/serverpod_cli/lib/src/util/string_validators.dart
@@ -22,6 +22,11 @@ class StringValidators {
     return false;
   }
 
+  static bool isValidEnumName(String name) {
+    // alpha numeric and underscore but cannot start with a number.
+    return RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$').hasMatch(name);
+  }
+
   static bool isInvalidFieldValueInfoSeverity(String name) {
     if (isValidFieldName(name)) return false;
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_values_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_values_test.dart
@@ -371,7 +371,8 @@ void main() {
     );
   });
 
-   test('Given a value starting with an _ value then no errors are generated.', () {
+  test('Given a value starting with an _ value then no errors are generated.',
+      () {
     var modelSources = [
       ModelSourceBuilder().withYaml(
         '''


### PR DESCRIPTION
# Changes

Allow enums to have uppercase in a snakecase string. 
Remove any info level warnings on enums.

Only restrict values to valid dart enum names. 

Defer the info warning linting to dart in this case as we do not support toggling rules and users may want to allow non-standard naming conventions in their code. 

Closes: #1813 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none