### PR TITLE
fix: Give explicit errors when using migration system in a mini project.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -441,6 +441,12 @@ class Serverpod {
 
       if (Features.enableMigrations) {
         await _applyMigrations();
+      } else if (commandLineArgs.applyMigrations ||
+          commandLineArgs.applyRepairMigration) {
+        stderr.writeln(
+          'Migrations are disabled in this project, skipping applying migration(s).',
+        );
+        _exitCode = 1;
       }
 
       // Setup log manager.

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -125,11 +125,11 @@ class ServerpodConfig {
     var str = '';
 
     str += apiServer.toString();
-    str += insightsServer.toString();
-    str += webServer.toString();
+    if (insightsServer != null) str += insightsServer.toString();
+    if (webServer != null) str += webServer.toString();
 
-    str += database.toString();
-    str += redis.toString();
+    if (database != null) str += database.toString();
+    if (redis != null) str += redis.toString();
 
     return str;
   }

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -184,7 +184,7 @@ class Restrictions {
     String _,
     SourceSpan? span,
   ) {
-    if (!config.enabledFeatures.contains(ServerpodFeature.database)) {
+    if (!config.isFeatureEnabled(ServerpodFeature.database)) {
       return [
         SourceSpanSeverityException(
             'The "table" property cannot be used when the database feature is disabled.',

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/exit_exception.dart';
@@ -53,6 +54,14 @@ class CreateMigrationCommand extends ServerpodCommand {
     try {
       config = await GeneratorConfig.load();
     } catch (_) {
+      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+    }
+
+    if (!config.isFeatureEnabled(ServerpodFeature.database)) {
+      log.error(
+        'The database feature is not enabled in this project. '
+        'This command cannot be used.',
+      );
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/exit_exception.dart';
@@ -62,6 +63,21 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
       log.error(
         'Invalid tag name. Tag names can only contain lowercase letters, '
         'number, and dashes.',
+      );
+      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+    }
+
+    GeneratorConfig config;
+    try {
+      config = await GeneratorConfig.load();
+    } catch (_) {
+      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+    }
+
+    if (!config.isFeatureEnabled(ServerpodFeature.database)) {
+      log.error(
+        'The database feature is not enabled in this project. '
+        'This command cannot be used.',
       );
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -133,6 +133,9 @@ class GeneratorConfig {
   /// All the features that are enabled in the serverpod project.
   final List<ServerpodFeature> enabledFeatures;
 
+  bool isFeatureEnabled(ServerpodFeature feature) =>
+      enabledFeatures.contains(feature);
+
   /// All the modules defined in the config (of type module).
   List<ModuleConfig> get modules => _modules
       .where((module) => module.type == PackageType.module)


### PR DESCRIPTION
# Changes

In a project with the database feature disabled:
* Gives an error for command `serverpod create-migration`
* Gives an error for the command `serverpod create-repair-migration`
* Gives an error if starting the server with the `--apply-migrations` flag
* Gives an error if starting the server with the `--apply-repair-migration` flag

Remove prints of null values in the config.

Related issue: #1725 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None
