### PR TITLE
fix: syntax highlight comments for indexes in model files.

### DIFF
--- a/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
+++ b/tools/serverpod_vscode_extension/syntaxes/serverpod.tmLanguage.json
@@ -155,6 +155,9 @@
           "include": "#params"
         },
         {
+          "include": "#comments"
+        },
+        {
           "include": "#basic_value_types"
         },
         {


### PR DESCRIPTION
### Change
- Correctly syntax highlight comments under indexes.

<img width="1123" alt="Screenshot 2024-02-13 at 09 57 51" src="https://github.com/serverpod/serverpod/assets/137198655/dbf21597-ecbe-4234-97f9-0a4e4fa52503">

Closes: #1909

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
