### PR TITLE
fix: Remove non legacy deprecated member use.

### DIFF
--- a/packages/serverpod/lib/src/server/future_call_manager.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager.dart
@@ -108,14 +108,26 @@ class FutureCallManager {
         enableLogging: false,
       );
 
-      // TODO: replace when we got batch ops.
-      // ignore: deprecated_member_use_from_same_package
-      var rows = await tempSession.db.deleteAndReturn<FutureCallEntry>(
-        where: (FutureCallEntry.t.time <= now),
-      );
+      var rows = await tempSession.dbNext
+          .transaction<List<FutureCallEntry>>((transaction) async {
+        var activeFutureCalls = await FutureCallEntry.db.find(
+          tempSession,
+          where: (t) => t.time <= now,
+          transaction: transaction,
+        );
+
+        await FutureCallEntry.db.deleteWhere(
+          tempSession,
+          where: (t) => t.time <= now,
+          transaction: transaction,
+        );
+
+        return activeFutureCalls;
+      });
+
       await tempSession.close();
 
-      for (var entry in rows.cast<FutureCallEntry>()) {
+      for (var entry in rows) {
         var call = _futureCalls[entry.name];
         if (call == null) {
           continue;

--- a/tests/serverpod_test_server/lib/src/endpoints/database_transactions.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_transactions.dart
@@ -1,13 +1,11 @@
-// ignore_for_file: deprecated_member_use
-
 import 'package:serverpod/serverpod.dart';
 
 import '../generated/protocol.dart';
 
 class TransactionsDatabaseEndpoint extends Endpoint {
   Future<void> removeRow(Session session, int num) async {
-    await session.db.transaction((transaction) async {
-      await session.db.delete<SimpleData>(
+    await session.dbNext.transaction((transaction) async {
+      await session.dbNext.deleteWhere<SimpleData>(
         where: SimpleData.t.num.equals(num),
         transaction: transaction,
       );
@@ -16,20 +14,20 @@ class TransactionsDatabaseEndpoint extends Endpoint {
 
   Future<bool> updateInsertDelete(
       Session session, int numUpdate, int numInsert, int numDelete) async {
-    var data = await session.db.findSingleRow<SimpleData>(
+    var data = await session.dbNext.findFirstRow<SimpleData>(
       where: SimpleData.t.num.equals(numUpdate),
     );
 
-    return await session.db.transaction((transaction) async {
+    return await session.dbNext.transaction((transaction) async {
       data!.num = 1000;
-      await session.db.update(data, transaction: transaction);
+      await session.dbNext.updateRow(data, transaction: transaction);
 
       var newData = SimpleData(
         num: numInsert,
       );
-      await session.db.insert(newData, transaction: transaction);
+      await session.dbNext.insertRow(newData, transaction: transaction);
 
-      await session.db.delete<SimpleData>(
+      await session.dbNext.deleteWhere<SimpleData>(
         where: SimpleData.t.num.equals(numDelete),
         transaction: transaction,
       );

--- a/tests/serverpod_test_server/lib/src/endpoints/field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/field_scopes.dart
@@ -1,18 +1,17 @@
-// ignore_for_file: deprecated_member_use_from_same_package
-
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 
 class FieldScopesEndpoint extends Endpoint {
   Future<void> storeObject(Session session, ObjectFieldScopes object) async {
     // Delete all old objects
-    await ObjectFieldScopes.delete(session, where: (t) => Constant.bool(true));
+    await ObjectFieldScopes.db
+        .deleteWhere(session, where: (t) => Constant.bool(true));
 
     // Insert object
-    await ObjectFieldScopes.insert(session, object);
+    await ObjectFieldScopes.db.insertRow(session, object);
   }
 
   Future<ObjectFieldScopes?> retrieveObject(Session session) async {
-    return await ObjectFieldScopes.findSingleRow(session);
+    return await ObjectFieldScopes.db.findFirstRow(session);
   }
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/logging.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/logging.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: deprecated_member_use
-
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 
@@ -17,7 +15,7 @@ class LoggingEndpoint extends Endpoint {
 
   Future<void> twoQueries(Session session) async {
     var data = SimpleData(num: 42);
-    await session.db.insert(data);
-    data = (await session.db.findSingleRow<SimpleData>())!;
+    await session.dbNext.insertRow(data);
+    data = (await session.dbNext.findFirstRow<SimpleData>())!;
   }
 }


### PR DESCRIPTION
## Change:
- Converts the future call manager from using a deprecated db method to using a transaction.
- Updates non legacy tests to not use deprecated methods.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - functionally should operate the same.