### PR TITLE
refactor!: Rename db next to db.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -193,7 +193,7 @@ class ChannelRepository {
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<Channel>(
+    return session.db.find<Channel>(
       where: where?.call(Channel.t),
       orderBy: orderBy?.call(Channel.t),
       orderByList: orderByList?.call(Channel.t),
@@ -213,7 +213,7 @@ class ChannelRepository {
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<Channel>(
+    return session.db.findFirstRow<Channel>(
       where: where?.call(Channel.t),
       orderBy: orderBy?.call(Channel.t),
       orderByList: orderByList?.call(Channel.t),
@@ -228,7 +228,7 @@ class ChannelRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<Channel>(
+    return session.db.findById<Channel>(
       id,
       transaction: transaction,
     );
@@ -239,7 +239,7 @@ class ChannelRepository {
     List<Channel> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Channel>(
+    return session.db.insert<Channel>(
       rows,
       transaction: transaction,
     );
@@ -250,7 +250,7 @@ class ChannelRepository {
     Channel row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Channel>(
+    return session.db.insertRow<Channel>(
       row,
       transaction: transaction,
     );
@@ -262,7 +262,7 @@ class ChannelRepository {
     _i1.ColumnSelections<ChannelTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Channel>(
+    return session.db.update<Channel>(
       rows,
       columns: columns?.call(Channel.t),
       transaction: transaction,
@@ -275,7 +275,7 @@ class ChannelRepository {
     _i1.ColumnSelections<ChannelTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Channel>(
+    return session.db.updateRow<Channel>(
       row,
       columns: columns?.call(Channel.t),
       transaction: transaction,
@@ -287,7 +287,7 @@ class ChannelRepository {
     List<Channel> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Channel>(
+    return session.db.delete<Channel>(
       rows,
       transaction: transaction,
     );
@@ -298,7 +298,7 @@ class ChannelRepository {
     Channel row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Channel>(
+    return session.db.deleteRow<Channel>(
       row,
       transaction: transaction,
     );
@@ -309,7 +309,7 @@ class ChannelRepository {
     required _i1.WhereExpressionBuilder<ChannelTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Channel>(
+    return session.db.deleteWhere<Channel>(
       where: where(Channel.t),
       transaction: transaction,
     );
@@ -321,7 +321,7 @@ class ChannelRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Channel>(
+    return session.db.count<Channel>(
       where: where?.call(Channel.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -112,7 +112,7 @@ class Users {
 
     // Update all authentication keys too.
     var json = SerializationManager.encode(scopeStrs);
-    await session.dbNext.unsafeQuery(
+    await session.db.unsafeQuery(
         'UPDATE serverpod_auth_key SET "scopeNames"=\'$json\' WHERE "userId" = $userId');
 
     if (AuthConfig.current.onUserUpdated != null) {
@@ -134,7 +134,7 @@ class Users {
     }
     // Mark user as blocked in database
     userInfo.blocked = true;
-    await session.dbNext.updateRow(userInfo);
+    await session.db.updateRow(userInfo);
     await invalidateCacheForUser(session, userId);
     // Sign out user
     await session.auth.signOutUser(userId: userId);
@@ -149,7 +149,7 @@ class Users {
       throw 'userId $userId already unblocked';
     }
     userInfo.blocked = false;
-    await session.dbNext.updateRow(userInfo);
+    await session.db.updateRow(userInfo);
   }
 
   /// Invalidates the cache for a user and makes sure the next time a user info

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -216,7 +216,7 @@ class EmailAuthRepository {
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<EmailAuth>(
+    return session.db.find<EmailAuth>(
       where: where?.call(EmailAuth.t),
       orderBy: orderBy?.call(EmailAuth.t),
       orderByList: orderByList?.call(EmailAuth.t),
@@ -236,7 +236,7 @@ class EmailAuthRepository {
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<EmailAuth>(
+    return session.db.findFirstRow<EmailAuth>(
       where: where?.call(EmailAuth.t),
       orderBy: orderBy?.call(EmailAuth.t),
       orderByList: orderByList?.call(EmailAuth.t),
@@ -251,7 +251,7 @@ class EmailAuthRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<EmailAuth>(
+    return session.db.findById<EmailAuth>(
       id,
       transaction: transaction,
     );
@@ -262,7 +262,7 @@ class EmailAuthRepository {
     List<EmailAuth> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<EmailAuth>(
+    return session.db.insert<EmailAuth>(
       rows,
       transaction: transaction,
     );
@@ -273,7 +273,7 @@ class EmailAuthRepository {
     EmailAuth row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<EmailAuth>(
+    return session.db.insertRow<EmailAuth>(
       row,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class EmailAuthRepository {
     _i1.ColumnSelections<EmailAuthTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<EmailAuth>(
+    return session.db.update<EmailAuth>(
       rows,
       columns: columns?.call(EmailAuth.t),
       transaction: transaction,
@@ -298,7 +298,7 @@ class EmailAuthRepository {
     _i1.ColumnSelections<EmailAuthTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<EmailAuth>(
+    return session.db.updateRow<EmailAuth>(
       row,
       columns: columns?.call(EmailAuth.t),
       transaction: transaction,
@@ -310,7 +310,7 @@ class EmailAuthRepository {
     List<EmailAuth> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<EmailAuth>(
+    return session.db.delete<EmailAuth>(
       rows,
       transaction: transaction,
     );
@@ -321,7 +321,7 @@ class EmailAuthRepository {
     EmailAuth row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<EmailAuth>(
+    return session.db.deleteRow<EmailAuth>(
       row,
       transaction: transaction,
     );
@@ -332,7 +332,7 @@ class EmailAuthRepository {
     required _i1.WhereExpressionBuilder<EmailAuthTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<EmailAuth>(
+    return session.db.deleteWhere<EmailAuth>(
       where: where(EmailAuth.t),
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class EmailAuthRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<EmailAuth>(
+    return session.db.count<EmailAuth>(
       where: where?.call(EmailAuth.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -239,7 +239,7 @@ class EmailCreateAccountRequestRepository {
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<EmailCreateAccountRequest>(
+    return session.db.find<EmailCreateAccountRequest>(
       where: where?.call(EmailCreateAccountRequest.t),
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
@@ -259,7 +259,7 @@ class EmailCreateAccountRequestRepository {
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<EmailCreateAccountRequest>(
+    return session.db.findFirstRow<EmailCreateAccountRequest>(
       where: where?.call(EmailCreateAccountRequest.t),
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
@@ -274,7 +274,7 @@ class EmailCreateAccountRequestRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<EmailCreateAccountRequest>(
+    return session.db.findById<EmailCreateAccountRequest>(
       id,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class EmailCreateAccountRequestRepository {
     List<EmailCreateAccountRequest> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<EmailCreateAccountRequest>(
+    return session.db.insert<EmailCreateAccountRequest>(
       rows,
       transaction: transaction,
     );
@@ -296,7 +296,7 @@ class EmailCreateAccountRequestRepository {
     EmailCreateAccountRequest row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<EmailCreateAccountRequest>(
+    return session.db.insertRow<EmailCreateAccountRequest>(
       row,
       transaction: transaction,
     );
@@ -308,7 +308,7 @@ class EmailCreateAccountRequestRepository {
     _i1.ColumnSelections<EmailCreateAccountRequestTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<EmailCreateAccountRequest>(
+    return session.db.update<EmailCreateAccountRequest>(
       rows,
       columns: columns?.call(EmailCreateAccountRequest.t),
       transaction: transaction,
@@ -321,7 +321,7 @@ class EmailCreateAccountRequestRepository {
     _i1.ColumnSelections<EmailCreateAccountRequestTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<EmailCreateAccountRequest>(
+    return session.db.updateRow<EmailCreateAccountRequest>(
       row,
       columns: columns?.call(EmailCreateAccountRequest.t),
       transaction: transaction,
@@ -333,7 +333,7 @@ class EmailCreateAccountRequestRepository {
     List<EmailCreateAccountRequest> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<EmailCreateAccountRequest>(
+    return session.db.delete<EmailCreateAccountRequest>(
       rows,
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class EmailCreateAccountRequestRepository {
     EmailCreateAccountRequest row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<EmailCreateAccountRequest>(
+    return session.db.deleteRow<EmailCreateAccountRequest>(
       row,
       transaction: transaction,
     );
@@ -355,7 +355,7 @@ class EmailCreateAccountRequestRepository {
     required _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<EmailCreateAccountRequest>(
+    return session.db.deleteWhere<EmailCreateAccountRequest>(
       where: where(EmailCreateAccountRequest.t),
       transaction: transaction,
     );
@@ -367,7 +367,7 @@ class EmailCreateAccountRequestRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<EmailCreateAccountRequest>(
+    return session.db.count<EmailCreateAccountRequest>(
       where: where?.call(EmailCreateAccountRequest.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -219,7 +219,7 @@ class EmailFailedSignInRepository {
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<EmailFailedSignIn>(
+    return session.db.find<EmailFailedSignIn>(
       where: where?.call(EmailFailedSignIn.t),
       orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderByList: orderByList?.call(EmailFailedSignIn.t),
@@ -239,7 +239,7 @@ class EmailFailedSignInRepository {
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<EmailFailedSignIn>(
+    return session.db.findFirstRow<EmailFailedSignIn>(
       where: where?.call(EmailFailedSignIn.t),
       orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderByList: orderByList?.call(EmailFailedSignIn.t),
@@ -254,7 +254,7 @@ class EmailFailedSignInRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<EmailFailedSignIn>(
+    return session.db.findById<EmailFailedSignIn>(
       id,
       transaction: transaction,
     );
@@ -265,7 +265,7 @@ class EmailFailedSignInRepository {
     List<EmailFailedSignIn> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<EmailFailedSignIn>(
+    return session.db.insert<EmailFailedSignIn>(
       rows,
       transaction: transaction,
     );
@@ -276,7 +276,7 @@ class EmailFailedSignInRepository {
     EmailFailedSignIn row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<EmailFailedSignIn>(
+    return session.db.insertRow<EmailFailedSignIn>(
       row,
       transaction: transaction,
     );
@@ -288,7 +288,7 @@ class EmailFailedSignInRepository {
     _i1.ColumnSelections<EmailFailedSignInTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<EmailFailedSignIn>(
+    return session.db.update<EmailFailedSignIn>(
       rows,
       columns: columns?.call(EmailFailedSignIn.t),
       transaction: transaction,
@@ -301,7 +301,7 @@ class EmailFailedSignInRepository {
     _i1.ColumnSelections<EmailFailedSignInTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<EmailFailedSignIn>(
+    return session.db.updateRow<EmailFailedSignIn>(
       row,
       columns: columns?.call(EmailFailedSignIn.t),
       transaction: transaction,
@@ -313,7 +313,7 @@ class EmailFailedSignInRepository {
     List<EmailFailedSignIn> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<EmailFailedSignIn>(
+    return session.db.delete<EmailFailedSignIn>(
       rows,
       transaction: transaction,
     );
@@ -324,7 +324,7 @@ class EmailFailedSignInRepository {
     EmailFailedSignIn row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<EmailFailedSignIn>(
+    return session.db.deleteRow<EmailFailedSignIn>(
       row,
       transaction: transaction,
     );
@@ -335,7 +335,7 @@ class EmailFailedSignInRepository {
     required _i1.WhereExpressionBuilder<EmailFailedSignInTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<EmailFailedSignIn>(
+    return session.db.deleteWhere<EmailFailedSignIn>(
       where: where(EmailFailedSignIn.t),
       transaction: transaction,
     );
@@ -347,7 +347,7 @@ class EmailFailedSignInRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<EmailFailedSignIn>(
+    return session.db.count<EmailFailedSignIn>(
       where: where?.call(EmailFailedSignIn.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -218,7 +218,7 @@ class EmailResetRepository {
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<EmailReset>(
+    return session.db.find<EmailReset>(
       where: where?.call(EmailReset.t),
       orderBy: orderBy?.call(EmailReset.t),
       orderByList: orderByList?.call(EmailReset.t),
@@ -238,7 +238,7 @@ class EmailResetRepository {
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<EmailReset>(
+    return session.db.findFirstRow<EmailReset>(
       where: where?.call(EmailReset.t),
       orderBy: orderBy?.call(EmailReset.t),
       orderByList: orderByList?.call(EmailReset.t),
@@ -253,7 +253,7 @@ class EmailResetRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<EmailReset>(
+    return session.db.findById<EmailReset>(
       id,
       transaction: transaction,
     );
@@ -264,7 +264,7 @@ class EmailResetRepository {
     List<EmailReset> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<EmailReset>(
+    return session.db.insert<EmailReset>(
       rows,
       transaction: transaction,
     );
@@ -275,7 +275,7 @@ class EmailResetRepository {
     EmailReset row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<EmailReset>(
+    return session.db.insertRow<EmailReset>(
       row,
       transaction: transaction,
     );
@@ -287,7 +287,7 @@ class EmailResetRepository {
     _i1.ColumnSelections<EmailResetTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<EmailReset>(
+    return session.db.update<EmailReset>(
       rows,
       columns: columns?.call(EmailReset.t),
       transaction: transaction,
@@ -300,7 +300,7 @@ class EmailResetRepository {
     _i1.ColumnSelections<EmailResetTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<EmailReset>(
+    return session.db.updateRow<EmailReset>(
       row,
       columns: columns?.call(EmailReset.t),
       transaction: transaction,
@@ -312,7 +312,7 @@ class EmailResetRepository {
     List<EmailReset> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<EmailReset>(
+    return session.db.delete<EmailReset>(
       rows,
       transaction: transaction,
     );
@@ -323,7 +323,7 @@ class EmailResetRepository {
     EmailReset row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<EmailReset>(
+    return session.db.deleteRow<EmailReset>(
       row,
       transaction: transaction,
     );
@@ -334,7 +334,7 @@ class EmailResetRepository {
     required _i1.WhereExpressionBuilder<EmailResetTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<EmailReset>(
+    return session.db.deleteWhere<EmailReset>(
       where: where(EmailReset.t),
       transaction: transaction,
     );
@@ -346,7 +346,7 @@ class EmailResetRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<EmailReset>(
+    return session.db.count<EmailReset>(
       where: where?.call(EmailReset.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -195,7 +195,7 @@ class GoogleRefreshTokenRepository {
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<GoogleRefreshToken>(
+    return session.db.find<GoogleRefreshToken>(
       where: where?.call(GoogleRefreshToken.t),
       orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderByList: orderByList?.call(GoogleRefreshToken.t),
@@ -215,7 +215,7 @@ class GoogleRefreshTokenRepository {
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<GoogleRefreshToken>(
+    return session.db.findFirstRow<GoogleRefreshToken>(
       where: where?.call(GoogleRefreshToken.t),
       orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderByList: orderByList?.call(GoogleRefreshToken.t),
@@ -230,7 +230,7 @@ class GoogleRefreshTokenRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<GoogleRefreshToken>(
+    return session.db.findById<GoogleRefreshToken>(
       id,
       transaction: transaction,
     );
@@ -241,7 +241,7 @@ class GoogleRefreshTokenRepository {
     List<GoogleRefreshToken> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<GoogleRefreshToken>(
+    return session.db.insert<GoogleRefreshToken>(
       rows,
       transaction: transaction,
     );
@@ -252,7 +252,7 @@ class GoogleRefreshTokenRepository {
     GoogleRefreshToken row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<GoogleRefreshToken>(
+    return session.db.insertRow<GoogleRefreshToken>(
       row,
       transaction: transaction,
     );
@@ -264,7 +264,7 @@ class GoogleRefreshTokenRepository {
     _i1.ColumnSelections<GoogleRefreshTokenTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<GoogleRefreshToken>(
+    return session.db.update<GoogleRefreshToken>(
       rows,
       columns: columns?.call(GoogleRefreshToken.t),
       transaction: transaction,
@@ -277,7 +277,7 @@ class GoogleRefreshTokenRepository {
     _i1.ColumnSelections<GoogleRefreshTokenTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<GoogleRefreshToken>(
+    return session.db.updateRow<GoogleRefreshToken>(
       row,
       columns: columns?.call(GoogleRefreshToken.t),
       transaction: transaction,
@@ -289,7 +289,7 @@ class GoogleRefreshTokenRepository {
     List<GoogleRefreshToken> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<GoogleRefreshToken>(
+    return session.db.delete<GoogleRefreshToken>(
       rows,
       transaction: transaction,
     );
@@ -300,7 +300,7 @@ class GoogleRefreshTokenRepository {
     GoogleRefreshToken row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<GoogleRefreshToken>(
+    return session.db.deleteRow<GoogleRefreshToken>(
       row,
       transaction: transaction,
     );
@@ -311,7 +311,7 @@ class GoogleRefreshTokenRepository {
     required _i1.WhereExpressionBuilder<GoogleRefreshTokenTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<GoogleRefreshToken>(
+    return session.db.deleteWhere<GoogleRefreshToken>(
       where: where(GoogleRefreshToken.t),
       transaction: transaction,
     );
@@ -323,7 +323,7 @@ class GoogleRefreshTokenRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<GoogleRefreshToken>(
+    return session.db.count<GoogleRefreshToken>(
       where: where?.call(GoogleRefreshToken.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -216,7 +216,7 @@ class UserImageRepository {
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<UserImage>(
+    return session.db.find<UserImage>(
       where: where?.call(UserImage.t),
       orderBy: orderBy?.call(UserImage.t),
       orderByList: orderByList?.call(UserImage.t),
@@ -236,7 +236,7 @@ class UserImageRepository {
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<UserImage>(
+    return session.db.findFirstRow<UserImage>(
       where: where?.call(UserImage.t),
       orderBy: orderBy?.call(UserImage.t),
       orderByList: orderByList?.call(UserImage.t),
@@ -251,7 +251,7 @@ class UserImageRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<UserImage>(
+    return session.db.findById<UserImage>(
       id,
       transaction: transaction,
     );
@@ -262,7 +262,7 @@ class UserImageRepository {
     List<UserImage> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<UserImage>(
+    return session.db.insert<UserImage>(
       rows,
       transaction: transaction,
     );
@@ -273,7 +273,7 @@ class UserImageRepository {
     UserImage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<UserImage>(
+    return session.db.insertRow<UserImage>(
       row,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class UserImageRepository {
     _i1.ColumnSelections<UserImageTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<UserImage>(
+    return session.db.update<UserImage>(
       rows,
       columns: columns?.call(UserImage.t),
       transaction: transaction,
@@ -298,7 +298,7 @@ class UserImageRepository {
     _i1.ColumnSelections<UserImageTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<UserImage>(
+    return session.db.updateRow<UserImage>(
       row,
       columns: columns?.call(UserImage.t),
       transaction: transaction,
@@ -310,7 +310,7 @@ class UserImageRepository {
     List<UserImage> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<UserImage>(
+    return session.db.delete<UserImage>(
       rows,
       transaction: transaction,
     );
@@ -321,7 +321,7 @@ class UserImageRepository {
     UserImage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<UserImage>(
+    return session.db.deleteRow<UserImage>(
       row,
       transaction: transaction,
     );
@@ -332,7 +332,7 @@ class UserImageRepository {
     required _i1.WhereExpressionBuilder<UserImageTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<UserImage>(
+    return session.db.deleteWhere<UserImage>(
       where: where(UserImage.t),
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class UserImageRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<UserImage>(
+    return session.db.count<UserImage>(
       where: where?.call(UserImage.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -334,7 +334,7 @@ class UserInfoRepository {
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<UserInfo>(
+    return session.db.find<UserInfo>(
       where: where?.call(UserInfo.t),
       orderBy: orderBy?.call(UserInfo.t),
       orderByList: orderByList?.call(UserInfo.t),
@@ -354,7 +354,7 @@ class UserInfoRepository {
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<UserInfo>(
+    return session.db.findFirstRow<UserInfo>(
       where: where?.call(UserInfo.t),
       orderBy: orderBy?.call(UserInfo.t),
       orderByList: orderByList?.call(UserInfo.t),
@@ -369,7 +369,7 @@ class UserInfoRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<UserInfo>(
+    return session.db.findById<UserInfo>(
       id,
       transaction: transaction,
     );
@@ -380,7 +380,7 @@ class UserInfoRepository {
     List<UserInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<UserInfo>(
+    return session.db.insert<UserInfo>(
       rows,
       transaction: transaction,
     );
@@ -391,7 +391,7 @@ class UserInfoRepository {
     UserInfo row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<UserInfo>(
+    return session.db.insertRow<UserInfo>(
       row,
       transaction: transaction,
     );
@@ -403,7 +403,7 @@ class UserInfoRepository {
     _i1.ColumnSelections<UserInfoTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<UserInfo>(
+    return session.db.update<UserInfo>(
       rows,
       columns: columns?.call(UserInfo.t),
       transaction: transaction,
@@ -416,7 +416,7 @@ class UserInfoRepository {
     _i1.ColumnSelections<UserInfoTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<UserInfo>(
+    return session.db.updateRow<UserInfo>(
       row,
       columns: columns?.call(UserInfo.t),
       transaction: transaction,
@@ -428,7 +428,7 @@ class UserInfoRepository {
     List<UserInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<UserInfo>(
+    return session.db.delete<UserInfo>(
       rows,
       transaction: transaction,
     );
@@ -439,7 +439,7 @@ class UserInfoRepository {
     UserInfo row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<UserInfo>(
+    return session.db.deleteRow<UserInfo>(
       row,
       transaction: transaction,
     );
@@ -450,7 +450,7 @@ class UserInfoRepository {
     required _i1.WhereExpressionBuilder<UserInfoTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<UserInfo>(
+    return session.db.deleteWhere<UserInfo>(
       where: where(UserInfo.t),
       transaction: transaction,
     );
@@ -462,7 +462,7 @@ class UserInfoRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<UserInfo>(
+    return session.db.count<UserInfo>(
       where: where?.call(UserInfo.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -335,7 +335,7 @@ class ChatMessageRepository {
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ChatMessage>(
+    return session.db.find<ChatMessage>(
       where: where?.call(ChatMessage.t),
       orderBy: orderBy?.call(ChatMessage.t),
       orderByList: orderByList?.call(ChatMessage.t),
@@ -355,7 +355,7 @@ class ChatMessageRepository {
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ChatMessage>(
+    return session.db.findFirstRow<ChatMessage>(
       where: where?.call(ChatMessage.t),
       orderBy: orderBy?.call(ChatMessage.t),
       orderByList: orderByList?.call(ChatMessage.t),
@@ -370,7 +370,7 @@ class ChatMessageRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ChatMessage>(
+    return session.db.findById<ChatMessage>(
       id,
       transaction: transaction,
     );
@@ -381,7 +381,7 @@ class ChatMessageRepository {
     List<ChatMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ChatMessage>(
+    return session.db.insert<ChatMessage>(
       rows,
       transaction: transaction,
     );
@@ -392,7 +392,7 @@ class ChatMessageRepository {
     ChatMessage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ChatMessage>(
+    return session.db.insertRow<ChatMessage>(
       row,
       transaction: transaction,
     );
@@ -404,7 +404,7 @@ class ChatMessageRepository {
     _i1.ColumnSelections<ChatMessageTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ChatMessage>(
+    return session.db.update<ChatMessage>(
       rows,
       columns: columns?.call(ChatMessage.t),
       transaction: transaction,
@@ -417,7 +417,7 @@ class ChatMessageRepository {
     _i1.ColumnSelections<ChatMessageTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ChatMessage>(
+    return session.db.updateRow<ChatMessage>(
       row,
       columns: columns?.call(ChatMessage.t),
       transaction: transaction,
@@ -429,7 +429,7 @@ class ChatMessageRepository {
     List<ChatMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ChatMessage>(
+    return session.db.delete<ChatMessage>(
       rows,
       transaction: transaction,
     );
@@ -440,7 +440,7 @@ class ChatMessageRepository {
     ChatMessage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ChatMessage>(
+    return session.db.deleteRow<ChatMessage>(
       row,
       transaction: transaction,
     );
@@ -451,7 +451,7 @@ class ChatMessageRepository {
     required _i1.WhereExpressionBuilder<ChatMessageTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ChatMessage>(
+    return session.db.deleteWhere<ChatMessage>(
       where: where(ChatMessage.t),
       transaction: transaction,
     );
@@ -463,7 +463,7 @@ class ChatMessageRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ChatMessage>(
+    return session.db.count<ChatMessage>(
       where: where?.call(ChatMessage.t),
       limit: limit,
       transaction: transaction,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -217,7 +217,7 @@ class ChatReadMessageRepository {
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ChatReadMessage>(
+    return session.db.find<ChatReadMessage>(
       where: where?.call(ChatReadMessage.t),
       orderBy: orderBy?.call(ChatReadMessage.t),
       orderByList: orderByList?.call(ChatReadMessage.t),
@@ -237,7 +237,7 @@ class ChatReadMessageRepository {
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ChatReadMessage>(
+    return session.db.findFirstRow<ChatReadMessage>(
       where: where?.call(ChatReadMessage.t),
       orderBy: orderBy?.call(ChatReadMessage.t),
       orderByList: orderByList?.call(ChatReadMessage.t),
@@ -252,7 +252,7 @@ class ChatReadMessageRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ChatReadMessage>(
+    return session.db.findById<ChatReadMessage>(
       id,
       transaction: transaction,
     );
@@ -263,7 +263,7 @@ class ChatReadMessageRepository {
     List<ChatReadMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ChatReadMessage>(
+    return session.db.insert<ChatReadMessage>(
       rows,
       transaction: transaction,
     );
@@ -274,7 +274,7 @@ class ChatReadMessageRepository {
     ChatReadMessage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ChatReadMessage>(
+    return session.db.insertRow<ChatReadMessage>(
       row,
       transaction: transaction,
     );
@@ -286,7 +286,7 @@ class ChatReadMessageRepository {
     _i1.ColumnSelections<ChatReadMessageTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ChatReadMessage>(
+    return session.db.update<ChatReadMessage>(
       rows,
       columns: columns?.call(ChatReadMessage.t),
       transaction: transaction,
@@ -299,7 +299,7 @@ class ChatReadMessageRepository {
     _i1.ColumnSelections<ChatReadMessageTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ChatReadMessage>(
+    return session.db.updateRow<ChatReadMessage>(
       row,
       columns: columns?.call(ChatReadMessage.t),
       transaction: transaction,
@@ -311,7 +311,7 @@ class ChatReadMessageRepository {
     List<ChatReadMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ChatReadMessage>(
+    return session.db.delete<ChatReadMessage>(
       rows,
       transaction: transaction,
     );
@@ -322,7 +322,7 @@ class ChatReadMessageRepository {
     ChatReadMessage row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ChatReadMessage>(
+    return session.db.deleteRow<ChatReadMessage>(
       row,
       transaction: transaction,
     );
@@ -333,7 +333,7 @@ class ChatReadMessageRepository {
     required _i1.WhereExpressionBuilder<ChatReadMessageTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ChatReadMessage>(
+    return session.db.deleteWhere<ChatReadMessage>(
       where: where(ChatReadMessage.t),
       transaction: transaction,
     );
@@ -345,7 +345,7 @@ class ChatReadMessageRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ChatReadMessage>(
+    return session.db.count<ChatReadMessage>(
       where: where?.call(ChatReadMessage.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/authentication/default_authentication_handler.dart
+++ b/packages/serverpod/lib/src/authentication/default_authentication_handler.dart
@@ -24,7 +24,7 @@ Future<AuthenticationInfo?> defaultAuthenticationHandler(
       enableLogging: false,
     );
 
-    var authKey = await tempSession.dbNext.findById<AuthKey>(keyId);
+    var authKey = await tempSession.db.findById<AuthKey>(keyId);
     await tempSession.close();
 
     if (authKey == null) return null;

--- a/packages/serverpod/lib/src/cloud_storage/public_endpoint.dart
+++ b/packages/serverpod/lib/src/cloud_storage/public_endpoint.dart
@@ -55,14 +55,14 @@ class CloudStoragePublicEndpoint extends Endpoint {
       String key) async {
     // Confirm that we are allowed to do the upload
     var uploadInfo =
-        await session.dbNext.findFirstRow<CloudStorageDirectUploadEntry>(
+        await session.db.findFirstRow<CloudStorageDirectUploadEntry>(
       where: CloudStorageDirectUploadEntry.t.storageId.equals(storageId) &
           CloudStorageDirectUploadEntry.t.path.equals(path),
     );
 
     if (uploadInfo == null) return false;
 
-    await session.dbNext.deleteRow(uploadInfo);
+    await session.db.deleteRow(uploadInfo);
 
     if (uploadInfo.authKey != key) return false;
 

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -54,7 +54,7 @@ class MigrationManager {
   Future<bool> verifyDatabaseIntegrity(Session session) async {
     var warnings = <String>[];
 
-    var liveDatabase = await DatabaseAnalyzer.analyze(session.dbNext);
+    var liveDatabase = await DatabaseAnalyzer.analyze(session.db);
     var targetTables =
         session.serverpod.serializationManager.getTargetTableDefinitions();
 
@@ -147,7 +147,7 @@ class MigrationManager {
       return null;
     }
 
-    await session.dbNext.unsafeExecute(repairMigration.sqlMigration);
+    await session.db.unsafeExecute(repairMigration.sqlMigration);
     return repairMigration.versionName;
   }
 
@@ -186,7 +186,7 @@ class MigrationManager {
     var migrationsApplied = <String>[];
     for (var code in sqlToExecute) {
       try {
-        await session.dbNext.unsafeExecute(code.sql);
+        await session.db.unsafeExecute(code.sql);
         migrationsApplied.add(code.version);
       } catch (e) {
         stderr.writeln('Failed to apply migration ${code.version}.');

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -38,7 +38,7 @@ class InsightsEndpoint extends Endpoint {
 
   /// Clear all server logs.
   Future<void> clearAllLogs(Session session) async {
-    await session.dbNext.deleteWhere<SessionLogEntry>(
+    await session.db.deleteWhere<SessionLogEntry>(
       where: Constant.bool(true),
     );
   }
@@ -78,7 +78,7 @@ class InsightsEndpoint extends Endpoint {
       where = where & (SessionLogEntry.t.id < filter.lastSessionLogId);
     }
 
-    var rows = (await session.dbNext.find<SessionLogEntry>(
+    var rows = (await session.db.find<SessionLogEntry>(
       where: where,
       limit: numEntries,
       orderBy: SessionLogEntry.t.id,
@@ -88,15 +88,15 @@ class InsightsEndpoint extends Endpoint {
 
     var sessionLogInfo = <SessionLogInfo>[];
     for (var logEntry in rows) {
-      var logRows = await session.dbNext.find<LogEntry>(
+      var logRows = await session.db.find<LogEntry>(
         where: LogEntry.t.sessionLogId.equals(logEntry.id),
       );
 
-      var queryRows = await session.dbNext.find<QueryLogEntry>(
+      var queryRows = await session.db.find<QueryLogEntry>(
         where: QueryLogEntry.t.sessionLogId.equals(logEntry.id),
       );
 
-      var messageRows = await session.dbNext.find<MessageLogEntry>(
+      var messageRows = await session.db.find<MessageLogEntry>(
         where: MessageLogEntry.t.sessionLogId.equals(logEntry.id),
       );
 
@@ -207,7 +207,7 @@ class InsightsEndpoint extends Endpoint {
   /// - [getTargetTableDefinition]
   Future<DatabaseDefinition> getLiveDatabaseDefinition(Session session) async {
     // Get database definition of the live database.
-    var databaseDefinition = await DatabaseAnalyzer.analyze(session.dbNext);
+    var databaseDefinition = await DatabaseAnalyzer.analyze(session.db);
 
     // Make sure that the migration manager is up-to-date.
     await session.serverpod.migrationManager.initialize(session);
@@ -258,7 +258,7 @@ class InsightsEndpoint extends Endpoint {
   }) async {
     try {
       return DatabaseBulkData.exportTableData(
-        database: session.dbNext,
+        database: session.db,
         table: table,
         lastId: startingId,
         limit: limit,
@@ -279,7 +279,7 @@ class InsightsEndpoint extends Endpoint {
   ) async {
     try {
       var result = await DatabaseBulkData.executeQueries(
-        database: session.dbNext,
+        database: session.db,
         queries: queries,
       );
       return result;
@@ -302,7 +302,7 @@ class InsightsEndpoint extends Endpoint {
     required String table,
   }) async {
     return DatabaseBulkData.approximateRowCount(
-      database: session.dbNext,
+      database: session.db,
       table: table,
     );
   }
@@ -310,7 +310,7 @@ class InsightsEndpoint extends Endpoint {
   /// Executes SQL commands. Returns the number of rows affected.
   Future<int> executeSql(Session session, String sql) async {
     try {
-      return await session.dbNext.unsafeExecute(sql);
+      return await session.db.unsafeExecute(sql);
     } catch (e) {
       throw ServerpodSqlException(
         message: '$e',

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -253,7 +253,7 @@ class AuthKeyRepository {
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<AuthKey>(
+    return session.db.find<AuthKey>(
       where: where?.call(AuthKey.t),
       orderBy: orderBy?.call(AuthKey.t),
       orderByList: orderByList?.call(AuthKey.t),
@@ -273,7 +273,7 @@ class AuthKeyRepository {
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<AuthKey>(
+    return session.db.findFirstRow<AuthKey>(
       where: where?.call(AuthKey.t),
       orderBy: orderBy?.call(AuthKey.t),
       orderByList: orderByList?.call(AuthKey.t),
@@ -288,7 +288,7 @@ class AuthKeyRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<AuthKey>(
+    return session.db.findById<AuthKey>(
       id,
       transaction: transaction,
     );
@@ -299,7 +299,7 @@ class AuthKeyRepository {
     List<AuthKey> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<AuthKey>(
+    return session.db.insert<AuthKey>(
       rows,
       transaction: transaction,
     );
@@ -310,7 +310,7 @@ class AuthKeyRepository {
     AuthKey row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<AuthKey>(
+    return session.db.insertRow<AuthKey>(
       row,
       transaction: transaction,
     );
@@ -322,7 +322,7 @@ class AuthKeyRepository {
     _i1.ColumnSelections<AuthKeyTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<AuthKey>(
+    return session.db.update<AuthKey>(
       rows,
       columns: columns?.call(AuthKey.t),
       transaction: transaction,
@@ -335,7 +335,7 @@ class AuthKeyRepository {
     _i1.ColumnSelections<AuthKeyTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<AuthKey>(
+    return session.db.updateRow<AuthKey>(
       row,
       columns: columns?.call(AuthKey.t),
       transaction: transaction,
@@ -347,7 +347,7 @@ class AuthKeyRepository {
     List<AuthKey> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<AuthKey>(
+    return session.db.delete<AuthKey>(
       rows,
       transaction: transaction,
     );
@@ -358,7 +358,7 @@ class AuthKeyRepository {
     AuthKey row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<AuthKey>(
+    return session.db.deleteRow<AuthKey>(
       row,
       transaction: transaction,
     );
@@ -369,7 +369,7 @@ class AuthKeyRepository {
     required _i1.WhereExpressionBuilder<AuthKeyTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<AuthKey>(
+    return session.db.deleteWhere<AuthKey>(
       where: where(AuthKey.t),
       transaction: transaction,
     );
@@ -381,7 +381,7 @@ class AuthKeyRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<AuthKey>(
+    return session.db.count<AuthKey>(
       where: where?.call(AuthKey.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -284,7 +284,7 @@ class CloudStorageEntryRepository {
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<CloudStorageEntry>(
+    return session.db.find<CloudStorageEntry>(
       where: where?.call(CloudStorageEntry.t),
       orderBy: orderBy?.call(CloudStorageEntry.t),
       orderByList: orderByList?.call(CloudStorageEntry.t),
@@ -304,7 +304,7 @@ class CloudStorageEntryRepository {
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<CloudStorageEntry>(
+    return session.db.findFirstRow<CloudStorageEntry>(
       where: where?.call(CloudStorageEntry.t),
       orderBy: orderBy?.call(CloudStorageEntry.t),
       orderByList: orderByList?.call(CloudStorageEntry.t),
@@ -319,7 +319,7 @@ class CloudStorageEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<CloudStorageEntry>(
+    return session.db.findById<CloudStorageEntry>(
       id,
       transaction: transaction,
     );
@@ -330,7 +330,7 @@ class CloudStorageEntryRepository {
     List<CloudStorageEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<CloudStorageEntry>(
+    return session.db.insert<CloudStorageEntry>(
       rows,
       transaction: transaction,
     );
@@ -341,7 +341,7 @@ class CloudStorageEntryRepository {
     CloudStorageEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<CloudStorageEntry>(
+    return session.db.insertRow<CloudStorageEntry>(
       row,
       transaction: transaction,
     );
@@ -353,7 +353,7 @@ class CloudStorageEntryRepository {
     _i1.ColumnSelections<CloudStorageEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<CloudStorageEntry>(
+    return session.db.update<CloudStorageEntry>(
       rows,
       columns: columns?.call(CloudStorageEntry.t),
       transaction: transaction,
@@ -366,7 +366,7 @@ class CloudStorageEntryRepository {
     _i1.ColumnSelections<CloudStorageEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<CloudStorageEntry>(
+    return session.db.updateRow<CloudStorageEntry>(
       row,
       columns: columns?.call(CloudStorageEntry.t),
       transaction: transaction,
@@ -378,7 +378,7 @@ class CloudStorageEntryRepository {
     List<CloudStorageEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<CloudStorageEntry>(
+    return session.db.delete<CloudStorageEntry>(
       rows,
       transaction: transaction,
     );
@@ -389,7 +389,7 @@ class CloudStorageEntryRepository {
     CloudStorageEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<CloudStorageEntry>(
+    return session.db.deleteRow<CloudStorageEntry>(
       row,
       transaction: transaction,
     );
@@ -400,7 +400,7 @@ class CloudStorageEntryRepository {
     required _i1.WhereExpressionBuilder<CloudStorageEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<CloudStorageEntry>(
+    return session.db.deleteWhere<CloudStorageEntry>(
       where: where(CloudStorageEntry.t),
       transaction: transaction,
     );
@@ -412,7 +412,7 @@ class CloudStorageEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<CloudStorageEntry>(
+    return session.db.count<CloudStorageEntry>(
       where: where?.call(CloudStorageEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -239,7 +239,7 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<CloudStorageDirectUploadEntry>(
+    return session.db.find<CloudStorageDirectUploadEntry>(
       where: where?.call(CloudStorageDirectUploadEntry.t),
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
@@ -259,7 +259,7 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<CloudStorageDirectUploadEntry>(
+    return session.db.findFirstRow<CloudStorageDirectUploadEntry>(
       where: where?.call(CloudStorageDirectUploadEntry.t),
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
@@ -274,7 +274,7 @@ class CloudStorageDirectUploadEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<CloudStorageDirectUploadEntry>(
+    return session.db.findById<CloudStorageDirectUploadEntry>(
       id,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class CloudStorageDirectUploadEntryRepository {
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<CloudStorageDirectUploadEntry>(
+    return session.db.insert<CloudStorageDirectUploadEntry>(
       rows,
       transaction: transaction,
     );
@@ -296,7 +296,7 @@ class CloudStorageDirectUploadEntryRepository {
     CloudStorageDirectUploadEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<CloudStorageDirectUploadEntry>(
+    return session.db.insertRow<CloudStorageDirectUploadEntry>(
       row,
       transaction: transaction,
     );
@@ -308,7 +308,7 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.ColumnSelections<CloudStorageDirectUploadEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<CloudStorageDirectUploadEntry>(
+    return session.db.update<CloudStorageDirectUploadEntry>(
       rows,
       columns: columns?.call(CloudStorageDirectUploadEntry.t),
       transaction: transaction,
@@ -321,7 +321,7 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.ColumnSelections<CloudStorageDirectUploadEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<CloudStorageDirectUploadEntry>(
+    return session.db.updateRow<CloudStorageDirectUploadEntry>(
       row,
       columns: columns?.call(CloudStorageDirectUploadEntry.t),
       transaction: transaction,
@@ -333,7 +333,7 @@ class CloudStorageDirectUploadEntryRepository {
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<CloudStorageDirectUploadEntry>(
+    return session.db.delete<CloudStorageDirectUploadEntry>(
       rows,
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class CloudStorageDirectUploadEntryRepository {
     CloudStorageDirectUploadEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<CloudStorageDirectUploadEntry>(
+    return session.db.deleteRow<CloudStorageDirectUploadEntry>(
       row,
       transaction: transaction,
     );
@@ -356,7 +356,7 @@ class CloudStorageDirectUploadEntryRepository {
         where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<CloudStorageDirectUploadEntry>(
+    return session.db.deleteWhere<CloudStorageDirectUploadEntry>(
       where: where(CloudStorageDirectUploadEntry.t),
       transaction: transaction,
     );
@@ -368,7 +368,7 @@ class CloudStorageDirectUploadEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<CloudStorageDirectUploadEntry>(
+    return session.db.count<CloudStorageDirectUploadEntry>(
       where: where?.call(CloudStorageDirectUploadEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -218,7 +218,7 @@ class DatabaseMigrationVersionRepository {
     _i1.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<DatabaseMigrationVersion>(
+    return session.db.find<DatabaseMigrationVersion>(
       where: where?.call(DatabaseMigrationVersion.t),
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
@@ -238,7 +238,7 @@ class DatabaseMigrationVersionRepository {
     _i1.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<DatabaseMigrationVersion>(
+    return session.db.findFirstRow<DatabaseMigrationVersion>(
       where: where?.call(DatabaseMigrationVersion.t),
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
@@ -253,7 +253,7 @@ class DatabaseMigrationVersionRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<DatabaseMigrationVersion>(
+    return session.db.findById<DatabaseMigrationVersion>(
       id,
       transaction: transaction,
     );
@@ -264,7 +264,7 @@ class DatabaseMigrationVersionRepository {
     List<DatabaseMigrationVersion> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<DatabaseMigrationVersion>(
+    return session.db.insert<DatabaseMigrationVersion>(
       rows,
       transaction: transaction,
     );
@@ -275,7 +275,7 @@ class DatabaseMigrationVersionRepository {
     DatabaseMigrationVersion row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<DatabaseMigrationVersion>(
+    return session.db.insertRow<DatabaseMigrationVersion>(
       row,
       transaction: transaction,
     );
@@ -287,7 +287,7 @@ class DatabaseMigrationVersionRepository {
     _i1.ColumnSelections<DatabaseMigrationVersionTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<DatabaseMigrationVersion>(
+    return session.db.update<DatabaseMigrationVersion>(
       rows,
       columns: columns?.call(DatabaseMigrationVersion.t),
       transaction: transaction,
@@ -300,7 +300,7 @@ class DatabaseMigrationVersionRepository {
     _i1.ColumnSelections<DatabaseMigrationVersionTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<DatabaseMigrationVersion>(
+    return session.db.updateRow<DatabaseMigrationVersion>(
       row,
       columns: columns?.call(DatabaseMigrationVersion.t),
       transaction: transaction,
@@ -312,7 +312,7 @@ class DatabaseMigrationVersionRepository {
     List<DatabaseMigrationVersion> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<DatabaseMigrationVersion>(
+    return session.db.delete<DatabaseMigrationVersion>(
       rows,
       transaction: transaction,
     );
@@ -323,7 +323,7 @@ class DatabaseMigrationVersionRepository {
     DatabaseMigrationVersion row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<DatabaseMigrationVersion>(
+    return session.db.deleteRow<DatabaseMigrationVersion>(
       row,
       transaction: transaction,
     );
@@ -334,7 +334,7 @@ class DatabaseMigrationVersionRepository {
     required _i1.WhereExpressionBuilder<DatabaseMigrationVersionTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<DatabaseMigrationVersion>(
+    return session.db.deleteWhere<DatabaseMigrationVersion>(
       where: where(DatabaseMigrationVersion.t),
       transaction: transaction,
     );
@@ -346,7 +346,7 @@ class DatabaseMigrationVersionRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<DatabaseMigrationVersion>(
+    return session.db.count<DatabaseMigrationVersion>(
       where: where?.call(DatabaseMigrationVersion.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -263,7 +263,7 @@ class FutureCallEntryRepository {
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<FutureCallEntry>(
+    return session.db.find<FutureCallEntry>(
       where: where?.call(FutureCallEntry.t),
       orderBy: orderBy?.call(FutureCallEntry.t),
       orderByList: orderByList?.call(FutureCallEntry.t),
@@ -283,7 +283,7 @@ class FutureCallEntryRepository {
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<FutureCallEntry>(
+    return session.db.findFirstRow<FutureCallEntry>(
       where: where?.call(FutureCallEntry.t),
       orderBy: orderBy?.call(FutureCallEntry.t),
       orderByList: orderByList?.call(FutureCallEntry.t),
@@ -298,7 +298,7 @@ class FutureCallEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<FutureCallEntry>(
+    return session.db.findById<FutureCallEntry>(
       id,
       transaction: transaction,
     );
@@ -309,7 +309,7 @@ class FutureCallEntryRepository {
     List<FutureCallEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<FutureCallEntry>(
+    return session.db.insert<FutureCallEntry>(
       rows,
       transaction: transaction,
     );
@@ -320,7 +320,7 @@ class FutureCallEntryRepository {
     FutureCallEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<FutureCallEntry>(
+    return session.db.insertRow<FutureCallEntry>(
       row,
       transaction: transaction,
     );
@@ -332,7 +332,7 @@ class FutureCallEntryRepository {
     _i1.ColumnSelections<FutureCallEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<FutureCallEntry>(
+    return session.db.update<FutureCallEntry>(
       rows,
       columns: columns?.call(FutureCallEntry.t),
       transaction: transaction,
@@ -345,7 +345,7 @@ class FutureCallEntryRepository {
     _i1.ColumnSelections<FutureCallEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<FutureCallEntry>(
+    return session.db.updateRow<FutureCallEntry>(
       row,
       columns: columns?.call(FutureCallEntry.t),
       transaction: transaction,
@@ -357,7 +357,7 @@ class FutureCallEntryRepository {
     List<FutureCallEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<FutureCallEntry>(
+    return session.db.delete<FutureCallEntry>(
       rows,
       transaction: transaction,
     );
@@ -368,7 +368,7 @@ class FutureCallEntryRepository {
     FutureCallEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<FutureCallEntry>(
+    return session.db.deleteRow<FutureCallEntry>(
       row,
       transaction: transaction,
     );
@@ -379,7 +379,7 @@ class FutureCallEntryRepository {
     required _i1.WhereExpressionBuilder<FutureCallEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<FutureCallEntry>(
+    return session.db.deleteWhere<FutureCallEntry>(
       where: where(FutureCallEntry.t),
       transaction: transaction,
     );
@@ -391,7 +391,7 @@ class FutureCallEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<FutureCallEntry>(
+    return session.db.count<FutureCallEntry>(
       where: where?.call(FutureCallEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -372,7 +372,7 @@ class LogEntryRepository {
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<LogEntry>(
+    return session.db.find<LogEntry>(
       where: where?.call(LogEntry.t),
       orderBy: orderBy?.call(LogEntry.t),
       orderByList: orderByList?.call(LogEntry.t),
@@ -392,7 +392,7 @@ class LogEntryRepository {
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<LogEntry>(
+    return session.db.findFirstRow<LogEntry>(
       where: where?.call(LogEntry.t),
       orderBy: orderBy?.call(LogEntry.t),
       orderByList: orderByList?.call(LogEntry.t),
@@ -407,7 +407,7 @@ class LogEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<LogEntry>(
+    return session.db.findById<LogEntry>(
       id,
       transaction: transaction,
     );
@@ -418,7 +418,7 @@ class LogEntryRepository {
     List<LogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<LogEntry>(
+    return session.db.insert<LogEntry>(
       rows,
       transaction: transaction,
     );
@@ -429,7 +429,7 @@ class LogEntryRepository {
     LogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<LogEntry>(
+    return session.db.insertRow<LogEntry>(
       row,
       transaction: transaction,
     );
@@ -441,7 +441,7 @@ class LogEntryRepository {
     _i1.ColumnSelections<LogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<LogEntry>(
+    return session.db.update<LogEntry>(
       rows,
       columns: columns?.call(LogEntry.t),
       transaction: transaction,
@@ -454,7 +454,7 @@ class LogEntryRepository {
     _i1.ColumnSelections<LogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<LogEntry>(
+    return session.db.updateRow<LogEntry>(
       row,
       columns: columns?.call(LogEntry.t),
       transaction: transaction,
@@ -466,7 +466,7 @@ class LogEntryRepository {
     List<LogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<LogEntry>(
+    return session.db.delete<LogEntry>(
       rows,
       transaction: transaction,
     );
@@ -477,7 +477,7 @@ class LogEntryRepository {
     LogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<LogEntry>(
+    return session.db.deleteRow<LogEntry>(
       row,
       transaction: transaction,
     );
@@ -488,7 +488,7 @@ class LogEntryRepository {
     required _i1.WhereExpressionBuilder<LogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<LogEntry>(
+    return session.db.deleteWhere<LogEntry>(
       where: where(LogEntry.t),
       transaction: transaction,
     );
@@ -500,7 +500,7 @@ class LogEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<LogEntry>(
+    return session.db.count<LogEntry>(
       where: where?.call(LogEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -373,7 +373,7 @@ class MessageLogEntryRepository {
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<MessageLogEntry>(
+    return session.db.find<MessageLogEntry>(
       where: where?.call(MessageLogEntry.t),
       orderBy: orderBy?.call(MessageLogEntry.t),
       orderByList: orderByList?.call(MessageLogEntry.t),
@@ -393,7 +393,7 @@ class MessageLogEntryRepository {
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<MessageLogEntry>(
+    return session.db.findFirstRow<MessageLogEntry>(
       where: where?.call(MessageLogEntry.t),
       orderBy: orderBy?.call(MessageLogEntry.t),
       orderByList: orderByList?.call(MessageLogEntry.t),
@@ -408,7 +408,7 @@ class MessageLogEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<MessageLogEntry>(
+    return session.db.findById<MessageLogEntry>(
       id,
       transaction: transaction,
     );
@@ -419,7 +419,7 @@ class MessageLogEntryRepository {
     List<MessageLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<MessageLogEntry>(
+    return session.db.insert<MessageLogEntry>(
       rows,
       transaction: transaction,
     );
@@ -430,7 +430,7 @@ class MessageLogEntryRepository {
     MessageLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<MessageLogEntry>(
+    return session.db.insertRow<MessageLogEntry>(
       row,
       transaction: transaction,
     );
@@ -442,7 +442,7 @@ class MessageLogEntryRepository {
     _i1.ColumnSelections<MessageLogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<MessageLogEntry>(
+    return session.db.update<MessageLogEntry>(
       rows,
       columns: columns?.call(MessageLogEntry.t),
       transaction: transaction,
@@ -455,7 +455,7 @@ class MessageLogEntryRepository {
     _i1.ColumnSelections<MessageLogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<MessageLogEntry>(
+    return session.db.updateRow<MessageLogEntry>(
       row,
       columns: columns?.call(MessageLogEntry.t),
       transaction: transaction,
@@ -467,7 +467,7 @@ class MessageLogEntryRepository {
     List<MessageLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<MessageLogEntry>(
+    return session.db.delete<MessageLogEntry>(
       rows,
       transaction: transaction,
     );
@@ -478,7 +478,7 @@ class MessageLogEntryRepository {
     MessageLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<MessageLogEntry>(
+    return session.db.deleteRow<MessageLogEntry>(
       row,
       transaction: transaction,
     );
@@ -489,7 +489,7 @@ class MessageLogEntryRepository {
     required _i1.WhereExpressionBuilder<MessageLogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<MessageLogEntry>(
+    return session.db.deleteWhere<MessageLogEntry>(
       where: where(MessageLogEntry.t),
       transaction: transaction,
     );
@@ -501,7 +501,7 @@ class MessageLogEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<MessageLogEntry>(
+    return session.db.count<MessageLogEntry>(
       where: where?.call(MessageLogEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -195,7 +195,7 @@ class MethodInfoRepository {
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<MethodInfo>(
+    return session.db.find<MethodInfo>(
       where: where?.call(MethodInfo.t),
       orderBy: orderBy?.call(MethodInfo.t),
       orderByList: orderByList?.call(MethodInfo.t),
@@ -215,7 +215,7 @@ class MethodInfoRepository {
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<MethodInfo>(
+    return session.db.findFirstRow<MethodInfo>(
       where: where?.call(MethodInfo.t),
       orderBy: orderBy?.call(MethodInfo.t),
       orderByList: orderByList?.call(MethodInfo.t),
@@ -230,7 +230,7 @@ class MethodInfoRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<MethodInfo>(
+    return session.db.findById<MethodInfo>(
       id,
       transaction: transaction,
     );
@@ -241,7 +241,7 @@ class MethodInfoRepository {
     List<MethodInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<MethodInfo>(
+    return session.db.insert<MethodInfo>(
       rows,
       transaction: transaction,
     );
@@ -252,7 +252,7 @@ class MethodInfoRepository {
     MethodInfo row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<MethodInfo>(
+    return session.db.insertRow<MethodInfo>(
       row,
       transaction: transaction,
     );
@@ -264,7 +264,7 @@ class MethodInfoRepository {
     _i1.ColumnSelections<MethodInfoTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<MethodInfo>(
+    return session.db.update<MethodInfo>(
       rows,
       columns: columns?.call(MethodInfo.t),
       transaction: transaction,
@@ -277,7 +277,7 @@ class MethodInfoRepository {
     _i1.ColumnSelections<MethodInfoTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<MethodInfo>(
+    return session.db.updateRow<MethodInfo>(
       row,
       columns: columns?.call(MethodInfo.t),
       transaction: transaction,
@@ -289,7 +289,7 @@ class MethodInfoRepository {
     List<MethodInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<MethodInfo>(
+    return session.db.delete<MethodInfo>(
       rows,
       transaction: transaction,
     );
@@ -300,7 +300,7 @@ class MethodInfoRepository {
     MethodInfo row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<MethodInfo>(
+    return session.db.deleteRow<MethodInfo>(
       row,
       transaction: transaction,
     );
@@ -311,7 +311,7 @@ class MethodInfoRepository {
     required _i1.WhereExpressionBuilder<MethodInfoTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<MethodInfo>(
+    return session.db.deleteWhere<MethodInfo>(
       where: where(MethodInfo.t),
       transaction: transaction,
     );
@@ -323,7 +323,7 @@ class MethodInfoRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<MethodInfo>(
+    return session.db.count<MethodInfo>(
       where: where?.call(MethodInfo.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -373,7 +373,7 @@ class QueryLogEntryRepository {
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<QueryLogEntry>(
+    return session.db.find<QueryLogEntry>(
       where: where?.call(QueryLogEntry.t),
       orderBy: orderBy?.call(QueryLogEntry.t),
       orderByList: orderByList?.call(QueryLogEntry.t),
@@ -393,7 +393,7 @@ class QueryLogEntryRepository {
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<QueryLogEntry>(
+    return session.db.findFirstRow<QueryLogEntry>(
       where: where?.call(QueryLogEntry.t),
       orderBy: orderBy?.call(QueryLogEntry.t),
       orderByList: orderByList?.call(QueryLogEntry.t),
@@ -408,7 +408,7 @@ class QueryLogEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<QueryLogEntry>(
+    return session.db.findById<QueryLogEntry>(
       id,
       transaction: transaction,
     );
@@ -419,7 +419,7 @@ class QueryLogEntryRepository {
     List<QueryLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<QueryLogEntry>(
+    return session.db.insert<QueryLogEntry>(
       rows,
       transaction: transaction,
     );
@@ -430,7 +430,7 @@ class QueryLogEntryRepository {
     QueryLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<QueryLogEntry>(
+    return session.db.insertRow<QueryLogEntry>(
       row,
       transaction: transaction,
     );
@@ -442,7 +442,7 @@ class QueryLogEntryRepository {
     _i1.ColumnSelections<QueryLogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<QueryLogEntry>(
+    return session.db.update<QueryLogEntry>(
       rows,
       columns: columns?.call(QueryLogEntry.t),
       transaction: transaction,
@@ -455,7 +455,7 @@ class QueryLogEntryRepository {
     _i1.ColumnSelections<QueryLogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<QueryLogEntry>(
+    return session.db.updateRow<QueryLogEntry>(
       row,
       columns: columns?.call(QueryLogEntry.t),
       transaction: transaction,
@@ -467,7 +467,7 @@ class QueryLogEntryRepository {
     List<QueryLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<QueryLogEntry>(
+    return session.db.delete<QueryLogEntry>(
       rows,
       transaction: transaction,
     );
@@ -478,7 +478,7 @@ class QueryLogEntryRepository {
     QueryLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<QueryLogEntry>(
+    return session.db.deleteRow<QueryLogEntry>(
       row,
       transaction: transaction,
     );
@@ -489,7 +489,7 @@ class QueryLogEntryRepository {
     required _i1.WhereExpressionBuilder<QueryLogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<QueryLogEntry>(
+    return session.db.deleteWhere<QueryLogEntry>(
       where: where(QueryLogEntry.t),
       transaction: transaction,
     );
@@ -501,7 +501,7 @@ class QueryLogEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<QueryLogEntry>(
+    return session.db.count<QueryLogEntry>(
       where: where?.call(QueryLogEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -174,7 +174,7 @@ class ReadWriteTestEntryRepository {
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ReadWriteTestEntry>(
+    return session.db.find<ReadWriteTestEntry>(
       where: where?.call(ReadWriteTestEntry.t),
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
@@ -194,7 +194,7 @@ class ReadWriteTestEntryRepository {
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ReadWriteTestEntry>(
+    return session.db.findFirstRow<ReadWriteTestEntry>(
       where: where?.call(ReadWriteTestEntry.t),
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
@@ -209,7 +209,7 @@ class ReadWriteTestEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ReadWriteTestEntry>(
+    return session.db.findById<ReadWriteTestEntry>(
       id,
       transaction: transaction,
     );
@@ -220,7 +220,7 @@ class ReadWriteTestEntryRepository {
     List<ReadWriteTestEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ReadWriteTestEntry>(
+    return session.db.insert<ReadWriteTestEntry>(
       rows,
       transaction: transaction,
     );
@@ -231,7 +231,7 @@ class ReadWriteTestEntryRepository {
     ReadWriteTestEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ReadWriteTestEntry>(
+    return session.db.insertRow<ReadWriteTestEntry>(
       row,
       transaction: transaction,
     );
@@ -243,7 +243,7 @@ class ReadWriteTestEntryRepository {
     _i1.ColumnSelections<ReadWriteTestEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ReadWriteTestEntry>(
+    return session.db.update<ReadWriteTestEntry>(
       rows,
       columns: columns?.call(ReadWriteTestEntry.t),
       transaction: transaction,
@@ -256,7 +256,7 @@ class ReadWriteTestEntryRepository {
     _i1.ColumnSelections<ReadWriteTestEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ReadWriteTestEntry>(
+    return session.db.updateRow<ReadWriteTestEntry>(
       row,
       columns: columns?.call(ReadWriteTestEntry.t),
       transaction: transaction,
@@ -268,7 +268,7 @@ class ReadWriteTestEntryRepository {
     List<ReadWriteTestEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ReadWriteTestEntry>(
+    return session.db.delete<ReadWriteTestEntry>(
       rows,
       transaction: transaction,
     );
@@ -279,7 +279,7 @@ class ReadWriteTestEntryRepository {
     ReadWriteTestEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ReadWriteTestEntry>(
+    return session.db.deleteRow<ReadWriteTestEntry>(
       row,
       transaction: transaction,
     );
@@ -290,7 +290,7 @@ class ReadWriteTestEntryRepository {
     required _i1.WhereExpressionBuilder<ReadWriteTestEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ReadWriteTestEntry>(
+    return session.db.deleteWhere<ReadWriteTestEntry>(
       where: where(ReadWriteTestEntry.t),
       transaction: transaction,
     );
@@ -302,7 +302,7 @@ class ReadWriteTestEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ReadWriteTestEntry>(
+    return session.db.count<ReadWriteTestEntry>(
       where: where?.call(ReadWriteTestEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -245,7 +245,7 @@ class RuntimeSettingsRepository {
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<RuntimeSettings>(
+    return session.db.find<RuntimeSettings>(
       where: where?.call(RuntimeSettings.t),
       orderBy: orderBy?.call(RuntimeSettings.t),
       orderByList: orderByList?.call(RuntimeSettings.t),
@@ -265,7 +265,7 @@ class RuntimeSettingsRepository {
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<RuntimeSettings>(
+    return session.db.findFirstRow<RuntimeSettings>(
       where: where?.call(RuntimeSettings.t),
       orderBy: orderBy?.call(RuntimeSettings.t),
       orderByList: orderByList?.call(RuntimeSettings.t),
@@ -280,7 +280,7 @@ class RuntimeSettingsRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<RuntimeSettings>(
+    return session.db.findById<RuntimeSettings>(
       id,
       transaction: transaction,
     );
@@ -291,7 +291,7 @@ class RuntimeSettingsRepository {
     List<RuntimeSettings> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<RuntimeSettings>(
+    return session.db.insert<RuntimeSettings>(
       rows,
       transaction: transaction,
     );
@@ -302,7 +302,7 @@ class RuntimeSettingsRepository {
     RuntimeSettings row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<RuntimeSettings>(
+    return session.db.insertRow<RuntimeSettings>(
       row,
       transaction: transaction,
     );
@@ -314,7 +314,7 @@ class RuntimeSettingsRepository {
     _i1.ColumnSelections<RuntimeSettingsTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<RuntimeSettings>(
+    return session.db.update<RuntimeSettings>(
       rows,
       columns: columns?.call(RuntimeSettings.t),
       transaction: transaction,
@@ -327,7 +327,7 @@ class RuntimeSettingsRepository {
     _i1.ColumnSelections<RuntimeSettingsTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<RuntimeSettings>(
+    return session.db.updateRow<RuntimeSettings>(
       row,
       columns: columns?.call(RuntimeSettings.t),
       transaction: transaction,
@@ -339,7 +339,7 @@ class RuntimeSettingsRepository {
     List<RuntimeSettings> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<RuntimeSettings>(
+    return session.db.delete<RuntimeSettings>(
       rows,
       transaction: transaction,
     );
@@ -350,7 +350,7 @@ class RuntimeSettingsRepository {
     RuntimeSettings row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<RuntimeSettings>(
+    return session.db.deleteRow<RuntimeSettings>(
       row,
       transaction: transaction,
     );
@@ -361,7 +361,7 @@ class RuntimeSettingsRepository {
     required _i1.WhereExpressionBuilder<RuntimeSettingsTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<RuntimeSettings>(
+    return session.db.deleteWhere<RuntimeSettings>(
       where: where(RuntimeSettings.t),
       transaction: transaction,
     );
@@ -373,7 +373,7 @@ class RuntimeSettingsRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<RuntimeSettings>(
+    return session.db.count<RuntimeSettings>(
       where: where?.call(RuntimeSettings.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -287,7 +287,7 @@ class ServerHealthConnectionInfoRepository {
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ServerHealthConnectionInfo>(
+    return session.db.find<ServerHealthConnectionInfo>(
       where: where?.call(ServerHealthConnectionInfo.t),
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
@@ -307,7 +307,7 @@ class ServerHealthConnectionInfoRepository {
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ServerHealthConnectionInfo>(
+    return session.db.findFirstRow<ServerHealthConnectionInfo>(
       where: where?.call(ServerHealthConnectionInfo.t),
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
@@ -322,7 +322,7 @@ class ServerHealthConnectionInfoRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ServerHealthConnectionInfo>(
+    return session.db.findById<ServerHealthConnectionInfo>(
       id,
       transaction: transaction,
     );
@@ -333,7 +333,7 @@ class ServerHealthConnectionInfoRepository {
     List<ServerHealthConnectionInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ServerHealthConnectionInfo>(
+    return session.db.insert<ServerHealthConnectionInfo>(
       rows,
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class ServerHealthConnectionInfoRepository {
     ServerHealthConnectionInfo row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ServerHealthConnectionInfo>(
+    return session.db.insertRow<ServerHealthConnectionInfo>(
       row,
       transaction: transaction,
     );
@@ -356,7 +356,7 @@ class ServerHealthConnectionInfoRepository {
     _i1.ColumnSelections<ServerHealthConnectionInfoTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ServerHealthConnectionInfo>(
+    return session.db.update<ServerHealthConnectionInfo>(
       rows,
       columns: columns?.call(ServerHealthConnectionInfo.t),
       transaction: transaction,
@@ -369,7 +369,7 @@ class ServerHealthConnectionInfoRepository {
     _i1.ColumnSelections<ServerHealthConnectionInfoTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ServerHealthConnectionInfo>(
+    return session.db.updateRow<ServerHealthConnectionInfo>(
       row,
       columns: columns?.call(ServerHealthConnectionInfo.t),
       transaction: transaction,
@@ -381,7 +381,7 @@ class ServerHealthConnectionInfoRepository {
     List<ServerHealthConnectionInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ServerHealthConnectionInfo>(
+    return session.db.delete<ServerHealthConnectionInfo>(
       rows,
       transaction: transaction,
     );
@@ -392,7 +392,7 @@ class ServerHealthConnectionInfoRepository {
     ServerHealthConnectionInfo row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ServerHealthConnectionInfo>(
+    return session.db.deleteRow<ServerHealthConnectionInfo>(
       row,
       transaction: transaction,
     );
@@ -403,7 +403,7 @@ class ServerHealthConnectionInfoRepository {
     required _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ServerHealthConnectionInfo>(
+    return session.db.deleteWhere<ServerHealthConnectionInfo>(
       where: where(ServerHealthConnectionInfo.t),
       transaction: transaction,
     );
@@ -415,7 +415,7 @@ class ServerHealthConnectionInfoRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ServerHealthConnectionInfo>(
+    return session.db.count<ServerHealthConnectionInfo>(
       where: where?.call(ServerHealthConnectionInfo.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -287,7 +287,7 @@ class ServerHealthMetricRepository {
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ServerHealthMetric>(
+    return session.db.find<ServerHealthMetric>(
       where: where?.call(ServerHealthMetric.t),
       orderBy: orderBy?.call(ServerHealthMetric.t),
       orderByList: orderByList?.call(ServerHealthMetric.t),
@@ -307,7 +307,7 @@ class ServerHealthMetricRepository {
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ServerHealthMetric>(
+    return session.db.findFirstRow<ServerHealthMetric>(
       where: where?.call(ServerHealthMetric.t),
       orderBy: orderBy?.call(ServerHealthMetric.t),
       orderByList: orderByList?.call(ServerHealthMetric.t),
@@ -322,7 +322,7 @@ class ServerHealthMetricRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ServerHealthMetric>(
+    return session.db.findById<ServerHealthMetric>(
       id,
       transaction: transaction,
     );
@@ -333,7 +333,7 @@ class ServerHealthMetricRepository {
     List<ServerHealthMetric> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ServerHealthMetric>(
+    return session.db.insert<ServerHealthMetric>(
       rows,
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class ServerHealthMetricRepository {
     ServerHealthMetric row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ServerHealthMetric>(
+    return session.db.insertRow<ServerHealthMetric>(
       row,
       transaction: transaction,
     );
@@ -356,7 +356,7 @@ class ServerHealthMetricRepository {
     _i1.ColumnSelections<ServerHealthMetricTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ServerHealthMetric>(
+    return session.db.update<ServerHealthMetric>(
       rows,
       columns: columns?.call(ServerHealthMetric.t),
       transaction: transaction,
@@ -369,7 +369,7 @@ class ServerHealthMetricRepository {
     _i1.ColumnSelections<ServerHealthMetricTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ServerHealthMetric>(
+    return session.db.updateRow<ServerHealthMetric>(
       row,
       columns: columns?.call(ServerHealthMetric.t),
       transaction: transaction,
@@ -381,7 +381,7 @@ class ServerHealthMetricRepository {
     List<ServerHealthMetric> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ServerHealthMetric>(
+    return session.db.delete<ServerHealthMetric>(
       rows,
       transaction: transaction,
     );
@@ -392,7 +392,7 @@ class ServerHealthMetricRepository {
     ServerHealthMetric row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ServerHealthMetric>(
+    return session.db.deleteRow<ServerHealthMetric>(
       row,
       transaction: transaction,
     );
@@ -403,7 +403,7 @@ class ServerHealthMetricRepository {
     required _i1.WhereExpressionBuilder<ServerHealthMetricTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ServerHealthMetric>(
+    return session.db.deleteWhere<ServerHealthMetric>(
       where: where(ServerHealthMetric.t),
       transaction: transaction,
     );
@@ -415,7 +415,7 @@ class ServerHealthMetricRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ServerHealthMetric>(
+    return session.db.count<ServerHealthMetric>(
       where: where?.call(ServerHealthMetric.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -449,7 +449,7 @@ class SessionLogEntryRepository {
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<SessionLogEntry>(
+    return session.db.find<SessionLogEntry>(
       where: where?.call(SessionLogEntry.t),
       orderBy: orderBy?.call(SessionLogEntry.t),
       orderByList: orderByList?.call(SessionLogEntry.t),
@@ -469,7 +469,7 @@ class SessionLogEntryRepository {
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<SessionLogEntry>(
+    return session.db.findFirstRow<SessionLogEntry>(
       where: where?.call(SessionLogEntry.t),
       orderBy: orderBy?.call(SessionLogEntry.t),
       orderByList: orderByList?.call(SessionLogEntry.t),
@@ -484,7 +484,7 @@ class SessionLogEntryRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<SessionLogEntry>(
+    return session.db.findById<SessionLogEntry>(
       id,
       transaction: transaction,
     );
@@ -495,7 +495,7 @@ class SessionLogEntryRepository {
     List<SessionLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<SessionLogEntry>(
+    return session.db.insert<SessionLogEntry>(
       rows,
       transaction: transaction,
     );
@@ -506,7 +506,7 @@ class SessionLogEntryRepository {
     SessionLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<SessionLogEntry>(
+    return session.db.insertRow<SessionLogEntry>(
       row,
       transaction: transaction,
     );
@@ -518,7 +518,7 @@ class SessionLogEntryRepository {
     _i1.ColumnSelections<SessionLogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<SessionLogEntry>(
+    return session.db.update<SessionLogEntry>(
       rows,
       columns: columns?.call(SessionLogEntry.t),
       transaction: transaction,
@@ -531,7 +531,7 @@ class SessionLogEntryRepository {
     _i1.ColumnSelections<SessionLogEntryTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<SessionLogEntry>(
+    return session.db.updateRow<SessionLogEntry>(
       row,
       columns: columns?.call(SessionLogEntry.t),
       transaction: transaction,
@@ -543,7 +543,7 @@ class SessionLogEntryRepository {
     List<SessionLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<SessionLogEntry>(
+    return session.db.delete<SessionLogEntry>(
       rows,
       transaction: transaction,
     );
@@ -554,7 +554,7 @@ class SessionLogEntryRepository {
     SessionLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<SessionLogEntry>(
+    return session.db.deleteRow<SessionLogEntry>(
       row,
       transaction: transaction,
     );
@@ -565,7 +565,7 @@ class SessionLogEntryRepository {
     required _i1.WhereExpressionBuilder<SessionLogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<SessionLogEntry>(
+    return session.db.deleteWhere<SessionLogEntry>(
       where: where(SessionLogEntry.t),
       transaction: transaction,
     );
@@ -577,7 +577,7 @@ class SessionLogEntryRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<SessionLogEntry>(
+    return session.db.count<SessionLogEntry>(
       where: where?.call(SessionLogEntry.t),
       limit: limit,
       transaction: transaction,

--- a/packages/serverpod/lib/src/server/future_call_manager.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager.dart
@@ -108,7 +108,7 @@ class FutureCallManager {
         enableLogging: false,
       );
 
-      var rows = await tempSession.dbNext
+      var rows = await tempSession.db
           .transaction<List<FutureCallEntry>>((transaction) async {
         var activeFutureCalls = await FutureCallEntry.db.find(
           tempSession,

--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -110,12 +110,12 @@ class HealthCheckManager {
       // Touch all sessions that have been opened by this server.
       var touchQuery =
           'UPDATE serverpod_session_log SET touched = $now WHERE "serverId" = $serverId AND "isOpen" = TRUE AND "time" > $serverStartTime';
-      await session.dbNext.unsafeQuery(touchQuery);
+      await session.db.unsafeQuery(touchQuery);
 
       // Close sessions that haven't been touched in 3 minutes.
       var closeQuery =
           'UPDATE serverpod_session_log SET "isOpen" = FALSE WHERE "isOpen" = TRUE AND "touched" < $threeMinutesAgo';
-      await session.dbNext.unsafeQuery(closeQuery);
+      await session.db.unsafeQuery(closeQuery);
     } catch (e, stackTrace) {
       stderr.writeln('Failed to cleanup closed sessions: $e');
       stderr.write('$stackTrace');

--- a/packages/serverpod/lib/src/server/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager.dart
@@ -93,7 +93,7 @@ class DatabaseLogWriter extends LogWriter {
       enableLogging: false,
     );
 
-    var result = await tempSession.dbNext.insertRow<T>(entry);
+    var result = await tempSession.db.insertRow<T>(entry);
 
     await tempSession.close();
 
@@ -111,23 +111,23 @@ class DatabaseLogWriter extends LogWriter {
     );
 
     var sessionLog =
-        await tempSession.dbNext.insertRow<SessionLogEntry>(sessionLogEntry);
+        await tempSession.db.insertRow<SessionLogEntry>(sessionLogEntry);
     var sessionLogId = sessionLog.id!;
 
     // Write log entries
     for (var logInfo in cache.logEntries) {
       logInfo.sessionLogId = sessionLogId;
-      await tempSession.dbNext.insertRow<LogEntry>(logInfo);
+      await tempSession.db.insertRow<LogEntry>(logInfo);
     }
     // Write queries
     for (var queryInfo in cache.queries) {
       queryInfo.sessionLogId = sessionLogId;
-      await tempSession.dbNext.insertRow<QueryLogEntry>(queryInfo);
+      await tempSession.db.insertRow<QueryLogEntry>(queryInfo);
     }
     // Write streaming messages
     for (var messageInfo in cache.messages) {
       messageInfo.sessionLogId = sessionLogId;
-      await tempSession.dbNext.insertRow<MessageLogEntry>(messageInfo);
+      await tempSession.db.insertRow<MessageLogEntry>(messageInfo);
     }
 
     await tempSession.close();

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -794,7 +794,7 @@ class Serverpod {
       attempts++;
       var session = await createSession(enableLogging: enableLogging);
       try {
-        await session.dbNext.testConnection();
+        await session.db.testConnection();
         return session;
       } catch (e, stackTrace) {
         // Write connection error to stderr.

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -40,7 +40,7 @@ abstract class Session {
   dynamic userObject;
 
   /// Access to the database.
-  late final Database? _db;
+  Database? _db;
 
   /// Access to the database.
   Database get db {
@@ -94,8 +94,6 @@ abstract class Session {
 
     if (Features.enableDatabase) {
       _db = Database(session: this);
-    } else {
-      _db = null;
     }
 
     sessionLogs = server.serverpod.logManager.initializeSessionLog(this);

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -39,12 +39,12 @@ abstract class Session {
   /// useful for keeping track of the state in a [StreamingEndpoint].
   dynamic userObject;
 
-  /// Access to the database. Replaces db in the future.
-  late final Database? _dbNext;
+  /// Access to the database.
+  late final Database? _db;
 
-  /// Access to the database. Replaces db in the future.
-  Database get dbNext {
-    var database = _dbNext;
+  /// Access to the database.
+  Database get db {
+    var database = _db;
     if (database == null) {
       throw Exception('Database is not available in this session.');
     }
@@ -93,9 +93,9 @@ abstract class Session {
     messages = MessageCentralAccess._(this);
 
     if (Features.enableDatabase) {
-      _dbNext = Database(session: this);
+      _db = Database(session: this);
     } else {
-      _dbNext = null;
+      _db = null;
     }
 
     sessionLogs = server.serverpod.logManager.initializeSessionLog(this);
@@ -402,7 +402,7 @@ class UserAuthetication {
     userId ??= await authenticatedUserId;
     if (userId == null) return;
 
-    await _session.dbNext
+    await _session.db
         .deleteWhere<AuthKey>(where: AuthKey.t.userId.equals(userId));
     _session._authenticatedUser = null;
   }

--- a/tests/serverpod_test_server/lib/src/endpoints/async_tasks.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/async_tasks.dart
@@ -17,7 +17,7 @@ class AsyncTasksEndpoint extends Endpoint {
     var data = SimpleData(
       num: num,
     );
-    await session.dbNext.insertRow(data);
+    await session.db.insertRow(data);
   }
 
   Future<void> throwExceptionAfterDelay(Session session, int seconds) async {

--- a/tests/serverpod_test_server/lib/src/endpoints/authentication.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/authentication.dart
@@ -3,11 +3,11 @@ import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 
 class AuthenticationEndpoint extends Endpoint {
   Future<void> removeAllUsers(Session session) async {
-    await session.dbNext.deleteWhere<UserInfo>(where: Constant.bool(true));
+    await session.db.deleteWhere<UserInfo>(where: Constant.bool(true));
   }
 
   Future<int> countUsers(Session session) async {
-    return await session.dbNext.count<UserInfo>();
+    return await session.db.count<UserInfo>();
   }
 
   Future<void> createUser(

--- a/tests/serverpod_test_server/lib/src/endpoints/cloud_storage.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/cloud_storage.dart
@@ -6,9 +6,8 @@ import 'package:serverpod/serverpod.dart';
 class CloudStorageEndpoint extends Endpoint {
   Future<void> reset(Session session) async {
     // Remove all entries
-    await session.dbNext
-        .deleteWhere<CloudStorageEntry>(where: Constant.bool(true));
-    await session.dbNext
+    await session.db.deleteWhere<CloudStorageEntry>(where: Constant.bool(true));
+    await session.db
         .deleteWhere<CloudStorageDirectUploadEntry>(where: Constant.bool(true));
   }
 

--- a/tests/serverpod_test_server/lib/src/endpoints/database_basic.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_basic.dart
@@ -152,7 +152,7 @@ class BasicDatabase extends Endpoint {
 
   Future<int?> getTypesRawQuery(Session session, int id) async {
     var query = 'SELECT * FROM types WHERE id = $id';
-    var result = await session.dbNext.unsafeQuery(query);
+    var result = await session.db.unsafeQuery(query);
     if (result.length != 1) {
       return null;
     }

--- a/tests/serverpod_test_server/lib/src/endpoints/database_batch.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_batch.dart
@@ -6,35 +6,35 @@ class DatabaseBatch extends Endpoint {
     Session session,
     List<UniqueData> value,
   ) async {
-    return session.dbNext.insert<UniqueData>(value);
+    return session.db.insert<UniqueData>(value);
   }
 
   Future<List<Types>> batchInsertTypes(
     Session session,
     List<Types> value,
   ) async {
-    return session.dbNext.insert<Types>(value);
+    return session.db.insert<Types>(value);
   }
 
   Future<List<UniqueData>> batchUpdate(
     Session session,
     List<UniqueData> value,
   ) async {
-    return session.dbNext.update<UniqueData>(value);
+    return session.db.update<UniqueData>(value);
   }
 
   Future<List<Types>> batchUpdateTypes(
     Session session,
     List<Types> value,
   ) async {
-    return session.dbNext.update<Types>(value);
+    return session.db.update<Types>(value);
   }
 
   Future<List<int>> batchDelete(
     Session session,
     List<UniqueData> value,
   ) async {
-    return session.dbNext.delete<UniqueData>(value);
+    return session.db.delete<UniqueData>(value);
   }
 
   Future<RelatedUniqueData> insertRelatedUniqueData(

--- a/tests/serverpod_test_server/lib/src/endpoints/database_transactions.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_transactions.dart
@@ -4,8 +4,8 @@ import '../generated/protocol.dart';
 
 class TransactionsDatabaseEndpoint extends Endpoint {
   Future<void> removeRow(Session session, int num) async {
-    await session.dbNext.transaction((transaction) async {
-      await session.dbNext.deleteWhere<SimpleData>(
+    await session.db.transaction((transaction) async {
+      await session.db.deleteWhere<SimpleData>(
         where: SimpleData.t.num.equals(num),
         transaction: transaction,
       );
@@ -14,20 +14,20 @@ class TransactionsDatabaseEndpoint extends Endpoint {
 
   Future<bool> updateInsertDelete(
       Session session, int numUpdate, int numInsert, int numDelete) async {
-    var data = await session.dbNext.findFirstRow<SimpleData>(
+    var data = await session.db.findFirstRow<SimpleData>(
       where: SimpleData.t.num.equals(numUpdate),
     );
 
-    return await session.dbNext.transaction((transaction) async {
+    return await session.db.transaction((transaction) async {
       data!.num = 1000;
-      await session.dbNext.updateRow(data, transaction: transaction);
+      await session.db.updateRow(data, transaction: transaction);
 
       var newData = SimpleData(
         num: numInsert,
       );
-      await session.dbNext.insertRow(newData, transaction: transaction);
+      await session.db.insertRow(newData, transaction: transaction);
 
-      await session.dbNext.deleteWhere<SimpleData>(
+      await session.db.deleteWhere<SimpleData>(
         where: SimpleData.t.num.equals(numDelete),
         transaction: transaction,
       );

--- a/tests/serverpod_test_server/lib/src/endpoints/failed_calls.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/failed_calls.dart
@@ -7,14 +7,14 @@ class FailedCallsEndpoint extends Endpoint {
 
   Future<void> failedDatabaseQuery(Session session) async {
     // This call should fail and throw an exception
-    await session.dbNext.unsafeQuery(
+    await session.db.unsafeQuery(
       'SELECT * FROM non_existing_table LIMIT 1',
     );
   }
 
   Future<bool> failedDatabaseQueryCaughtException(Session session) async {
     try {
-      await session.dbNext.unsafeQuery(
+      await session.db.unsafeQuery(
         'SELECT * FROM non_existing_table LIMIT 1',
       );
     } catch (e) {

--- a/tests/serverpod_test_server/lib/src/endpoints/logging.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/logging.dart
@@ -15,7 +15,7 @@ class LoggingEndpoint extends Endpoint {
 
   Future<void> twoQueries(Session session) async {
     var data = SimpleData(num: 42);
-    await session.dbNext.insertRow(data);
-    data = (await session.dbNext.findFirstRow<SimpleData>())!;
+    await session.db.insertRow(data);
+    data = (await session.db.findFirstRow<SimpleData>())!;
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -321,7 +321,7 @@ class CityWithLongTableNameRepository {
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.find<CityWithLongTableName>(
+    return session.db.find<CityWithLongTableName>(
       where: where?.call(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
@@ -343,7 +343,7 @@ class CityWithLongTableNameRepository {
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<CityWithLongTableName>(
+    return session.db.findFirstRow<CityWithLongTableName>(
       where: where?.call(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
@@ -360,7 +360,7 @@ class CityWithLongTableNameRepository {
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.findById<CityWithLongTableName>(
+    return session.db.findById<CityWithLongTableName>(
       id,
       transaction: transaction,
       include: include,
@@ -372,7 +372,7 @@ class CityWithLongTableNameRepository {
     List<CityWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<CityWithLongTableName>(
+    return session.db.insert<CityWithLongTableName>(
       rows,
       transaction: transaction,
     );
@@ -383,7 +383,7 @@ class CityWithLongTableNameRepository {
     CityWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<CityWithLongTableName>(
+    return session.db.insertRow<CityWithLongTableName>(
       row,
       transaction: transaction,
     );
@@ -395,7 +395,7 @@ class CityWithLongTableNameRepository {
     _i1.ColumnSelections<CityWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<CityWithLongTableName>(
+    return session.db.update<CityWithLongTableName>(
       rows,
       columns: columns?.call(CityWithLongTableName.t),
       transaction: transaction,
@@ -408,7 +408,7 @@ class CityWithLongTableNameRepository {
     _i1.ColumnSelections<CityWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<CityWithLongTableName>(
+    return session.db.updateRow<CityWithLongTableName>(
       row,
       columns: columns?.call(CityWithLongTableName.t),
       transaction: transaction,
@@ -420,7 +420,7 @@ class CityWithLongTableNameRepository {
     List<CityWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<CityWithLongTableName>(
+    return session.db.delete<CityWithLongTableName>(
       rows,
       transaction: transaction,
     );
@@ -431,7 +431,7 @@ class CityWithLongTableNameRepository {
     CityWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<CityWithLongTableName>(
+    return session.db.deleteRow<CityWithLongTableName>(
       row,
       transaction: transaction,
     );
@@ -442,7 +442,7 @@ class CityWithLongTableNameRepository {
     required _i1.WhereExpressionBuilder<CityWithLongTableNameTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<CityWithLongTableName>(
+    return session.db.deleteWhere<CityWithLongTableName>(
       where: where(CityWithLongTableName.t),
       transaction: transaction,
     );
@@ -454,7 +454,7 @@ class CityWithLongTableNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<CityWithLongTableName>(
+    return session.db.count<CityWithLongTableName>(
       where: where?.call(CityWithLongTableName.t),
       limit: limit,
       transaction: transaction,
@@ -484,7 +484,7 @@ class CityWithLongTableNameAttachRepository {
                   cityWithLongTableName.id,
             ))
         .toList();
-    await session.dbNext.update<_i2.PersonWithLongTableName>(
+    await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [
         _i2.PersonWithLongTableName.t
@@ -508,7 +508,7 @@ class CityWithLongTableNameAttachRepository {
     var $organizationWithLongTableName = organizationWithLongTableName
         .map((e) => e.copyWith(cityId: cityWithLongTableName.id))
         .toList();
-    await session.dbNext.update<_i2.OrganizationWithLongTableName>(
+    await session.db.update<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
     );
@@ -535,7 +535,7 @@ class CityWithLongTableNameAttachRowRepository {
       $_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id:
           cityWithLongTableName.id,
     );
-    await session.dbNext.updateRow<_i2.PersonWithLongTableName>(
+    await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [
         _i2.PersonWithLongTableName.t
@@ -558,7 +558,7 @@ class CityWithLongTableNameAttachRowRepository {
 
     var $organizationWithLongTableName = organizationWithLongTableName.copyWith(
         cityId: cityWithLongTableName.id);
-    await session.dbNext.updateRow<_i2.OrganizationWithLongTableName>(
+    await session.db.updateRow<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
     );
@@ -583,7 +583,7 @@ class CityWithLongTableNameDetachRepository {
                   null,
             ))
         .toList();
-    await session.dbNext.update<_i2.PersonWithLongTableName>(
+    await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [
         _i2.PersonWithLongTableName.t
@@ -603,7 +603,7 @@ class CityWithLongTableNameDetachRepository {
     var $organizationWithLongTableName = organizationWithLongTableName
         .map((e) => e.copyWith(cityId: null))
         .toList();
-    await session.dbNext.update<_i2.OrganizationWithLongTableName>(
+    await session.db.update<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
     );
@@ -625,7 +625,7 @@ class CityWithLongTableNameDetachRowRepository {
       personWithLongTableName,
       $_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id: null,
     );
-    await session.dbNext.updateRow<_i2.PersonWithLongTableName>(
+    await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [
         _i2.PersonWithLongTableName.t
@@ -644,7 +644,7 @@ class CityWithLongTableNameDetachRowRepository {
 
     var $organizationWithLongTableName =
         organizationWithLongTableName.copyWith(cityId: null);
-    await session.dbNext.updateRow<_i2.OrganizationWithLongTableName>(
+    await session.db.updateRow<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -313,7 +313,7 @@ class OrganizationWithLongTableNameRepository {
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.find<OrganizationWithLongTableName>(
+    return session.db.find<OrganizationWithLongTableName>(
       where: where?.call(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
@@ -335,7 +335,7 @@ class OrganizationWithLongTableNameRepository {
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<OrganizationWithLongTableName>(
+    return session.db.findFirstRow<OrganizationWithLongTableName>(
       where: where?.call(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
@@ -352,7 +352,7 @@ class OrganizationWithLongTableNameRepository {
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.findById<OrganizationWithLongTableName>(
+    return session.db.findById<OrganizationWithLongTableName>(
       id,
       transaction: transaction,
       include: include,
@@ -364,7 +364,7 @@ class OrganizationWithLongTableNameRepository {
     List<OrganizationWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<OrganizationWithLongTableName>(
+    return session.db.insert<OrganizationWithLongTableName>(
       rows,
       transaction: transaction,
     );
@@ -375,7 +375,7 @@ class OrganizationWithLongTableNameRepository {
     OrganizationWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<OrganizationWithLongTableName>(
+    return session.db.insertRow<OrganizationWithLongTableName>(
       row,
       transaction: transaction,
     );
@@ -387,7 +387,7 @@ class OrganizationWithLongTableNameRepository {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<OrganizationWithLongTableName>(
+    return session.db.update<OrganizationWithLongTableName>(
       rows,
       columns: columns?.call(OrganizationWithLongTableName.t),
       transaction: transaction,
@@ -400,7 +400,7 @@ class OrganizationWithLongTableNameRepository {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<OrganizationWithLongTableName>(
+    return session.db.updateRow<OrganizationWithLongTableName>(
       row,
       columns: columns?.call(OrganizationWithLongTableName.t),
       transaction: transaction,
@@ -412,7 +412,7 @@ class OrganizationWithLongTableNameRepository {
     List<OrganizationWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<OrganizationWithLongTableName>(
+    return session.db.delete<OrganizationWithLongTableName>(
       rows,
       transaction: transaction,
     );
@@ -423,7 +423,7 @@ class OrganizationWithLongTableNameRepository {
     OrganizationWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<OrganizationWithLongTableName>(
+    return session.db.deleteRow<OrganizationWithLongTableName>(
       row,
       transaction: transaction,
     );
@@ -435,7 +435,7 @@ class OrganizationWithLongTableNameRepository {
         where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<OrganizationWithLongTableName>(
+    return session.db.deleteWhere<OrganizationWithLongTableName>(
       where: where(OrganizationWithLongTableName.t),
       transaction: transaction,
     );
@@ -447,7 +447,7 @@ class OrganizationWithLongTableNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<OrganizationWithLongTableName>(
+    return session.db.count<OrganizationWithLongTableName>(
       where: where?.call(OrganizationWithLongTableName.t),
       limit: limit,
       transaction: transaction,
@@ -474,7 +474,7 @@ class OrganizationWithLongTableNameAttachRepository {
         .map(
             (e) => e.copyWith(organizationId: organizationWithLongTableName.id))
         .toList();
-    await session.dbNext.update<_i2.PersonWithLongTableName>(
+    await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
     );
@@ -498,7 +498,7 @@ class OrganizationWithLongTableNameAttachRowRepository {
 
     var $organizationWithLongTableName =
         organizationWithLongTableName.copyWith(cityId: city.id);
-    await session.dbNext.updateRow<OrganizationWithLongTableName>(
+    await session.db.updateRow<OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [OrganizationWithLongTableName.t.cityId],
     );
@@ -518,7 +518,7 @@ class OrganizationWithLongTableNameAttachRowRepository {
 
     var $personWithLongTableName = personWithLongTableName.copyWith(
         organizationId: organizationWithLongTableName.id);
-    await session.dbNext.updateRow<_i2.PersonWithLongTableName>(
+    await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
     );
@@ -539,7 +539,7 @@ class OrganizationWithLongTableNameDetachRepository {
     var $personWithLongTableName = personWithLongTableName
         .map((e) => e.copyWith(organizationId: null))
         .toList();
-    await session.dbNext.update<_i2.PersonWithLongTableName>(
+    await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
     );
@@ -559,7 +559,7 @@ class OrganizationWithLongTableNameDetachRowRepository {
 
     var $organizationwithlongtablename =
         organizationwithlongtablename.copyWith(cityId: null);
-    await session.dbNext.updateRow<OrganizationWithLongTableName>(
+    await session.db.updateRow<OrganizationWithLongTableName>(
       $organizationwithlongtablename,
       columns: [OrganizationWithLongTableName.t.cityId],
     );
@@ -575,7 +575,7 @@ class OrganizationWithLongTableNameDetachRowRepository {
 
     var $personWithLongTableName =
         personWithLongTableName.copyWith(organizationId: null);
-    await session.dbNext.updateRow<_i2.PersonWithLongTableName>(
+    await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -298,7 +298,7 @@ class PersonWithLongTableNameRepository {
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.find<PersonWithLongTableName>(
+    return session.db.find<PersonWithLongTableName>(
       where: where?.call(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
@@ -320,7 +320,7 @@ class PersonWithLongTableNameRepository {
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<PersonWithLongTableName>(
+    return session.db.findFirstRow<PersonWithLongTableName>(
       where: where?.call(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
@@ -337,7 +337,7 @@ class PersonWithLongTableNameRepository {
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
   }) async {
-    return session.dbNext.findById<PersonWithLongTableName>(
+    return session.db.findById<PersonWithLongTableName>(
       id,
       transaction: transaction,
       include: include,
@@ -349,7 +349,7 @@ class PersonWithLongTableNameRepository {
     List<PersonWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<PersonWithLongTableName>(
+    return session.db.insert<PersonWithLongTableName>(
       rows,
       transaction: transaction,
     );
@@ -360,7 +360,7 @@ class PersonWithLongTableNameRepository {
     PersonWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<PersonWithLongTableName>(
+    return session.db.insertRow<PersonWithLongTableName>(
       row,
       transaction: transaction,
     );
@@ -372,7 +372,7 @@ class PersonWithLongTableNameRepository {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<PersonWithLongTableName>(
+    return session.db.update<PersonWithLongTableName>(
       rows,
       columns: columns?.call(PersonWithLongTableName.t),
       transaction: transaction,
@@ -385,7 +385,7 @@ class PersonWithLongTableNameRepository {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<PersonWithLongTableName>(
+    return session.db.updateRow<PersonWithLongTableName>(
       row,
       columns: columns?.call(PersonWithLongTableName.t),
       transaction: transaction,
@@ -397,7 +397,7 @@ class PersonWithLongTableNameRepository {
     List<PersonWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<PersonWithLongTableName>(
+    return session.db.delete<PersonWithLongTableName>(
       rows,
       transaction: transaction,
     );
@@ -408,7 +408,7 @@ class PersonWithLongTableNameRepository {
     PersonWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<PersonWithLongTableName>(
+    return session.db.deleteRow<PersonWithLongTableName>(
       row,
       transaction: transaction,
     );
@@ -419,7 +419,7 @@ class PersonWithLongTableNameRepository {
     required _i1.WhereExpressionBuilder<PersonWithLongTableNameTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<PersonWithLongTableName>(
+    return session.db.deleteWhere<PersonWithLongTableName>(
       where: where(PersonWithLongTableName.t),
       transaction: transaction,
     );
@@ -431,7 +431,7 @@ class PersonWithLongTableNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<PersonWithLongTableName>(
+    return session.db.count<PersonWithLongTableName>(
       where: where?.call(PersonWithLongTableName.t),
       limit: limit,
       transaction: transaction,
@@ -456,7 +456,7 @@ class PersonWithLongTableNameAttachRowRepository {
 
     var $personWithLongTableName =
         personWithLongTableName.copyWith(organizationId: organization.id);
-    await session.dbNext.updateRow<PersonWithLongTableName>(
+    await session.db.updateRow<PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [PersonWithLongTableName.t.organizationId],
     );
@@ -476,7 +476,7 @@ class PersonWithLongTableNameDetachRowRepository {
 
     var $personwithlongtablename =
         personwithlongtablename.copyWith(organizationId: null);
-    await session.dbNext.updateRow<PersonWithLongTableName>(
+    await session.db.updateRow<PersonWithLongTableName>(
       $personwithlongtablename,
       columns: [PersonWithLongTableName.t.organizationId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -180,7 +180,7 @@ class MaxFieldNameRepository {
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<MaxFieldName>(
+    return session.db.find<MaxFieldName>(
       where: where?.call(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
@@ -200,7 +200,7 @@ class MaxFieldNameRepository {
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<MaxFieldName>(
+    return session.db.findFirstRow<MaxFieldName>(
       where: where?.call(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
@@ -215,7 +215,7 @@ class MaxFieldNameRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<MaxFieldName>(
+    return session.db.findById<MaxFieldName>(
       id,
       transaction: transaction,
     );
@@ -226,7 +226,7 @@ class MaxFieldNameRepository {
     List<MaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<MaxFieldName>(
+    return session.db.insert<MaxFieldName>(
       rows,
       transaction: transaction,
     );
@@ -237,7 +237,7 @@ class MaxFieldNameRepository {
     MaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<MaxFieldName>(
+    return session.db.insertRow<MaxFieldName>(
       row,
       transaction: transaction,
     );
@@ -249,7 +249,7 @@ class MaxFieldNameRepository {
     _i1.ColumnSelections<MaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<MaxFieldName>(
+    return session.db.update<MaxFieldName>(
       rows,
       columns: columns?.call(MaxFieldName.t),
       transaction: transaction,
@@ -262,7 +262,7 @@ class MaxFieldNameRepository {
     _i1.ColumnSelections<MaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<MaxFieldName>(
+    return session.db.updateRow<MaxFieldName>(
       row,
       columns: columns?.call(MaxFieldName.t),
       transaction: transaction,
@@ -274,7 +274,7 @@ class MaxFieldNameRepository {
     List<MaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<MaxFieldName>(
+    return session.db.delete<MaxFieldName>(
       rows,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class MaxFieldNameRepository {
     MaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<MaxFieldName>(
+    return session.db.deleteRow<MaxFieldName>(
       row,
       transaction: transaction,
     );
@@ -296,7 +296,7 @@ class MaxFieldNameRepository {
     required _i1.WhereExpressionBuilder<MaxFieldNameTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<MaxFieldName>(
+    return session.db.deleteWhere<MaxFieldName>(
       where: where(MaxFieldName.t),
       transaction: transaction,
     );
@@ -308,7 +308,7 @@ class MaxFieldNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<MaxFieldName>(
+    return session.db.count<MaxFieldName>(
       where: where?.call(MaxFieldName.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -219,7 +219,7 @@ class LongImplicitIdFieldRepository {
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<LongImplicitIdField>(
+    return session.db.find<LongImplicitIdField>(
       where: where?.call(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
@@ -239,7 +239,7 @@ class LongImplicitIdFieldRepository {
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<LongImplicitIdField>(
+    return session.db.findFirstRow<LongImplicitIdField>(
       where: where?.call(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
@@ -254,7 +254,7 @@ class LongImplicitIdFieldRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<LongImplicitIdField>(
+    return session.db.findById<LongImplicitIdField>(
       id,
       transaction: transaction,
     );
@@ -265,7 +265,7 @@ class LongImplicitIdFieldRepository {
     List<LongImplicitIdField> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<LongImplicitIdField>(
+    return session.db.insert<LongImplicitIdField>(
       rows,
       transaction: transaction,
     );
@@ -276,7 +276,7 @@ class LongImplicitIdFieldRepository {
     LongImplicitIdField row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<LongImplicitIdField>(
+    return session.db.insertRow<LongImplicitIdField>(
       row,
       transaction: transaction,
     );
@@ -288,7 +288,7 @@ class LongImplicitIdFieldRepository {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<LongImplicitIdField>(
+    return session.db.update<LongImplicitIdField>(
       rows,
       columns: columns?.call(LongImplicitIdField.t),
       transaction: transaction,
@@ -301,7 +301,7 @@ class LongImplicitIdFieldRepository {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<LongImplicitIdField>(
+    return session.db.updateRow<LongImplicitIdField>(
       row,
       columns: columns?.call(LongImplicitIdField.t),
       transaction: transaction,
@@ -313,7 +313,7 @@ class LongImplicitIdFieldRepository {
     List<LongImplicitIdField> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<LongImplicitIdField>(
+    return session.db.delete<LongImplicitIdField>(
       rows,
       transaction: transaction,
     );
@@ -324,7 +324,7 @@ class LongImplicitIdFieldRepository {
     LongImplicitIdField row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<LongImplicitIdField>(
+    return session.db.deleteRow<LongImplicitIdField>(
       row,
       transaction: transaction,
     );
@@ -335,7 +335,7 @@ class LongImplicitIdFieldRepository {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<LongImplicitIdField>(
+    return session.db.deleteWhere<LongImplicitIdField>(
       where: where(LongImplicitIdField.t),
       transaction: transaction,
     );
@@ -347,7 +347,7 @@ class LongImplicitIdFieldRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<LongImplicitIdField>(
+    return session.db.count<LongImplicitIdField>(
       where: where?.call(LongImplicitIdField.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -286,7 +286,7 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
   }) async {
-    return session.dbNext.find<LongImplicitIdFieldCollection>(
+    return session.db.find<LongImplicitIdFieldCollection>(
       where: where?.call(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
@@ -308,7 +308,7 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<LongImplicitIdFieldCollection>(
+    return session.db.findFirstRow<LongImplicitIdFieldCollection>(
       where: where?.call(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
@@ -325,7 +325,7 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
   }) async {
-    return session.dbNext.findById<LongImplicitIdFieldCollection>(
+    return session.db.findById<LongImplicitIdFieldCollection>(
       id,
       transaction: transaction,
       include: include,
@@ -337,7 +337,7 @@ class LongImplicitIdFieldCollectionRepository {
     List<LongImplicitIdFieldCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<LongImplicitIdFieldCollection>(
+    return session.db.insert<LongImplicitIdFieldCollection>(
       rows,
       transaction: transaction,
     );
@@ -348,7 +348,7 @@ class LongImplicitIdFieldCollectionRepository {
     LongImplicitIdFieldCollection row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<LongImplicitIdFieldCollection>(
+    return session.db.insertRow<LongImplicitIdFieldCollection>(
       row,
       transaction: transaction,
     );
@@ -360,7 +360,7 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<LongImplicitIdFieldCollection>(
+    return session.db.update<LongImplicitIdFieldCollection>(
       rows,
       columns: columns?.call(LongImplicitIdFieldCollection.t),
       transaction: transaction,
@@ -373,7 +373,7 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<LongImplicitIdFieldCollection>(
+    return session.db.updateRow<LongImplicitIdFieldCollection>(
       row,
       columns: columns?.call(LongImplicitIdFieldCollection.t),
       transaction: transaction,
@@ -385,7 +385,7 @@ class LongImplicitIdFieldCollectionRepository {
     List<LongImplicitIdFieldCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<LongImplicitIdFieldCollection>(
+    return session.db.delete<LongImplicitIdFieldCollection>(
       rows,
       transaction: transaction,
     );
@@ -396,7 +396,7 @@ class LongImplicitIdFieldCollectionRepository {
     LongImplicitIdFieldCollection row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<LongImplicitIdFieldCollection>(
+    return session.db.deleteRow<LongImplicitIdFieldCollection>(
       row,
       transaction: transaction,
     );
@@ -408,7 +408,7 @@ class LongImplicitIdFieldCollectionRepository {
         where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<LongImplicitIdFieldCollection>(
+    return session.db.deleteWhere<LongImplicitIdFieldCollection>(
       where: where(LongImplicitIdFieldCollection.t),
       transaction: transaction,
     );
@@ -420,7 +420,7 @@ class LongImplicitIdFieldCollectionRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<LongImplicitIdFieldCollection>(
+    return session.db.count<LongImplicitIdFieldCollection>(
       where: where?.call(LongImplicitIdFieldCollection.t),
       limit: limit,
       transaction: transaction,
@@ -450,7 +450,7 @@ class LongImplicitIdFieldCollectionAttachRepository {
                   longImplicitIdFieldCollection.id,
             ))
         .toList();
-    await session.dbNext.update<_i2.LongImplicitIdField>(
+    await session.db.update<_i2.LongImplicitIdField>(
       $longImplicitIdField,
       columns: [
         _i2.LongImplicitIdField.t
@@ -480,7 +480,7 @@ class LongImplicitIdFieldCollectionAttachRowRepository {
       $_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id:
           longImplicitIdFieldCollection.id,
     );
-    await session.dbNext.updateRow<_i2.LongImplicitIdField>(
+    await session.db.updateRow<_i2.LongImplicitIdField>(
       $longImplicitIdField,
       columns: [
         _i2.LongImplicitIdField.t
@@ -508,7 +508,7 @@ class LongImplicitIdFieldCollectionDetachRepository {
                   null,
             ))
         .toList();
-    await session.dbNext.update<_i2.LongImplicitIdField>(
+    await session.db.update<_i2.LongImplicitIdField>(
       $longImplicitIdField,
       columns: [
         _i2.LongImplicitIdField.t
@@ -533,7 +533,7 @@ class LongImplicitIdFieldCollectionDetachRowRepository {
       longImplicitIdField,
       $_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id: null,
     );
-    await session.dbNext.updateRow<_i2.LongImplicitIdField>(
+    await session.db.updateRow<_i2.LongImplicitIdField>(
       $longImplicitIdField,
       columns: [
         _i2.LongImplicitIdField.t

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -255,7 +255,7 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
   }) async {
-    return session.dbNext.find<RelationToMultipleMaxFieldName>(
+    return session.db.find<RelationToMultipleMaxFieldName>(
       where: where?.call(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
@@ -277,7 +277,7 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<RelationToMultipleMaxFieldName>(
+    return session.db.findFirstRow<RelationToMultipleMaxFieldName>(
       where: where?.call(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
@@ -294,7 +294,7 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
   }) async {
-    return session.dbNext.findById<RelationToMultipleMaxFieldName>(
+    return session.db.findById<RelationToMultipleMaxFieldName>(
       id,
       transaction: transaction,
       include: include,
@@ -306,7 +306,7 @@ class RelationToMultipleMaxFieldNameRepository {
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<RelationToMultipleMaxFieldName>(
+    return session.db.insert<RelationToMultipleMaxFieldName>(
       rows,
       transaction: transaction,
     );
@@ -317,7 +317,7 @@ class RelationToMultipleMaxFieldNameRepository {
     RelationToMultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<RelationToMultipleMaxFieldName>(
+    return session.db.insertRow<RelationToMultipleMaxFieldName>(
       row,
       transaction: transaction,
     );
@@ -329,7 +329,7 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.ColumnSelections<RelationToMultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<RelationToMultipleMaxFieldName>(
+    return session.db.update<RelationToMultipleMaxFieldName>(
       rows,
       columns: columns?.call(RelationToMultipleMaxFieldName.t),
       transaction: transaction,
@@ -342,7 +342,7 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.ColumnSelections<RelationToMultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<RelationToMultipleMaxFieldName>(
+    return session.db.updateRow<RelationToMultipleMaxFieldName>(
       row,
       columns: columns?.call(RelationToMultipleMaxFieldName.t),
       transaction: transaction,
@@ -354,7 +354,7 @@ class RelationToMultipleMaxFieldNameRepository {
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<RelationToMultipleMaxFieldName>(
+    return session.db.delete<RelationToMultipleMaxFieldName>(
       rows,
       transaction: transaction,
     );
@@ -365,7 +365,7 @@ class RelationToMultipleMaxFieldNameRepository {
     RelationToMultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<RelationToMultipleMaxFieldName>(
+    return session.db.deleteRow<RelationToMultipleMaxFieldName>(
       row,
       transaction: transaction,
     );
@@ -377,7 +377,7 @@ class RelationToMultipleMaxFieldNameRepository {
         where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<RelationToMultipleMaxFieldName>(
+    return session.db.deleteWhere<RelationToMultipleMaxFieldName>(
       where: where(RelationToMultipleMaxFieldName.t),
       transaction: transaction,
     );
@@ -389,7 +389,7 @@ class RelationToMultipleMaxFieldNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<RelationToMultipleMaxFieldName>(
+    return session.db.count<RelationToMultipleMaxFieldName>(
       where: where?.call(RelationToMultipleMaxFieldName.t),
       limit: limit,
       transaction: transaction,
@@ -419,7 +419,7 @@ class RelationToMultipleMaxFieldNameAttachRepository {
                   relationToMultipleMaxFieldName.id,
             ))
         .toList();
-    await session.dbNext.update<_i2.MultipleMaxFieldName>(
+    await session.db.update<_i2.MultipleMaxFieldName>(
       $multipleMaxFieldName,
       columns: [
         _i2.MultipleMaxFieldName.t
@@ -449,7 +449,7 @@ class RelationToMultipleMaxFieldNameAttachRowRepository {
       $_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId:
           relationToMultipleMaxFieldName.id,
     );
-    await session.dbNext.updateRow<_i2.MultipleMaxFieldName>(
+    await session.db.updateRow<_i2.MultipleMaxFieldName>(
       $multipleMaxFieldName,
       columns: [
         _i2.MultipleMaxFieldName.t
@@ -477,7 +477,7 @@ class RelationToMultipleMaxFieldNameDetachRepository {
                   null,
             ))
         .toList();
-    await session.dbNext.update<_i2.MultipleMaxFieldName>(
+    await session.db.update<_i2.MultipleMaxFieldName>(
       $multipleMaxFieldName,
       columns: [
         _i2.MultipleMaxFieldName.t
@@ -502,7 +502,7 @@ class RelationToMultipleMaxFieldNameDetachRowRepository {
       multipleMaxFieldName,
       $_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId: null,
     );
-    await session.dbNext.updateRow<_i2.MultipleMaxFieldName>(
+    await session.db.updateRow<_i2.MultipleMaxFieldName>(
       $multipleMaxFieldName,
       columns: [
         _i2.MultipleMaxFieldName.t

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -218,7 +218,7 @@ class UserNoteRepository {
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<UserNote>(
+    return session.db.find<UserNote>(
       where: where?.call(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
@@ -238,7 +238,7 @@ class UserNoteRepository {
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<UserNote>(
+    return session.db.findFirstRow<UserNote>(
       where: where?.call(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
@@ -253,7 +253,7 @@ class UserNoteRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<UserNote>(
+    return session.db.findById<UserNote>(
       id,
       transaction: transaction,
     );
@@ -264,7 +264,7 @@ class UserNoteRepository {
     List<UserNote> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<UserNote>(
+    return session.db.insert<UserNote>(
       rows,
       transaction: transaction,
     );
@@ -275,7 +275,7 @@ class UserNoteRepository {
     UserNote row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<UserNote>(
+    return session.db.insertRow<UserNote>(
       row,
       transaction: transaction,
     );
@@ -287,7 +287,7 @@ class UserNoteRepository {
     _i1.ColumnSelections<UserNoteTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<UserNote>(
+    return session.db.update<UserNote>(
       rows,
       columns: columns?.call(UserNote.t),
       transaction: transaction,
@@ -300,7 +300,7 @@ class UserNoteRepository {
     _i1.ColumnSelections<UserNoteTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<UserNote>(
+    return session.db.updateRow<UserNote>(
       row,
       columns: columns?.call(UserNote.t),
       transaction: transaction,
@@ -312,7 +312,7 @@ class UserNoteRepository {
     List<UserNote> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<UserNote>(
+    return session.db.delete<UserNote>(
       rows,
       transaction: transaction,
     );
@@ -323,7 +323,7 @@ class UserNoteRepository {
     UserNote row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<UserNote>(
+    return session.db.deleteRow<UserNote>(
       row,
       transaction: transaction,
     );
@@ -334,7 +334,7 @@ class UserNoteRepository {
     required _i1.WhereExpressionBuilder<UserNoteTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<UserNote>(
+    return session.db.deleteWhere<UserNote>(
       where: where(UserNote.t),
       transaction: transaction,
     );
@@ -346,7 +346,7 @@ class UserNoteRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<UserNote>(
+    return session.db.count<UserNote>(
       where: where?.call(UserNote.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -253,7 +253,7 @@ class UserNoteCollectionRepository {
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
   }) async {
-    return session.dbNext.find<UserNoteCollection>(
+    return session.db.find<UserNoteCollection>(
       where: where?.call(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
@@ -275,7 +275,7 @@ class UserNoteCollectionRepository {
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<UserNoteCollection>(
+    return session.db.findFirstRow<UserNoteCollection>(
       where: where?.call(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
@@ -292,7 +292,7 @@ class UserNoteCollectionRepository {
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
   }) async {
-    return session.dbNext.findById<UserNoteCollection>(
+    return session.db.findById<UserNoteCollection>(
       id,
       transaction: transaction,
       include: include,
@@ -304,7 +304,7 @@ class UserNoteCollectionRepository {
     List<UserNoteCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<UserNoteCollection>(
+    return session.db.insert<UserNoteCollection>(
       rows,
       transaction: transaction,
     );
@@ -315,7 +315,7 @@ class UserNoteCollectionRepository {
     UserNoteCollection row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<UserNoteCollection>(
+    return session.db.insertRow<UserNoteCollection>(
       row,
       transaction: transaction,
     );
@@ -327,7 +327,7 @@ class UserNoteCollectionRepository {
     _i1.ColumnSelections<UserNoteCollectionTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<UserNoteCollection>(
+    return session.db.update<UserNoteCollection>(
       rows,
       columns: columns?.call(UserNoteCollection.t),
       transaction: transaction,
@@ -340,7 +340,7 @@ class UserNoteCollectionRepository {
     _i1.ColumnSelections<UserNoteCollectionTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<UserNoteCollection>(
+    return session.db.updateRow<UserNoteCollection>(
       row,
       columns: columns?.call(UserNoteCollection.t),
       transaction: transaction,
@@ -352,7 +352,7 @@ class UserNoteCollectionRepository {
     List<UserNoteCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<UserNoteCollection>(
+    return session.db.delete<UserNoteCollection>(
       rows,
       transaction: transaction,
     );
@@ -363,7 +363,7 @@ class UserNoteCollectionRepository {
     UserNoteCollection row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<UserNoteCollection>(
+    return session.db.deleteRow<UserNoteCollection>(
       row,
       transaction: transaction,
     );
@@ -374,7 +374,7 @@ class UserNoteCollectionRepository {
     required _i1.WhereExpressionBuilder<UserNoteCollectionTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<UserNoteCollection>(
+    return session.db.deleteWhere<UserNoteCollection>(
       where: where(UserNoteCollection.t),
       transaction: transaction,
     );
@@ -386,7 +386,7 @@ class UserNoteCollectionRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<UserNoteCollection>(
+    return session.db.count<UserNoteCollection>(
       where: where?.call(UserNoteCollection.t),
       limit: limit,
       transaction: transaction,
@@ -416,7 +416,7 @@ class UserNoteCollectionAttachRepository {
                   userNoteCollection.id,
             ))
         .toList();
-    await session.dbNext.update<_i2.UserNote>(
+    await session.db.update<_i2.UserNote>(
       $userNote,
       columns: [
         _i2.UserNote.t
@@ -446,7 +446,7 @@ class UserNoteCollectionAttachRowRepository {
       $_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId:
           userNoteCollection.id,
     );
-    await session.dbNext.updateRow<_i2.UserNote>(
+    await session.db.updateRow<_i2.UserNote>(
       $userNote,
       columns: [
         _i2.UserNote.t
@@ -474,7 +474,7 @@ class UserNoteCollectionDetachRepository {
                   null,
             ))
         .toList();
-    await session.dbNext.update<_i2.UserNote>(
+    await session.db.update<_i2.UserNote>(
       $userNote,
       columns: [
         _i2.UserNote.t
@@ -499,7 +499,7 @@ class UserNoteCollectionDetachRowRepository {
       userNote,
       $_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId: null,
     );
-    await session.dbNext.updateRow<_i2.UserNote>(
+    await session.db.updateRow<_i2.UserNote>(
       $userNote,
       columns: [
         _i2.UserNote.t

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -250,7 +250,7 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
   }) async {
-    return session.dbNext.find<UserNoteCollectionWithALongName>(
+    return session.db.find<UserNoteCollectionWithALongName>(
       where: where?.call(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
@@ -272,7 +272,7 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<UserNoteCollectionWithALongName>(
+    return session.db.findFirstRow<UserNoteCollectionWithALongName>(
       where: where?.call(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
@@ -289,7 +289,7 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
   }) async {
-    return session.dbNext.findById<UserNoteCollectionWithALongName>(
+    return session.db.findById<UserNoteCollectionWithALongName>(
       id,
       transaction: transaction,
       include: include,
@@ -301,7 +301,7 @@ class UserNoteCollectionWithALongNameRepository {
     List<UserNoteCollectionWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<UserNoteCollectionWithALongName>(
+    return session.db.insert<UserNoteCollectionWithALongName>(
       rows,
       transaction: transaction,
     );
@@ -312,7 +312,7 @@ class UserNoteCollectionWithALongNameRepository {
     UserNoteCollectionWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<UserNoteCollectionWithALongName>(
+    return session.db.insertRow<UserNoteCollectionWithALongName>(
       row,
       transaction: transaction,
     );
@@ -324,7 +324,7 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.ColumnSelections<UserNoteCollectionWithALongNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<UserNoteCollectionWithALongName>(
+    return session.db.update<UserNoteCollectionWithALongName>(
       rows,
       columns: columns?.call(UserNoteCollectionWithALongName.t),
       transaction: transaction,
@@ -337,7 +337,7 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.ColumnSelections<UserNoteCollectionWithALongNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<UserNoteCollectionWithALongName>(
+    return session.db.updateRow<UserNoteCollectionWithALongName>(
       row,
       columns: columns?.call(UserNoteCollectionWithALongName.t),
       transaction: transaction,
@@ -349,7 +349,7 @@ class UserNoteCollectionWithALongNameRepository {
     List<UserNoteCollectionWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<UserNoteCollectionWithALongName>(
+    return session.db.delete<UserNoteCollectionWithALongName>(
       rows,
       transaction: transaction,
     );
@@ -360,7 +360,7 @@ class UserNoteCollectionWithALongNameRepository {
     UserNoteCollectionWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<UserNoteCollectionWithALongName>(
+    return session.db.deleteRow<UserNoteCollectionWithALongName>(
       row,
       transaction: transaction,
     );
@@ -372,7 +372,7 @@ class UserNoteCollectionWithALongNameRepository {
         where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<UserNoteCollectionWithALongName>(
+    return session.db.deleteWhere<UserNoteCollectionWithALongName>(
       where: where(UserNoteCollectionWithALongName.t),
       transaction: transaction,
     );
@@ -384,7 +384,7 @@ class UserNoteCollectionWithALongNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<UserNoteCollectionWithALongName>(
+    return session.db.count<UserNoteCollectionWithALongName>(
       where: where?.call(UserNoteCollectionWithALongName.t),
       limit: limit,
       transaction: transaction,
@@ -414,7 +414,7 @@ class UserNoteCollectionWithALongNameAttachRepository {
                   userNoteCollectionWithALongName.id,
             ))
         .toList();
-    await session.dbNext.update<_i2.UserNoteWithALongName>(
+    await session.db.update<_i2.UserNoteWithALongName>(
       $userNoteWithALongName,
       columns: [
         _i2.UserNoteWithALongName.t
@@ -444,7 +444,7 @@ class UserNoteCollectionWithALongNameAttachRowRepository {
       $_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId:
           userNoteCollectionWithALongName.id,
     );
-    await session.dbNext.updateRow<_i2.UserNoteWithALongName>(
+    await session.db.updateRow<_i2.UserNoteWithALongName>(
       $userNoteWithALongName,
       columns: [
         _i2.UserNoteWithALongName.t
@@ -472,7 +472,7 @@ class UserNoteCollectionWithALongNameDetachRepository {
                   null,
             ))
         .toList();
-    await session.dbNext.update<_i2.UserNoteWithALongName>(
+    await session.db.update<_i2.UserNoteWithALongName>(
       $userNoteWithALongName,
       columns: [
         _i2.UserNoteWithALongName.t
@@ -497,7 +497,7 @@ class UserNoteCollectionWithALongNameDetachRowRepository {
       userNoteWithALongName,
       $_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId: null,
     );
-    await session.dbNext.updateRow<_i2.UserNoteWithALongName>(
+    await session.db.updateRow<_i2.UserNoteWithALongName>(
       $userNoteWithALongName,
       columns: [
         _i2.UserNoteWithALongName.t

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -219,7 +219,7 @@ class UserNoteWithALongNameRepository {
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<UserNoteWithALongName>(
+    return session.db.find<UserNoteWithALongName>(
       where: where?.call(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
@@ -239,7 +239,7 @@ class UserNoteWithALongNameRepository {
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<UserNoteWithALongName>(
+    return session.db.findFirstRow<UserNoteWithALongName>(
       where: where?.call(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
@@ -254,7 +254,7 @@ class UserNoteWithALongNameRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<UserNoteWithALongName>(
+    return session.db.findById<UserNoteWithALongName>(
       id,
       transaction: transaction,
     );
@@ -265,7 +265,7 @@ class UserNoteWithALongNameRepository {
     List<UserNoteWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<UserNoteWithALongName>(
+    return session.db.insert<UserNoteWithALongName>(
       rows,
       transaction: transaction,
     );
@@ -276,7 +276,7 @@ class UserNoteWithALongNameRepository {
     UserNoteWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<UserNoteWithALongName>(
+    return session.db.insertRow<UserNoteWithALongName>(
       row,
       transaction: transaction,
     );
@@ -288,7 +288,7 @@ class UserNoteWithALongNameRepository {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<UserNoteWithALongName>(
+    return session.db.update<UserNoteWithALongName>(
       rows,
       columns: columns?.call(UserNoteWithALongName.t),
       transaction: transaction,
@@ -301,7 +301,7 @@ class UserNoteWithALongNameRepository {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<UserNoteWithALongName>(
+    return session.db.updateRow<UserNoteWithALongName>(
       row,
       columns: columns?.call(UserNoteWithALongName.t),
       transaction: transaction,
@@ -313,7 +313,7 @@ class UserNoteWithALongNameRepository {
     List<UserNoteWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<UserNoteWithALongName>(
+    return session.db.delete<UserNoteWithALongName>(
       rows,
       transaction: transaction,
     );
@@ -324,7 +324,7 @@ class UserNoteWithALongNameRepository {
     UserNoteWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<UserNoteWithALongName>(
+    return session.db.deleteRow<UserNoteWithALongName>(
       row,
       transaction: transaction,
     );
@@ -335,7 +335,7 @@ class UserNoteWithALongNameRepository {
     required _i1.WhereExpressionBuilder<UserNoteWithALongNameTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<UserNoteWithALongName>(
+    return session.db.deleteWhere<UserNoteWithALongName>(
       where: where(UserNoteWithALongName.t),
       transaction: transaction,
     );
@@ -347,7 +347,7 @@ class UserNoteWithALongNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<UserNoteWithALongName>(
+    return session.db.count<UserNoteWithALongName>(
       where: where?.call(UserNoteWithALongName.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -271,7 +271,7 @@ class MultipleMaxFieldNameRepository {
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<MultipleMaxFieldName>(
+    return session.db.find<MultipleMaxFieldName>(
       where: where?.call(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
@@ -291,7 +291,7 @@ class MultipleMaxFieldNameRepository {
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<MultipleMaxFieldName>(
+    return session.db.findFirstRow<MultipleMaxFieldName>(
       where: where?.call(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
@@ -306,7 +306,7 @@ class MultipleMaxFieldNameRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<MultipleMaxFieldName>(
+    return session.db.findById<MultipleMaxFieldName>(
       id,
       transaction: transaction,
     );
@@ -317,7 +317,7 @@ class MultipleMaxFieldNameRepository {
     List<MultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<MultipleMaxFieldName>(
+    return session.db.insert<MultipleMaxFieldName>(
       rows,
       transaction: transaction,
     );
@@ -328,7 +328,7 @@ class MultipleMaxFieldNameRepository {
     MultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<MultipleMaxFieldName>(
+    return session.db.insertRow<MultipleMaxFieldName>(
       row,
       transaction: transaction,
     );
@@ -340,7 +340,7 @@ class MultipleMaxFieldNameRepository {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<MultipleMaxFieldName>(
+    return session.db.update<MultipleMaxFieldName>(
       rows,
       columns: columns?.call(MultipleMaxFieldName.t),
       transaction: transaction,
@@ -353,7 +353,7 @@ class MultipleMaxFieldNameRepository {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<MultipleMaxFieldName>(
+    return session.db.updateRow<MultipleMaxFieldName>(
       row,
       columns: columns?.call(MultipleMaxFieldName.t),
       transaction: transaction,
@@ -365,7 +365,7 @@ class MultipleMaxFieldNameRepository {
     List<MultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<MultipleMaxFieldName>(
+    return session.db.delete<MultipleMaxFieldName>(
       rows,
       transaction: transaction,
     );
@@ -376,7 +376,7 @@ class MultipleMaxFieldNameRepository {
     MultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<MultipleMaxFieldName>(
+    return session.db.deleteRow<MultipleMaxFieldName>(
       row,
       transaction: transaction,
     );
@@ -387,7 +387,7 @@ class MultipleMaxFieldNameRepository {
     required _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<MultipleMaxFieldName>(
+    return session.db.deleteWhere<MultipleMaxFieldName>(
       where: where(MultipleMaxFieldName.t),
       transaction: transaction,
     );
@@ -399,7 +399,7 @@ class MultipleMaxFieldNameRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<MultipleMaxFieldName>(
+    return session.db.count<MultipleMaxFieldName>(
       where: where?.call(MultipleMaxFieldName.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -313,7 +313,7 @@ class CityRepository {
     _i1.Transaction? transaction,
     CityInclude? include,
   }) async {
-    return session.dbNext.find<City>(
+    return session.db.find<City>(
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
@@ -335,7 +335,7 @@ class CityRepository {
     _i1.Transaction? transaction,
     CityInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<City>(
+    return session.db.findFirstRow<City>(
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
@@ -352,7 +352,7 @@ class CityRepository {
     _i1.Transaction? transaction,
     CityInclude? include,
   }) async {
-    return session.dbNext.findById<City>(
+    return session.db.findById<City>(
       id,
       transaction: transaction,
       include: include,
@@ -364,7 +364,7 @@ class CityRepository {
     List<City> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<City>(
+    return session.db.insert<City>(
       rows,
       transaction: transaction,
     );
@@ -375,7 +375,7 @@ class CityRepository {
     City row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<City>(
+    return session.db.insertRow<City>(
       row,
       transaction: transaction,
     );
@@ -387,7 +387,7 @@ class CityRepository {
     _i1.ColumnSelections<CityTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<City>(
+    return session.db.update<City>(
       rows,
       columns: columns?.call(City.t),
       transaction: transaction,
@@ -400,7 +400,7 @@ class CityRepository {
     _i1.ColumnSelections<CityTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<City>(
+    return session.db.updateRow<City>(
       row,
       columns: columns?.call(City.t),
       transaction: transaction,
@@ -412,7 +412,7 @@ class CityRepository {
     List<City> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<City>(
+    return session.db.delete<City>(
       rows,
       transaction: transaction,
     );
@@ -423,7 +423,7 @@ class CityRepository {
     City row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<City>(
+    return session.db.deleteRow<City>(
       row,
       transaction: transaction,
     );
@@ -434,7 +434,7 @@ class CityRepository {
     required _i1.WhereExpressionBuilder<CityTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<City>(
+    return session.db.deleteWhere<City>(
       where: where(City.t),
       transaction: transaction,
     );
@@ -446,7 +446,7 @@ class CityRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<City>(
+    return session.db.count<City>(
       where: where?.call(City.t),
       limit: limit,
       transaction: transaction,
@@ -475,7 +475,7 @@ class CityAttachRepository {
               $_cityCitizensCityId: city.id,
             ))
         .toList();
-    await session.dbNext.update<_i2.Person>(
+    await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
     );
@@ -495,7 +495,7 @@ class CityAttachRepository {
 
     var $organization =
         organization.map((e) => e.copyWith(cityId: city.id)).toList();
-    await session.dbNext.update<_i2.Organization>(
+    await session.db.update<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
     );
@@ -521,7 +521,7 @@ class CityAttachRowRepository {
       person,
       $_cityCitizensCityId: city.id,
     );
-    await session.dbNext.updateRow<_i2.Person>(
+    await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
     );
@@ -540,7 +540,7 @@ class CityAttachRowRepository {
     }
 
     var $organization = organization.copyWith(cityId: city.id);
-    await session.dbNext.updateRow<_i2.Organization>(
+    await session.db.updateRow<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
     );
@@ -564,7 +564,7 @@ class CityDetachRepository {
               $_cityCitizensCityId: null,
             ))
         .toList();
-    await session.dbNext.update<_i2.Person>(
+    await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
     );
@@ -580,7 +580,7 @@ class CityDetachRepository {
 
     var $organization =
         organization.map((e) => e.copyWith(cityId: null)).toList();
-    await session.dbNext.update<_i2.Organization>(
+    await session.db.update<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
     );
@@ -602,7 +602,7 @@ class CityDetachRowRepository {
       person,
       $_cityCitizensCityId: null,
     );
-    await session.dbNext.updateRow<_i2.Person>(
+    await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
     );
@@ -617,7 +617,7 @@ class CityDetachRowRepository {
     }
 
     var $organization = organization.copyWith(cityId: null);
-    await session.dbNext.updateRow<_i2.Organization>(
+    await session.db.updateRow<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -307,7 +307,7 @@ class OrganizationRepository {
     _i1.Transaction? transaction,
     OrganizationInclude? include,
   }) async {
-    return session.dbNext.find<Organization>(
+    return session.db.find<Organization>(
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
@@ -329,7 +329,7 @@ class OrganizationRepository {
     _i1.Transaction? transaction,
     OrganizationInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Organization>(
+    return session.db.findFirstRow<Organization>(
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
@@ -346,7 +346,7 @@ class OrganizationRepository {
     _i1.Transaction? transaction,
     OrganizationInclude? include,
   }) async {
-    return session.dbNext.findById<Organization>(
+    return session.db.findById<Organization>(
       id,
       transaction: transaction,
       include: include,
@@ -358,7 +358,7 @@ class OrganizationRepository {
     List<Organization> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Organization>(
+    return session.db.insert<Organization>(
       rows,
       transaction: transaction,
     );
@@ -369,7 +369,7 @@ class OrganizationRepository {
     Organization row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Organization>(
+    return session.db.insertRow<Organization>(
       row,
       transaction: transaction,
     );
@@ -381,7 +381,7 @@ class OrganizationRepository {
     _i1.ColumnSelections<OrganizationTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Organization>(
+    return session.db.update<Organization>(
       rows,
       columns: columns?.call(Organization.t),
       transaction: transaction,
@@ -394,7 +394,7 @@ class OrganizationRepository {
     _i1.ColumnSelections<OrganizationTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Organization>(
+    return session.db.updateRow<Organization>(
       row,
       columns: columns?.call(Organization.t),
       transaction: transaction,
@@ -406,7 +406,7 @@ class OrganizationRepository {
     List<Organization> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Organization>(
+    return session.db.delete<Organization>(
       rows,
       transaction: transaction,
     );
@@ -417,7 +417,7 @@ class OrganizationRepository {
     Organization row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Organization>(
+    return session.db.deleteRow<Organization>(
       row,
       transaction: transaction,
     );
@@ -428,7 +428,7 @@ class OrganizationRepository {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Organization>(
+    return session.db.deleteWhere<Organization>(
       where: where(Organization.t),
       transaction: transaction,
     );
@@ -440,7 +440,7 @@ class OrganizationRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Organization>(
+    return session.db.count<Organization>(
       where: where?.call(Organization.t),
       limit: limit,
       transaction: transaction,
@@ -465,7 +465,7 @@ class OrganizationAttachRepository {
 
     var $person =
         person.map((e) => e.copyWith(organizationId: organization.id)).toList();
-    await session.dbNext.update<_i2.Person>(
+    await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
     );
@@ -488,7 +488,7 @@ class OrganizationAttachRowRepository {
     }
 
     var $organization = organization.copyWith(cityId: city.id);
-    await session.dbNext.updateRow<Organization>(
+    await session.db.updateRow<Organization>(
       $organization,
       columns: [Organization.t.cityId],
     );
@@ -507,7 +507,7 @@ class OrganizationAttachRowRepository {
     }
 
     var $person = person.copyWith(organizationId: organization.id);
-    await session.dbNext.updateRow<_i2.Person>(
+    await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
     );
@@ -526,7 +526,7 @@ class OrganizationDetachRepository {
     }
 
     var $person = person.map((e) => e.copyWith(organizationId: null)).toList();
-    await session.dbNext.update<_i2.Person>(
+    await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
     );
@@ -545,7 +545,7 @@ class OrganizationDetachRowRepository {
     }
 
     var $organization = organization.copyWith(cityId: null);
-    await session.dbNext.updateRow<Organization>(
+    await session.db.updateRow<Organization>(
       $organization,
       columns: [Organization.t.cityId],
     );
@@ -560,7 +560,7 @@ class OrganizationDetachRowRepository {
     }
 
     var $person = person.copyWith(organizationId: null);
-    await session.dbNext.updateRow<_i2.Person>(
+    await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -285,7 +285,7 @@ class PersonRepository {
     _i1.Transaction? transaction,
     PersonInclude? include,
   }) async {
-    return session.dbNext.find<Person>(
+    return session.db.find<Person>(
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
@@ -307,7 +307,7 @@ class PersonRepository {
     _i1.Transaction? transaction,
     PersonInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Person>(
+    return session.db.findFirstRow<Person>(
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
@@ -324,7 +324,7 @@ class PersonRepository {
     _i1.Transaction? transaction,
     PersonInclude? include,
   }) async {
-    return session.dbNext.findById<Person>(
+    return session.db.findById<Person>(
       id,
       transaction: transaction,
       include: include,
@@ -336,7 +336,7 @@ class PersonRepository {
     List<Person> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Person>(
+    return session.db.insert<Person>(
       rows,
       transaction: transaction,
     );
@@ -347,7 +347,7 @@ class PersonRepository {
     Person row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Person>(
+    return session.db.insertRow<Person>(
       row,
       transaction: transaction,
     );
@@ -359,7 +359,7 @@ class PersonRepository {
     _i1.ColumnSelections<PersonTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Person>(
+    return session.db.update<Person>(
       rows,
       columns: columns?.call(Person.t),
       transaction: transaction,
@@ -372,7 +372,7 @@ class PersonRepository {
     _i1.ColumnSelections<PersonTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Person>(
+    return session.db.updateRow<Person>(
       row,
       columns: columns?.call(Person.t),
       transaction: transaction,
@@ -384,7 +384,7 @@ class PersonRepository {
     List<Person> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Person>(
+    return session.db.delete<Person>(
       rows,
       transaction: transaction,
     );
@@ -395,7 +395,7 @@ class PersonRepository {
     Person row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Person>(
+    return session.db.deleteRow<Person>(
       row,
       transaction: transaction,
     );
@@ -406,7 +406,7 @@ class PersonRepository {
     required _i1.WhereExpressionBuilder<PersonTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Person>(
+    return session.db.deleteWhere<Person>(
       where: where(Person.t),
       transaction: transaction,
     );
@@ -418,7 +418,7 @@ class PersonRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Person>(
+    return session.db.count<Person>(
       where: where?.call(Person.t),
       limit: limit,
       transaction: transaction,
@@ -442,7 +442,7 @@ class PersonAttachRowRepository {
     }
 
     var $person = person.copyWith(organizationId: organization.id);
-    await session.dbNext.updateRow<Person>(
+    await session.db.updateRow<Person>(
       $person,
       columns: [Person.t.organizationId],
     );
@@ -461,7 +461,7 @@ class PersonDetachRowRepository {
     }
 
     var $person = person.copyWith(organizationId: null);
-    await session.dbNext.updateRow<Person>(
+    await session.db.updateRow<Person>(
       $person,
       columns: [Person.t.organizationId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -243,7 +243,7 @@ class CourseRepository {
     _i1.Transaction? transaction,
     CourseInclude? include,
   }) async {
-    return session.dbNext.find<Course>(
+    return session.db.find<Course>(
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
@@ -265,7 +265,7 @@ class CourseRepository {
     _i1.Transaction? transaction,
     CourseInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Course>(
+    return session.db.findFirstRow<Course>(
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
@@ -282,7 +282,7 @@ class CourseRepository {
     _i1.Transaction? transaction,
     CourseInclude? include,
   }) async {
-    return session.dbNext.findById<Course>(
+    return session.db.findById<Course>(
       id,
       transaction: transaction,
       include: include,
@@ -294,7 +294,7 @@ class CourseRepository {
     List<Course> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Course>(
+    return session.db.insert<Course>(
       rows,
       transaction: transaction,
     );
@@ -305,7 +305,7 @@ class CourseRepository {
     Course row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Course>(
+    return session.db.insertRow<Course>(
       row,
       transaction: transaction,
     );
@@ -317,7 +317,7 @@ class CourseRepository {
     _i1.ColumnSelections<CourseTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Course>(
+    return session.db.update<Course>(
       rows,
       columns: columns?.call(Course.t),
       transaction: transaction,
@@ -330,7 +330,7 @@ class CourseRepository {
     _i1.ColumnSelections<CourseTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Course>(
+    return session.db.updateRow<Course>(
       row,
       columns: columns?.call(Course.t),
       transaction: transaction,
@@ -342,7 +342,7 @@ class CourseRepository {
     List<Course> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Course>(
+    return session.db.delete<Course>(
       rows,
       transaction: transaction,
     );
@@ -353,7 +353,7 @@ class CourseRepository {
     Course row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Course>(
+    return session.db.deleteRow<Course>(
       row,
       transaction: transaction,
     );
@@ -364,7 +364,7 @@ class CourseRepository {
     required _i1.WhereExpressionBuilder<CourseTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Course>(
+    return session.db.deleteWhere<Course>(
       where: where(Course.t),
       transaction: transaction,
     );
@@ -376,7 +376,7 @@ class CourseRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Course>(
+    return session.db.count<Course>(
       where: where?.call(Course.t),
       limit: limit,
       transaction: transaction,
@@ -401,7 +401,7 @@ class CourseAttachRepository {
 
     var $enrollment =
         enrollment.map((e) => e.copyWith(courseId: course.id)).toList();
-    await session.dbNext.update<_i2.Enrollment>(
+    await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
     );
@@ -424,7 +424,7 @@ class CourseAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(courseId: course.id);
-    await session.dbNext.updateRow<_i2.Enrollment>(
+    await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
     );
@@ -444,7 +444,7 @@ class CourseDetachRepository {
 
     var $enrollment =
         enrollment.map((e) => e.copyWith(courseId: null)).toList();
-    await session.dbNext.update<_i2.Enrollment>(
+    await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
     );
@@ -463,7 +463,7 @@ class CourseDetachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(courseId: null);
-    await session.dbNext.updateRow<_i2.Enrollment>(
+    await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -279,7 +279,7 @@ class EnrollmentRepository {
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
   }) async {
-    return session.dbNext.find<Enrollment>(
+    return session.db.find<Enrollment>(
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
@@ -301,7 +301,7 @@ class EnrollmentRepository {
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Enrollment>(
+    return session.db.findFirstRow<Enrollment>(
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
@@ -318,7 +318,7 @@ class EnrollmentRepository {
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
   }) async {
-    return session.dbNext.findById<Enrollment>(
+    return session.db.findById<Enrollment>(
       id,
       transaction: transaction,
       include: include,
@@ -330,7 +330,7 @@ class EnrollmentRepository {
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Enrollment>(
+    return session.db.insert<Enrollment>(
       rows,
       transaction: transaction,
     );
@@ -341,7 +341,7 @@ class EnrollmentRepository {
     Enrollment row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Enrollment>(
+    return session.db.insertRow<Enrollment>(
       row,
       transaction: transaction,
     );
@@ -353,7 +353,7 @@ class EnrollmentRepository {
     _i1.ColumnSelections<EnrollmentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Enrollment>(
+    return session.db.update<Enrollment>(
       rows,
       columns: columns?.call(Enrollment.t),
       transaction: transaction,
@@ -366,7 +366,7 @@ class EnrollmentRepository {
     _i1.ColumnSelections<EnrollmentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Enrollment>(
+    return session.db.updateRow<Enrollment>(
       row,
       columns: columns?.call(Enrollment.t),
       transaction: transaction,
@@ -378,7 +378,7 @@ class EnrollmentRepository {
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Enrollment>(
+    return session.db.delete<Enrollment>(
       rows,
       transaction: transaction,
     );
@@ -389,7 +389,7 @@ class EnrollmentRepository {
     Enrollment row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Enrollment>(
+    return session.db.deleteRow<Enrollment>(
       row,
       transaction: transaction,
     );
@@ -400,7 +400,7 @@ class EnrollmentRepository {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Enrollment>(
+    return session.db.deleteWhere<Enrollment>(
       where: where(Enrollment.t),
       transaction: transaction,
     );
@@ -412,7 +412,7 @@ class EnrollmentRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Enrollment>(
+    return session.db.count<Enrollment>(
       where: where?.call(Enrollment.t),
       limit: limit,
       transaction: transaction,
@@ -436,7 +436,7 @@ class EnrollmentAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(studentId: student.id);
-    await session.dbNext.updateRow<Enrollment>(
+    await session.db.updateRow<Enrollment>(
       $enrollment,
       columns: [Enrollment.t.studentId],
     );
@@ -455,7 +455,7 @@ class EnrollmentAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(courseId: course.id);
-    await session.dbNext.updateRow<Enrollment>(
+    await session.db.updateRow<Enrollment>(
       $enrollment,
       columns: [Enrollment.t.courseId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -239,7 +239,7 @@ class StudentRepository {
     _i1.Transaction? transaction,
     StudentInclude? include,
   }) async {
-    return session.dbNext.find<Student>(
+    return session.db.find<Student>(
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
@@ -261,7 +261,7 @@ class StudentRepository {
     _i1.Transaction? transaction,
     StudentInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Student>(
+    return session.db.findFirstRow<Student>(
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
@@ -278,7 +278,7 @@ class StudentRepository {
     _i1.Transaction? transaction,
     StudentInclude? include,
   }) async {
-    return session.dbNext.findById<Student>(
+    return session.db.findById<Student>(
       id,
       transaction: transaction,
       include: include,
@@ -290,7 +290,7 @@ class StudentRepository {
     List<Student> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Student>(
+    return session.db.insert<Student>(
       rows,
       transaction: transaction,
     );
@@ -301,7 +301,7 @@ class StudentRepository {
     Student row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Student>(
+    return session.db.insertRow<Student>(
       row,
       transaction: transaction,
     );
@@ -313,7 +313,7 @@ class StudentRepository {
     _i1.ColumnSelections<StudentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Student>(
+    return session.db.update<Student>(
       rows,
       columns: columns?.call(Student.t),
       transaction: transaction,
@@ -326,7 +326,7 @@ class StudentRepository {
     _i1.ColumnSelections<StudentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Student>(
+    return session.db.updateRow<Student>(
       row,
       columns: columns?.call(Student.t),
       transaction: transaction,
@@ -338,7 +338,7 @@ class StudentRepository {
     List<Student> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Student>(
+    return session.db.delete<Student>(
       rows,
       transaction: transaction,
     );
@@ -349,7 +349,7 @@ class StudentRepository {
     Student row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Student>(
+    return session.db.deleteRow<Student>(
       row,
       transaction: transaction,
     );
@@ -360,7 +360,7 @@ class StudentRepository {
     required _i1.WhereExpressionBuilder<StudentTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Student>(
+    return session.db.deleteWhere<Student>(
       where: where(Student.t),
       transaction: transaction,
     );
@@ -372,7 +372,7 @@ class StudentRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Student>(
+    return session.db.count<Student>(
       where: where?.call(Student.t),
       limit: limit,
       transaction: transaction,
@@ -397,7 +397,7 @@ class StudentAttachRepository {
 
     var $enrollment =
         enrollment.map((e) => e.copyWith(studentId: student.id)).toList();
-    await session.dbNext.update<_i2.Enrollment>(
+    await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.studentId],
     );
@@ -420,7 +420,7 @@ class StudentAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(studentId: student.id);
-    await session.dbNext.updateRow<_i2.Enrollment>(
+    await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.studentId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -234,7 +234,7 @@ class ObjectUserRepository {
     _i1.Transaction? transaction,
     ObjectUserInclude? include,
   }) async {
-    return session.dbNext.find<ObjectUser>(
+    return session.db.find<ObjectUser>(
       where: where?.call(ObjectUser.t),
       orderBy: orderBy?.call(ObjectUser.t),
       orderByList: orderByList?.call(ObjectUser.t),
@@ -256,7 +256,7 @@ class ObjectUserRepository {
     _i1.Transaction? transaction,
     ObjectUserInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<ObjectUser>(
+    return session.db.findFirstRow<ObjectUser>(
       where: where?.call(ObjectUser.t),
       orderBy: orderBy?.call(ObjectUser.t),
       orderByList: orderByList?.call(ObjectUser.t),
@@ -273,7 +273,7 @@ class ObjectUserRepository {
     _i1.Transaction? transaction,
     ObjectUserInclude? include,
   }) async {
-    return session.dbNext.findById<ObjectUser>(
+    return session.db.findById<ObjectUser>(
       id,
       transaction: transaction,
       include: include,
@@ -285,7 +285,7 @@ class ObjectUserRepository {
     List<ObjectUser> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectUser>(
+    return session.db.insert<ObjectUser>(
       rows,
       transaction: transaction,
     );
@@ -296,7 +296,7 @@ class ObjectUserRepository {
     ObjectUser row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectUser>(
+    return session.db.insertRow<ObjectUser>(
       row,
       transaction: transaction,
     );
@@ -308,7 +308,7 @@ class ObjectUserRepository {
     _i1.ColumnSelections<ObjectUserTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectUser>(
+    return session.db.update<ObjectUser>(
       rows,
       columns: columns?.call(ObjectUser.t),
       transaction: transaction,
@@ -321,7 +321,7 @@ class ObjectUserRepository {
     _i1.ColumnSelections<ObjectUserTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectUser>(
+    return session.db.updateRow<ObjectUser>(
       row,
       columns: columns?.call(ObjectUser.t),
       transaction: transaction,
@@ -333,7 +333,7 @@ class ObjectUserRepository {
     List<ObjectUser> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectUser>(
+    return session.db.delete<ObjectUser>(
       rows,
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class ObjectUserRepository {
     ObjectUser row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectUser>(
+    return session.db.deleteRow<ObjectUser>(
       row,
       transaction: transaction,
     );
@@ -355,7 +355,7 @@ class ObjectUserRepository {
     required _i1.WhereExpressionBuilder<ObjectUserTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectUser>(
+    return session.db.deleteWhere<ObjectUser>(
       where: where(ObjectUser.t),
       transaction: transaction,
     );
@@ -367,7 +367,7 @@ class ObjectUserRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectUser>(
+    return session.db.count<ObjectUser>(
       where: where?.call(ObjectUser.t),
       limit: limit,
       transaction: transaction,
@@ -391,7 +391,7 @@ class ObjectUserAttachRowRepository {
     }
 
     var $objectUser = objectUser.copyWith(userInfoId: userInfo.id);
-    await session.dbNext.updateRow<ObjectUser>(
+    await session.db.updateRow<ObjectUser>(
       $objectUser,
       columns: [ObjectUser.t.userInfoId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -189,7 +189,7 @@ class ParentUserRepository {
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ParentUser>(
+    return session.db.find<ParentUser>(
       where: where?.call(ParentUser.t),
       orderBy: orderBy?.call(ParentUser.t),
       orderByList: orderByList?.call(ParentUser.t),
@@ -209,7 +209,7 @@ class ParentUserRepository {
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ParentUser>(
+    return session.db.findFirstRow<ParentUser>(
       where: where?.call(ParentUser.t),
       orderBy: orderBy?.call(ParentUser.t),
       orderByList: orderByList?.call(ParentUser.t),
@@ -224,7 +224,7 @@ class ParentUserRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ParentUser>(
+    return session.db.findById<ParentUser>(
       id,
       transaction: transaction,
     );
@@ -235,7 +235,7 @@ class ParentUserRepository {
     List<ParentUser> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ParentUser>(
+    return session.db.insert<ParentUser>(
       rows,
       transaction: transaction,
     );
@@ -246,7 +246,7 @@ class ParentUserRepository {
     ParentUser row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ParentUser>(
+    return session.db.insertRow<ParentUser>(
       row,
       transaction: transaction,
     );
@@ -258,7 +258,7 @@ class ParentUserRepository {
     _i1.ColumnSelections<ParentUserTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ParentUser>(
+    return session.db.update<ParentUser>(
       rows,
       columns: columns?.call(ParentUser.t),
       transaction: transaction,
@@ -271,7 +271,7 @@ class ParentUserRepository {
     _i1.ColumnSelections<ParentUserTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ParentUser>(
+    return session.db.updateRow<ParentUser>(
       row,
       columns: columns?.call(ParentUser.t),
       transaction: transaction,
@@ -283,7 +283,7 @@ class ParentUserRepository {
     List<ParentUser> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ParentUser>(
+    return session.db.delete<ParentUser>(
       rows,
       transaction: transaction,
     );
@@ -294,7 +294,7 @@ class ParentUserRepository {
     ParentUser row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ParentUser>(
+    return session.db.deleteRow<ParentUser>(
       row,
       transaction: transaction,
     );
@@ -305,7 +305,7 @@ class ParentUserRepository {
     required _i1.WhereExpressionBuilder<ParentUserTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ParentUser>(
+    return session.db.deleteWhere<ParentUser>(
       where: where(ParentUser.t),
       transaction: transaction,
     );
@@ -317,7 +317,7 @@ class ParentUserRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ParentUser>(
+    return session.db.count<ParentUser>(
       where: where?.call(ParentUser.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -214,7 +214,7 @@ class ArenaRepository {
     _i1.Transaction? transaction,
     ArenaInclude? include,
   }) async {
-    return session.dbNext.find<Arena>(
+    return session.db.find<Arena>(
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
@@ -236,7 +236,7 @@ class ArenaRepository {
     _i1.Transaction? transaction,
     ArenaInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Arena>(
+    return session.db.findFirstRow<Arena>(
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
@@ -253,7 +253,7 @@ class ArenaRepository {
     _i1.Transaction? transaction,
     ArenaInclude? include,
   }) async {
-    return session.dbNext.findById<Arena>(
+    return session.db.findById<Arena>(
       id,
       transaction: transaction,
       include: include,
@@ -265,7 +265,7 @@ class ArenaRepository {
     List<Arena> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Arena>(
+    return session.db.insert<Arena>(
       rows,
       transaction: transaction,
     );
@@ -276,7 +276,7 @@ class ArenaRepository {
     Arena row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Arena>(
+    return session.db.insertRow<Arena>(
       row,
       transaction: transaction,
     );
@@ -288,7 +288,7 @@ class ArenaRepository {
     _i1.ColumnSelections<ArenaTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Arena>(
+    return session.db.update<Arena>(
       rows,
       columns: columns?.call(Arena.t),
       transaction: transaction,
@@ -301,7 +301,7 @@ class ArenaRepository {
     _i1.ColumnSelections<ArenaTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Arena>(
+    return session.db.updateRow<Arena>(
       row,
       columns: columns?.call(Arena.t),
       transaction: transaction,
@@ -313,7 +313,7 @@ class ArenaRepository {
     List<Arena> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Arena>(
+    return session.db.delete<Arena>(
       rows,
       transaction: transaction,
     );
@@ -324,7 +324,7 @@ class ArenaRepository {
     Arena row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Arena>(
+    return session.db.deleteRow<Arena>(
       row,
       transaction: transaction,
     );
@@ -335,7 +335,7 @@ class ArenaRepository {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Arena>(
+    return session.db.deleteWhere<Arena>(
       where: where(Arena.t),
       transaction: transaction,
     );
@@ -347,7 +347,7 @@ class ArenaRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Arena>(
+    return session.db.count<Arena>(
       where: where?.call(Arena.t),
       limit: limit,
       transaction: transaction,
@@ -371,7 +371,7 @@ class ArenaAttachRowRepository {
     }
 
     var $team = team.copyWith(arenaId: arena.id);
-    await session.dbNext.updateRow<_i2.Team>(
+    await session.db.updateRow<_i2.Team>(
       $team,
       columns: [_i2.Team.t.arenaId],
     );
@@ -398,7 +398,7 @@ class ArenaDetachRowRepository {
     }
 
     var $$team = $team.copyWith(arenaId: null);
-    await session.dbNext.updateRow<_i2.Team>(
+    await session.db.updateRow<_i2.Team>(
       $$team,
       columns: [_i2.Team.t.arenaId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -234,7 +234,7 @@ class PlayerRepository {
     _i1.Transaction? transaction,
     PlayerInclude? include,
   }) async {
-    return session.dbNext.find<Player>(
+    return session.db.find<Player>(
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
@@ -256,7 +256,7 @@ class PlayerRepository {
     _i1.Transaction? transaction,
     PlayerInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Player>(
+    return session.db.findFirstRow<Player>(
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
@@ -273,7 +273,7 @@ class PlayerRepository {
     _i1.Transaction? transaction,
     PlayerInclude? include,
   }) async {
-    return session.dbNext.findById<Player>(
+    return session.db.findById<Player>(
       id,
       transaction: transaction,
       include: include,
@@ -285,7 +285,7 @@ class PlayerRepository {
     List<Player> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Player>(
+    return session.db.insert<Player>(
       rows,
       transaction: transaction,
     );
@@ -296,7 +296,7 @@ class PlayerRepository {
     Player row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Player>(
+    return session.db.insertRow<Player>(
       row,
       transaction: transaction,
     );
@@ -308,7 +308,7 @@ class PlayerRepository {
     _i1.ColumnSelections<PlayerTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Player>(
+    return session.db.update<Player>(
       rows,
       columns: columns?.call(Player.t),
       transaction: transaction,
@@ -321,7 +321,7 @@ class PlayerRepository {
     _i1.ColumnSelections<PlayerTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Player>(
+    return session.db.updateRow<Player>(
       row,
       columns: columns?.call(Player.t),
       transaction: transaction,
@@ -333,7 +333,7 @@ class PlayerRepository {
     List<Player> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Player>(
+    return session.db.delete<Player>(
       rows,
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class PlayerRepository {
     Player row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Player>(
+    return session.db.deleteRow<Player>(
       row,
       transaction: transaction,
     );
@@ -355,7 +355,7 @@ class PlayerRepository {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Player>(
+    return session.db.deleteWhere<Player>(
       where: where(Player.t),
       transaction: transaction,
     );
@@ -367,7 +367,7 @@ class PlayerRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Player>(
+    return session.db.count<Player>(
       where: where?.call(Player.t),
       limit: limit,
       transaction: transaction,
@@ -391,7 +391,7 @@ class PlayerAttachRowRepository {
     }
 
     var $player = player.copyWith(teamId: team.id);
-    await session.dbNext.updateRow<Player>(
+    await session.db.updateRow<Player>(
       $player,
       columns: [Player.t.teamId],
     );
@@ -410,7 +410,7 @@ class PlayerDetachRowRepository {
     }
 
     var $player = player.copyWith(teamId: null);
-    await session.dbNext.updateRow<Player>(
+    await session.db.updateRow<Player>(
       $player,
       columns: [Player.t.teamId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -307,7 +307,7 @@ class TeamRepository {
     _i1.Transaction? transaction,
     TeamInclude? include,
   }) async {
-    return session.dbNext.find<Team>(
+    return session.db.find<Team>(
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
@@ -329,7 +329,7 @@ class TeamRepository {
     _i1.Transaction? transaction,
     TeamInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Team>(
+    return session.db.findFirstRow<Team>(
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
@@ -346,7 +346,7 @@ class TeamRepository {
     _i1.Transaction? transaction,
     TeamInclude? include,
   }) async {
-    return session.dbNext.findById<Team>(
+    return session.db.findById<Team>(
       id,
       transaction: transaction,
       include: include,
@@ -358,7 +358,7 @@ class TeamRepository {
     List<Team> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Team>(
+    return session.db.insert<Team>(
       rows,
       transaction: transaction,
     );
@@ -369,7 +369,7 @@ class TeamRepository {
     Team row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Team>(
+    return session.db.insertRow<Team>(
       row,
       transaction: transaction,
     );
@@ -381,7 +381,7 @@ class TeamRepository {
     _i1.ColumnSelections<TeamTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Team>(
+    return session.db.update<Team>(
       rows,
       columns: columns?.call(Team.t),
       transaction: transaction,
@@ -394,7 +394,7 @@ class TeamRepository {
     _i1.ColumnSelections<TeamTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Team>(
+    return session.db.updateRow<Team>(
       row,
       columns: columns?.call(Team.t),
       transaction: transaction,
@@ -406,7 +406,7 @@ class TeamRepository {
     List<Team> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Team>(
+    return session.db.delete<Team>(
       rows,
       transaction: transaction,
     );
@@ -417,7 +417,7 @@ class TeamRepository {
     Team row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Team>(
+    return session.db.deleteRow<Team>(
       row,
       transaction: transaction,
     );
@@ -428,7 +428,7 @@ class TeamRepository {
     required _i1.WhereExpressionBuilder<TeamTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Team>(
+    return session.db.deleteWhere<Team>(
       where: where(Team.t),
       transaction: transaction,
     );
@@ -440,7 +440,7 @@ class TeamRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Team>(
+    return session.db.count<Team>(
       where: where?.call(Team.t),
       limit: limit,
       transaction: transaction,
@@ -464,7 +464,7 @@ class TeamAttachRepository {
     }
 
     var $player = player.map((e) => e.copyWith(teamId: team.id)).toList();
-    await session.dbNext.update<_i2.Player>(
+    await session.db.update<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
     );
@@ -487,7 +487,7 @@ class TeamAttachRowRepository {
     }
 
     var $team = team.copyWith(arenaId: arena.id);
-    await session.dbNext.updateRow<Team>(
+    await session.db.updateRow<Team>(
       $team,
       columns: [Team.t.arenaId],
     );
@@ -506,7 +506,7 @@ class TeamAttachRowRepository {
     }
 
     var $player = player.copyWith(teamId: team.id);
-    await session.dbNext.updateRow<_i2.Player>(
+    await session.db.updateRow<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
     );
@@ -525,7 +525,7 @@ class TeamDetachRepository {
     }
 
     var $player = player.map((e) => e.copyWith(teamId: null)).toList();
-    await session.dbNext.update<_i2.Player>(
+    await session.db.update<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
     );
@@ -544,7 +544,7 @@ class TeamDetachRowRepository {
     }
 
     var $team = team.copyWith(arenaId: null);
-    await session.dbNext.updateRow<Team>(
+    await session.db.updateRow<Team>(
       $team,
       columns: [Team.t.arenaId],
     );
@@ -559,7 +559,7 @@ class TeamDetachRowRepository {
     }
 
     var $player = player.copyWith(teamId: null);
-    await session.dbNext.updateRow<_i2.Player>(
+    await session.db.updateRow<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -233,7 +233,7 @@ class CommentRepository {
     _i1.Transaction? transaction,
     CommentInclude? include,
   }) async {
-    return session.dbNext.find<Comment>(
+    return session.db.find<Comment>(
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
@@ -255,7 +255,7 @@ class CommentRepository {
     _i1.Transaction? transaction,
     CommentInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Comment>(
+    return session.db.findFirstRow<Comment>(
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
@@ -272,7 +272,7 @@ class CommentRepository {
     _i1.Transaction? transaction,
     CommentInclude? include,
   }) async {
-    return session.dbNext.findById<Comment>(
+    return session.db.findById<Comment>(
       id,
       transaction: transaction,
       include: include,
@@ -284,7 +284,7 @@ class CommentRepository {
     List<Comment> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Comment>(
+    return session.db.insert<Comment>(
       rows,
       transaction: transaction,
     );
@@ -295,7 +295,7 @@ class CommentRepository {
     Comment row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Comment>(
+    return session.db.insertRow<Comment>(
       row,
       transaction: transaction,
     );
@@ -307,7 +307,7 @@ class CommentRepository {
     _i1.ColumnSelections<CommentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Comment>(
+    return session.db.update<Comment>(
       rows,
       columns: columns?.call(Comment.t),
       transaction: transaction,
@@ -320,7 +320,7 @@ class CommentRepository {
     _i1.ColumnSelections<CommentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Comment>(
+    return session.db.updateRow<Comment>(
       row,
       columns: columns?.call(Comment.t),
       transaction: transaction,
@@ -332,7 +332,7 @@ class CommentRepository {
     List<Comment> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Comment>(
+    return session.db.delete<Comment>(
       rows,
       transaction: transaction,
     );
@@ -343,7 +343,7 @@ class CommentRepository {
     Comment row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Comment>(
+    return session.db.deleteRow<Comment>(
       row,
       transaction: transaction,
     );
@@ -354,7 +354,7 @@ class CommentRepository {
     required _i1.WhereExpressionBuilder<CommentTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Comment>(
+    return session.db.deleteWhere<Comment>(
       where: where(Comment.t),
       transaction: transaction,
     );
@@ -366,7 +366,7 @@ class CommentRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Comment>(
+    return session.db.count<Comment>(
       where: where?.call(Comment.t),
       limit: limit,
       transaction: transaction,
@@ -390,7 +390,7 @@ class CommentAttachRowRepository {
     }
 
     var $comment = comment.copyWith(orderId: order.id);
-    await session.dbNext.updateRow<Comment>(
+    await session.db.updateRow<Comment>(
       $comment,
       columns: [Comment.t.orderId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -241,7 +241,7 @@ class CustomerRepository {
     _i1.Transaction? transaction,
     CustomerInclude? include,
   }) async {
-    return session.dbNext.find<Customer>(
+    return session.db.find<Customer>(
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
@@ -263,7 +263,7 @@ class CustomerRepository {
     _i1.Transaction? transaction,
     CustomerInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Customer>(
+    return session.db.findFirstRow<Customer>(
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
@@ -280,7 +280,7 @@ class CustomerRepository {
     _i1.Transaction? transaction,
     CustomerInclude? include,
   }) async {
-    return session.dbNext.findById<Customer>(
+    return session.db.findById<Customer>(
       id,
       transaction: transaction,
       include: include,
@@ -292,7 +292,7 @@ class CustomerRepository {
     List<Customer> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Customer>(
+    return session.db.insert<Customer>(
       rows,
       transaction: transaction,
     );
@@ -303,7 +303,7 @@ class CustomerRepository {
     Customer row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Customer>(
+    return session.db.insertRow<Customer>(
       row,
       transaction: transaction,
     );
@@ -315,7 +315,7 @@ class CustomerRepository {
     _i1.ColumnSelections<CustomerTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Customer>(
+    return session.db.update<Customer>(
       rows,
       columns: columns?.call(Customer.t),
       transaction: transaction,
@@ -328,7 +328,7 @@ class CustomerRepository {
     _i1.ColumnSelections<CustomerTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Customer>(
+    return session.db.updateRow<Customer>(
       row,
       columns: columns?.call(Customer.t),
       transaction: transaction,
@@ -340,7 +340,7 @@ class CustomerRepository {
     List<Customer> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Customer>(
+    return session.db.delete<Customer>(
       rows,
       transaction: transaction,
     );
@@ -351,7 +351,7 @@ class CustomerRepository {
     Customer row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Customer>(
+    return session.db.deleteRow<Customer>(
       row,
       transaction: transaction,
     );
@@ -362,7 +362,7 @@ class CustomerRepository {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Customer>(
+    return session.db.deleteWhere<Customer>(
       where: where(Customer.t),
       transaction: transaction,
     );
@@ -374,7 +374,7 @@ class CustomerRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Customer>(
+    return session.db.count<Customer>(
       where: where?.call(Customer.t),
       limit: limit,
       transaction: transaction,
@@ -398,7 +398,7 @@ class CustomerAttachRepository {
     }
 
     var $order = order.map((e) => e.copyWith(customerId: customer.id)).toList();
-    await session.dbNext.update<_i2.Order>(
+    await session.db.update<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
     );
@@ -421,7 +421,7 @@ class CustomerAttachRowRepository {
     }
 
     var $order = order.copyWith(customerId: customer.id);
-    await session.dbNext.updateRow<_i2.Order>(
+    await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
     );
@@ -440,7 +440,7 @@ class CustomerDetachRepository {
     }
 
     var $order = order.map((e) => e.copyWith(customerId: null)).toList();
-    await session.dbNext.update<_i2.Order>(
+    await session.db.update<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
     );
@@ -459,7 +459,7 @@ class CustomerDetachRowRepository {
     }
 
     var $order = order.copyWith(customerId: null);
-    await session.dbNext.updateRow<_i2.Order>(
+    await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -306,7 +306,7 @@ class OrderRepository {
     _i1.Transaction? transaction,
     OrderInclude? include,
   }) async {
-    return session.dbNext.find<Order>(
+    return session.db.find<Order>(
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
@@ -328,7 +328,7 @@ class OrderRepository {
     _i1.Transaction? transaction,
     OrderInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Order>(
+    return session.db.findFirstRow<Order>(
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
@@ -345,7 +345,7 @@ class OrderRepository {
     _i1.Transaction? transaction,
     OrderInclude? include,
   }) async {
-    return session.dbNext.findById<Order>(
+    return session.db.findById<Order>(
       id,
       transaction: transaction,
       include: include,
@@ -357,7 +357,7 @@ class OrderRepository {
     List<Order> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Order>(
+    return session.db.insert<Order>(
       rows,
       transaction: transaction,
     );
@@ -368,7 +368,7 @@ class OrderRepository {
     Order row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Order>(
+    return session.db.insertRow<Order>(
       row,
       transaction: transaction,
     );
@@ -380,7 +380,7 @@ class OrderRepository {
     _i1.ColumnSelections<OrderTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Order>(
+    return session.db.update<Order>(
       rows,
       columns: columns?.call(Order.t),
       transaction: transaction,
@@ -393,7 +393,7 @@ class OrderRepository {
     _i1.ColumnSelections<OrderTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Order>(
+    return session.db.updateRow<Order>(
       row,
       columns: columns?.call(Order.t),
       transaction: transaction,
@@ -405,7 +405,7 @@ class OrderRepository {
     List<Order> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Order>(
+    return session.db.delete<Order>(
       rows,
       transaction: transaction,
     );
@@ -416,7 +416,7 @@ class OrderRepository {
     Order row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Order>(
+    return session.db.deleteRow<Order>(
       row,
       transaction: transaction,
     );
@@ -427,7 +427,7 @@ class OrderRepository {
     required _i1.WhereExpressionBuilder<OrderTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Order>(
+    return session.db.deleteWhere<Order>(
       where: where(Order.t),
       transaction: transaction,
     );
@@ -439,7 +439,7 @@ class OrderRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Order>(
+    return session.db.count<Order>(
       where: where?.call(Order.t),
       limit: limit,
       transaction: transaction,
@@ -463,7 +463,7 @@ class OrderAttachRepository {
     }
 
     var $comment = comment.map((e) => e.copyWith(orderId: order.id)).toList();
-    await session.dbNext.update<_i2.Comment>(
+    await session.db.update<_i2.Comment>(
       $comment,
       columns: [_i2.Comment.t.orderId],
     );
@@ -486,7 +486,7 @@ class OrderAttachRowRepository {
     }
 
     var $order = order.copyWith(customerId: customer.id);
-    await session.dbNext.updateRow<Order>(
+    await session.db.updateRow<Order>(
       $order,
       columns: [Order.t.customerId],
     );
@@ -505,7 +505,7 @@ class OrderAttachRowRepository {
     }
 
     var $comment = comment.copyWith(orderId: order.id);
-    await session.dbNext.updateRow<_i2.Comment>(
+    await session.db.updateRow<_i2.Comment>(
       $comment,
       columns: [_i2.Comment.t.orderId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -236,7 +236,7 @@ class AddressRepository {
     _i1.Transaction? transaction,
     AddressInclude? include,
   }) async {
-    return session.dbNext.find<Address>(
+    return session.db.find<Address>(
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
@@ -258,7 +258,7 @@ class AddressRepository {
     _i1.Transaction? transaction,
     AddressInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Address>(
+    return session.db.findFirstRow<Address>(
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
@@ -275,7 +275,7 @@ class AddressRepository {
     _i1.Transaction? transaction,
     AddressInclude? include,
   }) async {
-    return session.dbNext.findById<Address>(
+    return session.db.findById<Address>(
       id,
       transaction: transaction,
       include: include,
@@ -287,7 +287,7 @@ class AddressRepository {
     List<Address> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Address>(
+    return session.db.insert<Address>(
       rows,
       transaction: transaction,
     );
@@ -298,7 +298,7 @@ class AddressRepository {
     Address row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Address>(
+    return session.db.insertRow<Address>(
       row,
       transaction: transaction,
     );
@@ -310,7 +310,7 @@ class AddressRepository {
     _i1.ColumnSelections<AddressTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Address>(
+    return session.db.update<Address>(
       rows,
       columns: columns?.call(Address.t),
       transaction: transaction,
@@ -323,7 +323,7 @@ class AddressRepository {
     _i1.ColumnSelections<AddressTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Address>(
+    return session.db.updateRow<Address>(
       row,
       columns: columns?.call(Address.t),
       transaction: transaction,
@@ -335,7 +335,7 @@ class AddressRepository {
     List<Address> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Address>(
+    return session.db.delete<Address>(
       rows,
       transaction: transaction,
     );
@@ -346,7 +346,7 @@ class AddressRepository {
     Address row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Address>(
+    return session.db.deleteRow<Address>(
       row,
       transaction: transaction,
     );
@@ -357,7 +357,7 @@ class AddressRepository {
     required _i1.WhereExpressionBuilder<AddressTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Address>(
+    return session.db.deleteWhere<Address>(
       where: where(Address.t),
       transaction: transaction,
     );
@@ -369,7 +369,7 @@ class AddressRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Address>(
+    return session.db.count<Address>(
       where: where?.call(Address.t),
       limit: limit,
       transaction: transaction,
@@ -393,7 +393,7 @@ class AddressAttachRowRepository {
     }
 
     var $address = address.copyWith(inhabitantId: inhabitant.id);
-    await session.dbNext.updateRow<Address>(
+    await session.db.updateRow<Address>(
       $address,
       columns: [Address.t.inhabitantId],
     );
@@ -412,7 +412,7 @@ class AddressDetachRowRepository {
     }
 
     var $address = address.copyWith(inhabitantId: null);
-    await session.dbNext.updateRow<Address>(
+    await session.db.updateRow<Address>(
       $address,
       columns: [Address.t.inhabitantId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -339,7 +339,7 @@ class CitizenRepository {
     _i1.Transaction? transaction,
     CitizenInclude? include,
   }) async {
-    return session.dbNext.find<Citizen>(
+    return session.db.find<Citizen>(
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
@@ -361,7 +361,7 @@ class CitizenRepository {
     _i1.Transaction? transaction,
     CitizenInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Citizen>(
+    return session.db.findFirstRow<Citizen>(
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
@@ -378,7 +378,7 @@ class CitizenRepository {
     _i1.Transaction? transaction,
     CitizenInclude? include,
   }) async {
-    return session.dbNext.findById<Citizen>(
+    return session.db.findById<Citizen>(
       id,
       transaction: transaction,
       include: include,
@@ -390,7 +390,7 @@ class CitizenRepository {
     List<Citizen> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Citizen>(
+    return session.db.insert<Citizen>(
       rows,
       transaction: transaction,
     );
@@ -401,7 +401,7 @@ class CitizenRepository {
     Citizen row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Citizen>(
+    return session.db.insertRow<Citizen>(
       row,
       transaction: transaction,
     );
@@ -413,7 +413,7 @@ class CitizenRepository {
     _i1.ColumnSelections<CitizenTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Citizen>(
+    return session.db.update<Citizen>(
       rows,
       columns: columns?.call(Citizen.t),
       transaction: transaction,
@@ -426,7 +426,7 @@ class CitizenRepository {
     _i1.ColumnSelections<CitizenTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Citizen>(
+    return session.db.updateRow<Citizen>(
       row,
       columns: columns?.call(Citizen.t),
       transaction: transaction,
@@ -438,7 +438,7 @@ class CitizenRepository {
     List<Citizen> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Citizen>(
+    return session.db.delete<Citizen>(
       rows,
       transaction: transaction,
     );
@@ -449,7 +449,7 @@ class CitizenRepository {
     Citizen row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Citizen>(
+    return session.db.deleteRow<Citizen>(
       row,
       transaction: transaction,
     );
@@ -460,7 +460,7 @@ class CitizenRepository {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Citizen>(
+    return session.db.deleteWhere<Citizen>(
       where: where(Citizen.t),
       transaction: transaction,
     );
@@ -472,7 +472,7 @@ class CitizenRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Citizen>(
+    return session.db.count<Citizen>(
       where: where?.call(Citizen.t),
       limit: limit,
       transaction: transaction,
@@ -496,7 +496,7 @@ class CitizenAttachRowRepository {
     }
 
     var $address = address.copyWith(inhabitantId: citizen.id);
-    await session.dbNext.updateRow<_i2.Address>(
+    await session.db.updateRow<_i2.Address>(
       $address,
       columns: [_i2.Address.t.inhabitantId],
     );
@@ -515,7 +515,7 @@ class CitizenAttachRowRepository {
     }
 
     var $citizen = citizen.copyWith(companyId: company.id);
-    await session.dbNext.updateRow<Citizen>(
+    await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.companyId],
     );
@@ -534,7 +534,7 @@ class CitizenAttachRowRepository {
     }
 
     var $citizen = citizen.copyWith(oldCompanyId: oldCompany.id);
-    await session.dbNext.updateRow<Citizen>(
+    await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.oldCompanyId],
     );
@@ -561,7 +561,7 @@ class CitizenDetachRowRepository {
     }
 
     var $$address = $address.copyWith(inhabitantId: null);
-    await session.dbNext.updateRow<_i2.Address>(
+    await session.db.updateRow<_i2.Address>(
       $$address,
       columns: [_i2.Address.t.inhabitantId],
     );
@@ -576,7 +576,7 @@ class CitizenDetachRowRepository {
     }
 
     var $citizen = citizen.copyWith(oldCompanyId: null);
-    await session.dbNext.updateRow<Citizen>(
+    await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.oldCompanyId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -232,7 +232,7 @@ class CompanyRepository {
     _i1.Transaction? transaction,
     CompanyInclude? include,
   }) async {
-    return session.dbNext.find<Company>(
+    return session.db.find<Company>(
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
@@ -254,7 +254,7 @@ class CompanyRepository {
     _i1.Transaction? transaction,
     CompanyInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Company>(
+    return session.db.findFirstRow<Company>(
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
@@ -271,7 +271,7 @@ class CompanyRepository {
     _i1.Transaction? transaction,
     CompanyInclude? include,
   }) async {
-    return session.dbNext.findById<Company>(
+    return session.db.findById<Company>(
       id,
       transaction: transaction,
       include: include,
@@ -283,7 +283,7 @@ class CompanyRepository {
     List<Company> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Company>(
+    return session.db.insert<Company>(
       rows,
       transaction: transaction,
     );
@@ -294,7 +294,7 @@ class CompanyRepository {
     Company row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Company>(
+    return session.db.insertRow<Company>(
       row,
       transaction: transaction,
     );
@@ -306,7 +306,7 @@ class CompanyRepository {
     _i1.ColumnSelections<CompanyTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Company>(
+    return session.db.update<Company>(
       rows,
       columns: columns?.call(Company.t),
       transaction: transaction,
@@ -319,7 +319,7 @@ class CompanyRepository {
     _i1.ColumnSelections<CompanyTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Company>(
+    return session.db.updateRow<Company>(
       row,
       columns: columns?.call(Company.t),
       transaction: transaction,
@@ -331,7 +331,7 @@ class CompanyRepository {
     List<Company> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Company>(
+    return session.db.delete<Company>(
       rows,
       transaction: transaction,
     );
@@ -342,7 +342,7 @@ class CompanyRepository {
     Company row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Company>(
+    return session.db.deleteRow<Company>(
       row,
       transaction: transaction,
     );
@@ -353,7 +353,7 @@ class CompanyRepository {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Company>(
+    return session.db.deleteWhere<Company>(
       where: where(Company.t),
       transaction: transaction,
     );
@@ -365,7 +365,7 @@ class CompanyRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Company>(
+    return session.db.count<Company>(
       where: where?.call(Company.t),
       limit: limit,
       transaction: transaction,
@@ -389,7 +389,7 @@ class CompanyAttachRowRepository {
     }
 
     var $company = company.copyWith(townId: town.id);
-    await session.dbNext.updateRow<Company>(
+    await session.db.updateRow<Company>(
       $company,
       columns: [Company.t.townId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -234,7 +234,7 @@ class TownRepository {
     _i1.Transaction? transaction,
     TownInclude? include,
   }) async {
-    return session.dbNext.find<Town>(
+    return session.db.find<Town>(
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
@@ -256,7 +256,7 @@ class TownRepository {
     _i1.Transaction? transaction,
     TownInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Town>(
+    return session.db.findFirstRow<Town>(
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
@@ -273,7 +273,7 @@ class TownRepository {
     _i1.Transaction? transaction,
     TownInclude? include,
   }) async {
-    return session.dbNext.findById<Town>(
+    return session.db.findById<Town>(
       id,
       transaction: transaction,
       include: include,
@@ -285,7 +285,7 @@ class TownRepository {
     List<Town> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Town>(
+    return session.db.insert<Town>(
       rows,
       transaction: transaction,
     );
@@ -296,7 +296,7 @@ class TownRepository {
     Town row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Town>(
+    return session.db.insertRow<Town>(
       row,
       transaction: transaction,
     );
@@ -308,7 +308,7 @@ class TownRepository {
     _i1.ColumnSelections<TownTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Town>(
+    return session.db.update<Town>(
       rows,
       columns: columns?.call(Town.t),
       transaction: transaction,
@@ -321,7 +321,7 @@ class TownRepository {
     _i1.ColumnSelections<TownTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Town>(
+    return session.db.updateRow<Town>(
       row,
       columns: columns?.call(Town.t),
       transaction: transaction,
@@ -333,7 +333,7 @@ class TownRepository {
     List<Town> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Town>(
+    return session.db.delete<Town>(
       rows,
       transaction: transaction,
     );
@@ -344,7 +344,7 @@ class TownRepository {
     Town row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Town>(
+    return session.db.deleteRow<Town>(
       row,
       transaction: transaction,
     );
@@ -355,7 +355,7 @@ class TownRepository {
     required _i1.WhereExpressionBuilder<TownTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Town>(
+    return session.db.deleteWhere<Town>(
       where: where(Town.t),
       transaction: transaction,
     );
@@ -367,7 +367,7 @@ class TownRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Town>(
+    return session.db.count<Town>(
       where: where?.call(Town.t),
       limit: limit,
       transaction: transaction,
@@ -391,7 +391,7 @@ class TownAttachRowRepository {
     }
 
     var $town = town.copyWith(mayorId: mayor.id);
-    await session.dbNext.updateRow<Town>(
+    await session.db.updateRow<Town>(
       $town,
       columns: [Town.t.mayorId],
     );
@@ -410,7 +410,7 @@ class TownDetachRowRepository {
     }
 
     var $town = town.copyWith(mayorId: null);
-    await session.dbNext.updateRow<Town>(
+    await session.db.updateRow<Town>(
       $town,
       columns: [Town.t.mayorId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -280,7 +280,7 @@ class BlockingRepository {
     _i1.Transaction? transaction,
     BlockingInclude? include,
   }) async {
-    return session.dbNext.find<Blocking>(
+    return session.db.find<Blocking>(
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
@@ -302,7 +302,7 @@ class BlockingRepository {
     _i1.Transaction? transaction,
     BlockingInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Blocking>(
+    return session.db.findFirstRow<Blocking>(
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
@@ -319,7 +319,7 @@ class BlockingRepository {
     _i1.Transaction? transaction,
     BlockingInclude? include,
   }) async {
-    return session.dbNext.findById<Blocking>(
+    return session.db.findById<Blocking>(
       id,
       transaction: transaction,
       include: include,
@@ -331,7 +331,7 @@ class BlockingRepository {
     List<Blocking> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Blocking>(
+    return session.db.insert<Blocking>(
       rows,
       transaction: transaction,
     );
@@ -342,7 +342,7 @@ class BlockingRepository {
     Blocking row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Blocking>(
+    return session.db.insertRow<Blocking>(
       row,
       transaction: transaction,
     );
@@ -354,7 +354,7 @@ class BlockingRepository {
     _i1.ColumnSelections<BlockingTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Blocking>(
+    return session.db.update<Blocking>(
       rows,
       columns: columns?.call(Blocking.t),
       transaction: transaction,
@@ -367,7 +367,7 @@ class BlockingRepository {
     _i1.ColumnSelections<BlockingTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Blocking>(
+    return session.db.updateRow<Blocking>(
       row,
       columns: columns?.call(Blocking.t),
       transaction: transaction,
@@ -379,7 +379,7 @@ class BlockingRepository {
     List<Blocking> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Blocking>(
+    return session.db.delete<Blocking>(
       rows,
       transaction: transaction,
     );
@@ -390,7 +390,7 @@ class BlockingRepository {
     Blocking row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Blocking>(
+    return session.db.deleteRow<Blocking>(
       row,
       transaction: transaction,
     );
@@ -401,7 +401,7 @@ class BlockingRepository {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Blocking>(
+    return session.db.deleteWhere<Blocking>(
       where: where(Blocking.t),
       transaction: transaction,
     );
@@ -413,7 +413,7 @@ class BlockingRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Blocking>(
+    return session.db.count<Blocking>(
       where: where?.call(Blocking.t),
       limit: limit,
       transaction: transaction,
@@ -437,7 +437,7 @@ class BlockingAttachRowRepository {
     }
 
     var $blocking = blocking.copyWith(blockedId: blocked.id);
-    await session.dbNext.updateRow<Blocking>(
+    await session.db.updateRow<Blocking>(
       $blocking,
       columns: [Blocking.t.blockedId],
     );
@@ -456,7 +456,7 @@ class BlockingAttachRowRepository {
     }
 
     var $blocking = blocking.copyWith(blockedById: blockedBy.id);
-    await session.dbNext.updateRow<Blocking>(
+    await session.db.updateRow<Blocking>(
       $blocking,
       columns: [Blocking.t.blockedById],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -308,7 +308,7 @@ class MemberRepository {
     _i1.Transaction? transaction,
     MemberInclude? include,
   }) async {
-    return session.dbNext.find<Member>(
+    return session.db.find<Member>(
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
@@ -330,7 +330,7 @@ class MemberRepository {
     _i1.Transaction? transaction,
     MemberInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Member>(
+    return session.db.findFirstRow<Member>(
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
@@ -347,7 +347,7 @@ class MemberRepository {
     _i1.Transaction? transaction,
     MemberInclude? include,
   }) async {
-    return session.dbNext.findById<Member>(
+    return session.db.findById<Member>(
       id,
       transaction: transaction,
       include: include,
@@ -359,7 +359,7 @@ class MemberRepository {
     List<Member> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Member>(
+    return session.db.insert<Member>(
       rows,
       transaction: transaction,
     );
@@ -370,7 +370,7 @@ class MemberRepository {
     Member row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Member>(
+    return session.db.insertRow<Member>(
       row,
       transaction: transaction,
     );
@@ -382,7 +382,7 @@ class MemberRepository {
     _i1.ColumnSelections<MemberTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Member>(
+    return session.db.update<Member>(
       rows,
       columns: columns?.call(Member.t),
       transaction: transaction,
@@ -395,7 +395,7 @@ class MemberRepository {
     _i1.ColumnSelections<MemberTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Member>(
+    return session.db.updateRow<Member>(
       row,
       columns: columns?.call(Member.t),
       transaction: transaction,
@@ -407,7 +407,7 @@ class MemberRepository {
     List<Member> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Member>(
+    return session.db.delete<Member>(
       rows,
       transaction: transaction,
     );
@@ -418,7 +418,7 @@ class MemberRepository {
     Member row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Member>(
+    return session.db.deleteRow<Member>(
       row,
       transaction: transaction,
     );
@@ -429,7 +429,7 @@ class MemberRepository {
     required _i1.WhereExpressionBuilder<MemberTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Member>(
+    return session.db.deleteWhere<Member>(
       where: where(Member.t),
       transaction: transaction,
     );
@@ -441,7 +441,7 @@ class MemberRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Member>(
+    return session.db.count<Member>(
       where: where?.call(Member.t),
       limit: limit,
       transaction: transaction,
@@ -466,7 +466,7 @@ class MemberAttachRepository {
 
     var $blocking =
         blocking.map((e) => e.copyWith(blockedById: member.id)).toList();
-    await session.dbNext.update<_i2.Blocking>(
+    await session.db.update<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedById],
     );
@@ -486,7 +486,7 @@ class MemberAttachRepository {
 
     var $blocking =
         blocking.map((e) => e.copyWith(blockedId: member.id)).toList();
-    await session.dbNext.update<_i2.Blocking>(
+    await session.db.update<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedId],
     );
@@ -509,7 +509,7 @@ class MemberAttachRowRepository {
     }
 
     var $blocking = blocking.copyWith(blockedById: member.id);
-    await session.dbNext.updateRow<_i2.Blocking>(
+    await session.db.updateRow<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedById],
     );
@@ -528,7 +528,7 @@ class MemberAttachRowRepository {
     }
 
     var $blocking = blocking.copyWith(blockedId: member.id);
-    await session.dbNext.updateRow<_i2.Blocking>(
+    await session.db.updateRow<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -307,7 +307,7 @@ class CatRepository {
     _i1.Transaction? transaction,
     CatInclude? include,
   }) async {
-    return session.dbNext.find<Cat>(
+    return session.db.find<Cat>(
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
@@ -329,7 +329,7 @@ class CatRepository {
     _i1.Transaction? transaction,
     CatInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Cat>(
+    return session.db.findFirstRow<Cat>(
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
@@ -346,7 +346,7 @@ class CatRepository {
     _i1.Transaction? transaction,
     CatInclude? include,
   }) async {
-    return session.dbNext.findById<Cat>(
+    return session.db.findById<Cat>(
       id,
       transaction: transaction,
       include: include,
@@ -358,7 +358,7 @@ class CatRepository {
     List<Cat> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Cat>(
+    return session.db.insert<Cat>(
       rows,
       transaction: transaction,
     );
@@ -369,7 +369,7 @@ class CatRepository {
     Cat row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Cat>(
+    return session.db.insertRow<Cat>(
       row,
       transaction: transaction,
     );
@@ -381,7 +381,7 @@ class CatRepository {
     _i1.ColumnSelections<CatTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Cat>(
+    return session.db.update<Cat>(
       rows,
       columns: columns?.call(Cat.t),
       transaction: transaction,
@@ -394,7 +394,7 @@ class CatRepository {
     _i1.ColumnSelections<CatTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Cat>(
+    return session.db.updateRow<Cat>(
       row,
       columns: columns?.call(Cat.t),
       transaction: transaction,
@@ -406,7 +406,7 @@ class CatRepository {
     List<Cat> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Cat>(
+    return session.db.delete<Cat>(
       rows,
       transaction: transaction,
     );
@@ -417,7 +417,7 @@ class CatRepository {
     Cat row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Cat>(
+    return session.db.deleteRow<Cat>(
       row,
       transaction: transaction,
     );
@@ -428,7 +428,7 @@ class CatRepository {
     required _i1.WhereExpressionBuilder<CatTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Cat>(
+    return session.db.deleteWhere<Cat>(
       where: where(Cat.t),
       transaction: transaction,
     );
@@ -440,7 +440,7 @@ class CatRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Cat>(
+    return session.db.count<Cat>(
       where: where?.call(Cat.t),
       limit: limit,
       transaction: transaction,
@@ -465,7 +465,7 @@ class CatAttachRepository {
 
     var $nestedCat =
         nestedCat.map((e) => e.copyWith(motherId: cat.id)).toList();
-    await session.dbNext.update<_i2.Cat>(
+    await session.db.update<_i2.Cat>(
       $nestedCat,
       columns: [_i2.Cat.t.motherId],
     );
@@ -488,7 +488,7 @@ class CatAttachRowRepository {
     }
 
     var $cat = cat.copyWith(motherId: mother.id);
-    await session.dbNext.updateRow<Cat>(
+    await session.db.updateRow<Cat>(
       $cat,
       columns: [Cat.t.motherId],
     );
@@ -507,7 +507,7 @@ class CatAttachRowRepository {
     }
 
     var $nestedCat = nestedCat.copyWith(motherId: cat.id);
-    await session.dbNext.updateRow<_i2.Cat>(
+    await session.db.updateRow<_i2.Cat>(
       $nestedCat,
       columns: [_i2.Cat.t.motherId],
     );
@@ -526,7 +526,7 @@ class CatDetachRepository {
     }
 
     var $cat = cat.map((e) => e.copyWith(motherId: null)).toList();
-    await session.dbNext.update<_i2.Cat>(
+    await session.db.update<_i2.Cat>(
       $cat,
       columns: [_i2.Cat.t.motherId],
     );
@@ -545,7 +545,7 @@ class CatDetachRowRepository {
     }
 
     var $cat = cat.copyWith(motherId: null);
-    await session.dbNext.updateRow<Cat>(
+    await session.db.updateRow<Cat>(
       $cat,
       columns: [Cat.t.motherId],
     );
@@ -560,7 +560,7 @@ class CatDetachRowRepository {
     }
 
     var $cat = cat.copyWith(motherId: null);
-    await session.dbNext.updateRow<_i2.Cat>(
+    await session.db.updateRow<_i2.Cat>(
       $cat,
       columns: [_i2.Cat.t.motherId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -281,7 +281,7 @@ class PostRepository {
     _i1.Transaction? transaction,
     PostInclude? include,
   }) async {
-    return session.dbNext.find<Post>(
+    return session.db.find<Post>(
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
@@ -303,7 +303,7 @@ class PostRepository {
     _i1.Transaction? transaction,
     PostInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<Post>(
+    return session.db.findFirstRow<Post>(
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
@@ -320,7 +320,7 @@ class PostRepository {
     _i1.Transaction? transaction,
     PostInclude? include,
   }) async {
-    return session.dbNext.findById<Post>(
+    return session.db.findById<Post>(
       id,
       transaction: transaction,
       include: include,
@@ -332,7 +332,7 @@ class PostRepository {
     List<Post> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Post>(
+    return session.db.insert<Post>(
       rows,
       transaction: transaction,
     );
@@ -343,7 +343,7 @@ class PostRepository {
     Post row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Post>(
+    return session.db.insertRow<Post>(
       row,
       transaction: transaction,
     );
@@ -355,7 +355,7 @@ class PostRepository {
     _i1.ColumnSelections<PostTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Post>(
+    return session.db.update<Post>(
       rows,
       columns: columns?.call(Post.t),
       transaction: transaction,
@@ -368,7 +368,7 @@ class PostRepository {
     _i1.ColumnSelections<PostTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Post>(
+    return session.db.updateRow<Post>(
       row,
       columns: columns?.call(Post.t),
       transaction: transaction,
@@ -380,7 +380,7 @@ class PostRepository {
     List<Post> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Post>(
+    return session.db.delete<Post>(
       rows,
       transaction: transaction,
     );
@@ -391,7 +391,7 @@ class PostRepository {
     Post row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Post>(
+    return session.db.deleteRow<Post>(
       row,
       transaction: transaction,
     );
@@ -402,7 +402,7 @@ class PostRepository {
     required _i1.WhereExpressionBuilder<PostTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Post>(
+    return session.db.deleteWhere<Post>(
       where: where(Post.t),
       transaction: transaction,
     );
@@ -414,7 +414,7 @@ class PostRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Post>(
+    return session.db.count<Post>(
       where: where?.call(Post.t),
       limit: limit,
       transaction: transaction,
@@ -438,7 +438,7 @@ class PostAttachRowRepository {
     }
 
     var $previous = previous.copyWith(nextId: post.id);
-    await session.dbNext.updateRow<_i2.Post>(
+    await session.db.updateRow<_i2.Post>(
       $previous,
       columns: [_i2.Post.t.nextId],
     );
@@ -457,7 +457,7 @@ class PostAttachRowRepository {
     }
 
     var $post = post.copyWith(nextId: next.id);
-    await session.dbNext.updateRow<Post>(
+    await session.db.updateRow<Post>(
       $post,
       columns: [Post.t.nextId],
     );
@@ -484,7 +484,7 @@ class PostDetachRowRepository {
     }
 
     var $$previous = $previous.copyWith(nextId: null);
-    await session.dbNext.updateRow<_i2.Post>(
+    await session.db.updateRow<_i2.Post>(
       $$previous,
       columns: [_i2.Post.t.nextId],
     );
@@ -499,7 +499,7 @@ class PostDetachRowRepository {
     }
 
     var $post = post.copyWith(nextId: null);
-    await session.dbNext.updateRow<Post>(
+    await session.db.updateRow<Post>(
       $post,
       columns: [Post.t.nextId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -201,7 +201,7 @@ class ObjectFieldScopesRepository {
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectFieldScopes>(
+    return session.db.find<ObjectFieldScopes>(
       where: where?.call(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
@@ -221,7 +221,7 @@ class ObjectFieldScopesRepository {
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectFieldScopes>(
+    return session.db.findFirstRow<ObjectFieldScopes>(
       where: where?.call(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
@@ -236,7 +236,7 @@ class ObjectFieldScopesRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectFieldScopes>(
+    return session.db.findById<ObjectFieldScopes>(
       id,
       transaction: transaction,
     );
@@ -247,7 +247,7 @@ class ObjectFieldScopesRepository {
     List<ObjectFieldScopes> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectFieldScopes>(
+    return session.db.insert<ObjectFieldScopes>(
       rows,
       transaction: transaction,
     );
@@ -258,7 +258,7 @@ class ObjectFieldScopesRepository {
     ObjectFieldScopes row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectFieldScopes>(
+    return session.db.insertRow<ObjectFieldScopes>(
       row,
       transaction: transaction,
     );
@@ -270,7 +270,7 @@ class ObjectFieldScopesRepository {
     _i1.ColumnSelections<ObjectFieldScopesTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectFieldScopes>(
+    return session.db.update<ObjectFieldScopes>(
       rows,
       columns: columns?.call(ObjectFieldScopes.t),
       transaction: transaction,
@@ -283,7 +283,7 @@ class ObjectFieldScopesRepository {
     _i1.ColumnSelections<ObjectFieldScopesTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectFieldScopes>(
+    return session.db.updateRow<ObjectFieldScopes>(
       row,
       columns: columns?.call(ObjectFieldScopes.t),
       transaction: transaction,
@@ -295,7 +295,7 @@ class ObjectFieldScopesRepository {
     List<ObjectFieldScopes> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectFieldScopes>(
+    return session.db.delete<ObjectFieldScopes>(
       rows,
       transaction: transaction,
     );
@@ -306,7 +306,7 @@ class ObjectFieldScopesRepository {
     ObjectFieldScopes row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectFieldScopes>(
+    return session.db.deleteRow<ObjectFieldScopes>(
       row,
       transaction: transaction,
     );
@@ -317,7 +317,7 @@ class ObjectFieldScopesRepository {
     required _i1.WhereExpressionBuilder<ObjectFieldScopesTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectFieldScopes>(
+    return session.db.deleteWhere<ObjectFieldScopes>(
       where: where(ObjectFieldScopes.t),
       transaction: transaction,
     );
@@ -329,7 +329,7 @@ class ObjectFieldScopesRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectFieldScopes>(
+    return session.db.count<ObjectFieldScopes>(
       where: where?.call(ObjectFieldScopes.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -172,7 +172,7 @@ class ObjectWithByteDataRepository {
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithByteData>(
+    return session.db.find<ObjectWithByteData>(
       where: where?.call(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
@@ -192,7 +192,7 @@ class ObjectWithByteDataRepository {
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithByteData>(
+    return session.db.findFirstRow<ObjectWithByteData>(
       where: where?.call(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
@@ -207,7 +207,7 @@ class ObjectWithByteDataRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithByteData>(
+    return session.db.findById<ObjectWithByteData>(
       id,
       transaction: transaction,
     );
@@ -218,7 +218,7 @@ class ObjectWithByteDataRepository {
     List<ObjectWithByteData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithByteData>(
+    return session.db.insert<ObjectWithByteData>(
       rows,
       transaction: transaction,
     );
@@ -229,7 +229,7 @@ class ObjectWithByteDataRepository {
     ObjectWithByteData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithByteData>(
+    return session.db.insertRow<ObjectWithByteData>(
       row,
       transaction: transaction,
     );
@@ -241,7 +241,7 @@ class ObjectWithByteDataRepository {
     _i1.ColumnSelections<ObjectWithByteDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithByteData>(
+    return session.db.update<ObjectWithByteData>(
       rows,
       columns: columns?.call(ObjectWithByteData.t),
       transaction: transaction,
@@ -254,7 +254,7 @@ class ObjectWithByteDataRepository {
     _i1.ColumnSelections<ObjectWithByteDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithByteData>(
+    return session.db.updateRow<ObjectWithByteData>(
       row,
       columns: columns?.call(ObjectWithByteData.t),
       transaction: transaction,
@@ -266,7 +266,7 @@ class ObjectWithByteDataRepository {
     List<ObjectWithByteData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithByteData>(
+    return session.db.delete<ObjectWithByteData>(
       rows,
       transaction: transaction,
     );
@@ -277,7 +277,7 @@ class ObjectWithByteDataRepository {
     ObjectWithByteData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithByteData>(
+    return session.db.deleteRow<ObjectWithByteData>(
       row,
       transaction: transaction,
     );
@@ -288,7 +288,7 @@ class ObjectWithByteDataRepository {
     required _i1.WhereExpressionBuilder<ObjectWithByteDataTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithByteData>(
+    return session.db.deleteWhere<ObjectWithByteData>(
       where: where(ObjectWithByteData.t),
       transaction: transaction,
     );
@@ -300,7 +300,7 @@ class ObjectWithByteDataRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithByteData>(
+    return session.db.count<ObjectWithByteData>(
       where: where?.call(ObjectWithByteData.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -171,7 +171,7 @@ class ObjectWithDurationRepository {
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithDuration>(
+    return session.db.find<ObjectWithDuration>(
       where: where?.call(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
@@ -191,7 +191,7 @@ class ObjectWithDurationRepository {
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithDuration>(
+    return session.db.findFirstRow<ObjectWithDuration>(
       where: where?.call(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
@@ -206,7 +206,7 @@ class ObjectWithDurationRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithDuration>(
+    return session.db.findById<ObjectWithDuration>(
       id,
       transaction: transaction,
     );
@@ -217,7 +217,7 @@ class ObjectWithDurationRepository {
     List<ObjectWithDuration> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithDuration>(
+    return session.db.insert<ObjectWithDuration>(
       rows,
       transaction: transaction,
     );
@@ -228,7 +228,7 @@ class ObjectWithDurationRepository {
     ObjectWithDuration row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithDuration>(
+    return session.db.insertRow<ObjectWithDuration>(
       row,
       transaction: transaction,
     );
@@ -240,7 +240,7 @@ class ObjectWithDurationRepository {
     _i1.ColumnSelections<ObjectWithDurationTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithDuration>(
+    return session.db.update<ObjectWithDuration>(
       rows,
       columns: columns?.call(ObjectWithDuration.t),
       transaction: transaction,
@@ -253,7 +253,7 @@ class ObjectWithDurationRepository {
     _i1.ColumnSelections<ObjectWithDurationTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithDuration>(
+    return session.db.updateRow<ObjectWithDuration>(
       row,
       columns: columns?.call(ObjectWithDuration.t),
       transaction: transaction,
@@ -265,7 +265,7 @@ class ObjectWithDurationRepository {
     List<ObjectWithDuration> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithDuration>(
+    return session.db.delete<ObjectWithDuration>(
       rows,
       transaction: transaction,
     );
@@ -276,7 +276,7 @@ class ObjectWithDurationRepository {
     ObjectWithDuration row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithDuration>(
+    return session.db.deleteRow<ObjectWithDuration>(
       row,
       transaction: transaction,
     );
@@ -287,7 +287,7 @@ class ObjectWithDurationRepository {
     required _i1.WhereExpressionBuilder<ObjectWithDurationTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithDuration>(
+    return session.db.deleteWhere<ObjectWithDuration>(
       where: where(ObjectWithDuration.t),
       transaction: transaction,
     );
@@ -299,7 +299,7 @@ class ObjectWithDurationRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithDuration>(
+    return session.db.count<ObjectWithDuration>(
       where: where?.call(ObjectWithDuration.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -259,7 +259,7 @@ class ObjectWithEnumRepository {
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithEnum>(
+    return session.db.find<ObjectWithEnum>(
       where: where?.call(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
@@ -279,7 +279,7 @@ class ObjectWithEnumRepository {
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithEnum>(
+    return session.db.findFirstRow<ObjectWithEnum>(
       where: where?.call(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
@@ -294,7 +294,7 @@ class ObjectWithEnumRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithEnum>(
+    return session.db.findById<ObjectWithEnum>(
       id,
       transaction: transaction,
     );
@@ -305,7 +305,7 @@ class ObjectWithEnumRepository {
     List<ObjectWithEnum> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithEnum>(
+    return session.db.insert<ObjectWithEnum>(
       rows,
       transaction: transaction,
     );
@@ -316,7 +316,7 @@ class ObjectWithEnumRepository {
     ObjectWithEnum row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithEnum>(
+    return session.db.insertRow<ObjectWithEnum>(
       row,
       transaction: transaction,
     );
@@ -328,7 +328,7 @@ class ObjectWithEnumRepository {
     _i1.ColumnSelections<ObjectWithEnumTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithEnum>(
+    return session.db.update<ObjectWithEnum>(
       rows,
       columns: columns?.call(ObjectWithEnum.t),
       transaction: transaction,
@@ -341,7 +341,7 @@ class ObjectWithEnumRepository {
     _i1.ColumnSelections<ObjectWithEnumTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithEnum>(
+    return session.db.updateRow<ObjectWithEnum>(
       row,
       columns: columns?.call(ObjectWithEnum.t),
       transaction: transaction,
@@ -353,7 +353,7 @@ class ObjectWithEnumRepository {
     List<ObjectWithEnum> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithEnum>(
+    return session.db.delete<ObjectWithEnum>(
       rows,
       transaction: transaction,
     );
@@ -364,7 +364,7 @@ class ObjectWithEnumRepository {
     ObjectWithEnum row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithEnum>(
+    return session.db.deleteRow<ObjectWithEnum>(
       row,
       transaction: transaction,
     );
@@ -375,7 +375,7 @@ class ObjectWithEnumRepository {
     required _i1.WhereExpressionBuilder<ObjectWithEnumTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithEnum>(
+    return session.db.deleteWhere<ObjectWithEnum>(
       where: where(ObjectWithEnum.t),
       transaction: transaction,
     );
@@ -387,7 +387,7 @@ class ObjectWithEnumRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithEnum>(
+    return session.db.count<ObjectWithEnum>(
       where: where?.call(ObjectWithEnum.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -190,7 +190,7 @@ class ObjectWithIndexRepository {
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithIndex>(
+    return session.db.find<ObjectWithIndex>(
       where: where?.call(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
@@ -210,7 +210,7 @@ class ObjectWithIndexRepository {
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithIndex>(
+    return session.db.findFirstRow<ObjectWithIndex>(
       where: where?.call(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
@@ -225,7 +225,7 @@ class ObjectWithIndexRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithIndex>(
+    return session.db.findById<ObjectWithIndex>(
       id,
       transaction: transaction,
     );
@@ -236,7 +236,7 @@ class ObjectWithIndexRepository {
     List<ObjectWithIndex> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithIndex>(
+    return session.db.insert<ObjectWithIndex>(
       rows,
       transaction: transaction,
     );
@@ -247,7 +247,7 @@ class ObjectWithIndexRepository {
     ObjectWithIndex row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithIndex>(
+    return session.db.insertRow<ObjectWithIndex>(
       row,
       transaction: transaction,
     );
@@ -259,7 +259,7 @@ class ObjectWithIndexRepository {
     _i1.ColumnSelections<ObjectWithIndexTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithIndex>(
+    return session.db.update<ObjectWithIndex>(
       rows,
       columns: columns?.call(ObjectWithIndex.t),
       transaction: transaction,
@@ -272,7 +272,7 @@ class ObjectWithIndexRepository {
     _i1.ColumnSelections<ObjectWithIndexTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithIndex>(
+    return session.db.updateRow<ObjectWithIndex>(
       row,
       columns: columns?.call(ObjectWithIndex.t),
       transaction: transaction,
@@ -284,7 +284,7 @@ class ObjectWithIndexRepository {
     List<ObjectWithIndex> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithIndex>(
+    return session.db.delete<ObjectWithIndex>(
       rows,
       transaction: transaction,
     );
@@ -295,7 +295,7 @@ class ObjectWithIndexRepository {
     ObjectWithIndex row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithIndex>(
+    return session.db.deleteRow<ObjectWithIndex>(
       row,
       transaction: transaction,
     );
@@ -306,7 +306,7 @@ class ObjectWithIndexRepository {
     required _i1.WhereExpressionBuilder<ObjectWithIndexTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithIndex>(
+    return session.db.deleteWhere<ObjectWithIndex>(
       where: where(ObjectWithIndex.t),
       transaction: transaction,
     );
@@ -318,7 +318,7 @@ class ObjectWithIndexRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithIndex>(
+    return session.db.count<ObjectWithIndex>(
       where: where?.call(ObjectWithIndex.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -292,7 +292,7 @@ class ObjectWithObjectRepository {
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithObject>(
+    return session.db.find<ObjectWithObject>(
       where: where?.call(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
@@ -312,7 +312,7 @@ class ObjectWithObjectRepository {
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithObject>(
+    return session.db.findFirstRow<ObjectWithObject>(
       where: where?.call(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
@@ -327,7 +327,7 @@ class ObjectWithObjectRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithObject>(
+    return session.db.findById<ObjectWithObject>(
       id,
       transaction: transaction,
     );
@@ -338,7 +338,7 @@ class ObjectWithObjectRepository {
     List<ObjectWithObject> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithObject>(
+    return session.db.insert<ObjectWithObject>(
       rows,
       transaction: transaction,
     );
@@ -349,7 +349,7 @@ class ObjectWithObjectRepository {
     ObjectWithObject row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithObject>(
+    return session.db.insertRow<ObjectWithObject>(
       row,
       transaction: transaction,
     );
@@ -361,7 +361,7 @@ class ObjectWithObjectRepository {
     _i1.ColumnSelections<ObjectWithObjectTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithObject>(
+    return session.db.update<ObjectWithObject>(
       rows,
       columns: columns?.call(ObjectWithObject.t),
       transaction: transaction,
@@ -374,7 +374,7 @@ class ObjectWithObjectRepository {
     _i1.ColumnSelections<ObjectWithObjectTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithObject>(
+    return session.db.updateRow<ObjectWithObject>(
       row,
       columns: columns?.call(ObjectWithObject.t),
       transaction: transaction,
@@ -386,7 +386,7 @@ class ObjectWithObjectRepository {
     List<ObjectWithObject> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithObject>(
+    return session.db.delete<ObjectWithObject>(
       rows,
       transaction: transaction,
     );
@@ -397,7 +397,7 @@ class ObjectWithObjectRepository {
     ObjectWithObject row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithObject>(
+    return session.db.deleteRow<ObjectWithObject>(
       row,
       transaction: transaction,
     );
@@ -408,7 +408,7 @@ class ObjectWithObjectRepository {
     required _i1.WhereExpressionBuilder<ObjectWithObjectTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithObject>(
+    return session.db.deleteWhere<ObjectWithObject>(
       where: where(ObjectWithObject.t),
       transaction: transaction,
     );
@@ -420,7 +420,7 @@ class ObjectWithObjectRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithObject>(
+    return session.db.count<ObjectWithObject>(
       where: where?.call(ObjectWithObject.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -169,7 +169,7 @@ class ObjectWithParentRepository {
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithParent>(
+    return session.db.find<ObjectWithParent>(
       where: where?.call(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
@@ -189,7 +189,7 @@ class ObjectWithParentRepository {
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithParent>(
+    return session.db.findFirstRow<ObjectWithParent>(
       where: where?.call(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
@@ -204,7 +204,7 @@ class ObjectWithParentRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithParent>(
+    return session.db.findById<ObjectWithParent>(
       id,
       transaction: transaction,
     );
@@ -215,7 +215,7 @@ class ObjectWithParentRepository {
     List<ObjectWithParent> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithParent>(
+    return session.db.insert<ObjectWithParent>(
       rows,
       transaction: transaction,
     );
@@ -226,7 +226,7 @@ class ObjectWithParentRepository {
     ObjectWithParent row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithParent>(
+    return session.db.insertRow<ObjectWithParent>(
       row,
       transaction: transaction,
     );
@@ -238,7 +238,7 @@ class ObjectWithParentRepository {
     _i1.ColumnSelections<ObjectWithParentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithParent>(
+    return session.db.update<ObjectWithParent>(
       rows,
       columns: columns?.call(ObjectWithParent.t),
       transaction: transaction,
@@ -251,7 +251,7 @@ class ObjectWithParentRepository {
     _i1.ColumnSelections<ObjectWithParentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithParent>(
+    return session.db.updateRow<ObjectWithParent>(
       row,
       columns: columns?.call(ObjectWithParent.t),
       transaction: transaction,
@@ -263,7 +263,7 @@ class ObjectWithParentRepository {
     List<ObjectWithParent> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithParent>(
+    return session.db.delete<ObjectWithParent>(
       rows,
       transaction: transaction,
     );
@@ -274,7 +274,7 @@ class ObjectWithParentRepository {
     ObjectWithParent row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithParent>(
+    return session.db.deleteRow<ObjectWithParent>(
       row,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class ObjectWithParentRepository {
     required _i1.WhereExpressionBuilder<ObjectWithParentTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithParent>(
+    return session.db.deleteWhere<ObjectWithParent>(
       where: where(ObjectWithParent.t),
       transaction: transaction,
     );
@@ -297,7 +297,7 @@ class ObjectWithParentRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithParent>(
+    return session.db.count<ObjectWithParent>(
       where: where?.call(ObjectWithParent.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -169,7 +169,7 @@ class ObjectWithSelfParentRepository {
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithSelfParent>(
+    return session.db.find<ObjectWithSelfParent>(
       where: where?.call(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
@@ -189,7 +189,7 @@ class ObjectWithSelfParentRepository {
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithSelfParent>(
+    return session.db.findFirstRow<ObjectWithSelfParent>(
       where: where?.call(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
@@ -204,7 +204,7 @@ class ObjectWithSelfParentRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithSelfParent>(
+    return session.db.findById<ObjectWithSelfParent>(
       id,
       transaction: transaction,
     );
@@ -215,7 +215,7 @@ class ObjectWithSelfParentRepository {
     List<ObjectWithSelfParent> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithSelfParent>(
+    return session.db.insert<ObjectWithSelfParent>(
       rows,
       transaction: transaction,
     );
@@ -226,7 +226,7 @@ class ObjectWithSelfParentRepository {
     ObjectWithSelfParent row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithSelfParent>(
+    return session.db.insertRow<ObjectWithSelfParent>(
       row,
       transaction: transaction,
     );
@@ -238,7 +238,7 @@ class ObjectWithSelfParentRepository {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithSelfParent>(
+    return session.db.update<ObjectWithSelfParent>(
       rows,
       columns: columns?.call(ObjectWithSelfParent.t),
       transaction: transaction,
@@ -251,7 +251,7 @@ class ObjectWithSelfParentRepository {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithSelfParent>(
+    return session.db.updateRow<ObjectWithSelfParent>(
       row,
       columns: columns?.call(ObjectWithSelfParent.t),
       transaction: transaction,
@@ -263,7 +263,7 @@ class ObjectWithSelfParentRepository {
     List<ObjectWithSelfParent> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithSelfParent>(
+    return session.db.delete<ObjectWithSelfParent>(
       rows,
       transaction: transaction,
     );
@@ -274,7 +274,7 @@ class ObjectWithSelfParentRepository {
     ObjectWithSelfParent row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithSelfParent>(
+    return session.db.deleteRow<ObjectWithSelfParent>(
       row,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class ObjectWithSelfParentRepository {
     required _i1.WhereExpressionBuilder<ObjectWithSelfParentTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithSelfParent>(
+    return session.db.deleteWhere<ObjectWithSelfParent>(
       where: where(ObjectWithSelfParent.t),
       transaction: transaction,
     );
@@ -297,7 +297,7 @@ class ObjectWithSelfParentRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithSelfParent>(
+    return session.db.count<ObjectWithSelfParent>(
       where: where?.call(ObjectWithSelfParent.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -192,7 +192,7 @@ class ObjectWithUuidRepository {
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ObjectWithUuid>(
+    return session.db.find<ObjectWithUuid>(
       where: where?.call(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
@@ -212,7 +212,7 @@ class ObjectWithUuidRepository {
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ObjectWithUuid>(
+    return session.db.findFirstRow<ObjectWithUuid>(
       where: where?.call(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
@@ -227,7 +227,7 @@ class ObjectWithUuidRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ObjectWithUuid>(
+    return session.db.findById<ObjectWithUuid>(
       id,
       transaction: transaction,
     );
@@ -238,7 +238,7 @@ class ObjectWithUuidRepository {
     List<ObjectWithUuid> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ObjectWithUuid>(
+    return session.db.insert<ObjectWithUuid>(
       rows,
       transaction: transaction,
     );
@@ -249,7 +249,7 @@ class ObjectWithUuidRepository {
     ObjectWithUuid row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ObjectWithUuid>(
+    return session.db.insertRow<ObjectWithUuid>(
       row,
       transaction: transaction,
     );
@@ -261,7 +261,7 @@ class ObjectWithUuidRepository {
     _i1.ColumnSelections<ObjectWithUuidTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ObjectWithUuid>(
+    return session.db.update<ObjectWithUuid>(
       rows,
       columns: columns?.call(ObjectWithUuid.t),
       transaction: transaction,
@@ -274,7 +274,7 @@ class ObjectWithUuidRepository {
     _i1.ColumnSelections<ObjectWithUuidTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ObjectWithUuid>(
+    return session.db.updateRow<ObjectWithUuid>(
       row,
       columns: columns?.call(ObjectWithUuid.t),
       transaction: transaction,
@@ -286,7 +286,7 @@ class ObjectWithUuidRepository {
     List<ObjectWithUuid> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ObjectWithUuid>(
+    return session.db.delete<ObjectWithUuid>(
       rows,
       transaction: transaction,
     );
@@ -297,7 +297,7 @@ class ObjectWithUuidRepository {
     ObjectWithUuid row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ObjectWithUuid>(
+    return session.db.deleteRow<ObjectWithUuid>(
       row,
       transaction: transaction,
     );
@@ -308,7 +308,7 @@ class ObjectWithUuidRepository {
     required _i1.WhereExpressionBuilder<ObjectWithUuidTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ObjectWithUuid>(
+    return session.db.deleteWhere<ObjectWithUuid>(
       where: where(ObjectWithUuid.t),
       transaction: transaction,
     );
@@ -320,7 +320,7 @@ class ObjectWithUuidRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ObjectWithUuid>(
+    return session.db.count<ObjectWithUuid>(
       where: where?.call(ObjectWithUuid.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -236,7 +236,7 @@ class RelatedUniqueDataRepository {
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
   }) async {
-    return session.dbNext.find<RelatedUniqueData>(
+    return session.db.find<RelatedUniqueData>(
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
@@ -258,7 +258,7 @@ class RelatedUniqueDataRepository {
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
   }) async {
-    return session.dbNext.findFirstRow<RelatedUniqueData>(
+    return session.db.findFirstRow<RelatedUniqueData>(
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
@@ -275,7 +275,7 @@ class RelatedUniqueDataRepository {
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
   }) async {
-    return session.dbNext.findById<RelatedUniqueData>(
+    return session.db.findById<RelatedUniqueData>(
       id,
       transaction: transaction,
       include: include,
@@ -287,7 +287,7 @@ class RelatedUniqueDataRepository {
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<RelatedUniqueData>(
+    return session.db.insert<RelatedUniqueData>(
       rows,
       transaction: transaction,
     );
@@ -298,7 +298,7 @@ class RelatedUniqueDataRepository {
     RelatedUniqueData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<RelatedUniqueData>(
+    return session.db.insertRow<RelatedUniqueData>(
       row,
       transaction: transaction,
     );
@@ -310,7 +310,7 @@ class RelatedUniqueDataRepository {
     _i1.ColumnSelections<RelatedUniqueDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<RelatedUniqueData>(
+    return session.db.update<RelatedUniqueData>(
       rows,
       columns: columns?.call(RelatedUniqueData.t),
       transaction: transaction,
@@ -323,7 +323,7 @@ class RelatedUniqueDataRepository {
     _i1.ColumnSelections<RelatedUniqueDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<RelatedUniqueData>(
+    return session.db.updateRow<RelatedUniqueData>(
       row,
       columns: columns?.call(RelatedUniqueData.t),
       transaction: transaction,
@@ -335,7 +335,7 @@ class RelatedUniqueDataRepository {
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<RelatedUniqueData>(
+    return session.db.delete<RelatedUniqueData>(
       rows,
       transaction: transaction,
     );
@@ -346,7 +346,7 @@ class RelatedUniqueDataRepository {
     RelatedUniqueData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<RelatedUniqueData>(
+    return session.db.deleteRow<RelatedUniqueData>(
       row,
       transaction: transaction,
     );
@@ -357,7 +357,7 @@ class RelatedUniqueDataRepository {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<RelatedUniqueData>(
+    return session.db.deleteWhere<RelatedUniqueData>(
       where: where(RelatedUniqueData.t),
       transaction: transaction,
     );
@@ -369,7 +369,7 @@ class RelatedUniqueDataRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<RelatedUniqueData>(
+    return session.db.count<RelatedUniqueData>(
       where: where?.call(RelatedUniqueData.t),
       limit: limit,
       transaction: transaction,
@@ -394,7 +394,7 @@ class RelatedUniqueDataAttachRowRepository {
 
     var $relatedUniqueData =
         relatedUniqueData.copyWith(uniqueDataId: uniqueData.id);
-    await session.dbNext.updateRow<RelatedUniqueData>(
+    await session.db.updateRow<RelatedUniqueData>(
       $relatedUniqueData,
       columns: [RelatedUniqueData.t.uniqueDataId],
     );

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -169,7 +169,7 @@ class ScopeNoneFieldsRepository {
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<ScopeNoneFields>(
+    return session.db.find<ScopeNoneFields>(
       where: where?.call(ScopeNoneFields.t),
       orderBy: orderBy?.call(ScopeNoneFields.t),
       orderByList: orderByList?.call(ScopeNoneFields.t),
@@ -189,7 +189,7 @@ class ScopeNoneFieldsRepository {
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<ScopeNoneFields>(
+    return session.db.findFirstRow<ScopeNoneFields>(
       where: where?.call(ScopeNoneFields.t),
       orderBy: orderBy?.call(ScopeNoneFields.t),
       orderByList: orderByList?.call(ScopeNoneFields.t),
@@ -204,7 +204,7 @@ class ScopeNoneFieldsRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<ScopeNoneFields>(
+    return session.db.findById<ScopeNoneFields>(
       id,
       transaction: transaction,
     );
@@ -215,7 +215,7 @@ class ScopeNoneFieldsRepository {
     List<ScopeNoneFields> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<ScopeNoneFields>(
+    return session.db.insert<ScopeNoneFields>(
       rows,
       transaction: transaction,
     );
@@ -226,7 +226,7 @@ class ScopeNoneFieldsRepository {
     ScopeNoneFields row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<ScopeNoneFields>(
+    return session.db.insertRow<ScopeNoneFields>(
       row,
       transaction: transaction,
     );
@@ -238,7 +238,7 @@ class ScopeNoneFieldsRepository {
     _i1.ColumnSelections<ScopeNoneFieldsTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<ScopeNoneFields>(
+    return session.db.update<ScopeNoneFields>(
       rows,
       columns: columns?.call(ScopeNoneFields.t),
       transaction: transaction,
@@ -251,7 +251,7 @@ class ScopeNoneFieldsRepository {
     _i1.ColumnSelections<ScopeNoneFieldsTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<ScopeNoneFields>(
+    return session.db.updateRow<ScopeNoneFields>(
       row,
       columns: columns?.call(ScopeNoneFields.t),
       transaction: transaction,
@@ -263,7 +263,7 @@ class ScopeNoneFieldsRepository {
     List<ScopeNoneFields> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<ScopeNoneFields>(
+    return session.db.delete<ScopeNoneFields>(
       rows,
       transaction: transaction,
     );
@@ -274,7 +274,7 @@ class ScopeNoneFieldsRepository {
     ScopeNoneFields row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<ScopeNoneFields>(
+    return session.db.deleteRow<ScopeNoneFields>(
       row,
       transaction: transaction,
     );
@@ -285,7 +285,7 @@ class ScopeNoneFieldsRepository {
     required _i1.WhereExpressionBuilder<ScopeNoneFieldsTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<ScopeNoneFields>(
+    return session.db.deleteWhere<ScopeNoneFields>(
       where: where(ScopeNoneFields.t),
       transaction: transaction,
     );
@@ -297,7 +297,7 @@ class ScopeNoneFieldsRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<ScopeNoneFields>(
+    return session.db.count<ScopeNoneFields>(
       where: where?.call(ScopeNoneFields.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -175,7 +175,7 @@ class SimpleDataRepository {
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<SimpleData>(
+    return session.db.find<SimpleData>(
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
@@ -195,7 +195,7 @@ class SimpleDataRepository {
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<SimpleData>(
+    return session.db.findFirstRow<SimpleData>(
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
@@ -210,7 +210,7 @@ class SimpleDataRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<SimpleData>(
+    return session.db.findById<SimpleData>(
       id,
       transaction: transaction,
     );
@@ -221,7 +221,7 @@ class SimpleDataRepository {
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<SimpleData>(
+    return session.db.insert<SimpleData>(
       rows,
       transaction: transaction,
     );
@@ -232,7 +232,7 @@ class SimpleDataRepository {
     SimpleData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<SimpleData>(
+    return session.db.insertRow<SimpleData>(
       row,
       transaction: transaction,
     );
@@ -244,7 +244,7 @@ class SimpleDataRepository {
     _i1.ColumnSelections<SimpleDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<SimpleData>(
+    return session.db.update<SimpleData>(
       rows,
       columns: columns?.call(SimpleData.t),
       transaction: transaction,
@@ -257,7 +257,7 @@ class SimpleDataRepository {
     _i1.ColumnSelections<SimpleDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<SimpleData>(
+    return session.db.updateRow<SimpleData>(
       row,
       columns: columns?.call(SimpleData.t),
       transaction: transaction,
@@ -269,7 +269,7 @@ class SimpleDataRepository {
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<SimpleData>(
+    return session.db.delete<SimpleData>(
       rows,
       transaction: transaction,
     );
@@ -280,7 +280,7 @@ class SimpleDataRepository {
     SimpleData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<SimpleData>(
+    return session.db.deleteRow<SimpleData>(
       row,
       transaction: transaction,
     );
@@ -291,7 +291,7 @@ class SimpleDataRepository {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<SimpleData>(
+    return session.db.deleteWhere<SimpleData>(
       where: where(SimpleData.t),
       transaction: transaction,
     );
@@ -303,7 +303,7 @@ class SimpleDataRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<SimpleData>(
+    return session.db.count<SimpleData>(
       where: where?.call(SimpleData.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -174,7 +174,7 @@ class SimpleDateTimeRepository {
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<SimpleDateTime>(
+    return session.db.find<SimpleDateTime>(
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
@@ -194,7 +194,7 @@ class SimpleDateTimeRepository {
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<SimpleDateTime>(
+    return session.db.findFirstRow<SimpleDateTime>(
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
@@ -209,7 +209,7 @@ class SimpleDateTimeRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<SimpleDateTime>(
+    return session.db.findById<SimpleDateTime>(
       id,
       transaction: transaction,
     );
@@ -220,7 +220,7 @@ class SimpleDateTimeRepository {
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<SimpleDateTime>(
+    return session.db.insert<SimpleDateTime>(
       rows,
       transaction: transaction,
     );
@@ -231,7 +231,7 @@ class SimpleDateTimeRepository {
     SimpleDateTime row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<SimpleDateTime>(
+    return session.db.insertRow<SimpleDateTime>(
       row,
       transaction: transaction,
     );
@@ -243,7 +243,7 @@ class SimpleDateTimeRepository {
     _i1.ColumnSelections<SimpleDateTimeTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<SimpleDateTime>(
+    return session.db.update<SimpleDateTime>(
       rows,
       columns: columns?.call(SimpleDateTime.t),
       transaction: transaction,
@@ -256,7 +256,7 @@ class SimpleDateTimeRepository {
     _i1.ColumnSelections<SimpleDateTimeTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<SimpleDateTime>(
+    return session.db.updateRow<SimpleDateTime>(
       row,
       columns: columns?.call(SimpleDateTime.t),
       transaction: transaction,
@@ -268,7 +268,7 @@ class SimpleDateTimeRepository {
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<SimpleDateTime>(
+    return session.db.delete<SimpleDateTime>(
       rows,
       transaction: transaction,
     );
@@ -279,7 +279,7 @@ class SimpleDateTimeRepository {
     SimpleDateTime row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<SimpleDateTime>(
+    return session.db.deleteRow<SimpleDateTime>(
       row,
       transaction: transaction,
     );
@@ -290,7 +290,7 @@ class SimpleDateTimeRepository {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<SimpleDateTime>(
+    return session.db.deleteWhere<SimpleDateTime>(
       where: where(SimpleDateTime.t),
       transaction: transaction,
     );
@@ -302,7 +302,7 @@ class SimpleDateTimeRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<SimpleDateTime>(
+    return session.db.count<SimpleDateTime>(
       where: where?.call(SimpleDateTime.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -359,7 +359,7 @@ class TypesRepository {
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<Types>(
+    return session.db.find<Types>(
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
@@ -379,7 +379,7 @@ class TypesRepository {
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<Types>(
+    return session.db.findFirstRow<Types>(
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
@@ -394,7 +394,7 @@ class TypesRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<Types>(
+    return session.db.findById<Types>(
       id,
       transaction: transaction,
     );
@@ -405,7 +405,7 @@ class TypesRepository {
     List<Types> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<Types>(
+    return session.db.insert<Types>(
       rows,
       transaction: transaction,
     );
@@ -416,7 +416,7 @@ class TypesRepository {
     Types row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<Types>(
+    return session.db.insertRow<Types>(
       row,
       transaction: transaction,
     );
@@ -428,7 +428,7 @@ class TypesRepository {
     _i1.ColumnSelections<TypesTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<Types>(
+    return session.db.update<Types>(
       rows,
       columns: columns?.call(Types.t),
       transaction: transaction,
@@ -441,7 +441,7 @@ class TypesRepository {
     _i1.ColumnSelections<TypesTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<Types>(
+    return session.db.updateRow<Types>(
       row,
       columns: columns?.call(Types.t),
       transaction: transaction,
@@ -453,7 +453,7 @@ class TypesRepository {
     List<Types> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<Types>(
+    return session.db.delete<Types>(
       rows,
       transaction: transaction,
     );
@@ -464,7 +464,7 @@ class TypesRepository {
     Types row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<Types>(
+    return session.db.deleteRow<Types>(
       row,
       transaction: transaction,
     );
@@ -475,7 +475,7 @@ class TypesRepository {
     required _i1.WhereExpressionBuilder<TypesTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<Types>(
+    return session.db.deleteWhere<Types>(
       where: where(Types.t),
       transaction: transaction,
     );
@@ -487,7 +487,7 @@ class TypesRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<Types>(
+    return session.db.count<Types>(
       where: where?.call(Types.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -189,7 +189,7 @@ class UniqueDataRepository {
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.find<UniqueData>(
+    return session.db.find<UniqueData>(
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
@@ -209,7 +209,7 @@ class UniqueDataRepository {
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findFirstRow<UniqueData>(
+    return session.db.findFirstRow<UniqueData>(
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
@@ -224,7 +224,7 @@ class UniqueDataRepository {
     int id, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.findById<UniqueData>(
+    return session.db.findById<UniqueData>(
       id,
       transaction: transaction,
     );
@@ -235,7 +235,7 @@ class UniqueDataRepository {
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insert<UniqueData>(
+    return session.db.insert<UniqueData>(
       rows,
       transaction: transaction,
     );
@@ -246,7 +246,7 @@ class UniqueDataRepository {
     UniqueData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.insertRow<UniqueData>(
+    return session.db.insertRow<UniqueData>(
       row,
       transaction: transaction,
     );
@@ -258,7 +258,7 @@ class UniqueDataRepository {
     _i1.ColumnSelections<UniqueDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.update<UniqueData>(
+    return session.db.update<UniqueData>(
       rows,
       columns: columns?.call(UniqueData.t),
       transaction: transaction,
@@ -271,7 +271,7 @@ class UniqueDataRepository {
     _i1.ColumnSelections<UniqueDataTable>? columns,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.updateRow<UniqueData>(
+    return session.db.updateRow<UniqueData>(
       row,
       columns: columns?.call(UniqueData.t),
       transaction: transaction,
@@ -283,7 +283,7 @@ class UniqueDataRepository {
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.delete<UniqueData>(
+    return session.db.delete<UniqueData>(
       rows,
       transaction: transaction,
     );
@@ -294,7 +294,7 @@ class UniqueDataRepository {
     UniqueData row, {
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteRow<UniqueData>(
+    return session.db.deleteRow<UniqueData>(
       row,
       transaction: transaction,
     );
@@ -305,7 +305,7 @@ class UniqueDataRepository {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.deleteWhere<UniqueData>(
+    return session.db.deleteWhere<UniqueData>(
       where: where(UniqueData.t),
       transaction: transaction,
     );
@@ -317,7 +317,7 @@ class UniqueDataRepository {
     int? limit,
     _i1.Transaction? transaction,
   }) async {
-    return session.dbNext.count<UniqueData>(
+    return session.db.count<UniqueData>(
       where: where?.call(UniqueData.t),
       limit: limit,
       transaction: transaction,

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
@@ -38,7 +38,7 @@ void main() async {
       () async {
     var stockholm = await City.db.insertRow(session, City(name: 'Stockholm'));
 
-    var city = await session.dbNext.findById<City>(
+    var city = await session.db.findById<City>(
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(),
@@ -61,7 +61,7 @@ void main() async {
     await City.db.attach.citizens(session, stockholm, [citizen1, citizen2]);
     await City.db.attach.citizens(session, gothenburg, [citizen3]);
 
-    var city = await session.dbNext.findById<City>(
+    var city = await session.db.findById<City>(
       stockholm.id!,
       include: City.include(
         citizens: Person.includeList(),
@@ -94,7 +94,7 @@ void main() async {
     await Organization.db.attach.people(session, serverpod, [person1, person2]);
     await Organization.db.attach.people(session, flutter, [person3]);
 
-    var organization = await session.dbNext.findById<Organization>(
+    var organization = await session.db.findById<Organization>(
       serverpod.id!,
       include: Organization.include(
         people: Person.includeList(),
@@ -127,7 +127,7 @@ void main() async {
     await Organization.db.attach.people(session, serverpod, [person1, person2]);
     await Organization.db.attach.people(session, flutter, [person3]);
 
-    var organizations = await session.dbNext.find<Organization>(
+    var organizations = await session.db.find<Organization>(
       where: Organization.t.name.equals('Serverpod'),
       include: Organization.include(
         people: Person.includeList(),

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -278,7 +278,7 @@ class BuildRepositoryClass {
       ])
       ..modifier = MethodModifier.async
       ..body = refer('session')
-          .property('dbNext')
+          .property('db')
           .property('find')
           .call([], {
             'where': refer('where').nullSafeProperty('call').call(
@@ -366,7 +366,7 @@ class BuildRepositoryClass {
       ])
       ..modifier = MethodModifier.async
       ..body = refer('session')
-          .property('dbNext')
+          .property('db')
           .property('findFirstRow')
           .call(
             [],
@@ -430,7 +430,7 @@ class BuildRepositoryClass {
       ])
       ..modifier = MethodModifier.async
       ..body = refer('session')
-          .property('dbNext')
+          .property('db')
           .property('findById')
           .call(
             [refer('id')],
@@ -472,7 +472,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('insert')
             .call([
               refer('rows')
@@ -514,7 +514,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('insertRow')
             .call([
               refer('row')
@@ -563,7 +563,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('update')
             .call([
               refer('rows')
@@ -615,7 +615,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('updateRow')
             .call([
               refer('row')
@@ -660,7 +660,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('delete')
             .call([
               refer('rows')
@@ -702,7 +702,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('deleteRow')
             .call([
               refer('row')
@@ -750,7 +750,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('deleteWhere')
             .call([], {
               'where': refer('where').call([refer(className).property('t')]),
@@ -801,7 +801,7 @@ class BuildRepositoryClass {
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
-            .property('dbNext')
+            .property('db')
             .property('count')
             .call([], {
               'where': refer('where').nullSafeProperty('call').call(
@@ -1705,7 +1705,7 @@ class BuildRepositoryClass {
     return (BlockBuilder()
           ..statements.addAll([
             refer('session')
-                .property('dbNext')
+                .property('db')
                 .property(property)
                 .call([
                   refer(localCopyVariable)


### PR DESCRIPTION
## Change:
- BREAKING! - Renames the database reference in Session from `dbNext` to `db`.
- Updates code generator so that it generates references to `db` instead of `dbNext`.
- Updates all direct references to `session.dbNext` to `session.db`.

This PR depends on: https://github.com/serverpod/serverpod/pull/1911

Documentation changes here: https://github.com/serverpod/serverpod_docs/pull/73

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

YES -> Renames the session field 'dbNext' to 'db'
