### PR TITLE
fix!: Remove deprecations in serverpod client, and serverpod auth and serverpod package.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
@@ -51,17 +51,6 @@ class SessionManager with ChangeNotifier {
   /// currently signed in.
   UserInfo? get signedInUser => _signedInUser;
 
-  @Deprecated('Use setSignedInUser instead.')
-  set signedInUser(UserInfo? userInfo) {
-    _signedInUser = userInfo;
-    // TODO: Avoid doing asynchronously.
-    keyManager.get().then((String? key) async {
-      await caller.client.updateStreamingConnectionAuthenticationKey(key);
-    });
-    _storeSharedPrefs();
-    notifyListeners();
-  }
-
   /// Registers the signed in user, updates the [keyManager], and upgrades the
   /// streaming connection if it is open.
   Future<void> registerSignedInUser(

--- a/packages/serverpod/lib/src/database/expressions.dart
+++ b/packages/serverpod/lib/src/database/expressions.dart
@@ -5,10 +5,6 @@ import 'package:serverpod/src/database/table_relation.dart';
 class Expression<T> {
   final T _expression;
 
-  /// Retrieves expression as a string.
-  @Deprecated('Use toString instead')
-  String get expression => toString();
-
   /// Creates a new [Expression].
   /// Note that the precedence of operators may not be what you think, so
   /// always use parentheses to make sure that that expressions are executed

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -207,12 +207,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
   }
 
   /// Open a streaming connection to the server.
-  @Deprecated('Renamed to openStreamingConnection')
-  Future<void> connectWebSocket() async {
-    await openStreamingConnection();
-  }
-
-  /// Open a streaming connection to the server.
   Future<void> openStreamingConnection({
     bool disconnectOnLostInternetConnection = true,
   }) async {
@@ -269,18 +263,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     await Future.delayed(const Duration(milliseconds: 100));
   }
 
-  /// Closes the current web socket connection (if open), then connects again.
-  @Deprecated('Use closeStreamingConnection / openStreamingConnection instead.')
-  Future<void> reconnectWebSocket() async {
-    if (_webSocket == null) return;
-
-    await _webSocket?.sink.close();
-    _webSocket = null;
-    _cancelConnectionTimer();
-
-    await openStreamingConnection();
-  }
-
   Future<void> _listenToWebSocketStream() async {
     if (_webSocket == null) return;
 
@@ -301,19 +283,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     _notifyWebSocketConnectionStatusListeners();
   }
 
-  /// Adds a callback for when the [isWebSocketConnected] property is
-  /// changed.
-  @Deprecated('Use addStreamingConnectionStatusListener instead.')
-  void addWebSocketConnectionStatusListener(VoidCallback listener) {
-    addStreamingConnectionStatusListener(listener);
-  }
-
-  /// Removes a connection status listener.
-  @Deprecated('Use removeStreamingConnectionStatusListener instead.')
-  void removeWebSocketConnectionStatusListener(VoidCallback listener) {
-    removeStreamingConnectionStatusListener(listener);
-  }
-
   /// Adds a callback for when the [streamingConnectionStatus] property is
   /// changed.
   void addStreamingConnectionStatusListener(VoidCallback listener) {
@@ -329,12 +298,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     for (var listener in _websocketConnectionStatusListeners) {
       listener();
     }
-  }
-
-  /// Returns true if the web socket is connected.
-  @Deprecated('Use streamingConnectionStatus instead.')
-  bool get isWebSocketConnected {
-    return _webSocket != null;
   }
 
   /// Returns the current status of the streaming connection. It can be one of


### PR DESCRIPTION
## Changes
- BREAKING: Remove deprecated methods in serverpod client (`serverpod_client_shared.dart`).
- BREAKING: Remove deprecated methods in serverpod auth (`session_manager.dart`).
- BREAKING: Remove deprecated methods in serverpod (`expressions.dart`)
 
Removes the last methods marked as deprecated.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

The following files have listed methods removed as part of this PR.

`serverpod_client_shared.dart` in serverpod_client package.
- `connectWebSocket()`
- `reconnectWebSocket()`
- `addWebSocketConnectionStatusListener(...)`
- `removeWebSocketConnectionStatusListener(...)`
- `isWebSocketConnected`

`session_manager.dart` in serverpod_auth package.
- `signedInUser(...)`

`expressions.dart` in serverpod package.
- `expression`