### PR TITLE
fix: Add maxMigratedEntries option to the migration helper method. (Targeting 1.2)

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -75,14 +75,14 @@ class Emails {
   ///
   ///[batchSize] is the number of entries to migrate in each batch.
   ///
-  /// [limit] is the maximum number of entries to migrate. If null,
-  /// all entries will be migrated.
+  /// [maxMigratedEntries] is the maximum number of entries that will be
+  /// migrated. If null, all entries in the database will be migrated.
   ///
   /// Returns the number of migrated entries.
   static Future<int> migrateLegacyPasswordHashes(
     Session session, {
     int batchSize = 100,
-    int? limit,
+    int? maxMigratedEntries,
   }) async {
     var updatedEntries = 0;
     int lastEntryId = 0;
@@ -99,12 +99,13 @@ class Emails {
         return updatedEntries;
       }
 
-      if (limit != null) {
-        if (limit == updatedEntries) {
+      if (maxMigratedEntries != null) {
+        if (maxMigratedEntries == updatedEntries) {
           return updatedEntries;
         }
 
-        var entrySurplus = (updatedEntries + entries.length) - limit;
+        var entrySurplus =
+            (updatedEntries + entries.length) - maxMigratedEntries;
         if (entrySurplus > 0) {
           entries = entries.sublist(0, entries.length - entrySurplus);
         }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -33,7 +33,8 @@ class Emails {
     String password,
     String email,
     String hash, {
-    void Function(String hash, String passwordHash)? onValidationFailure,
+    void Function({required String passwordHash, required String storedHash})?
+        onValidationFailure,
     void Function(Object e)? onError,
   }) async {
     try {
@@ -434,8 +435,12 @@ class Emails {
       password,
       email,
       entry.hash,
-      onValidationFailure: (hash, passwordHash) => session.log(
-        ' - $passwordHash saved: $hash',
+      onValidationFailure: ({
+        required String passwordHash,
+        required String storedHash,
+      }) =>
+          session.log(
+        ' - $passwordHash saved: $storedHash',
         level: LogLevel.debug,
       ),
       onError: (e) {

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -75,10 +75,14 @@ class Emails {
   ///
   ///[batchSize] is the number of entries to migrate in each batch.
   ///
+  /// [limit] is the maximum number of entries to migrate. If null,
+  /// all entries will be migrated.
+  ///
   /// Returns the number of migrated entries.
   static Future<int> migrateLegacyPasswordHashes(
     Session session, {
     int batchSize = 100,
+    int? limit,
   }) async {
     var updatedEntries = 0;
     int lastEntryId = 0;
@@ -93,6 +97,17 @@ class Emails {
 
       if (entries.isEmpty) {
         return updatedEntries;
+      }
+
+      if (limit != null) {
+        if (limit == updatedEntries) {
+          return updatedEntries;
+        }
+
+        var entrySurplus = (updatedEntries + entries.length) - limit;
+        if (entrySurplus > 0) {
+          entries = entries.sublist(0, entries.length - entrySurplus);
+        }
       }
 
       lastEntryId = entries.last.id!;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/password_hash.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/password_hash.dart
@@ -112,13 +112,19 @@ class PasswordHash {
   /// will be called with the hash and the password hash as arguments.
   Future<bool> validate(
     String password, {
-    void Function(String hash, String passwordHash)? onValidationFailure,
+    void Function({
+      required String storedHash,
+      required String passwordHash,
+    })? onValidationFailure,
   }) async {
     var passwordHash =
         await Isolate.run(() => _hashGenerator.generateHash(password));
 
     if (_hash != passwordHash) {
-      onValidationFailure?.call(passwordHash, _hash);
+      onValidationFailure?.call(
+        storedHash: _hash,
+        passwordHash: passwordHash,
+      );
       return false;
     }
 

--- a/modules/serverpod_auth/serverpod_auth_server/test/password_hash/legacy_password_hash_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/password_hash/legacy_password_hash_test.dart
@@ -3,66 +3,66 @@ import 'package:test/test.dart';
 
 void main() {
   group('Given password', () {
-    test('when generating hash then hash matches regression value', () {
+    test('when generating hash then hash matches regression value', () async {
       // This regression hash value was derived from the old serverpod hash
       // generation algorithm.
       var expectedHash =
           '0713234b3cb6a6f98f6978f17a55a54578c580698dc1d56371502be6abb457eb';
 
       var actualHash =
-          PasswordHash.legacyHash('hunter2', 'serverpod password salt');
+          await PasswordHash.legacyHash('hunter2', 'serverpod password salt');
 
       expect(actualHash, expectedHash);
     });
 
     test('when validating with correct password then validator returns true',
-        () {
+        () async {
       var salt = 'serverpod password salt';
       var password = 'hunter2';
 
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(password, salt),
+        await PasswordHash.legacyHash(password, salt),
         legacySalt: salt,
       );
 
-      expect(passwordHash.validate(password), isTrue);
+      expect(await passwordHash.validate(password), isTrue);
     });
 
     test('when validating with incorrect password then validator returns false',
-        () {
+        () async {
       var salt = 'serverpod password salt';
 
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash('hunter2', salt),
+        await PasswordHash.legacyHash('hunter2', salt),
         legacySalt: salt,
       );
 
-      expect(passwordHash.validate('chaser1'), isFalse);
+      expect(await passwordHash.validate('chaser1'), isFalse);
     });
 
     test('when validating with different salts then validator returns false',
-        () {
+        () async {
       var password = 'hunter2';
 
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(password, 'first salt'),
+        await PasswordHash.legacyHash(password, 'first salt'),
         legacySalt: 'second salt',
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
   });
 
   group('Given password and extra salt email', () {
     test(
         'when generating hash with email provided then result matches regression value',
-        () {
+        () async {
       // This regression hash value was derived from the old serverpod hash
       // generation algorithm.
       var expectedHash =
           '4005303e6e1effd8bc7293bc3e69fe3a480a88249453aef7f58fdcf264419147';
 
-      var actualHash = PasswordHash.legacyHash(
+      var actualHash = await PasswordHash.legacyHash(
         'hunter2',
         'serverpod password salt',
         email: 'test@serverpod.dev',
@@ -74,10 +74,10 @@ void main() {
 
   group('Given password hash', () {
     test('when checking if hash should be updated then no update is needed.',
-        () {
+        () async {
       var salt = 'saltySalt';
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(
+        await PasswordHash.legacyHash(
           'hunter2',
           salt,
         ),
@@ -87,10 +87,11 @@ void main() {
       expect(passwordHash.shouldUpdateHash(), isTrue);
     });
 
-    test('when checking if hash is legacy hash then method returns true.', () {
+    test('when checking if hash is legacy hash then method returns true.',
+        () async {
       var salt = 'saltySalt';
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(
+        await PasswordHash.legacyHash(
           'hunter2',
           salt,
         ),
@@ -100,13 +101,14 @@ void main() {
       expect(passwordHash.isLegacyHash(), isTrue);
     });
 
-    test('when matching with correct password then it evaluates to true', () {
+    test('when matching with correct password then it evaluates to true',
+        () async {
       var salt = 'serverpod password salt';
       var password = 'hunter2';
       var email = 'test@serverpod.dev';
 
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(
+        await PasswordHash.legacyHash(
           password,
           salt,
           email: email,
@@ -115,16 +117,16 @@ void main() {
         legacyEmail: email,
       );
 
-      expect(passwordHash.validate(password), isTrue);
+      expect(await passwordHash.validate(password), isTrue);
     });
 
     test('when matching with incorrect password then it evaluates to false',
-        () {
+        () async {
       var salt = 'serverpod password salt';
       var email = 'test@serverpod.dev';
 
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(
+        await PasswordHash.legacyHash(
           'hunter2',
           salt,
           email: email,
@@ -133,15 +135,16 @@ void main() {
         legacyEmail: email,
       );
 
-      expect(passwordHash.validate('chaser1'), isFalse);
+      expect(await passwordHash.validate('chaser1'), isFalse);
     });
 
-    test('when matching with incorrect salt then it evaluates to false', () {
+    test('when matching with incorrect salt then it evaluates to false',
+        () async {
       var password = 'hunter2';
       var email = 'test@serverpod.dev';
 
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(
+        await PasswordHash.legacyHash(
           password,
           'first salt',
           email: email,
@@ -150,15 +153,16 @@ void main() {
         legacyEmail: email,
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
 
-    test('when matching with incorrect email then it evaluates to false', () {
+    test('when matching with incorrect email then it evaluates to false',
+        () async {
       var salt = 'serverpod password salt';
       var password = 'hunter2';
 
       var passwordHash = PasswordHash(
-        PasswordHash.legacyHash(
+        await PasswordHash.legacyHash(
           password,
           salt,
           email: 'first@serverpod.dev',
@@ -167,7 +171,7 @@ void main() {
         legacyEmail: 'second@serverpod.dev',
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
   });
 }

--- a/modules/serverpod_auth/serverpod_auth_server/test/password_hash/legacy_to_argon2id_hash_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/password_hash/legacy_to_argon2id_hash_test.dart
@@ -6,17 +6,17 @@ import 'package:test/test.dart';
 void main() {
   test(
       'Given a hash from the legacy hash used as password for argon2id hash when generating hash using same salt and base password then same hash is produced',
-      () {
+      () async {
     var password = 'hunter2';
     var legacySalt = 'legacySalt';
     var salt = 'saltySalt';
 
-    var legacyHash = PasswordHash.legacyHash(password, legacySalt);
+    var legacyHash = await PasswordHash.legacyHash(password, legacySalt);
     var argon2idPasswordHashFromLegacy =
-        PasswordHash.argon2id(legacyHash, salt: salt);
+        await PasswordHash.argon2id(legacyHash, salt: salt);
     var expectedHash = argon2idPasswordHashFromLegacy.split('\$')[3];
 
-    var passwordHash = PasswordHash.migratedLegacyToArgon2idHash(
+    var passwordHash = await PasswordHash.migratedLegacyToArgon2idHash(
       legacyHash,
       legacySalt: legacySalt,
       salt: salt,
@@ -29,8 +29,8 @@ void main() {
 
   group('Given legacyHash, legacy salt and fixed salt', () {
     group('when generating password hash', () {
-      test('then hash has 4 sections split by \$.', () {
-        var passwordHash = PasswordHash.migratedLegacyToArgon2idHash(
+      test('then hash has 4 sections split by \$.', () async {
+        var passwordHash = await PasswordHash.migratedLegacyToArgon2idHash(
           'legacyHash',
           legacySalt: 'legacySalt',
           salt: 'saltySalt',
@@ -40,8 +40,8 @@ void main() {
         expect(parts, hasLength(4));
       });
 
-      test('then second section contains algorithm name.', () {
-        var passwordHash = PasswordHash.migratedLegacyToArgon2idHash(
+      test('then second section contains algorithm name.', () async {
+        var passwordHash = await PasswordHash.migratedLegacyToArgon2idHash(
           'legacyHash',
           legacySalt: 'legacySalt',
           salt: 'saltySalt',
@@ -51,10 +51,10 @@ void main() {
         expect(parts[1], 'migratedLegacy');
       });
 
-      test('then third section contains encoded salt.', () {
+      test('then third section contains encoded salt.', () async {
         var salt = 'saltySalt';
 
-        var passwordHash = PasswordHash.migratedLegacyToArgon2idHash(
+        var passwordHash = await PasswordHash.migratedLegacyToArgon2idHash(
           'legacyHash',
           legacySalt: 'legacySalt',
           salt: salt,
@@ -64,11 +64,11 @@ void main() {
         expect(parts[2], const Base64Encoder().convert(salt.codeUnits));
       });
 
-      test('then fourth section contains hash.', () {
+      test('then fourth section contains hash.', () async {
         var expectedHash =
             'aF5cAla/wBZ6Ka/kpGfmBC9kOftCRBr5srDZFhtAiF9SUqNUwefbsHBJZDX9cOo2B7MHNZzJDbNRg2VH6+VJtp70gHdveN7EJGrcSsaiReI1x4pX/sQ0l78FhIZ/+vYsuFGDCcr4qg1bkIk6apwmGMzJjKMSKy07bPXNcemm3EPhuCC9OLeBQHtS642TsWVKX9412XxGR2aDbRIDJItBMfWlLH0i3JSWxqcUZLtES7bwcvPdqj68jHT6nzAzFJAiOg4NkaTLye/SlKe/q6LjUci/NYYkJ9ujNnJD410E4AR6yVJqWZaGJMTrr38A0Vigayj4IvPaYaMCwho9Pr8/Jg==';
 
-        var passwordHash = PasswordHash.migratedLegacyToArgon2idHash(
+        var passwordHash = await PasswordHash.migratedLegacyToArgon2idHash(
           'legacyHash',
           legacySalt: 'legacySalt',
           salt: 'saltySalt',
@@ -85,17 +85,21 @@ void main() {
       var salt = 'saltySalt';
       var pepper = 'pepper';
 
-      var withoutPepper = PasswordHash.migratedLegacyToArgon2idHash(
-        password,
-        legacySalt: legacySalt,
-        salt: salt,
-      );
-      var withPepper = PasswordHash.migratedLegacyToArgon2idHash(
-        password,
-        legacySalt: legacySalt,
-        salt: salt,
-        pepper: pepper,
-      );
+      late String withoutPepper;
+      late String withPepper;
+      setUpAll(() async {
+        withoutPepper = await PasswordHash.migratedLegacyToArgon2idHash(
+          password,
+          legacySalt: legacySalt,
+          salt: salt,
+        );
+        withPepper = await PasswordHash.migratedLegacyToArgon2idHash(
+          password,
+          legacySalt: legacySalt,
+          salt: salt,
+          pepper: pepper,
+        );
+      });
 
       test('then salt is same.', () {
         var withoutPepperSalt = withoutPepper.split('\$')[2];
@@ -115,14 +119,19 @@ void main() {
     group('when generating password hash multiple times', () {
       var password = 'hunter2';
       var legacySalt = 'legacySalt';
-      var firstPasswordHash = PasswordHash.migratedLegacyToArgon2idHash(
-        password,
-        legacySalt: legacySalt,
-      );
-      var secondPasswordHash = PasswordHash.migratedLegacyToArgon2idHash(
-        password,
-        legacySalt: legacySalt,
-      );
+      late String firstPasswordHash;
+      late String secondPasswordHash;
+
+      setUpAll(() async {
+        firstPasswordHash = await PasswordHash.migratedLegacyToArgon2idHash(
+          password,
+          legacySalt: legacySalt,
+        );
+        secondPasswordHash = await PasswordHash.migratedLegacyToArgon2idHash(
+          password,
+          legacySalt: legacySalt,
+        );
+      });
       test('then unique salt is generated.', () {
         var firstSalt = firstPasswordHash.split('\$')[2];
         var secondSalt = secondPasswordHash.split('\$')[2];
@@ -139,10 +148,10 @@ void main() {
 
   group('Given password hash', () {
     test('when checking if hash should be updated then no update is needed.',
-        () {
+        () async {
       var salt = 'saltySalt';
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
+        await PasswordHash.migratedLegacyToArgon2idHash(
           'hunter2',
           legacySalt: salt,
         ),
@@ -152,10 +161,11 @@ void main() {
       expect(passwordHash.shouldUpdateHash(), isTrue);
     });
 
-    test('when checking if hash is legacy hash then method returns true.', () {
+    test('when checking if hash is legacy hash then method returns true.',
+        () async {
       var salt = 'saltySalt';
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
+        await PasswordHash.migratedLegacyToArgon2idHash(
           'hunter2',
           legacySalt: salt,
         ),
@@ -165,63 +175,65 @@ void main() {
       expect(passwordHash.isLegacyHash(), isFalse);
     });
     test('when validating with correct password then validator returns true',
-        () {
+        () async {
       var salt = 'saltySalt';
       var legacySalt = 'legacySalt';
       var password = 'hunter2';
 
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
-          PasswordHash.legacyHash(password, legacySalt),
+        await PasswordHash.migratedLegacyToArgon2idHash(
+          await PasswordHash.legacyHash(password, legacySalt),
           legacySalt: legacySalt,
           salt: salt,
         ),
         legacySalt: legacySalt,
       );
 
-      expect(passwordHash.validate(password), isTrue);
+      expect(await passwordHash.validate(password), isTrue);
     });
 
     test(
         'when validating with correct password but different legacy salt then validator returns false',
-        () {
+        () async {
       var password = 'hunter2';
       var legacySalt = 'legacySalt';
 
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
-          PasswordHash.legacyHash(password, legacySalt),
+        await PasswordHash.migratedLegacyToArgon2idHash(
+          await PasswordHash.legacyHash(password, legacySalt),
           legacySalt: legacySalt,
           salt: 'saltySalt',
         ),
         legacySalt: 'differentLegacySalt',
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
 
     test('when validating with incorrect password then validator returns false',
-        () {
+        () async {
       var salt = 'saltySalt';
       var legacySalt = 'legacySalt';
 
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
-          PasswordHash.legacyHash('hunter2', legacySalt),
+        await PasswordHash.migratedLegacyToArgon2idHash(
+          await PasswordHash.legacyHash('hunter2', legacySalt),
           legacySalt: legacySalt,
           salt: salt,
         ),
         legacySalt: legacySalt,
       );
 
-      expect(passwordHash.validate('chaser1'), isFalse);
+      expect(await passwordHash.validate('chaser1'), isFalse);
     });
 
-    test('when validating with modified salt then validator returns false', () {
+    test('when validating with modified salt then validator returns false',
+        () async {
       var password = 'hunter2';
       var legacySalt = 'legacySalt';
-      var originalPasswordHash = PasswordHash.migratedLegacyToArgon2idHash(
-        PasswordHash.legacyHash(password, legacySalt),
+      var originalPasswordHash =
+          await PasswordHash.migratedLegacyToArgon2idHash(
+        await PasswordHash.legacyHash(password, legacySalt),
         legacySalt: legacySalt,
         salt: 'original salt',
       );
@@ -236,18 +248,19 @@ void main() {
         legacySalt: legacySalt,
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
 
-    test('when validating with valid pepper then validator returns true.', () {
+    test('when validating with valid pepper then validator returns true.',
+        () async {
       var password = 'hunter2';
       var legacySalt = 'legacySalt';
       var salt = 'saltySalt';
       var pepper = 'pepper';
 
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
-          PasswordHash.legacyHash(password, legacySalt),
+        await PasswordHash.migratedLegacyToArgon2idHash(
+          await PasswordHash.legacyHash(password, legacySalt),
           legacySalt: legacySalt,
           salt: salt,
           pepper: pepper,
@@ -256,18 +269,18 @@ void main() {
         pepper: pepper,
       );
 
-      expect(passwordHash.validate(password), isTrue);
+      expect(await passwordHash.validate(password), isTrue);
     });
 
     test('when validating with invalid pepper then validator returns false.',
-        () {
+        () async {
       var password = 'hunter2';
       var legacySalt = 'legacySalt';
       var salt = 'saltySalt';
 
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
-          PasswordHash.legacyHash(password, legacySalt),
+        await PasswordHash.migratedLegacyToArgon2idHash(
+          await PasswordHash.legacyHash(password, legacySalt),
           legacySalt: legacySalt,
           salt: salt,
           pepper: 'pepper',
@@ -276,18 +289,18 @@ void main() {
         pepper: 'differentPepper',
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
 
     test('when validating with missing pepper then validator returns false.',
-        () {
+        () async {
       var password = 'hunter2';
       var legacySalt = 'legacySalt';
       var salt = 'saltySalt';
 
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
-          PasswordHash.legacyHash(password, legacySalt),
+        await PasswordHash.migratedLegacyToArgon2idHash(
+          await PasswordHash.legacyHash(password, legacySalt),
           legacySalt: legacySalt,
           salt: salt,
           pepper: 'pepper',
@@ -295,17 +308,18 @@ void main() {
         legacySalt: legacySalt,
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
 
-    test('when validating with added pepper then validator returns false.', () {
+    test('when validating with added pepper then validator returns false.',
+        () async {
       var password = 'hunter2';
       var legacySalt = 'legacySalt';
       var salt = 'saltySalt';
 
       var passwordHash = PasswordHash(
-        PasswordHash.migratedLegacyToArgon2idHash(
-          PasswordHash.legacyHash(password, legacySalt),
+        await PasswordHash.migratedLegacyToArgon2idHash(
+          await PasswordHash.legacyHash(password, legacySalt),
           legacySalt: legacySalt,
           salt: salt,
         ),
@@ -313,19 +327,19 @@ void main() {
         pepper: 'pepper',
       );
 
-      expect(passwordHash.validate(password), isFalse);
+      expect(await passwordHash.validate(password), isFalse);
     });
   });
 
   group('Given salt that contains \$', () {
     test(
         'when generating password hash then hash still only has 4 parts split by \$.',
-        () {
+        () async {
       var legacySalt = 'legacySalt';
       var salt = 'salty\$salt';
 
-      var passwordHash = PasswordHash.migratedLegacyToArgon2idHash(
-        PasswordHash.legacyHash('hunter2', legacySalt),
+      var passwordHash = await PasswordHash.migratedLegacyToArgon2idHash(
+        await PasswordHash.legacyHash('hunter2', legacySalt),
         legacySalt: legacySalt,
         salt: salt,
       );

--- a/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
@@ -217,6 +217,44 @@ void main() async {
     });
 
     test(
+        'when migrating auth entries with a limit then updated rows matches limit legacy hashes stored.',
+        () async {
+      var updatedRows = await Emails.migrateLegacyPasswordHashes(
+        session,
+        batchSize: 2,
+        limit: 0,
+      );
+      expect(updatedRows, 0);
+    });
+
+    test(
+        'when migrating auth entries with a limit then updated rows matches limit legacy hashes stored.',
+        () async {
+      var updatedRows = await Emails.migrateLegacyPasswordHashes(
+        session,
+        batchSize: 2,
+        limit: 3,
+      );
+      expect(updatedRows, 3);
+    });
+
+    test(
+        'when migrating auth entries multiple times with a limit then total updated rows matches total legacy hashes stored.',
+        () async {
+      var migrateHashes = () => Emails.migrateLegacyPasswordHashes(
+            session,
+            batchSize: 2,
+            limit: 3,
+          );
+      var updatedRows1 = await migrateHashes();
+      var updatedRows2 = await migrateHashes();
+      var updatedRows3 = await migrateHashes();
+
+      var totalUpdatedRows = updatedRows1 + updatedRows2 + updatedRows3;
+      expect(totalUpdatedRows, 5);
+    });
+
+    test(
         'when migrating auth entries then all legacy hashes are stored with migrate algorithm.',
         () async {
       await Emails.migrateLegacyPasswordHashes(session, batchSize: 2);

--- a/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
@@ -217,34 +217,34 @@ void main() async {
     });
 
     test(
-        'when migrating auth entries with a limit then updated rows matches limit legacy hashes stored.',
+        'when migrating auth entries with a maxMigratedEntries then updated rows matches maxMigratedEntries legacy hashes stored.',
         () async {
       var updatedRows = await Emails.migrateLegacyPasswordHashes(
         session,
         batchSize: 2,
-        limit: 0,
+        maxMigratedEntries: 0,
       );
       expect(updatedRows, 0);
     });
 
     test(
-        'when migrating auth entries with a limit then updated rows matches limit legacy hashes stored.',
+        'when migrating auth entries with a maxMigratedEntries then updated rows matches maxMigratedEntries legacy hashes stored.',
         () async {
       var updatedRows = await Emails.migrateLegacyPasswordHashes(
         session,
         batchSize: 2,
-        limit: 3,
+        maxMigratedEntries: 3,
       );
       expect(updatedRows, 3);
     });
 
     test(
-        'when migrating auth entries multiple times with a limit then total updated rows matches total legacy hashes stored.',
+        'when migrating auth entries multiple times with maxMigratedEntries defined then total updated rows matches total legacy hashes stored.',
         () async {
       var migrateHashes = () => Emails.migrateLegacyPasswordHashes(
             session,
             batchSize: 2,
-            limit: 3,
+            maxMigratedEntries: 3,
           );
       var updatedRows1 = await migrateHashes();
       var updatedRows2 = await migrateHashes();

--- a/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
@@ -344,4 +344,46 @@ void main() async {
       });
     });
   });
+
+  group('Given password not matching the hash when validating password', () {
+    // This is the hash from the password 'hunter4'
+    var hunter4PasswordHash =
+        '2ee3dc6432300eabf9630ac7827d6dd23fd23cc9120ec4cd58f8f66bd3ce2db9';
+    var notHunter4PasswordHash =
+        '1d24f0d21861e659c50c87ae03b679dc66ac7dd5fb1b03140e53f9331eeb0a31';
+
+    test('then validation fails.', () async {
+      expect(
+        await Emails.validatePasswordHash(
+          'notHunter4',
+          'test7@serverpod.dev',
+          hunter4PasswordHash,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'then validation failure callback is called with generated hash and passed in hash.',
+        () async {
+      late String actualStoredHash;
+      late String actualPasswordHash;
+
+      await Emails.validatePasswordHash(
+        'notHunter4',
+        'test7@serverpod.dev',
+        hunter4PasswordHash,
+        onValidationFailure: ({
+          required String storedHash,
+          required String passwordHash,
+        }) {
+          actualStoredHash = storedHash;
+          actualPasswordHash = passwordHash;
+        },
+      );
+
+      expect(actualStoredHash, hunter4PasswordHash);
+      expect(actualPasswordHash, notHunter4PasswordHash);
+    });
+  });
 }

--- a/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/email_auth_provider_test.dart
@@ -293,7 +293,7 @@ void main() async {
         var passwordHash = emailAuth!.hash;
 
         expect(
-          Emails.validatePasswordHash(
+          await Emails.validatePasswordHash(
             'hunter0',
             'test1@serverpod.dev',
             passwordHash,
@@ -314,7 +314,7 @@ void main() async {
         var passwordHash = emailAuth!.hash;
 
         expect(
-          Emails.validatePasswordHash(
+          await Emails.validatePasswordHash(
             'hunter2',
             'test6@serverpod.dev',
             passwordHash,
@@ -334,7 +334,7 @@ void main() async {
         var passwordHash = emailAuth!.hash;
 
         expect(
-          Emails.validatePasswordHash(
+          await Emails.validatePasswordHash(
             'hunter2',
             'test7@serverpod.dev',
             passwordHash,


### PR DESCRIPTION
### Change:
- Adds a limit option to the password migration helper.

This can be used to batch the number of migrations that are done.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this is a new method.