### PR TITLE
fix: Resolve internal relation pointers in class representations.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -1,4 +1,5 @@
 import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 
@@ -259,10 +260,16 @@ class UnresolvedListRelationDefinition extends RelationDefinition {
 /// to another Objects field name that holds the id of this object.
 class ListRelationDefinition extends RelationDefinition {
   /// References the field in the current object that points to the foreign table.
+  /// Normally this is the primary key.
   String fieldName;
 
   /// References the field in the other object holding the id of this object.
   String foreignFieldName;
+
+  /// References the field in the other object holding the data for the relation.
+  /// Meaning either an object of the type of the current object.
+  /// If this is null then there is no link from the other side.
+  SerializableModelFieldDefinition? foreignContainerField;
 
   final bool nullableRelation;
 
@@ -273,6 +280,7 @@ class ListRelationDefinition extends RelationDefinition {
     String? name,
     required this.fieldName,
     required this.foreignFieldName,
+    this.foreignContainerField,
     required this.nullableRelation,
     this.implicitForeignField = false,
   }) : super(name, false);
@@ -293,6 +301,11 @@ class ObjectRelationDefinition extends RelationDefinition {
   /// References the column in the unresolved [parentTable] that this field should be joined on.
   String foreignFieldName;
 
+  /// References the field in the other object that holds the data for the relation.
+  /// Meaning either an object or a list of objects of the type of the current object.
+  /// If this is null then there is no link from the other side.
+  SerializableModelFieldDefinition? foreignContainerField;
+
   final bool nullableRelation;
 
   ObjectRelationDefinition({
@@ -300,6 +313,7 @@ class ObjectRelationDefinition extends RelationDefinition {
     required this.parentTable,
     required this.fieldName,
     required this.foreignFieldName,
+    this.foreignContainerField,
     required bool isForeignKeyOrigin,
     required this.nullableRelation,
   }) : super(name, isForeignKeyOrigin);
@@ -377,6 +391,16 @@ class ForeignRelationDefinition extends RelationDefinition {
   /// References the column in the [parentTable] that this field should be joined on.
   String foreignFieldName;
 
+  /// References the field in the current object that hold the data for the relation.
+  /// Meaning either an object or a list of objects of the type of the [parentTable].
+  /// If this is null then there is no link from this side.
+  SerializableModelFieldDefinition? containerField;
+
+  /// References the field on the other side that hold the data for the links the relation.
+  /// Meaning either an object or a list of objects of the type of the current object.
+  /// If this is null then there is no link from the other side.
+  SerializableModelFieldDefinition? foreignContainerField;
+
   /// On delete behavior in the database.
   final ForeignKeyAction onDelete;
 
@@ -387,6 +411,8 @@ class ForeignRelationDefinition extends RelationDefinition {
     String? name,
     required this.parentTable,
     required this.foreignFieldName,
+    this.containerField,
+    this.foreignContainerField,
     this.onDelete = onDeleteDefault,
     this.onUpdate = onUpdateDefault,
   }) : super(name, true);

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_one_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_one_test.dart
@@ -6,6 +6,447 @@ import 'package:test/test.dart';
 
 void main() {
   group(
+      'Given a class with a only a foreign key field defined for the relation',
+      () {
+    var models = [
+      ModelSourceBuilder().withFileName('user').withYaml(
+        '''
+        class: User
+        table: user
+        fields:
+          addressId: int, relation(parent=address)
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
+        ''',
+      ).build(),
+      ModelSourceBuilder().withFileName('address').withYaml(
+        '''
+        class: Address
+        table: address
+        fields:
+          street: String
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var definitions = analyzer.validateAll();
+
+    var userDefinition = definitions.first as ClassDefinition;
+
+    var errors = collector.errors;
+
+    test('then no errors are collected.', () {
+      expect(errors, isEmpty);
+    });
+
+    group('then a relation is defined on the addressId', () {
+      var relation = userDefinition.findField('addressId')?.relation;
+
+      test('and has the relation type ForeignRelation', () {
+        expect(
+          relation.runtimeType,
+          ForeignRelationDefinition,
+        );
+      });
+
+      test('and has the foreignFieldName set to "id"', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.foreignFieldName,
+          'id',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the parent table is set to address', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.parentTable,
+          'address',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the foreignContainerField is null.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.foreignContainerField,
+          isNull,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the containerField is null.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.containerField,
+          isNull,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+    });
+  });
+
+  group(
+      'Given a class with a only a foreign key field defined for the relation',
+      () {
+    var models = [
+      ModelSourceBuilder().withFileName('user').withYaml(
+        '''
+        class: User
+        table: user
+        fields:
+          address: Address?, relation
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
+        ''',
+      ).build(),
+      ModelSourceBuilder().withFileName('address').withYaml(
+        '''
+        class: Address
+        table: address
+        fields:
+          street: String
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var definitions = analyzer.validateAll();
+
+    var userDefinition = definitions.first as ClassDefinition;
+
+    var errors = collector.errors;
+
+    test('then no errors are collected.', () {
+      expect(errors, isEmpty);
+    });
+
+    group('then a relation is defined on the addressId', () {
+      var relation = userDefinition.findField('addressId')?.relation;
+
+      test('and has the relation type ForeignRelation', () {
+        expect(
+          relation.runtimeType,
+          ForeignRelationDefinition,
+        );
+      });
+
+      test('and has the foreignFieldName set to "id"', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.foreignFieldName,
+          'id',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the parent table is set to address', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.parentTable,
+          'address',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the foreignContainerField is null.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.foreignContainerField,
+          isNull,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the containerField is null.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.containerField?.name,
+          'address',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+    });
+
+    group('then the address field has a relation', () {
+      var relation = userDefinition.findField('address')?.relation;
+      test('of ObjectRelation type', () {
+        expect(
+          relation.runtimeType,
+          ObjectRelationDefinition,
+        );
+      });
+
+      test('has the nullableRelation set to false', () {
+        expect((relation as ObjectRelationDefinition).nullableRelation, false);
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test('without a name for the relation', () {
+        expect(relation?.name, isNull);
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test('with the foreignContainerField set to null.', () {
+        var relationObject = relation as ObjectRelationDefinition;
+
+        expect(relationObject.foreignContainerField, isNull);
+      }, skip: relation is! ObjectRelationDefinition);
+    });
+  });
+
+  group(
+      'Given a class with a foreign key and object relation field defined for the relation',
+      () {
+    var models = [
+      ModelSourceBuilder().withFileName('user').withYaml(
+        '''
+        class: User
+        table: user
+        fields:
+          addressId: int
+          address: Address?, relation(field=addressId)
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
+        ''',
+      ).build(),
+      ModelSourceBuilder().withFileName('address').withYaml(
+        '''
+        class: Address
+        table: address
+        fields:
+          street: String
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var definitions = analyzer.validateAll();
+
+    var userDefinition = definitions.first as ClassDefinition;
+
+    var errors = collector.errors;
+
+    test('then no errors are collected.', () {
+      expect(errors, isEmpty);
+    });
+
+    group('then a relation is defined on the addressId', () {
+      var relation = userDefinition.findField('addressId')?.relation;
+
+      test('and has the relation type ForeignRelation', () {
+        expect(
+          relation.runtimeType,
+          ForeignRelationDefinition,
+        );
+      });
+
+      test('and has the foreignFieldName set to "id"', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.foreignFieldName,
+          'id',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the parent table is set to address', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.parentTable,
+          'address',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the foreignContainerField is null.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.foreignContainerField,
+          isNull,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and has the containerField set.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+        var containerField = userDefinition.findField('address');
+
+        expect(
+          foreignRelation.containerField,
+          containerField,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+    });
+
+    group('then the address field has a relation', () {
+      var relation = userDefinition.findField('address')?.relation;
+      test('of ObjectRelation type', () {
+        expect(
+          relation.runtimeType,
+          ObjectRelationDefinition,
+        );
+      });
+
+      test('has the nullableRelation set to false', () {
+        expect((relation as ObjectRelationDefinition).nullableRelation, false);
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test('without a name for the relation', () {
+        expect(relation?.name, isNull);
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test('with the foreignContainerField set to null.', () {
+        var relationObject = relation as ObjectRelationDefinition;
+
+        expect(relationObject.foreignContainerField, isNull);
+      }, skip: relation is! ObjectRelationDefinition);
+    });
+  });
+
+  group(
+      'Given a class with a foreign key field and named object relation on the other side',
+      () {
+    var models = [
+      ModelSourceBuilder().withFileName('user').withYaml(
+        '''
+        class: User
+        table: user
+        fields:
+          addressId: int, relation(name=user_address, parent=address)
+        indexes:
+          address_index_idx:
+            fields: addressId
+            unique: true
+        ''',
+      ).build(),
+      ModelSourceBuilder().withFileName('address').withYaml(
+        '''
+        class: Address
+        table: address
+        fields:
+          user: User?, relation(name=user_address)
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var definitions = analyzer.validateAll();
+
+    var userDefinition = definitions.first as ClassDefinition;
+    var addressDefinition = definitions.last as ClassDefinition;
+
+    var errors = collector.errors;
+
+    test('then no errors are collected.', () {
+      expect(errors, isEmpty);
+    });
+
+    group('then a relation is defined on the addressId', () {
+      var relation = userDefinition.findField('addressId')?.relation;
+
+      test('and has the relation type ForeignRelation', () {
+        expect(
+          relation.runtimeType,
+          ForeignRelationDefinition,
+        );
+      });
+
+      test('and has the foreignFieldName set to "id"', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.foreignFieldName,
+          'id',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the parent table is set to address', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.parentTable,
+          'address',
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and has the foreignContainerField set.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+        var foreignField = addressDefinition.findField('user');
+
+        expect(
+          foreignRelation.foreignContainerField,
+          foreignField,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and the containerField is null.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+
+        expect(
+          foreignRelation.containerField,
+          isNull,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+    });
+
+    group('then the user relation', () {
+      var relation = addressDefinition.findField('user')?.relation;
+
+      test('has the relation name set', () {
+        expect(relation?.name, 'user_address');
+      });
+
+      test('is an ObjectRelationDefinition', () {
+        expect(
+          relation.runtimeType,
+          ObjectRelationDefinition,
+          reason: 'Expected the relation to be an ObjectRelationDefinition.',
+        );
+      });
+
+      test('has the nullableRelation set to false', () {
+        expect((relation as ObjectRelationDefinition).nullableRelation, false);
+      });
+
+      test('has the parent table is set', () {
+        var validateRelation = relation as ObjectRelationDefinition;
+
+        expect(validateRelation.parentTable, 'user');
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test(
+          'has the foreignFieldName defined to the foreign key field on the other side.',
+          () {
+        var validateRelation = relation as ObjectRelationDefinition;
+
+        expect(validateRelation.foreignFieldName, 'addressId');
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test('has the fieldName defined to the primary key on this side.', () {
+        var validateRelation = relation as ObjectRelationDefinition;
+
+        expect(validateRelation.fieldName, 'id');
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test('with the foreignContainerField set to null.', () {
+        var relationObject = relation as ObjectRelationDefinition;
+
+        expect(relationObject.foreignContainerField, isNull);
+      }, skip: relation is! ObjectRelationDefinition);
+    });
+  });
+  group(
       'Given a class with a named object relation on both sides with a field references',
       () {
     var models = [
@@ -93,6 +534,12 @@ void main() {
 
         expect(validateRelation.fieldName, 'id');
       }, skip: relation is! ObjectRelationDefinition);
+
+      test('with the foreignContainerField set.', () {
+        var relationObject = relation as ObjectRelationDefinition;
+
+        expect(relationObject.foreignContainerField?.name, 'address');
+      }, skip: relation is! ObjectRelationDefinition);
     });
 
     test('then the defined addressId field exists.', () {
@@ -139,9 +586,29 @@ void main() {
           'user_address',
         );
       }, skip: relation is! ForeignRelationDefinition);
+
+      test('and has the foreignContainerField set.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+        var foreignField = addressDefinition.findField('user');
+
+        expect(
+          foreignRelation.foreignContainerField,
+          foreignField,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
+
+      test('and has the containerField set.', () {
+        var foreignRelation = relation as ForeignRelationDefinition;
+        var containerField = userDefinition.findField('address');
+
+        expect(
+          foreignRelation.containerField,
+          containerField,
+        );
+      }, skip: relation is! ForeignRelationDefinition);
     });
 
-    group('then the company field has a relation', () {
+    group('then the address field has a relation', () {
       var relation = userDefinition.findField('address')?.relation;
       test('of ObjectRelation type', () {
         expect(
@@ -156,6 +623,12 @@ void main() {
 
       test('without a name for the relation', () {
         expect(relation?.name, isNull);
+      }, skip: relation is! ObjectRelationDefinition);
+
+      test('with the foreignContainerField set.', () {
+        var relationObject = relation as ObjectRelationDefinition;
+
+        expect(relationObject.foreignContainerField?.name, 'user');
       }, skip: relation is! ObjectRelationDefinition);
     });
   });


### PR DESCRIPTION
# Changes

Adds additional field pointers in our internal class representation in the analyzer / code generator. This will help us make relational decisions when generating code.

Adds new tests to cover the new functionality and a few tests to cover some basic scenarios that was not tested explicitly before (different combinations of setups in the model files).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none
