### PR TITLE
fix!: Remove deprecated constant expression constructor.

### DIFF
--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -75,12 +75,6 @@ class EscapedExpression extends Expression {
 
 /// A constant [Expression].
 class Constant extends Expression {
-  // TODO: Handle more types
-
-  /// Creates a constant [Expression]. Currently supports [bool] and [String].
-  @Deprecated('Use Constant.bool or Constant.string instead.')
-  Constant(dynamic value) : super(_formatValue(value));
-
   const Constant._(super.value);
 
   /// Creates a constant [String] expression.
@@ -91,17 +85,6 @@ class Constant extends Expression {
 
   /// Creates a constant [null] expression.
   static Constant nullValue = const Constant._('NULL');
-
-  static String _formatValue(dynamic value) {
-    if (value == null) return 'NULL';
-    if (value is bool) {
-      return '$value'.toUpperCase();
-    } else if (value is String) {
-      return '\'$value\'';
-    } else {
-      throw const FormatException();
-    }
-  }
 }
 
 /// A database expression to invert the result of another expression.

--- a/packages/serverpod/test/database/expressions/constant_test.dart
+++ b/packages/serverpod/test/database/expressions/constant_test.dart
@@ -1,36 +1,7 @@
-// ignore_for_file: deprecated_member_use_from_same_package
-
 import 'package:serverpod/database.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Given a Deprecated Constant expression', () {
-    test('when initialized with null value then output is NULL.', () {
-      var expression = Constant(null);
-
-      expect(expression.toString(), 'NULL');
-    });
-
-    test(
-        'when initialized with bool value then output is uppercase bool value.',
-        () {
-      var expression = Constant(true);
-
-      expect(expression.toString(), 'TRUE');
-    });
-
-    test('when initialized with String value then output is escaped string.',
-        () {
-      var expression = Constant('test');
-
-      expect(expression.toString(), '\'test\'');
-    });
-
-    test('when initialized with unknown type then FormatException is thrown.',
-        () {
-      expect(() => Constant(DateTime.now()), throwsFormatException);
-    });
-  });
   group('Given a Constant expression', () {
     test('when null static is retrieved then output is NULL.', () {
       var expression = Constant.nullValue;


### PR DESCRIPTION
## Change:
- BREAKING: Removes the deprecated constant expression constructor.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

YES -> Removes the constant expression constructor.
