### PR TITLE
fix: Give error if none string value is supplied to parent keyword.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -638,6 +638,15 @@ class Restrictions {
   ) {
     if (content == null) return [];
 
+    if (content is! String) {
+      return [
+        SourceSpanSeverityException(
+          'The "parent" value must be a String.',
+          span,
+        )
+      ];
+    }
+
     var definition = documentDefinition;
     if (definition is ClassDefinition && definition.tableName == null) {
       return [

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_parent_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_parent_test.dart
@@ -182,4 +182,30 @@ void main() {
       );
     },
   );
+
+  test(
+    'Given a class with the parent keyword with a nested value then an error is collected that the parent ...',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          table: example
+          fields:
+            parentId: int, parent(relation=example)
+          ''',
+        ).build()
+      ];
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(models, onErrorsCollector(collector)).validateAll();
+
+      expect(collector.errors, isNotEmpty);
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The "parent" value must be a String.',
+      );
+    },
+  );
 }


### PR DESCRIPTION
# Changes

Fixes a crash if none string value was given to the parent keyword.

Closes: #1859 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None