### PR TITLE
refactor!: Hide database pool manager.

### DIFF
--- a/packages/serverpod/lib/database.dart
+++ b/packages/serverpod/lib/database.dart
@@ -1,7 +1,6 @@
 library database;
 
 export 'src/database/concepts/columns.dart';
-export 'src/database/database_pool_manager.dart';
 export 'src/database/concepts/expressions.dart';
 export 'src/database/concepts/includes.dart';
 export 'src/database/concepts/many_relation.dart';

--- a/packages/serverpod/lib/src/database/concepts/expressions.dart
+++ b/packages/serverpod/lib/src/database/concepts/expressions.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/database/database_pool_manager.dart';
 
 /// A function that returns an [Expression] for a [Table] to be used with where
 /// clauses.

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -6,6 +6,7 @@ import 'package:serverpod/src/database/concepts/columns.dart';
 import 'package:serverpod/src/database/concepts/includes.dart';
 import 'package:serverpod/src/database/concepts/order.dart';
 import 'package:serverpod/src/database/concepts/transaction.dart';
+import 'package:serverpod/src/database/database_pool_manager.dart';
 
 import '../server/session.dart';
 import 'adapters/postgres/database_connection.dart';
@@ -20,9 +21,9 @@ class Database {
 
   /// Creates a new [Database] object. Typically, this is done automatically
   /// when a [Session] is created.
-  Database({required Session session})
+  Database({required Session session, required DatabasePoolManager poolManager})
       : _session = session,
-        _databaseConnection = DatabaseConnection(session.server.databaseConfig);
+        _databaseConnection = DatabaseConnection(poolManager);
 
   /// Find a list of [TableRow]s from a table, using the provided [where]
   /// expression, optionally using [limit], [offset], and [orderBy]. To order by

--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import 'package:serverpod/src/serialization/serialization_manager.dart';
 import 'package:postgres_pool/postgres_pool.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
@@ -6,6 +7,7 @@ import 'package:serverpod_shared/serverpod_shared.dart';
 import 'adapters/postgres/value_encoder.dart';
 
 /// Configuration for connecting to the Postgresql database.
+@internal
 class DatabasePoolManager {
   /// Database configuration.
   final DatabaseConfig config;

--- a/packages/serverpod/lib/src/database/extensions.dart
+++ b/packages/serverpod/lib/src/database/extensions.dart
@@ -1,5 +1,5 @@
-import 'package:serverpod/database.dart';
 import 'package:serverpod/protocol.dart';
+import 'package:serverpod/src/database/database_pool_manager.dart';
 
 /// Comparison methods for [DatabaseDefinition].
 extension DatabaseComparisons on DatabaseDefinition {

--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/server/command_line_args.dart';
 import 'package:serverpod/src/server/health_check.dart';
 import 'package:serverpod_client/serverpod_client.dart';

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/database/database.dart';
 import 'package:serverpod/src/server/health_check.dart';
 
 import '../cache/caches.dart';
@@ -26,14 +27,17 @@ class Server {
   final String runMode;
 
   /// Current database configuration.
-  final DatabasePoolManager? _databaseConfig;
+  final DatabasePoolManager? _databasePoolManager;
 
-  /// Current database configuration.
-  DatabasePoolManager get databaseConfig {
-    if (_databaseConfig == null) {
+  /// Creates a new [Database] object with a connection to the configured
+  /// database.
+  Database createDatabase(Session session) {
+    var databasePoolManager = _databasePoolManager;
+    if (databasePoolManager == null) {
       throw ArgumentError('Database config not set');
     }
-    return _databaseConfig!;
+
+    return Database(session: session, poolManager: databasePoolManager);
   }
 
   /// The [SerializationManager] used by the server.
@@ -87,7 +91,7 @@ class Server {
     required this.serverId,
     required this.port,
     required this.serializationManager,
-    required DatabasePoolManager? databaseConfig,
+    required DatabasePoolManager? databasePoolManager,
     required this.passwords,
     required this.runMode,
     this.authenticationHandler,
@@ -99,7 +103,7 @@ class Server {
     required this.httpResponseHeaders,
     required this.httpOptionsResponseHeaders,
   })  : name = name ?? 'Server $serverId',
-        _databaseConfig = databaseConfig;
+        _databasePoolManager = databasePoolManager;
 
   /// Starts the server.
   /// Returns true if the server was started successfully.

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/database/database.dart';
+import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/server/health_check.dart';
 
 import '../cache/caches.dart';

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -5,6 +5,7 @@ import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/cloud_storage/public_endpoint.dart';
 import 'package:serverpod/src/config/version.dart';
+import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/database/migrations/migration_manager.dart';
 import 'package:serverpod/src/redis/controller.dart';
 import 'package:serverpod/src/server/features.dart';

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -80,20 +80,7 @@ class Serverpod {
   /// Definition of endpoints used by the server. This is typically generated.
   final EndpointDispatch endpoints;
 
-  DatabasePoolManager? _databaseConfig;
-
-  /// The database configuration.
-  DatabasePoolManager get databaseConfig {
-    var database = _databaseConfig;
-    if (database == null) {
-      throw StateError(
-        'Database is disabled, supply a database configuration to the '
-        'Serverpod constructor to enable this feature.',
-      );
-    }
-
-    return database;
-  }
+  DatabasePoolManager? _databasePoolManager;
 
   late Caches _caches;
 
@@ -321,11 +308,11 @@ class Serverpod {
     _logManager = LogManager(_defaultRuntimeSettings, _logWriter);
 
     // Setup database
-    var database = this.config.database;
-    if (Features.enableDatabase && database != null) {
-      _databaseConfig = DatabasePoolManager(
+    var databaseConfiguration = this.config.database;
+    if (Features.enableDatabase && databaseConfiguration != null) {
+      _databasePoolManager = DatabasePoolManager(
         serializationManager,
-        database,
+        databaseConfiguration,
       );
     }
 
@@ -365,7 +352,7 @@ class Serverpod {
       serverId: serverId,
       port: this.config.apiServer.port,
       serializationManager: serializationManager,
-      databaseConfig: _databaseConfig,
+      databasePoolManager: _databasePoolManager,
       passwords: _passwords,
       runMode: _runMode,
       caches: caches,
@@ -435,7 +422,7 @@ class Serverpod {
         CloudStoragePublicEndpoint().register(this);
       }
 
-      if (_databaseConfig == null) {
+      if (_databasePoolManager == null) {
         _runtimeSettings = _defaultRuntimeSettings;
       }
 
@@ -659,7 +646,7 @@ class Serverpod {
       serverId: serverId,
       port: config.insightsServer!.port,
       serializationManager: _internalSerializationManager,
-      databaseConfig: _databaseConfig,
+      databasePoolManager: _databasePoolManager,
       passwords: _passwords,
       runMode: _runMode,
       name: 'Insights',

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -93,7 +93,7 @@ abstract class Session {
     messages = MessageCentralAccess._(this);
 
     if (Features.enableDatabase) {
-      _db = Database(session: this);
+      _db = server.createDatabase(this);
     }
 
     sessionLogs = server.serverpod.logManager.initializeSessionLog(this);


### PR DESCRIPTION
## Changes:
- BREAKING: Removes accessor to database_pool_manager from `Serverpod` and `Server`.
- BREAKING: don't export `database_pool_manager.dart` from `database` library.
- Create a database object directly in `Server` from `Session`.

Preparation for https://github.com/serverpod/serverpod/issues/1766.

The goal is to isolate all library specific implementation around the database so that we get a stable user facing interface while we can change the internal implementation.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Yes -> Removes all accessors to DatabasePoolManager and stops the exporting of the class.