### PR TITLE
fix: Pin Dart and Busybox docker image versions.

### DIFF
--- a/templates/serverpod_templates/projectname_server/Dockerfile
+++ b/templates/serverpod_templates/projectname_server/Dockerfile
@@ -1,4 +1,6 @@
-FROM dart:3.0 AS build
+# If you update the dart version, make sure the image is
+# compatible with the busybox image.
+FROM dart:3.2.5 AS build
 
 WORKDIR /app
 COPY . .
@@ -6,7 +8,9 @@ COPY . .
 RUN dart pub get
 RUN dart compile exe bin/main.dart -o bin/main
 
-FROM busybox
+# If you update the busybox version, make sure the image is
+# compatible with the dart image.
+FROM busybox:1.36.1-glibc
 
 ENV runmode=development
 ENV serverid=default

--- a/tests/docker/tests_e2e_migrations/Dockerfile-server
+++ b/tests/docker/tests_e2e_migrations/Dockerfile-server
@@ -1,5 +1,5 @@
 # Specify the Dart SDK base image version
-FROM dart:3.0 AS build
+FROM dart:3.2.5 AS build
 
 # Install psql client.
 RUN apt-get update && apt-get install -y postgresql-client

--- a/tests/docker/tests_e2e_migrations/Dockerfile-tests
+++ b/tests/docker/tests_e2e_migrations/Dockerfile-tests
@@ -1,5 +1,5 @@
 # Specify the Dart SDK base image version
-FROM dart:3.0 AS build
+FROM dart:3.2.5 AS build
 
 # Install xz
 RUN apt-get update && apt-get install -y xz-utils

--- a/tests/docker/tests_integration/Dockerfile
+++ b/tests/docker/tests_integration/Dockerfile
@@ -1,5 +1,5 @@
 # Specify the Dart SDK base image version
-FROM dart:3.0 AS build
+FROM dart:3.2.5 AS build
 
 # Install psql client.
 RUN apt-get update && apt-get install -y postgresql-client

--- a/tests/docker/tests_single_server/Dockerfile-server
+++ b/tests/docker/tests_single_server/Dockerfile-server
@@ -1,5 +1,5 @@
 # Specify the Dart SDK base image version
-FROM dart:3.0 AS build
+FROM dart:3.2.5 AS build
 
 # Install psql client.
 RUN apt-get update && apt-get install -y postgresql-client

--- a/tests/docker/tests_single_server/Dockerfile-tests
+++ b/tests/docker/tests_single_server/Dockerfile-tests
@@ -1,5 +1,5 @@
 # Specify the Dart SDK base image version
-FROM dart:3.0 AS build
+FROM dart:3.2.5 AS build
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
## Change:
- Lock Dart and Busybox image versions to versions that are compatible.

When creating a new project a lot of users ran into issues where the Dart and Busybox image would resolve to incompatible versions. This was most notably seen in the error messages:

```
/bin/sh: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /bin/sh)
/bin/sh: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /bin/sh)
```

Closes: #1054
Closes: #1101
Closes: #882 (Should probably resolve this issue as well if using current released version of Serverpod).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this will only influence newly created projects.
