### PR TITLE
fix: Change default value for allowUnsecureRandom.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -130,7 +130,7 @@ class AuthConfig {
 
   /// True if unsecure random number generation is allowed. If set to false, an
   /// error will be thrown if the platform does not support secure random number
-  /// generation. Default is true but will be changed to false in Serverpod 2.0.
+  /// generation.
   final bool allowUnsecureRandom;
 
   /// Creates a new Auth configuration. Use the [set] method to replace the
@@ -161,6 +161,6 @@ class AuthConfig {
         'config/firebase_service_account_key.json',
     this.maxPasswordLength = 128,
     this.minPasswordLength = 8,
-    this.allowUnsecureRandom = true,
+    this.allowUnsecureRandom = false,
   });
 }


### PR DESCRIPTION
### Change:
- Disables unsecure random by default.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Default value for method changes which might cause the random call to throw.
