### PR TITLE
fix: Enable server to start with running but not migrated database.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -437,7 +437,7 @@ class Serverpod {
       await session.close();
 
       // Setup log manager.
-      _logManager = LogManager(_runtimeSettings!);
+      _logManager = LogManager(_runtimeSettings ?? _defaultRuntimeSettings);
 
       // Connect to Redis
       if (redisController != null) {


### PR DESCRIPTION
## Changes
- Fixes an issue where we would try to apply null runtime settings instead of the default runtime settings when database is not initialized.
- Adds an e2e test to start the server without applying any migrations.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Fixes a previously introduced issue.
