### PR TITLE
fix: Remove faulty certificate check.

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_io.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_io.dart
@@ -35,21 +35,6 @@ abstract class ServerpodClient extends ServerpodClientShared {
     // Setup client
     _httpClient = HttpClient(context: securityContext);
     _httpClient.connectionTimeout = connectionTimeout;
-
-    // TODO: Generate working certificates
-    _httpClient.badCertificateCallback =
-        ((X509Certificate cert, String host, int port) {
-//      print('Failed to verify server certificate');
-//      print('pem: ${cert.pem}');
-//      print('subject: ${cert.subject}');
-//      print('issuer: ${cert.issuer}');
-//      print('valid from: ${cert.startValidity}');
-//      print('valid to: ${cert.endValidity}');
-//      print('host: $host');
-//      print('port: $port');
-//      return false;
-      return true;
-    });
   }
 
   Future<void> _initialize() async {

--- a/tests/serverpod_test_server/test_e2e/tsl_client_test.dart
+++ b/tests/serverpod_test_server/test_e2e/tsl_client_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given valid certificates when a call to the health endpoint of a service with a valid certificate then the requests completes successfully.',
+      () async {
+    var client = Client('https://api.serverpod.app/');
+
+    expectLater(
+      client.callServerEndpoint<void>('', '', {}),
+      completes,
+    );
+  });
+
+  test(
+      'Given no valid certificates when a call to the health endpoint of a service then the requests is rejected with a handshake exception.',
+      () async {
+    var client = Client(
+      'https://api.serverpod.app/',
+      securityContext: SecurityContext(withTrustedRoots: false),
+    );
+
+    expectLater(
+      client.callServerEndpoint<void>('', '', {}),
+      throwsA(isA<HandshakeException>()),
+    );
+  });
+}


### PR DESCRIPTION
# Fix

- Remove callback that allowed any certificate to be valid.
- Add e2e test to validate that we now reject untrusted certificates. 

Closes: https://github.com/serverpod/serverpod/issues/2040

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

