### PR TITLE
feat: Give a warning if table keyword is used when the database is disabled.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -6,6 +6,7 @@ import 'package:serverpod_cli/src/analyzer/models/validation/model_validator.dar
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/class_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart';
+import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 import 'package:source_span/source_span.dart';
 // ignore: implementation_imports
@@ -96,6 +97,7 @@ class SerializableModelAnalyzer {
 
   /// Validates a yaml file against an expected syntax for model files.
   static void validateYamlDefinition(
+    GeneratorConfig config,
     String yaml,
     Uri sourceUri,
     CodeAnalysisCollector collector,
@@ -133,6 +135,7 @@ class SerializableModelAnalyzer {
     if (definitionType == null) return;
 
     var restrictions = Restrictions(
+      config: config,
       documentType: definitionType,
       documentContents: documentContents,
       documentDefinition: model,

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -9,12 +9,14 @@ var onErrorsCollector = (CodeGenerationCollector collector) {
 };
 
 class StatefulAnalyzer {
+  final GeneratorConfig config;
   final Map<String, _ModelState> _modelStates = {};
   List<SerializableModelDefinition> _models = [];
 
   Function(Uri, CodeGenerationCollector)? _onErrorsChangedNotifier;
 
   StatefulAnalyzer(
+    this.config,
     List<ModelSource> sources, [
     Function(Uri, CodeGenerationCollector)? onErrorsChangedNotifier,
   ]) {
@@ -131,6 +133,7 @@ class StatefulAnalyzer {
     for (var state in modelsToValidate) {
       var collector = CodeGenerationCollector();
       SerializableModelAnalyzer.validateYamlDefinition(
+        config,
         state.source.yaml,
         state.source.yamlSourceUri,
         collector,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -179,6 +179,23 @@ class Restrictions {
     return [];
   }
 
+  List<SourceSpanSeverityException> validateTableNameKey(
+    String parentNodeName,
+    String _,
+    SourceSpan? span,
+  ) {
+    if (!config.enabledFeatures.contains(ServerpodFeature.database)) {
+      return [
+        SourceSpanSeverityException(
+          'The "table" property cannot be used when the database feature is disabled.',
+          span,
+        )
+      ];
+    }
+
+    return [];
+  }
+
   List<SourceSpanSeverityException> validateTableName(
     String parentNodeName,
     dynamic tableName,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -187,9 +187,9 @@ class Restrictions {
     if (!config.enabledFeatures.contains(ServerpodFeature.database)) {
       return [
         SourceSpanSeverityException(
-          'The "table" property cannot be used when the database feature is disabled.',
-          span,
-        )
+            'The "table" property cannot be used when the database feature is disabled.',
+            span,
+            severity: SourceSpanSeverity.warning)
       ];
     }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -2,6 +2,7 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/checker/analyze_checker.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:source_span/source_span.dart';
@@ -116,12 +117,14 @@ const _maxColumnNameLength =
     DatabaseConstants.pgsqlMaxNameLimitation - _reservedColumnSuffixChars;
 
 class Restrictions {
+  final GeneratorConfig config;
   String documentType;
   YamlMap documentContents;
   SerializableModelDefinition? documentDefinition;
   ModelRelations? modelRelations;
 
   Restrictions({
+    required this.config,
     required this.documentType,
     required this.documentContents,
     this.documentDefinition,

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
@@ -25,6 +25,7 @@ class ClassYamlDefinition {
       ),
       ValidateNode(
         Keyword.table,
+        keyRestriction: restrictions.validateTableNameKey,
         valueRestriction: restrictions.validateTableName,
       ),
       ValidateNode(

--- a/tools/serverpod_cli/lib/src/config/serverpod_feature.dart
+++ b/tools/serverpod_cli/lib/src/config/serverpod_feature.dart
@@ -1,0 +1,3 @@
+enum ServerpodFeature {
+  database;
+}

--- a/tools/serverpod_cli/lib/src/generator/generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator.dart
@@ -18,7 +18,7 @@ Future<bool> performGenerate({
   log.debug('Analyzing serializable models in the protocol directory.');
   var protocols = await ModelHelper.loadProjectYamlModelsFromDisk(config);
 
-  var analyzer = StatefulAnalyzer(protocols, (uri, collector) {
+  var analyzer = StatefulAnalyzer(config, protocols, (uri, collector) {
     collector.printErrors();
 
     if (collector.hasSeverErrors) {

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -149,6 +149,7 @@ Future<ServerProject?> _loadServerProject(
   );
 
   var analyzer = StatefulAnalyzer(
+    config,
     yamlSources,
     (filePath, errors) => _reportDiagnosticErrors(connection, filePath, errors),
   );

--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -65,7 +65,7 @@ class MigrationGenerator {
     var models = await ModelHelper.loadProjectYamlModelsFromDisk(
       config,
     );
-    var modelDefinitions = StatefulAnalyzer(models, (uri, collector) {
+    var modelDefinitions = StatefulAnalyzer(config, models, (uri, collector) {
       collector.printErrors();
 
       if (collector.hasSeverErrors) {

--- a/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/generator_config_builder.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
 
 const _defaultName = 'example';
@@ -14,6 +15,7 @@ class GeneratorConfigBuilder {
   List<String> _relativeDartClientPackagePathParts;
   List<ModuleConfig> _modules;
   List<TypeDefinition> _extraClasses;
+  List<ServerpodFeature> _enabledFeatures;
 
   GeneratorConfigBuilder()
       : _name = _defaultName,
@@ -39,7 +41,8 @@ class GeneratorConfigBuilder {
             serverPackageDirectoryPathParts: [],
           ),
         ],
-        _extraClasses = [];
+        _extraClasses = [],
+        _enabledFeatures = [ServerpodFeature.database];
 
   GeneratorConfigBuilder withName(String name) {
     _name = name;
@@ -95,6 +98,11 @@ class GeneratorConfigBuilder {
     return this;
   }
 
+  GeneratorConfigBuilder withEnabledFeatures(List<ServerpodFeature> features) {
+    _enabledFeatures = features;
+    return this;
+  }
+
   GeneratorConfig build() {
     return GeneratorConfig(
       name: _name,
@@ -106,6 +114,7 @@ class GeneratorConfigBuilder {
       relativeDartClientPackagePathParts: _relativeDartClientPackagePathParts,
       modules: _modules,
       extraClasses: _extraClasses,
+      enabledFeatures: _enabledFeatures,
     );
   }
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_conflicts_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_conflicts_test.dart
@@ -1,9 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
       'Given two models with the same class name, then an error is collected that there is a collision in the class names.',
       () {
@@ -25,7 +28,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -54,7 +58,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/documentation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/documentation_test.dart
@@ -1,9 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
     'Given a class with a class documentation comment then an model with the class documentation set is generated.',
     () {
@@ -18,7 +21,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -41,7 +44,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -66,7 +69,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -88,7 +91,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -114,7 +117,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -139,7 +142,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -165,7 +168,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -188,7 +191,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as EnumDefinition;
 
@@ -214,7 +217,7 @@ void main() {
         ).build(),
       ];
 
-      StatefulAnalyzer analyzer = StatefulAnalyzer(modelSources);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, modelSources);
       var definitions = analyzer.validateAll();
       var definition = definitions.first as EnumDefinition;
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_serialized_as_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_serialized_as_test.dart
@@ -1,11 +1,14 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   group('Given a valid enum definition when validating', () {
     var modelSources = [
       ModelSourceBuilder().withYaml(
@@ -19,7 +22,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(modelSources, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
 
     var definitions = analyzer.validateAll();
 
@@ -50,7 +54,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(modelSources, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
 
     var definitions = analyzer.validateAll();
 
@@ -81,7 +86,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(modelSources, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
 
     var definitions = analyzer.validateAll();
 
@@ -112,7 +118,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(modelSources, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
 
     analyzer.validateAll();
 
@@ -147,6 +154,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       modelSources,
       onErrorsCollector(collector),
     );
@@ -194,6 +202,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       modelSources,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_values_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_values_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
     'Given an enum without a values property, then collect an error that the values property is required.',
     () {
@@ -17,7 +20,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -44,7 +47,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -73,7 +76,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -102,7 +105,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -130,7 +133,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -158,7 +161,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -186,7 +189,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -214,7 +217,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -243,7 +246,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -274,7 +277,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -297,7 +300,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -320,7 +324,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -341,7 +346,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -362,7 +368,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -384,7 +391,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -403,7 +411,8 @@ values:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(modelSources, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -427,7 +436,8 @@ values:
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(modelSources, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
 
     var definitions = analyzer.validateAll();
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   group('serverOnly property tests', () {
     test(
         'Given a class defined to serverOnly, then the serverOnly property is set to true.',
@@ -20,7 +23,7 @@ void main() {
         ).build()
       ];
 
-      var models = StatefulAnalyzer(modelSources).validateAll();
+      var models = StatefulAnalyzer(config, modelSources).validateAll();
 
       expect(models.first.serverOnly, isTrue);
     });
@@ -39,7 +42,7 @@ void main() {
         ).build()
       ];
 
-      var models = StatefulAnalyzer(modelSources).validateAll();
+      var models = StatefulAnalyzer(config, modelSources).validateAll();
 
       expect(models.first.serverOnly, isFalse);
     });
@@ -57,7 +60,7 @@ void main() {
         ).build()
       ];
 
-      var models = StatefulAnalyzer(modelSources).validateAll();
+      var models = StatefulAnalyzer(config, modelSources).validateAll();
 
       expect(models.first.serverOnly, isFalse);
     });
@@ -77,7 +80,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -105,7 +108,7 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
           .validateAll();
 
       expect(
@@ -135,8 +138,9 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var models = StatefulAnalyzer(modelSources, onErrorsCollector(collector))
-          .validateAll();
+      var models =
+          StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+              .validateAll();
 
       var model = models.first as ClassDefinition;
       expect(model.tableName, 'example');
@@ -157,7 +161,7 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
             .validateAll();
 
         expect(
@@ -190,7 +194,7 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
             .validateAll();
 
         expect(
@@ -222,7 +226,7 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
             .validateAll();
 
         expect(
@@ -262,7 +266,7 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
             .validateAll();
 
         expect(
@@ -296,7 +300,7 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
             .validateAll();
 
         expect(
@@ -332,7 +336,7 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
             .validateAll();
 
         expect(
@@ -365,7 +369,7 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(modelSources, onErrorsCollector(collector))
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
             .validateAll();
 
         expect(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
@@ -308,12 +309,14 @@ void main() {
         reason: 'Expected an error but none was generated.',
       );
 
-      var error = collector.errors.first;
+      var error = collector.errors.first as SourceSpanSeverityException;
       expect(
         error.message,
         contains(
             'The "table" property cannot be used when the database feature is disabled.'),
       );
+
+      expect(error.severity, SourceSpanSeverity.warning);
     });
   });
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
@@ -282,6 +282,39 @@ void main() {
         );
       },
     );
+
+    test(
+        'Given a class with a table defined but without the database feature enabled then an error is given.',
+        () {
+      var config = GeneratorConfigBuilder().withEnabledFeatures([]).build();
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          table: example
+          fields:
+            name: String
+          ''',
+        ).build()
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        contains(
+            'The "table" property cannot be used when the database feature is disabled.'),
+      );
+    });
   });
 
   group('Invalid properties', () {

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   group('Valid datatypes', () {
     var datatypes = [
       'String',
@@ -40,6 +42,7 @@ void main() {
 
         var collector = CodeGenerationCollector();
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -78,6 +81,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -118,6 +122,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -156,6 +161,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -194,6 +200,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -243,6 +250,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -264,6 +272,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -305,6 +314,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -348,6 +358,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -383,6 +394,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -424,6 +436,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -466,6 +479,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -530,6 +544,7 @@ void main() {
 
         var collector = CodeGenerationCollector();
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -593,6 +608,7 @@ void main() {
 
         var collector = CodeGenerationCollector();
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -628,6 +644,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -675,6 +692,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -709,6 +727,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -743,6 +762,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -777,6 +797,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -811,6 +832,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -844,6 +866,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -869,6 +892,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -896,6 +920,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -931,6 +956,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -965,6 +991,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -992,6 +1019,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -1017,6 +1045,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -1060,6 +1089,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_id_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_id_type_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   test(
     'Given a class with a table and a field called "id" defined, then collect an error that the id field is not allowed.',
     () {
@@ -20,7 +22,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       var error = collector.errors.first;
 
@@ -46,7 +49,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       var definition = definitions.first as ClassDefinition;
@@ -71,7 +75,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       var definition = definitions.first as ClassDefinition;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_parent_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_parent_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   test(
     'Given a class with a field with the parent keyword but without a value, then collect an error that the parent has to have a valid table name.',
     () {
@@ -19,7 +21,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -44,7 +47,7 @@ void main() {
             ''',
         ).build()
       ];
-      StatefulAnalyzer analyzer = StatefulAnalyzer(models);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, models);
       var definitions = analyzer.validateAll();
 
       var definition = definitions.first as ClassDefinition;
@@ -68,7 +71,7 @@ void main() {
             ''',
         ).build()
       ];
-      StatefulAnalyzer analyzer = StatefulAnalyzer(models);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, models);
 
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
@@ -93,7 +96,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -120,7 +124,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -146,7 +151,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -171,7 +177,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
       var error = collector.errors.first;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_persist_test.dart
@@ -2,10 +2,12 @@ import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   test(
     'Given a class with a field with no persist set but has a table, then the generated model should be persisted.',
     () {
@@ -21,7 +23,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
 
       var definitions = analyzer.validateAll();
 
@@ -44,7 +47,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
 
       var definitions = analyzer.validateAll();
 
@@ -74,7 +78,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
 
       var definitions = analyzer.validateAll();
 
@@ -101,7 +106,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
 
       var definitions = analyzer.validateAll();
 
@@ -128,7 +134,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
 
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
@@ -161,7 +168,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -189,7 +197,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -215,7 +224,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -245,7 +255,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -270,7 +281,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -295,7 +307,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -319,7 +332,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -345,7 +359,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors, isNotEmpty);
 
@@ -370,7 +385,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors.length, greaterThan(1));
 
@@ -403,7 +419,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(collector.errors.length, greaterThan(1));
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_restricted_names_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_restricted_names_test.dart
@@ -1,9 +1,11 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   /*
   The following types are not explicitly tested here because they are
   interpreted as the respective type. We are already validating the type of our
@@ -119,6 +121,7 @@ void main() {
         ];
 
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -153,6 +156,7 @@ void main() {
         ];
 
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -188,6 +192,7 @@ void main() {
         ];
 
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -222,6 +227,7 @@ void main() {
         ];
 
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -256,6 +262,7 @@ void main() {
         ];
 
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_scope_test.dart
@@ -2,10 +2,12 @@ import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   group('Database and api keyword tests', () {
     test(
       'Given a class with a field with two database keywords, then collect an error that only one database is allowed.',
@@ -21,7 +23,8 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -49,7 +52,8 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -76,7 +80,7 @@ void main() {
           ).build(),
         ];
 
-        StatefulAnalyzer analyzer = StatefulAnalyzer(models);
+        StatefulAnalyzer analyzer = StatefulAnalyzer(config, models);
         var definitions = analyzer.validateAll();
         var definition = definitions.first as ClassDefinition;
 
@@ -100,7 +104,7 @@ void main() {
           ).build(),
         ];
 
-        StatefulAnalyzer analyzer = StatefulAnalyzer(models);
+        StatefulAnalyzer analyzer = StatefulAnalyzer(config, models);
         var definitions = analyzer.validateAll();
         var definition = definitions.first as ClassDefinition;
 
@@ -125,7 +129,8 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -166,6 +171,7 @@ void main() {
 
         var collector = CodeGenerationCollector();
         var analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -211,7 +217,7 @@ void main() {
 
         var collector = CodeGenerationCollector();
         StatefulAnalyzer analyzer =
-            StatefulAnalyzer(models, onErrorsCollector(collector));
+            StatefulAnalyzer(config, models, onErrorsCollector(collector));
         var definitions = analyzer.validateAll();
         var definition = definitions.first as ClassDefinition;
 
@@ -252,7 +258,8 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(collector.errors.length, greaterThan(0));
 
@@ -276,7 +283,8 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(collector.errors.length, greaterThan(0));
 
@@ -302,7 +310,8 @@ void main() {
 
         var collector = CodeGenerationCollector();
 
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -338,7 +347,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer =
-          StatefulAnalyzer(models, onErrorsCollector(collector));
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -363,7 +372,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer =
-          StatefulAnalyzer(models, onErrorsCollector(collector));
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -406,7 +415,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer =
-        StatefulAnalyzer(models, onErrorsCollector(collector));
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -436,7 +445,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer =
-          StatefulAnalyzer(models, onErrorsCollector(collector));
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -467,7 +476,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer =
-          StatefulAnalyzer(models, onErrorsCollector(collector));
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(collector.errors, hasLength(greaterThan(1)));
@@ -501,6 +510,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -537,6 +547,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -568,6 +579,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_source_location_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_source_location_test.dart
@@ -1,9 +1,11 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   test(
     'Given a class with a field with an invalid key, then collect an error that locates the invalid key in the comma separated string.',
     () {
@@ -18,7 +20,8 @@ fields:
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -50,7 +53,8 @@ fields:
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -82,7 +86,8 @@ fields:
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -114,7 +119,8 @@ fields:
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -146,7 +152,8 @@ fields:
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -170,7 +177,8 @@ fields:
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -202,7 +210,8 @@ fields:
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_validation_test.dart
@@ -2,10 +2,12 @@ import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   group('Test invalid top level fields key values', () {
     test(
         'Given a class without the fields key, then collect an error that the fields key is required',
@@ -18,7 +20,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -41,7 +44,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -65,7 +69,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -92,7 +97,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -119,7 +125,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -146,7 +153,8 @@ void main() {
         ).build()
       ];
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -176,7 +184,8 @@ void main() {
           ).build()
         ];
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -202,7 +211,8 @@ void main() {
           ).build()
         ];
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -231,7 +241,8 @@ void main() {
           ).build()
         ];
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -260,7 +271,8 @@ void main() {
           ).build()
         ];
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -289,7 +301,8 @@ void main() {
           ).build()
         ];
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(collector.errors, isNotEmpty,
             reason: 'Expected an error but none was generated.');
@@ -319,6 +332,7 @@ void main() {
         ];
         var collector = CodeGenerationCollector();
         StatefulAnalyzer analyzer = StatefulAnalyzer(
+          config,
           models,
           onErrorsCollector(collector),
         );
@@ -346,6 +360,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -383,6 +398,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -418,6 +434,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_definition_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_definition_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
     'Given a class with the index property defined but without any index, then collect an error that at least one index has to be added.',
     () {
@@ -21,7 +24,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -55,7 +59,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -90,7 +95,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -117,7 +123,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       var errors = collector.errors;
@@ -161,7 +168,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       var errors = collector.errors;
@@ -223,7 +231,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
       var definition = definitions.first as ClassDefinition;
 
@@ -254,7 +263,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_field_test.dart
@@ -1,9 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
     'Given a class with an index without any fields, then collect an error that at least one field has to be added.',
     () {
@@ -22,7 +25,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -57,7 +61,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -92,7 +97,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -128,7 +134,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -163,7 +170,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_name_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_name_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   test(
       'Given a class with an index key that is not a string, then collect an error that the index name has to be defined as a string.',
       () {
@@ -23,7 +25,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -57,7 +60,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -104,7 +108,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(
@@ -139,7 +144,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -173,7 +179,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var errors = collector.errors;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_type_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   var validIndexTypes = [
     'btree',
     'hash',
@@ -35,6 +38,7 @@ void main() {
 
       var collector = CodeGenerationCollector();
       var analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -66,7 +70,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var definition = definitions.first as ClassDefinition;
@@ -95,7 +100,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -130,7 +136,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_unique_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/indexes/index_unique_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   test(
       'Given a class with an index with a unique key that is not a bool, then collect an error that the unique key has to be defined as a bool.',
       () {
@@ -24,7 +26,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -55,7 +58,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
     var definition = definitions.first as ClassDefinition;
 
@@ -82,7 +86,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
     var definition = definitions.first as ClassDefinition;
 
@@ -109,7 +114,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
     var definition = definitions.first as ClassDefinition;
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/managed_migration_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/managed_migration_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
     'Given a class without an explicit managed migration flag set then the internal state for the flag is true',
     () {
@@ -19,7 +22,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       expect(
@@ -49,7 +53,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       expect(
@@ -79,7 +84,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       expect(
@@ -109,7 +115,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       analyzer.validateAll();
 
       expect(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_types_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_types_test.dart
@@ -1,9 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test('Given a class with a null value as name, then collect an error', () {
     var models = [
       ModelSourceBuilder().withYaml(
@@ -16,7 +19,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -42,7 +46,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -64,7 +69,7 @@ void main() {
       ).build()
     ];
 
-    StatefulAnalyzer analyzer = StatefulAnalyzer(models);
+    StatefulAnalyzer analyzer = StatefulAnalyzer(config, models);
 
     var definitions = analyzer.validateAll();
     expect(definitions.first.className, 'PascalCASEString');
@@ -84,7 +89,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -113,7 +119,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -144,7 +151,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -174,7 +182,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -204,7 +213,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -234,7 +244,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -264,7 +275,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -295,7 +307,8 @@ void main() {
         ];
 
         var collector = CodeGenerationCollector();
-        StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
 
         expect(
           collector.errors,
@@ -326,7 +339,8 @@ fields:
     var collector = CodeGenerationCollector();
 
     test('Then return a human readable error message when analyzing.', () {
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -342,7 +356,8 @@ fields:
     });
 
     test('Then the second type is highlighted.', () {
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -374,7 +389,8 @@ fields:
     var collector = CodeGenerationCollector();
 
     test('then return a human readable error message when analyzing.', () {
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -405,7 +421,8 @@ fields:
     var collector = CodeGenerationCollector();
 
     test('then return a human readable error message when analyzing.', () {
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,
@@ -421,7 +438,8 @@ fields:
     });
 
     test('then the second and third type is highlighted.', () {
-      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
 
       expect(
         collector.errors,

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_class_name_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_class_name_test.dart
@@ -1,9 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().withAuthModule().build();
+
   test(
       'Given a module class with the same name as a user defined class then there is no name conflict reported.',
       () {
@@ -34,6 +37,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_model_output_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_model_output_test.dart
@@ -1,9 +1,11 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().withAuthModule().build();
   group(
       'Given module model classes in the reference list only the local models are returned',
       () {
@@ -31,6 +33,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_relation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_relation_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().withAuthModule().build();
   group('Given a class referencing a module class with a relation.', () {
     var models = [
       ModelSourceBuilder()
@@ -31,6 +33,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -79,6 +82,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -119,6 +123,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_table_name_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/modules/module_table_name_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().withAuthModule().build();
   test(
       'Given a module class with the same table name as a user defined table then there is an error reported.',
       () {
@@ -35,6 +37,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -67,6 +70,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -98,6 +102,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_database_action_test.dart
@@ -1,11 +1,14 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   var databaseActions = [
     'Cascade',
     'NoAction',
@@ -30,7 +33,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
 
       test('then no errors are detected.', () {
@@ -69,7 +73,8 @@ void main() {
       ];
 
       var collector = CodeGenerationCollector();
-      var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+      var analyzer =
+          StatefulAnalyzer(config, models, onErrorsCollector(collector));
       var definitions = analyzer.validateAll();
       var model = definitions.first as ClassDefinition;
 
@@ -104,7 +109,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
     var model = definitions.first as ClassDefinition;
 
@@ -142,7 +148,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -173,7 +180,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -217,7 +225,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
 
     analyzer.validateAll();
     var errors = collector.errors;
@@ -280,7 +289,8 @@ fields:
       ).build(),
     ];
 
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -336,7 +346,8 @@ fields:
       ).build(),
     ];
 
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -378,7 +389,8 @@ fields:
       ).build(),
     ];
 
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -408,7 +420,7 @@ fields:
             ''',
         ).build()
       ];
-      StatefulAnalyzer analyzer = StatefulAnalyzer(models);
+      StatefulAnalyzer analyzer = StatefulAnalyzer(config, models);
       var definitions = analyzer.validateAll();
 
       var definition = definitions.first as ClassDefinition;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
@@ -1,11 +1,14 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   group('Given a class with a self relation on a field with the class datatype',
       () {
     var models = [
@@ -21,6 +24,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -127,6 +131,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -170,7 +175,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer =
-        StatefulAnalyzer(models, onErrorsCollector(collector));
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
     var classDefinition = definitions.first as ClassDefinition;
 
@@ -211,7 +216,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer =
-        StatefulAnalyzer(models, onErrorsCollector(collector));
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(collector.errors, isEmpty, reason: 'Expected no errors');
@@ -233,6 +238,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -259,6 +265,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -283,6 +290,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -326,6 +334,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -358,6 +367,7 @@ void main() {
       ];
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -390,6 +400,7 @@ fields:
       ];
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -429,6 +440,7 @@ fields:
       ];
       var collector = CodeGenerationCollector();
       StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
         models,
         onErrorsCollector(collector),
       );
@@ -461,6 +473,7 @@ fields:
     ];
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -491,7 +504,8 @@ fields:
       ).build()
     ];
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -519,7 +533,8 @@ fields:
       ).build()
     ];
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(
       collector.errors,
@@ -547,7 +562,8 @@ fields:
       ).build()
     ];
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(collector.errors, isNotEmpty, reason: 'Expected an error');
 
@@ -580,6 +596,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -631,6 +648,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -673,6 +691,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -709,7 +728,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(collector.errors, isNotEmpty);
     expect(
@@ -741,7 +761,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     expect(collector.errors, isNotEmpty);
     expect(
@@ -772,7 +793,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
     expect(collector.errors, isNotEmpty, reason: 'Expected an error');
     expect(
       collector.errors.first.message,
@@ -796,6 +818,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -852,6 +875,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -915,6 +939,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_manual_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_manual_field_test.dart
@@ -1,10 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   group(
       'Given a class with a relation with a defined field name that holds the relation',
       () {
@@ -33,7 +35,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var exampleClass = definitions.first as ClassDefinition;
@@ -77,7 +80,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer =
-        StatefulAnalyzer(models, onErrorsCollector(collector));
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -129,7 +132,7 @@ fields:
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer =
-        StatefulAnalyzer(models, onErrorsCollector(collector));
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -181,7 +184,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
     var errors = collector.errors;
 
     test('then an error was collected.', () {
@@ -223,7 +227,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
     var errors = collector.errors;
 
     test('then an error was collected.', () {
@@ -265,7 +270,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
     var errors = collector.errors;
 
     test('then an error was collected.', () {
@@ -321,7 +327,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var exampleClass = definitions.first as ClassDefinition;
@@ -381,7 +388,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+    StatefulAnalyzer(config, models, onErrorsCollector(collector))
+        .validateAll();
 
     var errors = collector.errors;
 
@@ -432,7 +440,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -478,7 +487,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -526,7 +536,8 @@ fields:
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_many_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_many_to_many_test.dart
@@ -1,9 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
       'Given a class with an implicit many to many relation then an error is collected that it is not supported.',
       () {
@@ -30,6 +33,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_many_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   group('Given a class with a one to many relation', () {
     var models = [
       ModelSourceBuilder().withFileName('employee').withYaml(
@@ -27,6 +30,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -151,7 +155,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var employeeDefinition = definitions.first as ClassDefinition;
@@ -268,7 +273,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -308,7 +314,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -356,7 +363,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -394,7 +402,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var employeeDefinition = definitions.first as ClassDefinition;
@@ -481,7 +490,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var employeeDefinition = definitions.first as ClassDefinition;
@@ -551,6 +561,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -649,6 +660,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -702,6 +714,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_one_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_one_to_one_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   group(
       'Given a class with a only a foreign key field defined for the relation',
       () {
@@ -32,7 +35,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var userDefinition = definitions.first as ClassDefinition;
@@ -118,7 +122,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var userDefinition = definitions.first as ClassDefinition;
@@ -229,7 +234,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var userDefinition = definitions.first as ClassDefinition;
@@ -340,7 +346,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var userDefinition = definitions.first as ClassDefinition;
@@ -474,7 +481,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var userDefinition = definitions.first as ClassDefinition;
@@ -656,7 +664,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -713,7 +722,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -763,7 +773,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     expect(
@@ -811,7 +822,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -857,7 +869,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;
@@ -891,7 +904,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     analyzer.validateAll();
 
     var errors = collector.errors;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_many_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_many_to_many_test.dart
@@ -1,9 +1,12 @@
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   test(
       'Given a class with an implicit many to many relation then an error is collected that it is not supported.',
       () {
@@ -22,6 +25,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_one_to_many_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_one_to_many_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   group('Given a class with a one to many relation', () {
     var models = [
       ModelSourceBuilder().withFileName('cat').withYaml(
@@ -20,6 +23,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );
@@ -91,6 +95,7 @@ void main() {
 
     var collector = CodeGenerationCollector();
     StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
       models,
       onErrorsCollector(collector),
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_one_to_one_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_self_one_to_one_test.dart
@@ -1,10 +1,13 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
+
   group(
       'Given a class with a named object self relation on both sides with a field references where the side without the foreign key is declared first',
       () {
@@ -27,7 +30,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var errors = collector.errors;
@@ -164,7 +168,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var errors = collector.errors;
@@ -296,7 +301,8 @@ void main() {
     ];
 
     var collector = CodeGenerationCollector();
-    var analyzer = StatefulAnalyzer(models, onErrorsCollector(collector));
+    var analyzer =
+        StatefulAnalyzer(config, models, onErrorsCollector(collector));
     var definitions = analyzer.validateAll();
 
     var userDefinition = definitions.first as ClassDefinition;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/stateful_analyzer_test.dart
@@ -1,13 +1,15 @@
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 
 void main() {
+  var config = GeneratorConfigBuilder().build();
   test(
       'Given that no initial validation was done, then an empty list is returned when validating all files.',
       () {
-    var statefulAnalyzer = StatefulAnalyzer([]);
+    var statefulAnalyzer = StatefulAnalyzer(config, []);
 
     var models = statefulAnalyzer.validateAll();
 
@@ -17,7 +19,7 @@ void main() {
   test(
       'When we add and remove a model, then an empty list is returned when validating all files.',
       () {
-    var statefulAnalyzer = StatefulAnalyzer([]);
+    var statefulAnalyzer = StatefulAnalyzer(config, []);
 
     var modelUri = Uri(path: 'lib/src/model/example.yaml');
     var yamlSource = ModelSourceBuilder().withYamlSourceUri(modelUri).withYaml(
@@ -38,7 +40,7 @@ void main() {
   test(
       'Given an empty state, when removing a model that does not exist and validating all, then an empty list is returned',
       () {
-    var statefulAnalyzer = StatefulAnalyzer([]);
+    var statefulAnalyzer = StatefulAnalyzer(config, []);
 
     var modelUri = Uri(path: 'lib/src/model/example.yaml');
     statefulAnalyzer.removeYamlModel(modelUri);
@@ -51,7 +53,7 @@ void main() {
   test(
       'Given an empty state, when validating a single model, then an empty list is returned',
       () {
-    var statefulAnalyzer = StatefulAnalyzer([]);
+    var statefulAnalyzer = StatefulAnalyzer(config, []);
 
     var modelUri = Uri(path: 'lib/src/model/example.yaml');
     var yaml = '''
@@ -75,7 +77,7 @@ fields:
       ''',
     ).build();
 
-    var statefulAnalyzer = StatefulAnalyzer([yamlSource]);
+    var statefulAnalyzer = StatefulAnalyzer(config, [yamlSource]);
 
     var models = statefulAnalyzer.validateAll();
 
@@ -95,7 +97,8 @@ fields:
     ).build();
 
     var wasCalled = false;
-    var statefulAnalyzer = StatefulAnalyzer([yamlSource], (uri, errors) {
+    var statefulAnalyzer =
+        StatefulAnalyzer(config, [yamlSource], (uri, errors) {
       wasCalled = true;
     });
 
@@ -109,7 +112,8 @@ fields:
     var yamlSource = ModelSourceBuilder().withYaml('''''').build();
 
     var wasCalled = false;
-    var statefulAnalyzer = StatefulAnalyzer([yamlSource], (uri, errors) {
+    var statefulAnalyzer =
+        StatefulAnalyzer(config, [yamlSource], (uri, errors) {
       wasCalled = true;
     });
 
@@ -128,7 +132,7 @@ and neither is this line
     ).build();
 
     var collector = CodeGenerationCollector();
-    StatefulAnalyzer([invalidSource], onErrorsCollector(collector))
+    StatefulAnalyzer(config, [invalidSource], onErrorsCollector(collector))
         .validateAll();
 
     expect(
@@ -167,7 +171,8 @@ and neither is this line
     ).build();
 
     CodeGenerationCollector? reportedErrors;
-    var statefulAnalyzer = StatefulAnalyzer([invalidSource], (uri, errors) {
+    var statefulAnalyzer =
+        StatefulAnalyzer(config, [invalidSource], (uri, errors) {
       reportedErrors = errors;
     });
 
@@ -204,7 +209,7 @@ and neither is this line
     CodeGenerationCollector? reportedErrors;
 
     var statefulAnalyzer =
-        StatefulAnalyzer([yamlSource1, yamlSource2], (uri, errors) {
+        StatefulAnalyzer(config, [yamlSource1, yamlSource2], (uri, errors) {
       reportedErrors = errors;
     });
 
@@ -235,7 +240,7 @@ and neither is this line
 
     CodeGenerationCollector? reportedErrors;
     var statefulAnalyzer =
-        StatefulAnalyzer([yamlSource1, yamlSource2], (uri, errors) {
+        StatefulAnalyzer(config, [yamlSource1, yamlSource2], (uri, errors) {
       reportedErrors = errors;
     });
 
@@ -272,7 +277,8 @@ and neither is this line
     ).build();
 
     CodeGenerationCollector? reportedErrors;
-    var statefulAnalyzer = StatefulAnalyzer([yamlSource1], (uri, errors) {
+    var statefulAnalyzer =
+        StatefulAnalyzer(config, [yamlSource1], (uri, errors) {
       reportedErrors = errors;
     });
 

--- a/tools/serverpod_cli/test/integration/util/model_helper_test.dart
+++ b/tools/serverpod_cli/test/integration/util/model_helper_test.dart
@@ -18,6 +18,7 @@ GeneratorConfig createGeneratorConfig([
     relativeDartClientPackagePathParts: [],
     modules: [],
     extraClasses: [],
+    enabledFeatures: [],
   );
 }
 


### PR DESCRIPTION
# Changes

Introduces the concept of disabling the database feature in the analyzer. If the database is disabled a warning will be given on the `table` keyword in our yaml files.

The feature is toggled in two different ways. If the `config/generator.yaml` file is missing the database feature will be disabled (along with many other features as we are running in mini mode). 

The second way is a new keyword inside the `generator.yaml` file called `features`, where you can explicitly turn on the database feature. If the keyword `features` is missing everything is considered on, but if the keyword is present the features that should be turned on needs to be explicitly configured. Each feature is a key/value pair where the value is expected to be a bool.

Example syntax:
```yaml
type: server
...
features:
  database: true
```
Related issue: #1725 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None
