### PR TITLE
fix: Resolve and validate registered custom classes used as types in model fields.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -7,6 +7,7 @@ import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/class_yaml_de
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart';
 import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 import 'package:source_span/source_span.dart';
 // ignore: implementation_imports
@@ -38,7 +39,7 @@ class SerializableModelAnalyzer {
   /// Best effort attempt to extract an model definition from a yaml file.
   static SerializableModelDefinition? extractModelDefinition(
     ModelSource modelSource,
-    GeneratorConfig config,
+    List<TypeDefinition> extraClasses,
   ) {
     var outFileName = _transformFileNameWithoutPathOrExtension(
       modelSource.yamlSourceUri,
@@ -66,7 +67,7 @@ class SerializableModelAnalyzer {
           outFileName,
           documentContents,
           docsExtractor,
-          config.extraClasses,
+          extraClasses,
         );
       case Keyword.exceptionType:
         return ModelParser.serializeClassFile(
@@ -75,7 +76,7 @@ class SerializableModelAnalyzer {
           outFileName,
           documentContents,
           docsExtractor,
-          config.extraClasses,
+          extraClasses,
         );
       case Keyword.enumType:
         return ModelParser.serializeEnumFile(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -38,6 +38,7 @@ class SerializableModelAnalyzer {
   /// Best effort attempt to extract an model definition from a yaml file.
   static SerializableModelDefinition? extractModelDefinition(
     ModelSource modelSource,
+    GeneratorConfig config,
   ) {
     var outFileName = _transformFileNameWithoutPathOrExtension(
       modelSource.yamlSourceUri,
@@ -65,6 +66,7 @@ class SerializableModelAnalyzer {
           outFileName,
           documentContents,
           docsExtractor,
+          config.extraClasses,
         );
       case Keyword.exceptionType:
         return ModelParser.serializeClassFile(
@@ -73,6 +75,7 @@ class SerializableModelAnalyzer {
           outFileName,
           documentContents,
           docsExtractor,
+          config.extraClasses,
         );
       case Keyword.enumType:
         return ModelParser.serializeEnumFile(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -16,6 +16,7 @@ class ModelParser {
     String outFileName,
     YamlMap documentContents,
     YamlDocumentationExtractor docsExtractor,
+    List<TypeDefinition> extraClasses,
   ) {
     YamlNode? classNode = documentContents.nodes[documentTypeName];
 
@@ -39,6 +40,7 @@ class ModelParser {
       documentContents,
       docsExtractor,
       tableName != null,
+      extraClasses,
     );
     var indexes = _parseIndexes(documentContents, fields);
 
@@ -120,6 +122,7 @@ class ModelParser {
     YamlMap documentContents,
     YamlDocumentationExtractor docsExtractor,
     bool hasTable,
+    List<TypeDefinition> extraClasses,
   ) {
     var fieldsNode = documentContents.nodes[Keyword.fields];
     if (fieldsNode is! YamlMap) return [];
@@ -128,6 +131,7 @@ class ModelParser {
       return _parseModelFieldDefinition(
         fieldNode,
         docsExtractor,
+        extraClasses,
       );
     }).toList();
 
@@ -154,6 +158,7 @@ class ModelParser {
   static List<SerializableModelFieldDefinition> _parseModelFieldDefinition(
     MapEntry<dynamic, YamlNode> fieldNode,
     YamlDocumentationExtractor docsExtractor,
+    List<TypeDefinition> extraClasses,
   ) {
     var key = fieldNode.key;
     if (key is! YamlScalar) return [];
@@ -180,6 +185,7 @@ class ModelParser {
     var fieldDocumentation = docsExtractor.getDocumentation(key.span.start);
     var typeResult = parseType(
       typeValue,
+      extraClasses: extraClasses,
     );
 
     var scope = _parseClassFieldScope(node);

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -84,7 +84,7 @@ class StatefulAnalyzer {
 
     var doc = SerializableModelAnalyzer.extractModelDefinition(
       state.source,
-      config,
+      config.extraClasses,
     );
     state.model = doc;
     if (doc != null) {
@@ -100,7 +100,7 @@ class StatefulAnalyzer {
     for (var state in _modelStates.values) {
       var model = SerializableModelAnalyzer.extractModelDefinition(
         state.source,
-        config,
+        config.extraClasses,
       );
       state.model = model;
     }

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -82,7 +82,10 @@ class StatefulAnalyzer {
 
     state.source.yaml = yaml;
 
-    var doc = SerializableModelAnalyzer.extractModelDefinition(state.source);
+    var doc = SerializableModelAnalyzer.extractModelDefinition(
+      state.source,
+      config,
+    );
     state.model = doc;
     if (doc != null) {
       _upsertModel(doc, uri);
@@ -97,6 +100,7 @@ class StatefulAnalyzer {
     for (var state in _modelStates.values) {
       var model = SerializableModelAnalyzer.extractModelDefinition(
         state.source,
+        config,
       );
       state.model = model;
     }

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -1134,7 +1134,9 @@ class Restrictions {
   }
 
   bool _isValidType(TypeDefinition type) {
-    return whiteListedTypes.contains(type.className) || _isModelType(type);
+    return whiteListedTypes.contains(type.className) ||
+        _isModelType(type) ||
+        _isCustomType(type);
   }
 
   bool _isUnsupportedType(TypeDefinition type) {
@@ -1169,6 +1171,10 @@ class Restrictions {
     }
 
     return true;
+  }
+
+  bool _isCustomType(TypeDefinition type) {
+    return config.extraClasses.any((c) => c.className == type.className);
   }
 
   bool _hasTableDefined(SerializableModelDefinition classDefinition) {

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -254,7 +254,7 @@ class GeneratorConfig {
           extraClasses.add(
             parseType(
               extraClassConfig,
-              analyzingExtraClasses: true,
+              extraClasses: null,
             ),
           );
         }

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -362,6 +362,12 @@ class TypeDefinition {
         ...generics[1].generateDeserialization(serverCode, config: config),
       ];
     } else if (customClass) {
+      // This is the only place the customClass bool is used.
+      // It could be moved as we already know that we are working on custom classes
+      // when we generate the deserialization.
+      // But the additional functionality we get here is that we generate resolves for lists and maps
+      // if the custom class is used as a generic type. The day we create a more generic way to resolve generics
+      // in lists, maps, etc the customClass bool can be removed which will simplify the code.
       return [
         MapEntry(
             nullable
@@ -415,7 +421,7 @@ class TypeDefinition {
 /// [TypeDefinition.customClass].
 TypeDefinition parseType(
   String input, {
-  bool analyzingExtraClasses = false,
+  required List<TypeDefinition>? extraClasses,
 }) {
   var trimmedInput = input.trim();
 
@@ -428,7 +434,9 @@ TypeDefinition parseType(
 
     var genericsInputs = splitIgnoringBrackets(internalTypes);
 
-    generics = genericsInputs.map((generic) => parseType(generic)).toList();
+    generics = genericsInputs
+        .map((generic) => parseType(generic, extraClasses: extraClasses))
+        .toList();
   }
 
   bool isNullable = trimmedInput[trimmedInput.length - 1] == '?';
@@ -436,11 +444,17 @@ TypeDefinition parseType(
 
   String className = trimmedInput.substring(0, terminatedAt).trim();
 
+  var extraClass = extraClasses
+      ?.cast<TypeDefinition?>()
+      .firstWhere((c) => c?.className == className, orElse: () => null);
+
+  if (extraClass != null) return extraClass;
+
   return TypeDefinition.mixedUrlAndClassName(
     mixed: className,
     nullable: isNullable,
     generics: generics,
-    customClass: analyzingExtraClasses,
+    customClass: extraClasses == null,
   );
 }
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
@@ -1,6 +1,7 @@
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
 import 'package:test/test.dart';
@@ -1030,6 +1031,176 @@ void main() {
       isEmpty,
       reason: 'Expected no errors, but one was generated.',
     );
+  });
+
+  group('Given a class with a type set to the class name of a custom type', () {
+    var type = TypeDefinition(
+      className: 'CustomExample',
+      generics: const [],
+      nullable: false,
+      url: 'package:shared_package/src/lib/custom_example.dart',
+      customClass: true,
+    );
+
+    var config = GeneratorConfigBuilder().withExtraClasses([type]).build();
+    var models = [
+      ModelSourceBuilder().withYaml(
+        '''
+          class: Example
+          fields:
+            name: CustomExample
+          ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
+      models,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+
+    test('then no errors was generated', () {
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but one was generated.',
+      );
+    });
+
+    test('then the field type is set.', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(definition.fields.first.type.className, 'CustomExample');
+    });
+
+    test('then the type url is set to the custom type.', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(
+        definition.fields.first.type.url,
+        'package:shared_package/src/lib/custom_example.dart',
+      );
+    });
+  });
+
+  group(
+      'Given a class with a type set to a list of the class name of a custom type',
+      () {
+    var type = TypeDefinition(
+      className: 'CustomExample',
+      generics: const [],
+      nullable: false,
+      url: 'package:shared_package/src/lib/custom_example.dart',
+      customClass: true,
+    );
+
+    var config = GeneratorConfigBuilder().withExtraClasses([type]).build();
+    var models = [
+      ModelSourceBuilder().withYaml(
+        '''
+          class: Example
+          fields:
+            name: List<CustomExample>
+          ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
+      models,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+
+    test('then no errors was generated', () {
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but one was generated.',
+      );
+    });
+
+    test('then the field type is set.', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(
+        definition.fields.first.type.generics.first.className,
+        'CustomExample',
+      );
+    });
+
+    test('then the type url is set to the custom type.', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(
+        definition.fields.first.type.generics.first.url,
+        'package:shared_package/src/lib/custom_example.dart',
+      );
+    });
+  });
+
+  group(
+      'Given a class with a type set to a map of the class name of a custom type',
+      () {
+    var type = TypeDefinition(
+      className: 'CustomExample',
+      generics: const [],
+      nullable: false,
+      url: 'package:shared_package/src/lib/custom_example.dart',
+      customClass: true,
+    );
+
+    var config = GeneratorConfigBuilder().withExtraClasses([type]).build();
+    var models = [
+      ModelSourceBuilder().withYaml(
+        '''
+          class: Example
+          fields:
+            name: Map<CustomExample, CustomExample>
+          ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
+      models,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+
+    test('then no errors was generated', () {
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but one was generated.',
+      );
+    });
+
+    test('then the field type is set.', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(
+        definition.fields.first.type.generics.first.className,
+        'CustomExample',
+      );
+
+      expect(
+        definition.fields.first.type.generics.last.className,
+        'CustomExample',
+      );
+    });
+
+    test('then the type url is set to the custom type.', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(
+        definition.fields.first.type.generics.first.url,
+        'package:shared_package/src/lib/custom_example.dart',
+      );
+
+      expect(
+        definition.fields.first.type.generics.last.url,
+        'package:shared_package/src/lib/custom_example.dart',
+      );
+    });
   });
 
   group('Given a class with a field type to a module that is not imported', () {

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
@@ -1083,9 +1083,7 @@ void main() {
     });
   });
 
-  group(
-      'Given a class with a type set to a list of the class name of a custom type',
-      () {
+  group('Given a class with a type set to a list of custom classes', () {
     var type = TypeDefinition(
       className: 'CustomExample',
       generics: const [],
@@ -1138,9 +1136,7 @@ void main() {
     });
   });
 
-  group(
-      'Given a class with a type set to a map of the class name of a custom type',
-      () {
+  group('Given a class with a type set to a map of custom classes', () {
     var type = TypeDefinition(
       className: 'CustomExample',
       generics: const [],


### PR DESCRIPTION
# Changes

Fixes regression that gave error on valid custom classes, this applies to all generic types too.


Example:

```yaml
# generator.yaml
...
extraClasses:
  - package:serverpod_test_shared/serverpod_test_shared.dart:ExternalCustomClass
```

```yaml
# models/example.yaml
class: Example
fields:
  customClassField: ExternalCustomClass
  list: List<ExternalCustomClass>
  map: Map<String, ExternalCustomClass>
```

All of the above declarations gave an invalid type error when running `serverpod generate`.

With this PR all of the above will not give any error and will resolve the import paths correctly.


Closes: https://github.com/serverpod/serverpod/issues/1932

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None
