### PR TITLE
fix: Allow generate command in serverpod package project.

### DIFF
--- a/tools/serverpod_cli/lib/src/util/directory.dart
+++ b/tools/serverpod_cli/lib/src/util/directory.dart
@@ -25,6 +25,7 @@ bool isServerDirectory(Directory directory) {
   if (!pubspec.existsSync()) return false;
 
   var content = parsePubspec(pubspec);
+  if (content.name == 'serverpod') return true;
   if (!content.dependencies.containsKey('serverpod')) return false;
 
   return true;


### PR DESCRIPTION
# Fix

Bug that stopped the generated command to work in the serverpod package project.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None