### PR TITLE
fix: Support projects without a config generator file in cli.

### DIFF
--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -188,7 +188,7 @@ class GeneratorConfig {
 
     PackageType type = getPackageType(generatorConfig);
 
-    var relativeDartClientPackagePathParts = ['..', '$name\_client'];
+    var relativeDartClientPackagePathParts = ['..', '${name}_client'];
 
     if (generatorConfig['client_package_path'] != null) {
       relativeDartClientPackagePathParts =

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -161,39 +161,39 @@ class GeneratorConfig {
       );
     }
 
-    if (pubspec!['name'] == null) {
+    if (pubspec == null ||
+        pubspec['dependencies']?.containsKey('serverpod') != true) {
+      log.error(
+        'Could not find the Serverpod dependency. Are you running serverpod from your '
+        'projects root directory?',
+      );
+
+      throw const ServerpodProjectNotFoundException(
+        'Serverpod dependency not found.',
+      );
+    }
+
+    if (pubspec['name'] == null) {
       throw const FormatException('Package name is missing in pubspec.yaml');
     }
     var serverPackage = pubspec['name'];
     var name = _stripPackage(serverPackage);
 
-    Map? generatorConfig;
+    Map generatorConfig = {};
     try {
       var file = File(p.join(dir, 'config', 'generator.yaml'));
       var yamlStr = file.readAsStringSync();
       generatorConfig = loadYaml(yamlStr);
-    } catch (_) {
-      log.error('Failed to load config/generator.yaml. Is this a Serverpod '
-          'project?');
-
-      throw const ServerpodProjectNotFoundException(
-        'Failed to load config/generator.yaml',
-      );
-    }
-
-    if (generatorConfig == null) {
-      throw const FormatException(
-          'Failed to load config/generator.yaml. Is this a Serverpod project?');
-    }
+    } catch (_) {}
 
     PackageType type = getPackageType(generatorConfig);
 
-    if (generatorConfig['client_package_path'] == null) {
-      throw const FormatException(
-          'Option "client_package_path" is required in config/generator.yaml');
+    var relativeDartClientPackagePathParts = ['..', '$name\_client'];
+
+    if (generatorConfig['client_package_path'] != null) {
+      relativeDartClientPackagePathParts =
+          p.split(generatorConfig['client_package_path']);
     }
-    var relativeDartClientPackagePathParts =
-        p.split(generatorConfig['client_package_path']);
 
     late String dartClientPackage;
     late bool dartClientDependsOnServiceClient;
@@ -211,8 +211,8 @@ class GeneratorConfig {
           yaml['dependencies'].containsKey('serverpod_service_client');
     } catch (_) {
       log.error(
-        'Failed to load client pubspec.yaml. Is your client_package_path set '
-        'correctly?',
+        'Failed to load client pubspec.yaml. If you are using a none default '
+        'path it has to be specified in the config/generator.yaml file!',
       );
       throw const ServerpodProjectNotFoundException(
         'Failed to load client pubspec.yaml',


### PR DESCRIPTION
# Changes

Support running the `serverpod generate` command when the generator.yaml is not present in the project.
Will use the project name to find the path to the client project as a default. If the user want a none default path it has to be specified in the generator.yaml file.

Related issue: https://github.com/serverpod/serverpod/issues/1725

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None