### PR TITLE
docs: Mark file handling db methods as deprecated.

### DIFF
--- a/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
+++ b/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
@@ -66,6 +66,7 @@ class DatabaseCloudStorage extends CloudStorage {
   Future<ByteData?> retrieveFile(
       {required Session session, required String path}) async {
     try {
+      // ignore: deprecated_member_use_from_same_package
       return await session.dbNext.retrieveFile(storageId, path);
     } catch (e) {
       throw CloudStorageException('Failed to retrieve file. ($e)');
@@ -82,6 +83,7 @@ class DatabaseCloudStorage extends CloudStorage {
   }) async {
     try {
       await session.dbNext
+          // ignore: deprecated_member_use_from_same_package
           .storeFile(storageId, path, byteData, expiration, verified);
     } catch (e) {
       throw CloudStorageException('Failed to store file. ($e)');
@@ -133,6 +135,7 @@ class DatabaseCloudStorage extends CloudStorage {
     required Session session,
     required String path,
   }) async {
+    // ignore: deprecated_member_use_from_same_package
     return await session.dbNext.verifyFile(storageId, path);
   }
 

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -204,6 +204,8 @@ class Database {
 
   /// Stores a file in the database, specifically using the
   /// serverpod_cloud_storage table. Used by the the [DatabaseCloudStorage].
+  @Deprecated(
+      'Will be removed in 2.0.0. Use Session.storage.storeFile instead.')
   Future<void> storeFile(
     String storageId,
     String path,
@@ -219,6 +221,8 @@ class Database {
   /// Retrieves a file stored in the database or null if it doesn't exist,
   /// specifically using the serverpod_cloud_storage table. Used by the the
   /// [DatabaseCloudStorage].
+  @Deprecated(
+      'Will be removed in 2.0.0. Use Session.storage.retrieveFile instead.')
   Future<ByteData?> retrieveFile(
     String storageId,
     String path,
@@ -228,6 +232,8 @@ class Database {
   }
 
   /// Verifies that a file has been successfully uploaded.
+  @Deprecated(
+      'Will be removed in 2.0.0. Use Session.storage.verifyDirectFileUpload instead.')
   Future<bool> verifyFile(
     String storageId,
     String path,


### PR DESCRIPTION
## Changes:
- Marks the file handling methods in the database layer as deprecated for 2.0.0.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, simply an annotation change.
