### PR TITLE
fix: Pass transaction for delete method.

### DIFF
--- a/packages/serverpod/lib/src/database/database_connection.dart
+++ b/packages/serverpod/lib/src/database/database_connection.dart
@@ -256,6 +256,7 @@ class DatabaseConnection {
     return deleteWhere<T>(
       session,
       table.id.inSet(rows.map((row) => row.id!).toSet()),
+      transaction: transaction,
     );
   }
 


### PR DESCRIPTION
## Changes
- Passes transaction into the delete method.

This was probably overlooked at sometime.

Related PR targeting main here: https://github.com/serverpod/serverpod/pull/1920

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

## Breaking changes

None - Delete now properly functions with transactions.
