### PR TITLE
Upgrade file_picker dep to 8.0.0

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   shared_preferences: ^2.1.0
   cached_network_image: ^3.2.3
   image: ^4.0.15
-  file_picker: ^6.0.0
+  file_picker: ^8.0.0
 
   # See https://pub.dev/packages/image_cropper for installation instructions.
   image_cropper: ^5.0.0

--- a/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker: ^6.0.0
+  file_picker: ^8.0.0
   intl: ^0.18.0
   url_launcher: ^6.1.10
   path: ^1.8.2

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_shared_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   shared_preferences: ^2.1.0
   cached_network_image: ^3.2.3
   image: ^4.0.15
-  file_picker: ^6.0.0
+  file_picker: ^8.0.0
 
   # See https://pub.dev/packages/image_cropper for installation instructions.
   image_cropper: ^5.0.0

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker: ^6.0.0
+  file_picker: ^8.0.0
   intl: ^0.18.0
   url_launcher: ^6.1.10
   path: ^1.8.2


### PR DESCRIPTION
Version 8.0.0 of `file_picker` fixes an important compatibility bug for Android 14+.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, this should be backwards-compatible. This is just a bugfix release.

https://github.com/miguelpruivo/flutter_file_picker/releases