### PR TITLE
Port `serverpod_client` from `http` to `dio`

### DIFF
--- a/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   serverpod: 1.2.3
   amazon_cognito_identity_dart_2: ^3.0.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   serverpod: 1.2.3
   amazon_cognito_identity_dart_2: ^3.0.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   serverpod: 1.2.3
   amazon_cognito_identity_dart_2: ^3.0.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: 1.2.3
   amazon_cognito_identity_dart_2: ^3.0.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   serverpod: 1.2.3
   amazon_cognito_identity_dart_2: ^3.0.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: 1.2.3
   amazon_cognito_identity_dart_2: ^3.0.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   googleapis: ^11.0.0
   googleapis_auth: ^1.4.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   jose: ^0.3.3
 

--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   firebase_admin: ^0.2.0
   googleapis: ^11.0.0
   googleapis_auth: ^1.4.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   image: ^4.0.15
   jose: ^0.3.3
 

--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   firebase_admin: ^0.2.0
   googleapis: ^11.0.0
   googleapis_auth: ^1.4.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   jose: ^0.3.3
 

--- a/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_input.dart
+++ b/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_input.dart
@@ -208,15 +208,9 @@ class ChatInputState extends State<ChatInput> {
         });
       }
 
-      var stream = result.files.first.readStream;
-      // var stream = result.openRead();
-      Uint8List? bytes;
-      if (stream == null) {
-        bytes = result.files.first.bytes;
-        // bytes = await result.readAsBytes();
-      }
+      var bytes = result.files.first.bytes;
 
-      if (stream == null && bytes == null) {
+      if (bytes == null) {
         _uploadCancelled();
         return;
       }
@@ -229,14 +223,7 @@ class ChatInputState extends State<ChatInput> {
       }
 
       var uploader = FileUploader(uploadDescription.uploadDescription);
-      if (stream != null) {
-        await uploader.upload(stream, result.files.first.size);
-      } else if (bytes != null) {
-        await uploader.uploadByteData(ByteData.view(bytes.buffer));
-      } else {
-        _uploadCancelled();
-        return;
-      }
+      await uploader.uploadUint8List(bytes);
 
       var attachment = await widget.controller.module.chat
           .verifyAttachmentUpload(fileName, uploadDescription.filePath);

--- a/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   serverpod: 1.2.3
   serverpod_auth_server: 1.2.3
   serverpod_serialization: 1.2.3
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   image: ^4.0.15
   path: ^1.8.2
 

--- a/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   serverpod: 1.2.3
   serverpod_auth_server: 1.2.3
   serverpod_serialization: 1.2.3
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   path: ^1.8.2
 

--- a/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   serverpod_auth_server: 1.2.3
   serverpod_serialization: 1.2.3
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   path: ^1.8.2
 

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -176,7 +176,6 @@ class Server {
   void _handleRequest(HttpRequest request) async {
     serverpod
         .logVerbose('handleRequest: ${request.method} ${request.uri.path}');
-    Stopwatch stopwatch = Stopwatch()..start();
 
     for (var header in httpResponseHeaders.entries) {
       request.response.headers.add(header.key, header.value);

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -176,6 +176,7 @@ class Server {
   void _handleRequest(HttpRequest request) async {
     serverpod
         .logVerbose('handleRequest: ${request.method} ${request.uri.path}');
+    Stopwatch stopwatch = Stopwatch()..start();
 
     for (var header in httpResponseHeaders.entries) {
       request.response.headers.add(header.key, header.value);
@@ -281,7 +282,11 @@ class Server {
       body = '';
     }
 
+    print(
+        'Preprocessing: ${request.method} ${request.uri.path} took ${stopwatch.elapsedMilliseconds} ms');
     var result = await _handleUriCall(uri, body!, request);
+    print(
+        'Uri call: ${request.method} ${request.uri.path} took ${stopwatch.elapsedMilliseconds} ms');
 
     if (result is ResultInvalidParams) {
       if (serverpod.runtimeSettings.logMalformedCalls) {

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -282,11 +282,7 @@ class Server {
       body = '';
     }
 
-    print(
-        'Preprocessing: ${request.method} ${request.uri.path} took ${stopwatch.elapsedMilliseconds} ms');
     var result = await _handleUriCall(uri, body!, request);
-    print(
-        'Uri call: ${request.method} ${request.uri.path} took ${stopwatch.elapsedMilliseconds} ms');
 
     if (result is ResultInvalidParams) {
       if (serverpod.runtimeSettings.logMalformedCalls) {

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   args: ^2.4.0
   collection: ^1.17.1
   crypto: ^3.0.2
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   collection: ^1.17.1
   crypto: ^3.0.2
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   args: ^2.4.0
   collection: ^1.17.1
   crypto: ^3.0.2
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2

--- a/packages/serverpod_client/lib/src/file_uploader.dart
+++ b/packages/serverpod_client/lib/src/file_uploader.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:http/http.dart' as http;
+import 'package:dio/dio.dart';
 
 /// The file uploader uploads files to Serverpods cloud storage. On the server
 /// you can setup a custom storage service, such as S3 or Google Cloud. To
@@ -20,80 +20,59 @@ class FileUploader {
 
   /// Uploads a file contained by a [ByteData] object, returns true if
   /// successful.
-  Future<bool> uploadByteData(ByteData byteData) async {
-    var stream = http.ByteStream.fromBytes(byteData.buffer.asUint8List());
-    return upload(stream, byteData.lengthInBytes);
-  }
+  @Deprecated('Use uploadUint8List instead')
+  Future<bool> uploadByteData(ByteData byteData) =>
+      uploadUint8List(byteData.buffer.asUint8List());
 
   /// Uploads a file from a [Stream], returns true if successful.
+  @Deprecated('Use uploadUint8List instead')
   Future<bool> upload(Stream<List<int>> stream, int length) async {
+    var data = <int>[];
+    await for (var segment in stream) {
+      data += segment;
+    }
+    return await uploadUint8List(Uint8List.fromList(data));
+  }
+
+  /// Uploads a file contained by a [Uint8List] object, returns true if
+  /// successful.
+  Future<bool> uploadUint8List(Uint8List data) async {
     if (_attemptedUpload) {
       throw Exception(
           'Data has already been uploaded using this FileUploader.');
     }
     _attemptedUpload = true;
 
+    Object? dataToPost;
     if (_uploadDescription.type == _UploadType.binary) {
-      try {
-        var result = await http.post(
-          _uploadDescription.url,
-          body: await _readStreamData(stream),
-          headers: {
-            'Content-Type': 'application/octet-stream',
-            'Accept': '*/*',
-          },
-        );
-        return result.statusCode == 200;
-      } catch (e) {
-        return false;
-      }
+      dataToPost = data;
     } else if (_uploadDescription.type == _UploadType.multipart) {
-      // final stream = http.ByteStream(Stream.castFrom(file.openRead()));
-      // final length = await file.length();
-
-      // final stream = http.ByteStream.fromBytes(data.buffer.asUint8List());
-      // final length = await data.lengthInBytes;
-
-      var request = http.MultipartRequest('POST', _uploadDescription.url);
-      var multipartFile = http.MultipartFile(
-          _uploadDescription.field!, stream, length,
-          filename: _uploadDescription.fileName);
-
-      request.files.add(multipartFile);
-      for (var key in _uploadDescription.requestFields.keys) {
-        request.fields[key] = _uploadDescription.requestFields[key]!;
-      }
-
-      try {
-        var result = await request.send();
-        // var body = await _readBody(result.stream);
-        // print('body: $body');
-        return result.statusCode == 204;
-      } catch (e) {
-        return false;
-      }
+      dataToPost = FormData.fromMap({
+        'name': 'dio',
+        'date': DateTime.now().toIso8601String(),
+        'file': MultipartFile.fromBytes(
+          data,
+          filename: _uploadDescription.fileName,
+        ),
+      });
+    } else {
+      throw UnimplementedError('Unknown upload type');
     }
-    throw UnimplementedError('Unknown upload type');
-  }
-
-  // Future<String?> _readBody(http.ByteStream stream) async {
-  //   // TODO: Find more efficient solution?
-  //   var len = 0;
-  //   var data = <int>[];
-  //   await for (var segment in stream) {
-  //     len += segment.length;
-  //     data += segment;
-  //   }
-  //   return Utf8Decoder().convert(data);
-  // }
-
-  Future<List<int>> _readStreamData(Stream<List<int>> stream) async {
-    // TODO: Find more efficient solution?
-    var data = <int>[];
-    await for (var segment in stream) {
-      data += segment;
+    var dio = Dio();
+    dio.options.contentType = 'application/octet-stream';
+    dio.options.headers['Accept'] = '*/*';
+    try {
+      var result = await dio.post(_uploadDescription.url, data: dataToPost);
+      // var body = result.data == null ? '' : result.data.toString();
+      // print('body: $body');
+      return _uploadDescription.type == _UploadType.binary
+          ? result.statusCode == 200
+          : result.statusCode == 204;
+    } catch (e) {
+      return false;
+    } finally {
+      dio.close();
     }
-    return data;
   }
 }
 
@@ -104,7 +83,7 @@ enum _UploadType {
 
 class _UploadDescription {
   late _UploadType type;
-  late Uri url;
+  late String url;
   String? field;
   String? fileName;
   Map<String, String> requestFields = {};
@@ -119,7 +98,10 @@ class _UploadDescription {
       throw const FormatException('Missing type, can be binary or multipart');
     }
 
-    url = Uri.parse(data['url']);
+    if (data['url'] == null) {
+      throw const FormatException('Missing url');
+    }
+    url = data['url'];
 
     if (type == _UploadType.multipart) {
       field = data['field'];

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -48,6 +48,7 @@ abstract class ServerpodClient extends ServerpodClientShared {
           .post(
             '$host$endpoint',
             data: body,
+            options: Options(validateStatus: (_) => true),
           )
           .timeout(connectionTimeout);
 

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -69,7 +69,7 @@ abstract class ServerpodClient extends ServerpodClientShared {
     } catch (e) {
       if (e is DioException) {
         var message = data ?? 'Unknown server response code. ($e)';
-        throw (ServerpodClientException(message, -1));
+        throw (ServerpodClientException(message, e.response?.statusCode ?? -1));
       }
 
       if (logFailedCalls) {

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_print
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
@@ -52,12 +53,11 @@ abstract class ServerpodClient extends ServerpodClientShared {
 
       data = response.data.toString();
 
-      var statusCode = response.statusCode ?? 400;
-      if (statusCode != 200) {
+      if (response.statusCode != HttpStatus.ok) {
         throw getExceptionFrom(
           data: data,
           serializationManager: serializationManager,
-          statusCode: statusCode,
+          statusCode: response.statusCode ?? HttpStatus.badRequest,
         );
       }
 

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -67,12 +67,16 @@ abstract class ServerpodClient extends ServerpodClientShared {
         return parseData<T>(data, T, serializationManager);
       }
     } catch (e) {
+      if (e is DioException) {
+        var message = data ?? 'Unknown server response code. ($e)';
+        throw (ServerpodClientException(message, -1));
+      }
+
       if (logFailedCalls) {
         print('Failed call: $endpoint.$method');
         print('$e');
       }
-      throw (ServerpodClientException(
-          data ?? 'Error during POST request. ($e)', -1));
+      rethrow;
     }
   }
 

--- a/packages/serverpod_client/lib/src/serverpod_client_browser.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_browser.dart
@@ -48,7 +48,14 @@ abstract class ServerpodClient extends ServerpodClientShared {
           .post(
             '$host$endpoint',
             data: body,
-            options: Options(validateStatus: (_) => true),
+            options: Options(
+              sendTimeout: connectionTimeout,
+              receiveTimeout: connectionTimeout,
+              // Don't parse the JSON response, allow Serverpod to do it
+              responseType: ResponseType.plain,
+              // Don't throw an exception for non-200 status codes
+              validateStatus: (_) => true,
+            ),
           )
           .timeout(connectionTimeout);
 

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -74,6 +74,8 @@ abstract class ServerpodClient extends ServerpodClientShared {
             '$host$endpoint',
             data: body,
             options: Options(
+              sendTimeout: connectionTimeout,
+              receiveTimeout: connectionTimeout,
               contentType: 'application/json; charset=utf-8',
               headers: {Headers.contentLengthHeader: body.length},
               // Don't parse the JSON response, allow Serverpod to do it

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -1,9 +1,10 @@
 // ignore_for_file: avoid_print
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 import 'serverpod_client_shared.dart';
@@ -14,7 +15,7 @@ import 'serverpod_client_shared_private.dart';
 /// This is the concrete implementation using the io library
 /// (for Flutter native apps).
 abstract class ServerpodClient extends ServerpodClientShared {
-  late HttpClient _httpClient;
+  final _dio = Dio();
   bool _initialized = false;
 
   /// Creates a new ServerpodClient.
@@ -31,12 +32,13 @@ abstract class ServerpodClient extends ServerpodClientShared {
         'Context must be of type SecurityContext');
 
     // Setup client
-    _httpClient = HttpClient(context: securityContext);
-    _httpClient.connectionTimeout = connectionTimeout;
+    _dio.httpClientAdapter = IOHttpClientAdapter(
+      createHttpClient: () {
+        var httpClient = HttpClient(context: securityContext);
 
-    // TODO: Generate working certificates
-    _httpClient.badCertificateCallback =
-        ((X509Certificate cert, String host, int port) {
+        // TODO: Generate working certificates
+        httpClient.badCertificateCallback =
+            ((X509Certificate cert, String host, int port) {
 //      print('Failed to verify server certificate');
 //      print('pem: ${cert.pem}');
 //      print('subject: ${cert.subject}');
@@ -46,8 +48,12 @@ abstract class ServerpodClient extends ServerpodClientShared {
 //      print('host: $host');
 //      print('port: $port');
 //      return false;
-      return true;
-    });
+          return true;
+        });
+        return httpClient;
+      },
+    );
+    _dio.options.connectTimeout = connectionTimeout;
   }
 
   Future<void> _initialize() async {
@@ -63,25 +69,24 @@ abstract class ServerpodClient extends ServerpodClientShared {
       var body =
           formatArgs(args, await authenticationKeyManager?.get(), method);
 
-      var url = Uri.parse('$host$endpoint');
+      var response = await _dio
+          .post(
+            '$host$endpoint',
+            data: body,
+            options: Options(
+              contentType: 'application/json; charset=utf-8',
+              headers: {Headers.contentLengthHeader: body.length},
+            ),
+          )
+          .timeout(connectionTimeout);
 
-      var request = await _httpClient.postUrl(url);
-      request.headers.contentType =
-          ContentType('application', 'json', charset: 'utf-8');
-      request.contentLength = utf8.encode(body).length;
-      request.write(body);
-
-      await request.flush();
-
-      var response = await request.close().timeout(connectionTimeout);
-
-      var data = await _readResponse(response);
+      var data = response.data.toString();
 
       if (response.statusCode != HttpStatus.ok) {
         throw getExceptionFrom(
           data: data,
           serializationManager: serializationManager,
-          statusCode: response.statusCode,
+          statusCode: response.statusCode ?? HttpStatus.badRequest,
         );
       }
 
@@ -100,21 +105,9 @@ abstract class ServerpodClient extends ServerpodClientShared {
     }
   }
 
-  Future<String> _readResponse(HttpClientResponse response) {
-    var completer = Completer<String>();
-    var contents = StringBuffer();
-    response.transform(const Utf8Decoder()).listen((String data) {
-      contents.write(data);
-    }, onDone: () //
-        {
-      return completer.complete(contents.toString());
-    });
-    return completer.future;
-  }
-
   @override
   void close() {
-    _httpClient.close();
+    _dio.close();
     super.close();
   }
 }

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -78,6 +78,8 @@ abstract class ServerpodClient extends ServerpodClientShared {
               headers: {Headers.contentLengthHeader: body.length},
               // Don't parse the JSON response, allow Serverpod to do it
               responseType: ResponseType.plain,
+              // Don't throw an exception for non-200 status codes
+              validateStatus: (_) => true,
             ),
           )
           .timeout(connectionTimeout);

--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -76,6 +76,8 @@ abstract class ServerpodClient extends ServerpodClientShared {
             options: Options(
               contentType: 'application/json; charset=utf-8',
               headers: {Headers.contentLengthHeader: body.length},
+              // Don't parse the JSON response, allow Serverpod to do it
+              responseType: ResponseType.plain,
             ),
           )
           .timeout(connectionTimeout);

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -14,6 +14,7 @@ environment:
 dependencies:
   serverpod_serialization: 1.2.3
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   meta: ^1.8.0
   web_socket_channel: ^2.4.0
 

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   serverpod_serialization: 1.2.3
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   meta: ^1.8.0
   web_socket_channel: ^2.4.0
 

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   serverpod_serialization: 1.2.3
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   meta: ^1.8.0
   web_socket_channel: ^2.4.0
 

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: VERSION
   amazon_cognito_identity_dart_2: ^3.0.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   serverpod: VERSION
   amazon_cognito_identity_dart_2: ^3.0.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   serverpod: VERSION
   amazon_cognito_identity_dart_2: ^3.0.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   serverpod: VERSION
   amazon_cognito_identity_dart_2: ^3.0.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   serverpod: VERSION
   amazon_cognito_identity_dart_2: ^3.0.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   serverpod: VERSION
   amazon_cognito_identity_dart_2: ^3.0.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   built_collection: ^5.1.1
   built_value: ^8.4.4
   path: ^1.8.2

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   firebase_admin: ^0.2.0
   googleapis: ^11.0.0
   googleapis_auth: ^1.4.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   image: ^4.0.15
   jose: ^0.3.3
 

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   googleapis: ^11.0.0
   googleapis_auth: ^1.4.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   jose: ^0.3.3
 

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   firebase_admin: ^0.2.0
   googleapis: ^11.0.0
   googleapis_auth: ^1.4.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   jose: ^0.3.3
 

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   serverpod_auth_server: VERSION
   serverpod_serialization: VERSION
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   path: ^1.8.2
 

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   serverpod: VERSION
   serverpod_auth_server: VERSION
   serverpod_serialization: VERSION
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   image: ^4.0.15
   path: ^1.8.2
 

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   serverpod: VERSION
   serverpod_auth_server: VERSION
   serverpod_serialization: VERSION
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   image: ^4.0.15
   path: ^1.8.2
 

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   collection: ^1.17.1
   crypto: ^3.0.2
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   args: ^2.4.0
   collection: ^1.17.1
   crypto: ^3.0.2
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   args: ^2.4.0
   collection: ^1.17.1
   crypto: ^3.0.2
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   serverpod_serialization: VERSION
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   meta: ^1.8.0
   web_socket_channel: ^2.4.0
 

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 
 dependencies:
   serverpod_serialization: VERSION
+  http: ">=0.13.0 <2.0.0"
   dio: ^5.4.0
   meta: ^1.8.0
   web_socket_channel: ^2.4.0

--- a/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
+++ b/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   serverpod: VERSION
   uuid: ^4.0.0
 

--- a/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
+++ b/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   serverpod: VERSION
   uuid: ^4.0.0
 

--- a/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
+++ b/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   serverpod: VERSION
   uuid: ^4.0.0
 

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -10,7 +10,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   serverpod: VERSION
   serverpod_auth_server: VERSION
   serverpod_cloud_storage_s3: VERSION

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -10,7 +10,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   serverpod: VERSION
   serverpod_auth_server: VERSION
   serverpod_cloud_storage_s3: VERSION

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   serverpod: VERSION
   serverpod_auth_server: VERSION
   serverpod_cloud_storage_s3: VERSION

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   ci: ^0.1.0
   code_builder: ^4.4.0
   dart_style: ^2.3.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   ci: ^0.1.0
   code_builder: ^4.4.0
   dart_style: ^2.3.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1

--- a/tests/bootstrap_project/pubspec.yaml
+++ b/tests/bootstrap_project/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   serverpod: 1.2.3
   uuid: ^4.0.0
 

--- a/tests/bootstrap_project/pubspec.yaml
+++ b/tests/bootstrap_project/pubspec.yaml
@@ -8,7 +8,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   serverpod: 1.2.3
   uuid: ^4.0.0
 

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   serverpod: 1.2.3
   serverpod_auth_server: 1.2.3
   serverpod_cloud_storage_s3: 1.2.3

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -11,7 +11,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   serverpod: 1.2.3
   serverpod_auth_server: 1.2.3
   serverpod_cloud_storage_s3: 1.2.3

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -11,7 +11,7 @@ repository: https://github.com/serverpod/serverpod
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   serverpod: 1.2.3
   serverpod_auth_server: 1.2.3
   serverpod_cloud_storage_s3: 1.2.3

--- a/tests/serverpod_test_server/test_e2e/cloud_storage_test.dart
+++ b/tests/serverpod_test_server/test_e2e/cloud_storage_test.dart
@@ -146,7 +146,8 @@ void main() {
       var byteData = createByteData(1024);
 
       var uploader = FileUploader(uploadDescription!);
-      var result = await uploader.uploadByteData(byteData);
+      var result =
+          await uploader.uploadUint8List(byteData.buffer.asUint8List());
 
       expect(result, equals(true));
 

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   ci: ^0.1.0
   code_builder: ^4.4.0
   dart_style: ^2.3.0
-  http: ">=0.13.0 <2.0.0"
+  dio: ^5.4.0
   intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   ci: ^0.1.0
   code_builder: ^4.4.0
   dart_style: ^2.3.0
-  dio: ^5.4.0
+  http: ">=0.13.0 <2.0.0"
   intl: ^0.18.0
   recase: ^4.1.0
   built_collection: ^5.1.1


### PR DESCRIPTION
Ports usage of `http` to `dio` in `file_uploader.dart` and `serverpod_client_browser.dart`.

Fixes #1927.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

I deprecated `FileUploader.uploadByteData` and `FileUploader.upload` (because these were horrendously inefficient), in favor of a new `FileUploader.uploadUint8List`. The docs will need to be updated to show this API change.