### PR TITLE
fix!: Introduce and use Serverpod database exception.

### DIFF
--- a/packages/serverpod/lib/database.dart
+++ b/packages/serverpod/lib/database.dart
@@ -7,4 +7,5 @@ export 'src/database/concepts/many_relation.dart';
 export 'src/database/concepts/order.dart';
 export 'src/database/concepts/table.dart';
 export 'src/database/concepts/transaction.dart';
+export 'src/database/exceptions.dart';
 export 'src/generated/database/enum_serialization.dart';

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -353,10 +353,21 @@ class DatabaseConnection {
       );
       return result;
     } catch (exception, trace) {
-      _logQuery(session, query, startTime, exception: exception, trace: trace);
       if (exception is PostgreSQLException) {
-        throw DatabaseException(exception.message ?? '$exception');
+        var serverpodException = DatabaseException(
+          exception.message ?? '$exception',
+        );
+        _logQuery(
+          session,
+          query,
+          startTime,
+          exception: serverpodException,
+          trace: trace,
+        );
+        throw serverpodException;
       }
+
+      _logQuery(session, query, startTime, exception: exception, trace: trace);
       rethrow;
     }
   }
@@ -383,10 +394,20 @@ class DatabaseConnection {
       _logQuery(session, query, startTime);
       return result;
     } catch (exception, trace) {
-      _logQuery(session, query, startTime, exception: exception, trace: trace);
       if (exception is PostgreSQLException) {
-        throw DatabaseException(exception.message ?? '$exception');
+        var serverpodException = DatabaseException(
+          exception.message ?? '$exception',
+        );
+        _logQuery(
+          session,
+          query,
+          startTime,
+          exception: serverpodException,
+          trace: trace,
+        );
+        throw serverpodException;
       }
+      _logQuery(session, query, startTime, exception: exception, trace: trace);
       rethrow;
     }
   }

--- a/packages/serverpod/lib/src/database/exceptions.dart
+++ b/packages/serverpod/lib/src/database/exceptions.dart
@@ -1,0 +1,31 @@
+/// Exception thrown when an error occurs during a database operation.
+class DatabaseException implements Exception {
+  /// A message indicating the error.
+  final String message;
+
+  /// Creates a new [DatabaseException].
+  DatabaseException(this.message);
+
+  @override
+  String toString() {
+    return 'DatabaseException: $message';
+  }
+}
+
+/// Exception thrown when no row is inserted when inserting a row.
+class DatabaseInsertRowException extends DatabaseException {
+  /// Creates a new [DatabaseInsertRowException].
+  DatabaseInsertRowException(super.message);
+}
+
+/// Exception thrown when no rows is updated when updating a row.
+class DatabaseUpdateRowException extends DatabaseException {
+  /// Creates a new [DatabaseUpdateRowException].
+  DatabaseUpdateRowException(super.message);
+}
+
+/// Exception thrown when no rows is deleted when deleting a row.
+class DatabaseDeleteRowException extends DatabaseException {
+  /// Creates a new [DatabaseDeleteRowException].
+  DatabaseDeleteRowException(super.message);
+}

--- a/packages/serverpod/lib/src/endpoints/insights.dart
+++ b/packages/serverpod/lib/src/endpoints/insights.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:postgres/postgres.dart';
 import 'package:serverpod/src/database/analyze.dart';
 import 'package:serverpod/src/database/bulk_data.dart';
 import 'package:serverpod/src/database/migrations/migrations.dart';
@@ -284,7 +283,7 @@ class InsightsEndpoint extends Endpoint {
       );
       return result;
     } catch (e) {
-      if (e is PostgreSQLException) {
+      if (e is DatabaseException) {
         throw BulkDataException(
           message: 'Failed to execute query: ${e.message}',
         );


### PR DESCRIPTION
## Change:
- BREAKING: Throw library database exception instead of the Postgres libraries version of the exception.
- Catch the library version of the exception in the insights endpoint.

Preparation for: https://github.com/serverpod/serverpod/issues/1766

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Yes -> Stops Serverpod code from throwing Postgres library exception type.
