### PR TITLE
test: Add unit tests for table relation alias truncations.

### DIFF
--- a/packages/serverpod/test/database/table_relation_test.dart
+++ b/packages/serverpod/test/database/table_relation_test.dart
@@ -1,6 +1,8 @@
 import 'package:serverpod/src/database/columns.dart';
 import 'package:serverpod/src/database/expressions.dart';
 import 'package:serverpod/src/database/table_relation.dart';
+import 'package:serverpod/test_util/table_relation_builder.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -247,6 +249,128 @@ void main() {
 
       expect(lastRelation.foreignFieldNameWithJoins,
           '"citizen_favoriteRestaurant_restaurant"."id"');
+    });
+  });
+
+  group(
+      'Given a table relation between two tables with long table and relation field names',
+      () {
+    var companyTableName =
+        'company_company_company_company_company_company_company';
+    var companyTable = Table(
+      tableName: companyTableName,
+    );
+    var citizenTable = Table(
+      tableName: 'citizen_citizen_citizen_citizen_citizen_citizen_citizen',
+    );
+    var joiningColumn = ColumnInt(
+      'id_id_id_id_id_id_id_id_id_id_id_id_id_id_id_id_id_id_id_id',
+      companyTable,
+    );
+    var joiningForeignColumn = ColumnInt(
+        'employer_employer_employer_employer_employer_employer', citizenTable);
+    var relationTable = createRelationTable(
+      relationFieldName:
+          'ceo_ceo_ceo_ceo_ceo_ceo_ceo_ceo_ceo_ceo_ceo_ceo_ceo_ceo',
+      field: joiningColumn,
+      foreignField: joiningForeignColumn,
+      createTable: (foreignTableRelation) => Table(
+        tableName: companyTableName,
+        tableRelation: foreignTableRelation,
+      ),
+    );
+
+    var tableRelation = relationTable.tableRelation;
+
+    group('when getting field query alias', () {
+      test('then alias is truncated', () {
+        expect(
+          tableRelation?.fieldQueryAlias,
+          'company_company_company_company_company_company_company.id_2834',
+        );
+      });
+
+      test(
+          'then alias is deterministically truncated to same as colum query alias',
+          () {
+        expect(
+          tableRelation?.fieldQueryAlias,
+          truncateIdentifier(
+            joiningColumn.queryAlias,
+            DatabaseConstants.pgsqlMaxNameLimitation,
+          ),
+        );
+      });
+    });
+
+    group('when getting foreign field query alias then alias is truncated', () {
+      test('then alias is truncated', () {
+        expect(
+          tableRelation?.foreignFieldQueryAlias,
+          'citizen_citizen_citizen_citizen_citizen_citizen_citizen.emp4790',
+        );
+      });
+
+      test(
+          'then alias is deterministically truncated to same as colum query alias',
+          () {
+        expect(
+          tableRelation?.foreignFieldQueryAlias,
+          truncateIdentifier(
+            joiningForeignColumn.queryAlias,
+            DatabaseConstants.pgsqlMaxNameLimitation,
+          ),
+        );
+      });
+    });
+  });
+
+  group('Given a table relation between three tables with long table names',
+      () {
+    var citizenTable = Table(
+      tableName: 'citizen_citizen_citizen_citizen_citizen_citizen_citizen',
+    );
+    var companyTable = Table(
+      tableName: 'company_company_company_company_company_company_company',
+    );
+    var addressTable = Table(
+      tableName: 'address_address_address_address_address_address_address',
+    );
+    Table relationTable = TableRelationBuilder(companyTable).withRelationsFrom([
+      BuilderRelation(citizenTable, 'customer'),
+      BuilderRelation(addressTable, 'billing_address')
+    ]).build();
+
+    var tableRelation = relationTable.tableRelation;
+
+    test('when getting field query alias with joins then alias is truncated',
+        () {
+      expect(
+        tableRelation?.fieldQueryAliasWithJoins,
+        'citizen_citizen_citizen_citizen_citizen_citizen_citizen_cus5b19',
+      );
+    });
+
+    test('when getting field name with joins then alias is truncated', () {
+      expect(
+        tableRelation?.fieldNameWithJoins,
+        '"citizen_citizen_citizen_citizen_citizen_citizen_citizen_cusa803"."id"',
+      );
+    });
+
+    test('when getting foreign field name with joins then alias is truncated',
+        () {
+      expect(
+        tableRelation?.foreignFieldNameWithJoins,
+        '"citizen_citizen_citizen_citizen_citizen_citizen_citizen_cusa968"."id"',
+      );
+    });
+
+    test('when getting relation query alias then alias is truncated', () {
+      expect(
+        tableRelation?.relationQueryAlias,
+        'citizen_citizen_citizen_citizen_citizen_citizen_citizen_cusa968',
+      );
     });
   });
 }


### PR DESCRIPTION
## Changes:
- Adds unit tests for table relation alias truncations.

Closes: #1746

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - only tests.
