### PR TITLE
fix: Custom classes respect nullable configuration.

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -448,7 +448,9 @@ TypeDefinition parseType(
       ?.cast<TypeDefinition?>()
       .firstWhere((c) => c?.className == className, orElse: () => null);
 
-  if (extraClass != null) return extraClass;
+  if (extraClass != null) {
+    return isNullable ? extraClass.asNullable : extraClass;
+  }
 
   return TypeDefinition.mixedUrlAndClassName(
     mixed: className,

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
@@ -1081,6 +1081,55 @@ void main() {
         'package:shared_package/src/lib/custom_example.dart',
       );
     });
+
+    test('then the type is not nullable', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(definition.fields.first.type.nullable, isFalse);
+    });
+  });
+
+  group(
+      'Given a class with a nullable type set to the class name of a custom type',
+      () {
+    var type = TypeDefinition(
+      className: 'CustomExample',
+      generics: const [],
+      nullable: false,
+      url: 'package:shared_package/src/lib/custom_example.dart',
+      customClass: true,
+    );
+
+    var config = GeneratorConfigBuilder().withExtraClasses([type]).build();
+    var models = [
+      ModelSourceBuilder().withYaml(
+        '''
+          class: Example
+          fields:
+            name: CustomExample?
+          ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer analyzer = StatefulAnalyzer(
+      config,
+      models,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+
+    test('then no errors was generated', () {
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors, but one was generated.',
+      );
+    });
+
+    test('then the field type is nullable.', () {
+      var definition = definitions.first as ClassDefinition;
+      expect(definition.fields.first.type.nullable, isTrue);
+    });
   });
 
   group('Given a class with a type set to a list of custom classes', () {


### PR DESCRIPTION
# Changes

Add proper nullability check on custom classes.

Closes: https://github.com/serverpod/serverpod/issues/1947

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None
