### PR TITLE
fix!: Remove table from bulk query column description.

### DIFF
--- a/packages/serverpod/lib/src/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/database/bulk_data.dart
@@ -131,7 +131,6 @@ class DatabaseBulkData {
         headers: result.columnDescriptions
             .map((e) => BulkQueryColumnDescription(
                   name: e.columnName,
-                  table: e.tableName,
                 ))
             .toList(),
         data: SerializationManager.encode(result),

--- a/packages/serverpod/lib/src/generated/database/bulk_query_column_description.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_query_column_description.dart
@@ -11,69 +11,39 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class BulkQueryColumnDescription extends _i1.SerializableEntity {
-  BulkQueryColumnDescription._({
-    required this.name,
-    required this.table,
-  });
+  BulkQueryColumnDescription._({required this.name});
 
-  factory BulkQueryColumnDescription({
-    required String name,
-    required String table,
-  }) = _BulkQueryColumnDescriptionImpl;
+  factory BulkQueryColumnDescription({required String name}) =
+      _BulkQueryColumnDescriptionImpl;
 
   factory BulkQueryColumnDescription.fromJson(
     Map<String, dynamic> jsonSerialization,
     _i1.SerializationManager serializationManager,
   ) {
     return BulkQueryColumnDescription(
-      name: serializationManager.deserialize<String>(jsonSerialization['name']),
-      table:
-          serializationManager.deserialize<String>(jsonSerialization['table']),
-    );
+        name: serializationManager
+            .deserialize<String>(jsonSerialization['name']));
   }
 
   String name;
 
-  String table;
-
-  BulkQueryColumnDescription copyWith({
-    String? name,
-    String? table,
-  });
+  BulkQueryColumnDescription copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
-    return {
-      'name': name,
-      'table': table,
-    };
+    return {'name': name};
   }
 
   @override
   Map<String, dynamic> allToJson() {
-    return {
-      'name': name,
-      'table': table,
-    };
+    return {'name': name};
   }
 }
 
 class _BulkQueryColumnDescriptionImpl extends BulkQueryColumnDescription {
-  _BulkQueryColumnDescriptionImpl({
-    required String name,
-    required String table,
-  }) : super._(
-          name: name,
-          table: table,
-        );
+  _BulkQueryColumnDescriptionImpl({required String name}) : super._(name: name);
 
   @override
-  BulkQueryColumnDescription copyWith({
-    String? name,
-    String? table,
-  }) {
-    return BulkQueryColumnDescription(
-      name: name ?? this.name,
-      table: table ?? this.table,
-    );
+  BulkQueryColumnDescription copyWith({String? name}) {
+    return BulkQueryColumnDescription(name: name ?? this.name);
   }
 }

--- a/packages/serverpod/lib/src/models/database/bulk_query_column_description.spy.yaml
+++ b/packages/serverpod/lib/src/models/database/bulk_query_column_description.spy.yaml
@@ -1,4 +1,3 @@
 class: BulkQueryColumnDescription
 fields:
   name: String
-  table: String

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_column_description.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_column_description.dart
@@ -11,61 +11,34 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
 abstract class BulkQueryColumnDescription extends _i1.SerializableEntity {
-  BulkQueryColumnDescription._({
-    required this.name,
-    required this.table,
-  });
+  BulkQueryColumnDescription._({required this.name});
 
-  factory BulkQueryColumnDescription({
-    required String name,
-    required String table,
-  }) = _BulkQueryColumnDescriptionImpl;
+  factory BulkQueryColumnDescription({required String name}) =
+      _BulkQueryColumnDescriptionImpl;
 
   factory BulkQueryColumnDescription.fromJson(
     Map<String, dynamic> jsonSerialization,
     _i1.SerializationManager serializationManager,
   ) {
     return BulkQueryColumnDescription(
-      name: serializationManager.deserialize<String>(jsonSerialization['name']),
-      table:
-          serializationManager.deserialize<String>(jsonSerialization['table']),
-    );
+        name: serializationManager
+            .deserialize<String>(jsonSerialization['name']));
   }
 
   String name;
 
-  String table;
-
-  BulkQueryColumnDescription copyWith({
-    String? name,
-    String? table,
-  });
+  BulkQueryColumnDescription copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
-    return {
-      'name': name,
-      'table': table,
-    };
+    return {'name': name};
   }
 }
 
 class _BulkQueryColumnDescriptionImpl extends BulkQueryColumnDescription {
-  _BulkQueryColumnDescriptionImpl({
-    required String name,
-    required String table,
-  }) : super._(
-          name: name,
-          table: table,
-        );
+  _BulkQueryColumnDescriptionImpl({required String name}) : super._(name: name);
 
   @override
-  BulkQueryColumnDescription copyWith({
-    String? name,
-    String? table,
-  }) {
-    return BulkQueryColumnDescription(
-      name: name ?? this.name,
-      table: table ?? this.table,
-    );
+  BulkQueryColumnDescription copyWith({String? name}) {
+    return BulkQueryColumnDescription(name: name ?? this.name);
   }
 }


### PR DESCRIPTION
## Change:
- BREAKING: Removes table name from BulkQueryColumnDescription.

In the Postgres 3.0 library the table name is no longer included in the result schema information for each column.
We don't use it in insights so it should be safe for us to removed.

Done in preparation for https://github.com/serverpod/serverpod/issues/1766.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Yes -> Removes a field from an exposed class.
