### PR TITLE
fix: Misc developer experience fixes.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/upgrade.dart
+++ b/tools/serverpod_cli/lib/src/commands/upgrade.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:serverpod_cli/src/logger/logger.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+import 'package:serverpod_cli/src/util/exit_exception.dart';
 
 import '../generated/version.dart';
 
@@ -24,10 +25,11 @@ class UpgradeCommand extends ServerpodCommand {
       return await startProcess.exitCode == 0;
     });
 
-    if (success) {
-      log.info('Serverpod is up to date: $templateVersion version.');
-    } else {
+    if (!success) {
       log.info('Failed to update Serverpod.');
+      throw ExitException();
     }
+
+    log.info('Serverpod is up to date: $templateVersion version.');
   }
 }

--- a/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
+++ b/tools/serverpod_cli/lib/src/logger/loggers/std_out_logger.dart
@@ -124,7 +124,16 @@ class StdOutLogger extends Logger {
 
     _stopAnimationInProgress();
 
-    if (newParagraph) _write('', LogLevel.info, newParagraph: newParagraph);
+    // Write an empty line before the progress message if a new paragraph is
+    // requested.
+    if (newParagraph) {
+      _write(
+        '',
+        LogLevel.info,
+        newParagraph: false,
+        newLine: true,
+      );
+    }
 
     var progress = Progress(message, stdout);
     trackedAnimationInProgress = progress;

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
@@ -5,7 +5,7 @@ import 'package:serverpod_cli/src/logger/logger.dart';
 abstract class ServerpodCommand extends Command {
   @override
   void printUsage() {
-    log.info(usage, type: const RawLogType());
+    log.info(usage);
   }
 
   @override

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -153,7 +153,7 @@ class ServerpodCommandRunner extends CommandRunner {
 
   @override
   void printUsage() {
-    log.info(usage, type: const RawLogType());
+    log.info(usage);
   }
 
   @override


### PR DESCRIPTION
### Changes
- Non zero exit code when upgrade command fails.
- Command help message has new line at the end.
- Fixed an issue where `log.progress` would print two empty lines to create a new paragraph.

**Command help message after fix**
<img width="1392" alt="Screenshot 2024-03-21 at 10 56 23" src="https://github.com/serverpod/serverpod/assets/137198655/3830ba50-da38-4229-b4b9-ef913a6b4092">


**Log progress after fix:**
<img width="487" alt="Screenshot 2024-03-21 at 10 55 30" src="https://github.com/serverpod/serverpod/assets/137198655/a9d4f2ca-40f2-42fc-88fe-b77b929d0776">

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
