### PR TITLE
fix: Remove creating database connection in pool manager.

### DIFF
--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -3,7 +3,6 @@ import 'package:postgres_pool/postgres_pool.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
-import 'database_connection.dart';
 import 'value_encoder.dart';
 
 /// Configuration for connecting to the Postgresql database.
@@ -50,9 +49,4 @@ class DatabasePoolManager {
       settings: poolSettings,
     );
   }
-
-  /// Used internally by the [Server]. Creates a new connection to the database.
-  /// Typically, the [Database] provided by the [Session] object should be used
-  /// to connect with the database.
-  DatabaseConnection createConnection() => DatabaseConnection(this);
 }

--- a/packages/serverpod/lib/src/server/health_check.dart
+++ b/packages/serverpod/lib/src/server/health_check.dart
@@ -43,15 +43,13 @@ Future<ServerHealthResult> defaultHealthCheckMetrics(
     var startTime = DateTime.now();
     var rnd = Random().nextInt(1000000);
 
-    var databaseConnection = pod.databaseConfig.createConnection();
-
     // Write entry
     ReadWriteTestEntry? entry = ReadWriteTestEntry(
       number: rnd,
     );
 
     var session = await pod.createSession(enableLogging: false);
-    entry = await databaseConnection.insertRow(session, entry);
+    entry = await ReadWriteTestEntry.db.insertRow(session, entry);
 
     await session.close();
 


### PR DESCRIPTION
## Change
- Removes a method for creating a database connection from the pool manager.

Cleanups to alleviate bumping the Postgres package version https://github.com/serverpod/serverpod/issues/1766

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Internal method that should not have been used.
