### PR TITLE
fix!: Bump postgres package version.

### DIFF
--- a/packages/serverpod/lib/database.dart
+++ b/packages/serverpod/lib/database.dart
@@ -1,12 +1,13 @@
 library database;
 
 export 'src/database/concepts/columns.dart';
+export 'src/database/concepts/database_result.dart';
 export 'src/database/concepts/expressions.dart';
 export 'src/database/concepts/includes.dart';
 export 'src/database/concepts/many_relation.dart';
 export 'src/database/concepts/order.dart';
+export 'src/database/concepts/query_mode.dart';
 export 'src/database/concepts/table.dart';
 export 'src/database/concepts/transaction.dart';
-export 'src/database/concepts/database_result.dart';
 export 'src/database/exceptions.dart';
 export 'src/generated/database/enum_serialization.dart';

--- a/packages/serverpod/lib/database.dart
+++ b/packages/serverpod/lib/database.dart
@@ -6,7 +6,6 @@ export 'src/database/concepts/expressions.dart';
 export 'src/database/concepts/includes.dart';
 export 'src/database/concepts/many_relation.dart';
 export 'src/database/concepts/order.dart';
-export 'src/database/concepts/query_mode.dart';
 export 'src/database/concepts/table.dart';
 export 'src/database/concepts/transaction.dart';
 export 'src/database/exceptions.dart';

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -152,7 +152,7 @@ class DatabaseConnection {
         'INSERT INTO "${table.tableName}" ($columnNames) VALUES $values RETURNING *';
 
     var result =
-        await mappedResultsQuery(session, query, transaction: transaction);
+        await _mappedResultsQuery(session, query, transaction: transaction);
 
     return result
         .map((row) => _poolManager.serializationManager.deserialize<T>(row))
@@ -213,7 +213,7 @@ class DatabaseConnection {
         'UPDATE "${table.tableName}" AS t SET $setColumns FROM (VALUES $values) AS data($columnNames) WHERE data.id = t.id RETURNING *';
 
     var result =
-        await mappedResultsQuery(session, query, transaction: transaction);
+        await _mappedResultsQuery(session, query, transaction: transaction);
 
     return result
         .map((row) => _poolManager.serializationManager.deserialize<T>(row))
@@ -415,7 +415,7 @@ class DatabaseConnection {
   }
 
   /// For most cases use the corresponding method in [Database] instead.
-  Future<Iterable<Map<String, dynamic>>> mappedResultsQuery(
+  Future<Iterable<Map<String, dynamic>>> _mappedResultsQuery(
     Session session,
     String query, {
     int? timeoutInSeconds,
@@ -441,7 +441,7 @@ class DatabaseConnection {
     Transaction? transaction,
     Include? include,
   }) async {
-    var result = await mappedResultsQuery(
+    var result = await _mappedResultsQuery(
       session,
       query,
       timeoutInSeconds: timeoutInSeconds,
@@ -568,7 +568,7 @@ class DatabaseConnection {
             .withInclude(nestedInclude.include)
             .build();
 
-        var includeListResult = await mappedResultsQuery(session, query);
+        var includeListResult = await _mappedResultsQuery(session, query);
 
         var resolvedLists = await _queryIncludedLists(
           session,

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -352,6 +352,7 @@ class DatabaseConnection {
     int? timeoutInSeconds,
     Transaction? transaction,
     QueryMode? queryMode,
+    bool ignoreRows = false,
   }) async {
     var postgresTransaction = _castToPostgresTransaction(transaction);
     var timeout =
@@ -366,6 +367,7 @@ class DatabaseConnection {
         query,
         timeout: timeout,
         queryMode: _resolveQueryMode(queryMode),
+        ignoreRows: ignoreRows,
       );
 
       _logQuery(
@@ -409,6 +411,7 @@ class DatabaseConnection {
       timeoutInSeconds: timeoutInSeconds,
       transaction: transaction,
       queryMode: queryMode,
+      ignoreRows: true,
     );
 
     return result.affectedRows;

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -403,40 +403,15 @@ class DatabaseConnection {
     Transaction? transaction,
     QueryMode? queryMode,
   }) async {
-    var postgresTransaction = _castToPostgresTransaction(transaction);
+    var result = await _query(
+      session,
+      query,
+      timeoutInSeconds: timeoutInSeconds,
+      transaction: transaction,
+      queryMode: queryMode,
+    );
 
-    var timeout =
-        timeoutInSeconds != null ? Duration(seconds: timeoutInSeconds) : null;
-
-    var startTime = DateTime.now();
-    try {
-      var context =
-          postgresTransaction?.executionContext ?? _postgresConnection;
-
-      var result = await context.execute(
-        query,
-        timeout: timeout,
-        queryMode: _resolveQueryMode(queryMode),
-      );
-      _logQuery(session, query, startTime);
-      return result.affectedRows;
-    } catch (exception, trace) {
-      if (exception is pg.PgException) {
-        var serverpodException = DatabaseException(
-          exception.message,
-        );
-        _logQuery(
-          session,
-          query,
-          startTime,
-          exception: serverpodException,
-          trace: trace,
-        );
-        throw serverpodException;
-      }
-      _logQuery(session, query, startTime, exception: exception, trace: trace);
-      rethrow;
-    }
+    return result.affectedRows;
   }
 
   /// For most cases use the corresponding method in [Database] instead.

--- a/packages/serverpod/lib/src/database/adapters/postgres/postgres_database_result.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/postgres_database_result.dart
@@ -10,21 +10,21 @@ class _PostgresDatabaseResultSchemaColumn
 }
 
 class _PostgresDatabaseResultSchema implements DatabaseResultSchema {
-  final pg.PostgreSQLResult _result;
+  final pg.ResultSchema _schema;
 
-  _PostgresDatabaseResultSchema(this._result);
+  _PostgresDatabaseResultSchema(this._schema);
 
   @override
-  Iterable<DatabaseResultSchemaColumn> get columns => _result.columnDescriptions
-      .map((columnDescription) => _PostgresDatabaseResultSchemaColumn(
-            columnName: columnDescription.columnName,
+  Iterable<DatabaseResultSchemaColumn> get columns =>
+      _schema.columns.map((columnSchema) => _PostgresDatabaseResultSchemaColumn(
+            columnName: columnSchema.columnName,
           ));
 }
 
 class _PostgresDatabaseResultRow extends DatabaseResultRow {
-  final pg.PostgreSQLResultRow _row;
+  final pg.ResultRow _row;
 
-  _PostgresDatabaseResultRow(pg.PostgreSQLResultRow super.row) : _row = row;
+  _PostgresDatabaseResultRow(pg.ResultRow super.row) : _row = row;
 
   @override
   Map<String, dynamic> toColumnMap() {
@@ -34,16 +34,17 @@ class _PostgresDatabaseResultRow extends DatabaseResultRow {
 
 /// A postgres database result.
 class PostgresDatabaseResult extends DatabaseResult {
-  final pg.PostgreSQLResult _result;
+  final pg.Result _result;
 
   /// Creates a new database result from a postgres result.
-  PostgresDatabaseResult(pg.PostgreSQLResult result)
+  PostgresDatabaseResult(pg.Result result)
       : _result = result,
         super(result.map((row) => _PostgresDatabaseResultRow(row)));
 
   @override
-  int get affectedRowCount => _result.affectedRowCount;
+  int get affectedRowCount => _result.affectedRows;
 
   @override
-  DatabaseResultSchema get schema => _PostgresDatabaseResultSchema(_result);
+  DatabaseResultSchema get schema =>
+      _PostgresDatabaseResultSchema(_result.schema);
 }

--- a/packages/serverpod/lib/src/database/adapters/postgres/value_encoder.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/value_encoder.dart
@@ -2,14 +2,16 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 // ignore: implementation_imports
-import 'package:postgres/src/text_codec.dart';
+import 'package:postgres/src/types/text_codec.dart';
 import 'package:serverpod/serverpod.dart';
 
 /// Overrides the [PostgresTextEncoder] to add support for [ByteData].
 class ValueEncoder extends PostgresTextEncoder {
   @override
   String convert(dynamic input, {bool escapeStrings = true}) {
-    if (input is ByteData) {
+    if (input == null) {
+      return 'NULL';
+    } else if (input is ByteData) {
       var encoded = base64Encode(input.buffer.asUint8List());
       return 'decode(\'$encoded\', \'base64\')';
     } else if (input is DateTime) {

--- a/packages/serverpod/lib/src/database/analyze.dart
+++ b/packages/serverpod/lib/src/database/analyze.dart
@@ -180,7 +180,7 @@ WHERE t.relname = '$tableName' AND n.nspname = '$schemaName';
 // The first ARRAY resolves the column name for each of the columns in conkey.
 // The second ARRAY resolves the column name for each of the referenced columns in confkey.
         '''
-SELECT conname, confupdtype, confdeltype, confmatchtype,
+SELECT conname::text, confupdtype::text, confdeltype::text, confmatchtype::text,
 ARRAY(
        SELECT attname::text
        FROM unnest(conkey) as i

--- a/packages/serverpod/lib/src/database/analyze.dart
+++ b/packages/serverpod/lib/src/database/analyze.dart
@@ -18,33 +18,81 @@ class DatabaseAnalyzer {
     return DatabaseDefinition(
       moduleName: Protocol().getModuleName(),
       name: name,
-      tables: await Future.wait((await database.unsafeQuery(
+      tables: await _getTableDefinitions(database),
+      migrationApiVersion: DatabaseConstants.migrationApiVersion,
+      installedModules: installedModules,
+    );
+  }
+
+  static Future<List<TableDefinition>> _getTableDefinitions(
+    Database database,
+  ) async {
+    var tableSchemas = await database.unsafeQuery(
 // Get list of all tables and the schema they are in.
-          '''
+        '''
 SELECT schemaname, tablename
 FROM pg_catalog.pg_tables
 WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';
-''')).map((tableInfo) async {
-        var schemaName = tableInfo.first;
-        var tableName = tableInfo.last;
+''');
 
-        var columns = (await database.unsafeQuery(
+    return await Future.wait(tableSchemas.map((tableSchema) async {
+      var schemaName = tableSchema.first;
+      var tableName = tableSchema.last;
+
+      var columns = _getColumnDefinitions(database, schemaName, tableName);
+
+      var foreignKeys = _getForeignKeyDefinitions(
+        database,
+        schemaName,
+        tableName,
+      );
+
+      var indexes = _getIndexDefinitions(
+        database,
+        schemaName,
+        tableName,
+      );
+
+      return TableDefinition(
+        name: tableName,
+        schema: schemaName,
+        columns: await columns,
+        foreignKeys: await foreignKeys,
+        indexes: await indexes,
+      );
+    }));
+  }
+
+  static Future<List<ColumnDefinition>> _getColumnDefinitions(
+    Database database,
+    String schemaName,
+    String tableName,
+  ) async {
+    var queryResult = await database.unsafeQuery(
 // Get the columns of this table and sort them based on their position.
-                '''
+        '''
 SELECT column_name, column_default, is_nullable, data_type
 FROM information_schema.columns
 WHERE table_schema = '$schemaName' AND table_name = '$tableName'
 ORDER BY ordinal_position;
-'''))
-            .map((e) => ColumnDefinition(
-                name: e[0],
-                columnDefault: e[1],
-                columnType: ExtendedColumnType.fromSqlType(e[3]),
-                // SQL outputs YES or NO. So we have to convert it to a bool manually.
-                isNullable: e[2] == 'YES'))
-            .toList();
+''');
 
-        var indexes = (await database.unsafeQuery(
+    return queryResult
+        .map((e) => ColumnDefinition(
+            name: e[0],
+            columnDefault: e[1],
+            columnType: ExtendedColumnType.fromSqlType(e[3]),
+            // SQL outputs YES or NO. So we have to convert it to a bool manually.
+            isNullable: e[2] == 'YES'))
+        .toList();
+  }
+
+  static Future<List<IndexDefinition>> _getIndexDefinitions(
+    Database database,
+    String schemaName,
+    String tableName,
+  ) async {
+    var queryResult = await database.unsafeQuery(
 // We want to get the name (0), tablespace (1), isUnique (2), isPrimary (3),
 // elements (4), isElementAColumn (5), predicate (6) and type of each index for this table.
 //
@@ -75,7 +123,7 @@ ORDER BY ordinal_position;
 // So we check if the value is greater then zero to get a bool that tells us if it is a column.
 //
 // pg_get_expr gets us the expression for the predicate.
-            '''
+        '''
 SELECT i.relname, ts.spcname, indisunique, indisprimary,
 ARRAY(
        SELECT pg_get_indexdef(indexrelid, k + 1, true)
@@ -90,27 +138,34 @@ JOIN pg_class i ON i.oid = indexrelid
 LEFT JOIN pg_tablespace as ts ON i.reltablespace = ts.oid
 JOIN pg_am am ON am.oid=i.relam
 WHERE t.relname = '$tableName' AND n.nspname = '$schemaName';
-''')).map((index) {
-          return IndexDefinition(
-            indexName: index[0],
-            tableSpace: index[1],
-            elements: List.generate(
-                index[4].length,
-                (i) => IndexElementDefinition(
-                    type: index[5][i]
-                        ? IndexElementDefinitionType.column
-                        : IndexElementDefinitionType.expression,
-                    definition:
-                        (index[4][i] as String).removeSurroundingQuotes)),
-            type: index[7],
-            isUnique: index[2],
-            isPrimary: index[3],
-            //TODO: Maybe unquote in the future. Should be considered when Serverpod introduces partial indexes.
-            predicate: index[6],
-          );
-        }).toList();
+''');
 
-        var foreignKeys = (await database.unsafeQuery(
+    return queryResult.map((index) {
+      return IndexDefinition(
+        indexName: index[0],
+        tableSpace: index[1],
+        elements: List.generate(
+            index[4].length,
+            (i) => IndexElementDefinition(
+                type: index[5][i]
+                    ? IndexElementDefinitionType.column
+                    : IndexElementDefinitionType.expression,
+                definition: (index[4][i] as String).removeSurroundingQuotes)),
+        type: index[7],
+        isUnique: index[2],
+        isPrimary: index[3],
+        //TODO: Maybe unquote in the future. Should be considered when Serverpod introduces partial indexes.
+        predicate: index[6],
+      );
+    }).toList();
+  }
+
+  static Future<List<ForeignKeyDefinition>> _getForeignKeyDefinitions(
+    Database database,
+    String schemaName,
+    String tableName,
+  ) async {
+    var queryResult = await database.unsafeQuery(
 // We want to get the constraint name (0), on update type (1),
 // on delete type (2), match type (3), constraint columns (4)
 // referenced table (5), namespace / schema of the referenced table (6),
@@ -124,7 +179,7 @@ WHERE t.relname = '$tableName' AND n.nspname = '$schemaName';
 //
 // The first ARRAY resolves the column name for each of the columns in conkey.
 // The second ARRAY resolves the column name for each of the referenced columns in confkey.
-                '''
+        '''
 SELECT conname, confupdtype, confdeltype, confmatchtype,
 ARRAY(
        SELECT attname::text
@@ -143,30 +198,20 @@ JOIN pg_class r ON r.oid = confrelid
 JOIN pg_namespace nt ON nt.oid = t.relnamespace
 JOIN pg_namespace nr ON nr.oid = r.relnamespace
 WHERE contype = 'f' AND t.relname = '$tableName' AND nt.nspname = '$schemaName';
-'''))
-            .map((key) => ForeignKeyDefinition(
-                  constraintName: key[0],
-                  columns: key[4],
-                  referenceTable: key[5],
-                  referenceTableSchema: key[6],
-                  referenceColumns: key[7],
-                  onUpdate: (key[1] as String).toForeignKeyAction(),
-                  onDelete: (key[2] as String).toForeignKeyAction(),
-                  matchType: (key[3] as String).toForeignKeyMatchType(),
-                ))
-            .toList();
+''');
 
-        return TableDefinition(
-          name: tableName,
-          schema: schemaName,
-          columns: columns,
-          foreignKeys: foreignKeys,
-          indexes: indexes,
-        );
-      })),
-      migrationApiVersion: DatabaseConstants.migrationApiVersion,
-      installedModules: installedModules,
-    );
+    return queryResult
+        .map((key) => ForeignKeyDefinition(
+              constraintName: key[0],
+              columns: key[4],
+              referenceTable: key[5],
+              referenceTableSchema: key[6],
+              referenceColumns: key[7],
+              onUpdate: (key[1] as String).toForeignKeyAction(),
+              onDelete: (key[2] as String).toForeignKeyAction(),
+              matchType: (key[3] as String).toForeignKeyMatchType(),
+            ))
+        .toList();
   }
 
   /// Retrieves a list of installed database migrations.

--- a/packages/serverpod/lib/src/database/concepts/query_mode.dart
+++ b/packages/serverpod/lib/src/database/concepts/query_mode.dart
@@ -1,0 +1,8 @@
+/// Options for the Query Execution Mode
+enum QueryMode {
+  /// Extended Query Protocol
+  extended,
+
+  /// Simple Query Protocol
+  simple
+}

--- a/packages/serverpod/lib/src/database/concepts/query_mode.dart
+++ b/packages/serverpod/lib/src/database/concepts/query_mode.dart
@@ -1,8 +1,0 @@
-/// Options for the Query Execution Mode
-enum QueryMode {
-  /// Extended Query Protocol
-  extended,
-
-  /// Simple Query Protocol
-  simple
-}

--- a/packages/serverpod/lib/src/database/concepts/transaction.dart
+++ b/packages/serverpod/lib/src/database/concepts/transaction.dart
@@ -4,6 +4,7 @@ typedef TransactionFunction<R> = Future<R> Function(Transaction transaction);
 /// Holds the state of a running database transaction.
 abstract interface class Transaction {
   /// Cancels the transaction.
-  /// Subsequent calls to the database will have no effect.
+  /// Subsequent calls to the database will have no effect and might throw an
+  /// exception depending on driver.
   Future<void> cancel();
 }

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:serverpod/src/database/concepts/columns.dart';
 import 'package:serverpod/src/database/concepts/includes.dart';
 import 'package:serverpod/src/database/concepts/order.dart';
+import 'package:serverpod/src/database/concepts/query_mode.dart';
 import 'package:serverpod/src/database/concepts/transaction.dart';
 import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/database/concepts/database_result.dart';
@@ -212,12 +213,14 @@ class Database {
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,
+    QueryMode? queryMode,
   }) async {
     return _databaseConnection.mappedResultsQuery(
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
       transaction: transaction,
+      queryMode: queryMode,
     );
   }
 
@@ -228,12 +231,14 @@ class Database {
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,
+    QueryMode? queryMode,
   }) async {
     return _databaseConnection.query(
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
       transaction: transaction,
+      queryMode: queryMode,
     );
   }
 
@@ -244,12 +249,14 @@ class Database {
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,
+    QueryMode? queryMode,
   }) async {
     return _databaseConnection.execute(
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
       transaction: transaction,
+      queryMode: queryMode,
     );
   }
 

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:serverpod/src/database/concepts/columns.dart';
 import 'package:serverpod/src/database/concepts/includes.dart';
 import 'package:serverpod/src/database/concepts/order.dart';
-import 'package:serverpod/src/database/concepts/query_mode.dart';
 import 'package:serverpod/src/database/concepts/transaction.dart';
 import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/database/concepts/database_result.dart';
@@ -212,14 +211,12 @@ class Database {
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,
-    QueryMode? queryMode,
   }) async {
     return _databaseConnection.query(
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
       transaction: transaction,
-      queryMode: queryMode,
     );
   }
 
@@ -230,14 +227,49 @@ class Database {
     String query, {
     int? timeoutInSeconds,
     Transaction? transaction,
-    QueryMode? queryMode,
   }) async {
     return _databaseConnection.execute(
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
       transaction: transaction,
-      queryMode: queryMode,
+    );
+  }
+
+  /// Executes a single SQL query in simple query mode.
+  /// A [List] of rows represented of another [List] with columns will be
+  /// returned.
+  /// You are responsible to sanitize the query to avoid SQL injection.
+  ///
+  /// Simple query mode is useful for queries that contain multiple statements.
+  Future<DatabaseResult> unsafeSimpleQuery(
+    String query, {
+    int? timeoutInSeconds,
+    Transaction? transaction,
+  }) async {
+    return _databaseConnection.simpleQuery(
+      _session,
+      query,
+      timeoutInSeconds: timeoutInSeconds,
+      transaction: transaction,
+    );
+  }
+
+  /// Executes a single SQL query in simple query mode.
+  /// Returns the number of rows that were affected by the query.
+  /// You are responsible to sanitize the query to avoid SQL injection.
+  ///
+  /// Simple query mode is useful for queries that contain multiple statements.
+  Future<int> unsafeSimpleExecute(
+    String query, {
+    int? timeoutInSeconds,
+    Transaction? transaction,
+  }) async {
+    return _databaseConnection.simpleExecute(
+      _session,
+      query,
+      timeoutInSeconds: timeoutInSeconds,
+      transaction: transaction,
     );
   }
 

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -205,25 +205,6 @@ class Database {
     );
   }
 
-  /// Executes a single SQL query.
-  /// Returns an [Iterable] with the result rows represented by a [Map] with
-  /// the column name as key and column row content as value.
-  /// You are responsible to sanitize the query to avoid SQL injection.
-  Future<Iterable<Map<String, dynamic>>> unsafeQueryMappedResults(
-    String query, {
-    int? timeoutInSeconds,
-    Transaction? transaction,
-    QueryMode? queryMode,
-  }) async {
-    return _databaseConnection.mappedResultsQuery(
-      _session,
-      query,
-      timeoutInSeconds: timeoutInSeconds,
-      transaction: transaction,
-      queryMode: queryMode,
-    );
-  }
-
   /// Executes a single SQL query. A [List] of rows represented of another
   /// [List] with columns will be returned.
   /// You are responsible to sanitize the query to avoid SQL injection.

--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -1,8 +1,8 @@
 import 'package:meta/meta.dart';
-import 'package:serverpod/src/serialization/serialization_manager.dart';
-import 'package:postgres_pool/postgres_pool.dart';
+import 'package:postgres/postgres.dart' as pg;
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:serverpod/src/serialization/serialization_manager.dart';
 
 import 'adapters/postgres/value_encoder.dart';
 
@@ -17,10 +17,10 @@ class DatabasePoolManager {
   /// Access to the serialization manager.
   SerializationManager get serializationManager => _serializationManager;
 
-  late PgPool _pgPool;
+  late pg.Pool _pgPool;
 
   /// Postgresql connection pool created from configuration.
-  PgPool get pool => _pgPool;
+  pg.Pool get pool => _pgPool;
 
   /// The encoder used to encode objects for storing in the database.
   static final ValueEncoder encoder = ValueEncoder();
@@ -33,21 +33,24 @@ class DatabasePoolManager {
   ) {
     _serializationManager = serializationManager;
 
-    var poolSettings = PgPoolSettings();
-    poolSettings.concurrency = 10;
-    poolSettings.queryTimeout = const Duration(minutes: 1);
+    var poolSettings = pg.PoolSettings(
+      maxConnectionCount: 10,
+      queryTimeout: const Duration(minutes: 1),
+      sslMode: config.requireSsl ? pg.SslMode.require : pg.SslMode.disable,
+    );
 
     // Setup database connection pool
-    _pgPool = PgPool(
-      PgEndpoint(
-        host: config.host,
-        port: config.port,
-        database: config.name,
-        username: config.user,
-        password: config.password,
-        requireSsl: config.requireSsl,
-        isUnixSocket: config.isUnixSocket,
-      ),
+    _pgPool = pg.Pool.withEndpoints(
+      [
+        pg.Endpoint(
+          host: config.host,
+          port: config.port,
+          database: config.name,
+          username: config.user,
+          password: config.password,
+          isUnixSocket: config.isUnixSocket,
+        )
+      ],
       settings: poolSettings,
     );
   }

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -147,7 +147,10 @@ class MigrationManager {
       return null;
     }
 
-    await session.db.unsafeExecute(repairMigration.sqlMigration);
+    await session.db.unsafeExecute(
+      repairMigration.sqlMigration,
+      queryMode: QueryMode.simple,
+    );
     return repairMigration.versionName;
   }
 
@@ -186,7 +189,7 @@ class MigrationManager {
     var migrationsApplied = <String>[];
     for (var code in sqlToExecute) {
       try {
-        await session.db.unsafeExecute(code.sql);
+        await session.db.unsafeExecute(code.sql, queryMode: QueryMode.simple);
         migrationsApplied.add(code.version);
       } catch (e) {
         stderr.writeln('Failed to apply migration ${code.version}.');

--- a/packages/serverpod/lib/src/database/migrations/migration_manager.dart
+++ b/packages/serverpod/lib/src/database/migrations/migration_manager.dart
@@ -147,9 +147,8 @@ class MigrationManager {
       return null;
     }
 
-    await session.db.unsafeExecute(
+    await session.db.unsafeSimpleExecute(
       repairMigration.sqlMigration,
-      queryMode: QueryMode.simple,
     );
     return repairMigration.versionName;
   }
@@ -189,7 +188,7 @@ class MigrationManager {
     var migrationsApplied = <String>[];
     for (var code in sqlToExecute) {
       try {
-        await session.db.unsafeExecute(code.sql, queryMode: QueryMode.simple);
+        await session.db.unsafeSimpleExecute(code.sql);
         migrationsApplied.add(code.version);
       } catch (e) {
         stderr.writeln('Failed to apply migration ${code.version}.');

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -27,11 +27,10 @@ dependencies:
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2
-  postgres: ^2.6.1
+  postgres: ^3.0.0
   redis: ^4.0.0
   retry: ^3.1.1
   synchronized: ^3.1.0
-  postgres_pool: ^2.1.6
   system_resources: ^1.6.0
   vm_service: ">=13.0.0 <15.0.0"
   yaml: ^3.1.1

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -26,11 +26,10 @@ dependencies:
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2
-  postgres: ^2.6.1
+  postgres: ^3.0.0
   redis: ^4.0.0
   retry: ^3.1.1
   synchronized: ^3.1.0
-  postgres_pool: ^2.1.6
   system_resources: ^1.6.0
   vm_service: ">=13.0.0 <15.0.0"
   yaml: ^3.1.1

--- a/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
@@ -91,7 +91,15 @@ void main() async {
       (transaction) async {
         await UniqueData.db.insertRow(session, data, transaction: transaction);
         await transaction.cancel();
-        await UniqueData.db.insertRow(session, data2, transaction: transaction);
+        try {
+          await UniqueData.db.insertRow(
+            session,
+            data2,
+            transaction: transaction,
+          );
+        } catch (_) {
+          // Ignore
+        }
       },
     );
 

--- a/tests/serverpod_test_server/test_integration/database_operations/unsafe_query/database_result_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/unsafe_query/database_result_test.dart
@@ -45,7 +45,7 @@ void main() async {
     late Town town;
     late Company company;
     late DatabaseResult result;
-    setUp(() async {
+    setUpAll(() async {
       town = await Town.db.insertRow(
         session,
         Town(name: 'Stockholm'),
@@ -71,7 +71,7 @@ ORDER BY
       ''');
     });
 
-    tearDown(() async {
+    tearDownAll(() async {
       await Company.db.deleteWhere(session, where: (_) => Constant.bool(true));
       await Town.db.deleteWhere(session, where: (_) => Constant.bool(true));
     });


### PR DESCRIPTION
### Changes:
- Bumps Postgres package to ^3.0.
- Introduce Postgres query mode selection for unsafe queries.
- Refactors the code used to make calls for analyzing the database.

The reason we need to expose the query mode is because the driver now seems to always initiate an extended query behavior for all requests even if no functionality is used. The extended query behavior does not allow multiple queries to be executed as a single query, which is the way we apply our migrations. Therefore we expose it as a configurable for unsafe queries.

Closes: https://github.com/serverpod/serverpod/issues/1766

## Guidance for review:
Best reviewed commit by commit, it is mostly about adapting files to the new behaviors of the interface.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Probably, there are no breaking interface changes for Serverpod but the driver behavior is different compared to the last version which might pose behavior changes for the query interface of our users.
