### PR TITLE
fix: Remove unused param in unsafe mapped query.

### DIFF
--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -244,7 +244,6 @@ class Database {
   /// the value as the contents of the column.
   /// You are responsible to sanitize the query to avoid SQL injection.
   Future<List<Map<String, Map<String, dynamic>>>> unsafeQueryMappedResults(
-    Session session,
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,


### PR DESCRIPTION
# Changes

Removes the unused session param in unsafeMappedQueryResult. This looks like a copy paste error in the code and should not have been included in the first place.

Closes: #1890

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Breaks the interface of the method as the param was required before.
