### PR TITLE
fix: Prevent vscode extension from crashing on startup.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/language_server.dart
+++ b/tools/serverpod_cli/lib/src/commands/language_server.dart
@@ -2,8 +2,10 @@ import 'package:serverpod_cli/src/language_server/language_server.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 
 class LanguageServerCommand extends ServerpodCommand {
+  static String commandName = 'language-server';
+
   @override
-  final name = 'language-server';
+  final name = commandName;
 
   @override
   final description =

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -2,6 +2,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/analytics/analytics.dart';
+import 'package:serverpod_cli/src/commands/language_server.dart';
 import 'package:serverpod_cli/src/downloads/resource_manager.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/shared/environment.dart';
@@ -165,6 +166,9 @@ class ServerpodCommandRunner extends CommandRunner {
     if (topLevelResults[GlobalFlags.verbose]) {
       logLevel = LogLevel.debug;
     } else if (topLevelResults[GlobalFlags.quiet]) {
+      logLevel = LogLevel.nothing;
+    } else if (topLevelResults.command?.name ==
+        LanguageServerCommand.commandName) {
       logLevel = LogLevel.nothing;
     }
 

--- a/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
+++ b/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
@@ -1,6 +1,7 @@
 import 'package:args/command_runner.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/analytics/analytics.dart';
+import 'package:serverpod_cli/src/commands/language_server.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/logger/loggers/void_logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
@@ -49,14 +50,25 @@ class MockCommand extends Command {
   }
 }
 
+class LanguageServerMockCommand extends Command {
+  @override
+  final name = LanguageServerCommand.commandName;
+
+  @override
+  final description = 'Language Server Mock command used for testing.';
+
+  @override
+  void run() {}
+}
+
 class TestFixture {
   final MockAnalytics analytics;
-  final MockCommand command;
+  final MockCommand mockCommand;
   final ServerpodCommandRunner runner;
 
   TestFixture(
     this.analytics,
-    this.command,
+    this.mockCommand,
     this.runner,
   );
 }
@@ -69,9 +81,10 @@ TestFixture createTestFixture() {
     Version(1, 1, 0),
     onPreCommandEnvironmentCheck: () => Future(() => {}),
   );
-  var command = MockCommand();
-  runner.addCommand(command);
-  return TestFixture(analytics, command, runner);
+  var mockCommand = MockCommand();
+  runner.addCommand(mockCommand);
+  runner.addCommand(LanguageServerMockCommand());
+  return TestFixture(analytics, mockCommand, runner);
 }
 
 void main() {
@@ -134,7 +147,7 @@ void main() {
         fixture.analytics.trackedEvents.first,
         equals(MockCommand.commandName),
       );
-      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.mockCommand.numberOfRuns, equals(1));
     });
 
     test('when valid command but invalid option is provided', () async {
@@ -164,7 +177,7 @@ void main() {
         fixture.analytics.trackedEvents.first,
         equals(MockCommand.commandName),
       );
-      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.mockCommand.numberOfRuns, equals(1));
     });
 
     test('when analytics flag is omitted', () async {
@@ -172,7 +185,7 @@ void main() {
 
       await fixture.runner.run(args);
 
-      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.mockCommand.numberOfRuns, equals(1));
       expect(fixture.analytics.enabled, isTrue);
     });
 
@@ -186,7 +199,7 @@ void main() {
 
       await fixture.runner.run(args);
 
-      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.mockCommand.numberOfRuns, equals(1));
       expect(fixture.analytics.enabled, isTrue);
     });
 
@@ -200,7 +213,7 @@ void main() {
 
       await fixture.runner.run(args);
 
-      expect(fixture.command.numberOfRuns, equals(1));
+      expect(fixture.mockCommand.numberOfRuns, equals(1));
       expect(fixture.analytics.enabled, isFalse);
     });
   });
@@ -243,6 +256,15 @@ void main() {
       await fixture.runner.run(args);
 
       expect(log.logLevel, equals(LogLevel.debug));
+    });
+
+    test('when ${LanguageServerCommand.commandName} command is provided',
+        () async {
+      List<String> args = [LanguageServerCommand.commandName];
+
+      await fixture.runner.run(args);
+
+      expect(log.logLevel, equals(LogLevel.nothing));
     });
   });
 }

--- a/tools/serverpod_vscode_extension/package-lock.json
+++ b/tools/serverpod_vscode_extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverpod",
-  "version": "1.0.0",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverpod",
-      "version": "1.0.0",
+      "version": "1.2.4",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "vscode-languageclient": "^8.1.0"

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -8,7 +8,7 @@
     "color": "#020E24",
     "theme": "dark"
   },
-  "version": "1.2.3",
+  "version": "1.2.4",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/tools/serverpod_vscode_extension/src/extension.ts
+++ b/tools/serverpod_vscode_extension/src/extension.ts
@@ -28,7 +28,7 @@ export function activate(context: ExtensionContext) {
 
 	const serverOptions: ServerOptions = {
 		command: 'serverpod',
-		args: ['language-server'],
+		args: ['-q', 'language-server'],
 		options: {
 			env: process.env,
 			shell: true,


### PR DESCRIPTION
## Change
- Sets log level `nothing` when `language-server` command is provided to CLI.
- Adds the quite flag to the vs code extension so silence new version available warnings. This ensures that the extension starts working for all users that to not use the latest version of Serverpod.

Closes: #1847

When the CLI is run we perform a version check to see if a new version of serverpod is available. If a new version is available we print a message prompting the user to update. The LSP requires that no other messages are transmitted and therefore crashed on startup when an update prompted message was printed. 

This PR ensure we don't make any prints if when running the LSP.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
