### PR TITLE
fix!: Make transaction a generic interface.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -327,7 +327,7 @@ class DatabaseConnection {
     Transaction? transaction,
     Map<String, dynamic>? substitutionValues = const {},
   }) async {
-    var postgresTransaction = _getPostgresTransactionOrAssert(transaction);
+    var postgresTransaction = _castToPostgresTransaction(transaction);
 
     var startTime = DateTime.now();
     try {
@@ -361,7 +361,7 @@ class DatabaseConnection {
     int? timeoutInSeconds,
     Transaction? transaction,
   }) async {
-    var postgresTransaction = _getPostgresTransactionOrAssert(transaction);
+    var postgresTransaction = _castToPostgresTransaction(transaction);
 
     var startTime = DateTime.now();
     try {
@@ -389,7 +389,7 @@ class DatabaseConnection {
     Transaction? transaction,
   }) async {
     var startTime = DateTime.now();
-    var postgresTransaction = _getPostgresTransactionOrAssert(transaction);
+    var postgresTransaction = _castToPostgresTransaction(transaction);
 
     try {
       var context =
@@ -671,7 +671,8 @@ Current type was $T''');
   return table!;
 }
 
-_PostgresTransaction? _getPostgresTransactionOrAssert(
+/// Throws an exception if the given [transaction] is not a Postgres transaction.
+_PostgresTransaction? _castToPostgresTransaction(
   Transaction? transaction,
 ) {
   if (transaction == null) return null;

--- a/packages/serverpod/lib/src/database/concepts/transaction.dart
+++ b/packages/serverpod/lib/src/database/concepts/transaction.dart
@@ -1,14 +1,9 @@
-import 'package:postgres/postgres.dart';
-
 /// A function performing a transaction, passed to the transaction method.
 typedef TransactionFunction<R> = Future<R> Function(Transaction transaction);
 
 /// Holds the state of a running database transaction.
-abstract class Transaction {
-  /// The Postgresql execution context associated with a running transaction.
-  // TODO: Replace with a more generic database context and rename to executionContext.
-  final PostgreSQLExecutionContext postgresContext;
-
-  /// Constructs a new transaction object.
-  Transaction(this.postgresContext);
+abstract interface class Transaction {
+  /// Cancels the transaction.
+  /// Subsequent calls to the database will have no effect.
+  void cancel();
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
@@ -1,0 +1,138 @@
+import 'package:serverpod/database.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+class MockTransaction implements Transaction {
+  @override
+  void cancel() {}
+}
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  tearDown(() async {
+    await UniqueData.db.deleteWhere(session, where: (_) => Constant.bool(true));
+  });
+
+  group('Given a transaction that does not match required database transaction',
+      () {
+    var invalidTransactionType = MockTransaction();
+    test('when running a transaction then an error is thrown.', () async {
+      expect(
+        session.db.transaction<void>((transaction) async {
+          await UniqueData.db.findFirstRow(
+            session,
+            transaction: invalidTransactionType,
+          );
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('when making a query then an error is thrown.', () async {
+      expect(
+        session.db.unsafeExecute(
+          'SELECT 1;',
+          transaction: invalidTransactionType,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  test(
+      'Given transaction when inserting and then fetching row then the row is found.',
+      () async {
+    var data = UniqueData(number: 1, email: 'test@serverpod.dev');
+
+    var fetchedData = await session.db.transaction<UniqueData?>(
+      (transaction) async {
+        await UniqueData.db.insertRow(session, data, transaction: transaction);
+        return await UniqueData.db.findFirstRow(
+          session,
+          transaction: transaction,
+        );
+      },
+    );
+
+    expect(fetchedData, isNotNull);
+    var UniqueData(:number, :email) = fetchedData!;
+    expect(number, data.number);
+    expect(email, data.email);
+  });
+
+  test(
+      'Given row insertion transaction that is canceled when fetching row then the row is not found in database.',
+      () async {
+    var data = UniqueData(number: 1, email: 'test@serverpod.dev');
+    await session.db.transaction<void>(
+      (transaction) async {
+        await UniqueData.db.insertRow(session, data, transaction: transaction);
+        transaction.cancel();
+      },
+    );
+
+    var fetchedData = await UniqueData.db.findFirstRow(session);
+
+    expect(
+      fetchedData,
+      isNull,
+      reason: 'Row was inserted even though transaction was canceled.',
+    );
+  });
+
+  test(
+      'Given a transaction that is canceled when inserting row after transaction is canceled then insertion has no effect',
+      () async {
+    var data = UniqueData(number: 1, email: 'test@serverpod.dev');
+    var data2 = UniqueData(number: 2, email: 'test2@serverpod.dev');
+    await session.db.transaction<void>(
+      (transaction) async {
+        await UniqueData.db.insertRow(session, data, transaction: transaction);
+        transaction.cancel();
+        await UniqueData.db.insertRow(session, data2, transaction: transaction);
+      },
+    );
+
+    var fetchedData = await UniqueData.db.findFirstRow(session);
+
+    expect(
+      fetchedData,
+      isNull,
+      reason: 'Row was inserted after transaction was cancelled.',
+    );
+  });
+
+  test(
+      'Given a transaction when rolling back to savepoint and then saving row then committed rows are found in database.',
+      () async {
+    var data = UniqueData(number: 1, email: 'test@serverpod.dev');
+    var data2 = UniqueData(number: 2, email: 'test2@serverpod.dev');
+    var data3 = UniqueData(number: 3, email: 'test3@serverpod.dev');
+    await session.db.transaction<void>(
+      (transaction) async {
+        await UniqueData.db.insertRow(session, data, transaction: transaction);
+
+        await session.db.unsafeExecute(
+          'SAVEPOINT savepoint1;',
+          transaction: transaction,
+        );
+        await UniqueData.db.insertRow(session, data2, transaction: transaction);
+        await session.db.unsafeExecute(
+          'ROLLBACK TO SAVEPOINT savepoint1;',
+          transaction: transaction,
+        );
+
+        await UniqueData.db.insertRow(session, data3, transaction: transaction);
+      },
+    );
+
+    var fetchedData = await UniqueData.db.find(session);
+
+    expect(fetchedData, isNotEmpty);
+    expect(fetchedData, hasLength(2));
+    expect(fetchedData.elementAtOrNull(0)?.number, data.number);
+    expect(fetchedData.elementAtOrNull(1)?.number, data3.number);
+  });
+}


### PR DESCRIPTION
## Change
- Make the transaction object a more generic interface that does not depend on package dependency types.
- BREAKING: Removes the `PostgreSQLExecutionContext` from the transaction object.
- Adds a cancel method to the transaction object so that transactions can be cancelled.

This is done in preparation for https://github.com/serverpod/serverpod/issues/1766.

Serverpod needs to own its own interfaces so that we can make implementation changes (such has switching underlying packages) without making braking changes for our users.

This PR makes the transaction object generic and only exposes the `cancel` method that allows developers to cancel transactions.

All transaction functionality is still available using direct queries towards the database.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Yes -> Removes `PostgreSQLExecutionContext` from the transaction object.
