### PR TITLE
chore: Add deprecation message to setColumn method.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -83,6 +83,7 @@ abstract class Channel extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -94,6 +94,7 @@ abstract class EmailAuth extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -106,6 +106,7 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -97,6 +97,7 @@ abstract class EmailFailedSignIn extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -96,6 +96,7 @@ abstract class EmailReset extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -84,6 +84,7 @@ abstract class GoogleRefreshToken extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -94,6 +94,7 @@ abstract class UserImage extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -156,6 +156,7 @@ abstract class UserInfo extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -163,6 +163,7 @@ abstract class ChatMessage extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -95,6 +95,7 @@ abstract class ChatReadMessage extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -116,6 +116,7 @@ abstract class AuthKey extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -129,6 +129,7 @@ abstract class CloudStorageEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -106,6 +106,7 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -96,6 +96,7 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -117,6 +117,7 @@ abstract class FutureCallEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -173,6 +173,7 @@ abstract class LogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -172,6 +172,7 @@ abstract class MessageLogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -84,6 +84,7 @@ abstract class MethodInfo extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -172,6 +172,7 @@ abstract class QueryLogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -74,6 +74,7 @@ abstract class ReadWriteTestEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -111,6 +111,7 @@ abstract class RuntimeSettings extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -131,6 +131,7 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -131,6 +131,7 @@ abstract class ServerHealthMetric extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -211,6 +211,7 @@ abstract class SessionLogEntry extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -97,6 +97,7 @@ abstract class CityWithLongTableName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -103,6 +103,7 @@ abstract class OrganizationWithLongTableName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -99,6 +99,7 @@ abstract class PersonWithLongTableName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -76,6 +76,7 @@ abstract class MaxFieldName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -78,6 +78,7 @@ abstract class LongImplicitIdField extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -93,6 +93,7 @@ abstract class LongImplicitIdFieldCollection extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -86,6 +86,7 @@ abstract class RelationToMultipleMaxFieldName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -78,6 +78,7 @@ abstract class UserNote extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -86,6 +86,7 @@ abstract class UserNoteCollection extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -82,6 +82,7 @@ abstract class UserNoteCollectionWithALongName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -78,6 +78,7 @@ abstract class UserNoteWithALongName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -99,6 +99,7 @@ abstract class MultipleMaxFieldName extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -95,6 +95,7 @@ abstract class City extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -102,6 +102,7 @@ abstract class Organization extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -95,6 +95,7 @@ abstract class Person extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -83,6 +83,7 @@ abstract class Course extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -100,6 +100,7 @@ abstract class Enrollment extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -83,6 +83,7 @@ abstract class Student extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -91,6 +91,7 @@ abstract class ObjectUser extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -81,6 +81,7 @@ abstract class ParentUser extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -80,6 +80,7 @@ abstract class Arena extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -90,6 +90,7 @@ abstract class Player extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -102,6 +102,7 @@ abstract class Team extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -91,6 +91,7 @@ abstract class Comment extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -83,6 +83,7 @@ abstract class Customer extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -103,6 +103,7 @@ abstract class Order extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -91,6 +91,7 @@ abstract class Address extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -118,6 +118,7 @@ abstract class Citizen extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -90,6 +90,7 @@ abstract class Company extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -90,6 +90,7 @@ abstract class Town extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -100,6 +100,7 @@ abstract class Blocking extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -94,6 +94,7 @@ abstract class Member extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -102,6 +102,7 @@ abstract class Cat extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -100,6 +100,7 @@ abstract class Post extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -88,6 +88,7 @@ abstract class ObjectFieldScopes extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -73,6 +73,7 @@ abstract class ObjectWithByteData extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -72,6 +72,7 @@ abstract class ObjectWithDuration extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -117,6 +117,7 @@ abstract class ObjectWithEnum extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -81,6 +81,7 @@ abstract class ObjectWithIndex extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -135,6 +135,7 @@ abstract class ObjectWithObject extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -70,6 +70,7 @@ abstract class ObjectWithParent extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -70,6 +70,7 @@ abstract class ObjectWithSelfParent extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -82,6 +82,7 @@ abstract class ObjectWithUuid extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -91,6 +91,7 @@ abstract class RelatedUniqueData extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -56,6 +56,7 @@ abstract class ScopeNoneFields extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -74,6 +74,7 @@ abstract class SimpleData extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -74,6 +74,7 @@ abstract class SimpleDateTime extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -166,6 +166,7 @@ abstract class Types extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -81,6 +81,7 @@ abstract class UniqueData extends _i1.TableRow {
   }
 
   @override
+  @Deprecated('Will be removed in 2.0.0')
   void setColumn(
     String columnName,
     value,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1133,7 +1133,10 @@ class SerializableModelLibraryGenerator {
         fields.where((f) => f.shouldSerializeFieldForDatabase(serverCode));
 
     return Method((m) => m
-      ..annotations.add(refer('override'))
+      ..annotations.addAll([
+        refer('override'),
+        refer("Deprecated('Will be removed in 2.0.0')"),
+      ])
       ..name = 'setColumn'
       ..returns = refer('void')
       ..requiredParameters.addAll([


### PR DESCRIPTION
## Change:
- Add a deprecation message to the setColumn method that is no longer used.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this just adds an annotation.
