### PR TITLE
fix!: Remove usage of mappedResultQuery and update return type.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -150,7 +150,6 @@ class DatabaseConnection {
         await mappedResultsQuery(session, query, transaction: transaction);
 
     return result
-        .map((t) => t[table.tableName])
         .map((row) => _poolManager.serializationManager.deserialize<T>(row))
         .toList();
   }
@@ -211,7 +210,6 @@ class DatabaseConnection {
         await mappedResultsQuery(session, query, transaction: transaction);
 
     return result
-        .map((t) => t[table.tableName])
         .map((row) => _poolManager.serializationManager.deserialize<T>(row))
         .toList();
   }
@@ -378,35 +376,20 @@ class DatabaseConnection {
   }
 
   /// For most cases use the corresponding method in [Database] instead.
-  Future<List<Map<String, Map<String, dynamic>>>> mappedResultsQuery(
+  Future<Iterable<Map<String, dynamic>>> mappedResultsQuery(
     Session session,
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,
   }) async {
-    var startTime = DateTime.now();
+    var result = await this.query(
+      session,
+      query,
+      timeoutInSeconds: timeoutInSeconds,
+      transaction: transaction,
+    );
 
-    try {
-      var context = transaction?.postgresContext ?? _postgresConnection;
-
-      var result = await context.mappedResultsQuery(
-        query,
-        allowReuse: false,
-        timeoutInSeconds: timeoutInSeconds,
-        substitutionValues: {},
-      );
-
-      _logQuery(
-        session,
-        query,
-        startTime,
-        numRowsAffected: result.length,
-      );
-      return result;
-    } catch (exception, trace) {
-      _logQuery(session, query, startTime, exception: exception, trace: trace);
-      rethrow;
-    }
+    return result.map((row) => row.toColumnMap());
   }
 
   Future<List<T>> _deserializedMappedQuery<T extends TableRow>(
@@ -509,7 +492,7 @@ class DatabaseConnection {
     Session session,
     Table table,
     Include? include,
-    List<Map<String, Map<String, dynamic>>> previousResultSet,
+    Iterable<Map<String, dynamic>> previousResultSet,
   ) async {
     if (include == null) return {};
 
@@ -673,15 +656,11 @@ class _PostgresTransaction extends Transaction {
 /// Extracts all the primary keys from the result set that are referenced by
 /// the given [relationTable].
 Set<T> _extractPrimaryKeyForRelation<T>(
-  List<Map<String, Map<String, dynamic>>> resultSet,
+  Iterable<Map<String, dynamic>> resultSet,
   TableRelation tableRelation,
 ) {
-  var foreignTableName = tableRelation.fieldTableName;
   var idFieldName = tableRelation.fieldQueryAliasWithJoins;
 
-  var ids = resultSet
-      .map((e) => e[foreignTableName]?[idFieldName] as T?)
-      .whereType<T>()
-      .toSet();
+  var ids = resultSet.map((e) => e[idFieldName] as T?).whereType<T>().toSet();
   return ids;
 }

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_result.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_result.dart
@@ -5,17 +5,14 @@ import 'package:serverpod_shared/serverpod_shared.dart';
 /// This is typically only used internally by the serverpod framework.
 Map<String, dynamic>? resolvePrefixedQueryRow(
   Table table,
-  Map<String, Map<String, dynamic>> rawRow,
+  Map<String, dynamic> rawRow,
   Map<String, Map<int, List<dynamic>>> resolvedListRelations, {
   Include? include,
 }) {
   // Resolve this object.
-  var rawTableRow = rawRow[table.tableName];
-  if (rawTableRow == null) return null;
-
   var resolvedTableRow = _createColumnMapFromQueryAliasColumns(
     table.columns,
-    rawTableRow,
+    rawRow,
   );
 
   if (resolvedTableRow.isEmpty) {

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -205,11 +205,11 @@ class Database {
     );
   }
 
-  /// Executes a single SQL query. A [List] of rows represented of a [Map] with
-  /// the table name and value is another [Map] with the keys as column names and
-  /// the value as the contents of the column.
+  /// Executes a single SQL query.
+  /// Returns an [Iterable] with the result rows represented by a [Map] with
+  /// the column name as key and column row content as value.
   /// You are responsible to sanitize the query to avoid SQL injection.
-  Future<List<Map<String, Map<String, dynamic>>>> unsafeQueryMappedResults(
+  Future<Iterable<Map<String, dynamic>>> unsafeQueryMappedResults(
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,


### PR DESCRIPTION
## Change
- Removes usage of `mappedResultsQuery` in preparation for Postgres library V.3.
- BREAKING: Changes return type for `unsafeQueryMappedResults` to align with Postgres V.3 return types where mappedResultsQuery is removed.

This is done in preparation for: https://github.com/serverpod/serverpod/issues/1766

Upgrade instructions documentation PR here: https://github.com/serverpod/serverpod_docs/pull/75

## Example
Given the following query is executed through the `unsafeQueryMappedResults` method the following results can be observed.
```sql
SELECT
 "company"."id" AS "company.id",
 "company"."name" AS "company.name",
 "company"."townId" AS "company.townId",
 "company_town_town"."id" AS "company_town_town.id",
 "company_town_town"."name" AS "company_town_town.name",
 "company_town_town"."mayorId" AS "company_town_town.mayorId"
FROM
 "company"
LEFT JOIN
 "town" AS "company_town_town" ON "company"."townId" = "company_town_town"."id"
ORDER BY
 "company"."name"
```

### Before change:
```json
[
  {
    "company": {
      "company.id": 40,
      "company.name": "Apple",
      "company.townId": 64
    },
    "town": {
      "company_town_town.id": 64,
      "company_town_town.name": "San Francisco",
      "company_town_town.mayorId": null
    }
  },
  {
    "company": {
      "company.id": 39,
      "company.name": "Serverpod",
      "company.townId": 63
    },
    "town": {
      "company_town_town.id": 63,
      "company_town_town.name": "Stockholm",
      "company_town_town.mayorId": null
    }
  }
]
```

### After change:
```json
[
  {
    "company.id": 38,
    "company.name": "Apple",
    "company.townId": 62,
    "company_town_town.id": 62,
    "company_town_town.name": "San Francisco",
    "company_town_town.mayorId": null
  },
  {
    "company.id": 37,
    "company.name": "Serverpod",
    "company.townId": 61,
    "company_town_town.id": 61,
    "company_town_town.name": "Stockholm",
    "company_town_town.mayorId": null
  }
]
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Yes -> Change the return type for unsafeQueryMappedResults.
