### PR TITLE
fix: Fix issue when passing empty set to InSet and notInSet. 

### DIFF
--- a/packages/serverpod/lib/src/database/concepts/columns.dart
+++ b/packages/serverpod/lib/src/database/concepts/columns.dart
@@ -237,7 +237,12 @@ mixin _ColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
 
   /// Creates and [Expression] checking if the value in the column is included
   /// in the specified set of values.
+  /// If the set is empty the expression will match no rows.
   Expression inSet(Set<T> values) {
+    if (values.isEmpty) {
+      return Constant.bool(false);
+    }
+
     var valuesAsExpressions =
         values.map((e) => _encodeValueForQuery(e)).toList();
 
@@ -246,7 +251,12 @@ mixin _ColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
 
   /// Creates and [Expression] checking if the value in the column is NOT
   /// included in the specified set of values.
+  /// If the set is empty the expression will match all rows.
   Expression notInSet(Set<T> values) {
+    if (values.isEmpty) {
+      return Constant.bool(true);
+    }
+
     var valuesAsExpressions =
         values.map((e) => _encodeValueForQuery(e)).toList();
 
@@ -279,7 +289,13 @@ mixin _NullableColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
 
   /// Creates and [Expression] checking if the value in the column is included
   /// in the specified set of values.
+  /// If the set is empty, the expression will always be false and match no
+  /// rows.
   Expression inSet(Set<T> values) {
+    if (values.isEmpty) {
+      return Constant.bool(false);
+    }
+
     var valuesAsExpressions =
         values.map((e) => _encodeValueForQuery(e)).toList();
 
@@ -288,7 +304,13 @@ mixin _NullableColumnDefaultOperations<T> on _ValueOperatorColumn<T> {
 
   /// Creates and [Expression] checking if the value in the column is NOT
   /// included in the specified set of values.
+  /// If the set is empty, the expression will always be true and match all
+  /// rows.
   Expression notInSet(Set<T> values) {
+    if (values.isEmpty) {
+      return Constant.bool(true);
+    }
+
     var valuesAsExpressions =
         values.map((e) => _encodeValueForQuery(e)).toList();
 

--- a/packages/serverpod/test/database/columns/column_bool_test.dart
+++ b/packages/serverpod/test/database/columns/column_bool_test.dart
@@ -63,12 +63,28 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<bool>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<bool>{true, false});
 
         expect(comparisonExpression.toString(),
             '($column NOT IN (true, false) OR $column IS NULL)');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<bool>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
   });

--- a/packages/serverpod/test/database/columns/column_count_test.dart
+++ b/packages/serverpod/test/database/columns/column_count_test.dart
@@ -83,12 +83,28 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<int>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<int>{10, 11, 12});
 
         expect(comparisonExpression.toString(),
             '$countColumnInExpression NOT IN (10, 11, 12)');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<int>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
 

--- a/packages/serverpod/test/database/columns/column_date_time_test.dart
+++ b/packages/serverpod/test/database/columns/column_date_time_test.dart
@@ -69,6 +69,14 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<DateTime>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<DateTime>{
@@ -79,6 +87,17 @@ void main() {
 
         expect(comparisonExpression.toString(),
             '($column NOT IN (\'"1991-05-28T00:00:00.000Z"\', \'"1991-05-29T00:00:00.000Z"\', \'"1991-05-30T00:00:00.000Z"\') OR $column IS NULL)');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<DateTime>{});
+
+        expect(
+          comparisonExpression.toString(),
+          'TRUE',
+        );
       });
     });
 

--- a/packages/serverpod/test/database/columns/column_double_test.dart
+++ b/packages/serverpod/test/database/columns/column_double_test.dart
@@ -82,12 +82,28 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<double>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<double>{10.0, 11.0, 12.0});
 
         expect(comparisonExpression.toString(),
             '($column NOT IN (10.0, 11.0, 12.0) OR $column IS NULL)');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<double>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
 

--- a/packages/serverpod/test/database/columns/column_duration_test.dart
+++ b/packages/serverpod/test/database/columns/column_duration_test.dart
@@ -68,6 +68,14 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<Duration>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<Duration>{
@@ -78,6 +86,14 @@ void main() {
 
         expect(comparisonExpression.toString(),
             '($column NOT IN (\'36000000\', \'39600000\', \'43200000\') OR $column IS NULL)');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<Duration>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
 

--- a/packages/serverpod/test/database/columns/column_enum_test.dart
+++ b/packages/serverpod/test/database/columns/column_enum_test.dart
@@ -76,6 +76,14 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<TestEnum>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<TestEnum>{
@@ -86,6 +94,14 @@ void main() {
 
         expect(comparisonExpression.toString(),
             '($column NOT IN (0, 1, 2) OR $column IS NULL)');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<TestEnum>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
   });

--- a/packages/serverpod/test/database/columns/column_int_test.dart
+++ b/packages/serverpod/test/database/columns/column_int_test.dart
@@ -79,12 +79,28 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<int>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<int>{10, 11, 12});
 
         expect(comparisonExpression.toString(),
             '($column NOT IN (10, 11, 12) OR $column IS NULL)');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<int>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
 

--- a/packages/serverpod/test/database/columns/column_string_test.dart
+++ b/packages/serverpod/test/database/columns/column_string_test.dart
@@ -102,12 +102,19 @@ void main() {
       });
 
       test(
-          'when checking if expression is NOT in value set then output is NOT IN expression.',
+          'when checking if expression is in empty value set then output is FALSE expression.',
           () {
-        var comparisonExpression = column.notInSet(<String>{'a', 'b', 'c'});
+        var comparisonExpression = column.inSet(<String>{});
 
-        expect(comparisonExpression.toString(),
-            '($column NOT IN (\'a\', \'b\', \'c\') OR $column IS NULL)');
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<String>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
   });

--- a/packages/serverpod/test/database/columns/column_uuid_test.dart
+++ b/packages/serverpod/test/database/columns/column_uuid_test.dart
@@ -74,6 +74,14 @@ void main() {
       });
 
       test(
+          'when checking if expression is in empty value set then output is FALSE expression.',
+          () {
+        var comparisonExpression = column.inSet(<UuidValue>{});
+
+        expect(comparisonExpression.toString(), 'FALSE');
+      });
+
+      test(
           'when checking if expression is NOT in value set then output is NOT IN expression.',
           () {
         var comparisonExpression = column.notInSet(<UuidValue>{
@@ -86,6 +94,14 @@ void main() {
           comparisonExpression.toString(),
           '($column NOT IN (\'testuuid1\', \'testuuid2\', \'testuuid3\') OR $column IS NULL)',
         );
+      });
+
+      test(
+          'when checking if expression is NOT in empty value set then output is TRUE expression.',
+          () {
+        var comparisonExpression = column.notInSet(<UuidValue>{});
+
+        expect(comparisonExpression.toString(), 'TRUE');
       });
     });
   });

--- a/tests/serverpod_test_server/test_integration/column_operations/column_bool_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_bool_test.dart
@@ -83,6 +83,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aBool.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -91,6 +101,16 @@ void main() async {
       );
 
       expect(result.length, 2);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aBool.notInSet({}),
+      );
+
+      expect(result.length, 3);
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/column_operations/column_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_count_test.dart
@@ -136,6 +136,29 @@ void main() async {
       expect(resultNames, contains(customers[2].name));
     });
 
+    test('when filtering with an empty inSet then no rows are.', () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Customer 1'),
+        Customer(name: 'Customer 2'),
+        Customer(name: 'Customer 3'),
+      ]);
+
+      await Order.db.insert(session, [
+        // Customer 1 orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        // Customer 2 orders
+        Order(description: 'Order 2', customerId: customers[1].id!),
+        Order(description: 'Order 3', customerId: customers[1].id!),
+      ]);
+
+      var result = await Customer.db.find(
+        session,
+        where: (c) => c.orders.count().inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering on notInSet then matching row is returned.', () async {
       var customers = await Customer.db.insert(session, [
         Customer(name: 'Customer 1'),
@@ -160,6 +183,32 @@ void main() async {
       var resultNames = result.map((e) => e.name);
       expect(resultNames, contains(customers[1].name));
       expect(resultNames, contains(customers[2].name));
+    });
+
+    test('when filtering with empty notInSet then all rows are returned.',
+        () async {
+      var customers = await Customer.db.insert(session, [
+        Customer(name: 'Customer 1'),
+        Customer(name: 'Customer 2'),
+        Customer(name: 'Customer 3'),
+      ]);
+
+      await Order.db.insert(session, [
+        // Customer 1 orders
+        Order(description: 'Order 1', customerId: customers[0].id!),
+        // Customer 2 orders
+        Order(description: 'Order 2', customerId: customers[1].id!),
+        Order(description: 'Order 3', customerId: customers[1].id!),
+      ]);
+
+      var result = await Customer.db.find(
+        session,
+        where: (c) => c.orders.count().notInSet({}),
+      );
+
+      expect(result, hasLength(3));
+      var resultNames = result.map((e) => e.name);
+      expect(resultNames, containsAll(customers.map((e) => e.name)));
     });
 
     test('when filtering on greater than then matching rows are returned.',

--- a/tests/serverpod_test_server/test_integration/column_operations/column_date_time_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_date_time_test.dart
@@ -87,6 +87,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aDateTime.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -95,6 +105,16 @@ void main() async {
       );
 
       expect(result.length, 3);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aDateTime.notInSet({}),
+      );
+
+      expect(result.length, 4);
     });
 
     test('when filtering using greater than then matching rows are returned.',

--- a/tests/serverpod_test_server/test_integration/column_operations/column_double_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_double_test.dart
@@ -84,6 +84,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aDouble.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -92,6 +102,16 @@ void main() async {
       );
 
       expect(result.length, 3);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aDouble.notInSet({}),
+      );
+
+      expect(result.length, 4);
     });
 
     test('when filtering using greater than then matching rows are returned.',

--- a/tests/serverpod_test_server/test_integration/column_operations/column_duration_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_duration_test.dart
@@ -88,6 +88,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aDuration.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -96,6 +106,16 @@ void main() async {
       );
 
       expect(result.length, 3);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aDuration.notInSet({}),
+      );
+
+      expect(result.length, 4);
     });
 
     test('when filtering using greater than then matching rows are returned.',

--- a/tests/serverpod_test_server/test_integration/column_operations/column_enum_serialized_by_index_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_enum_serialized_by_index_test.dart
@@ -86,6 +86,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.anEnum.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -96,6 +106,16 @@ void main() async {
       );
 
       expect(result.length, 2);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.anEnum.notInSet({}),
+      );
+
+      expect(result.length, 3);
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/column_operations/column_enum_serialized_by_name_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_enum_serialized_by_name_test.dart
@@ -86,6 +86,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aStringifiedEnum.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -96,6 +106,16 @@ void main() async {
       );
 
       expect(result.length, 2);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aStringifiedEnum.notInSet({}),
+      );
+
+      expect(result.length, 3);
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/column_operations/column_int_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_int_test.dart
@@ -84,6 +84,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.anInt.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -92,6 +102,16 @@ void main() async {
       );
 
       expect(result.length, 3);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.anInt.notInSet({}),
+      );
+
+      expect(result.length, 4);
     });
 
     test('when filtering using greater than then matching rows are returned.',

--- a/tests/serverpod_test_server/test_integration/column_operations/column_string_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_string_test.dart
@@ -83,6 +83,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aString.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -91,6 +101,16 @@ void main() async {
       );
 
       expect(result.length, 2);
+    });
+
+    test('when filtering using empty notInSet then all rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aString.notInSet({}),
+      );
+
+      expect(result.length, 3);
     });
 
     test('when filtering using like then matching row is returned.', () async {

--- a/tests/serverpod_test_server/test_integration/column_operations/column_uuid_test.dart
+++ b/tests/serverpod_test_server/test_integration/column_operations/column_uuid_test.dart
@@ -86,6 +86,16 @@ void main() async {
       expect(result.length, 2);
     });
 
+    test('when filtering using empty inSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aUuid.inSet({}),
+      );
+
+      expect(result, isEmpty);
+    });
+
     test('when filtering using notInSet then matching row is returned.',
         () async {
       var result = await Types.db.find(
@@ -94,6 +104,16 @@ void main() async {
       );
 
       expect(result.length, 2);
+    });
+
+    test('when filtering using empty notInSet then no rows are returned.',
+        () async {
+      var result = await Types.db.find(
+        session,
+        where: (t) => t.aUuid.notInSet({}),
+      );
+
+      expect(result.length, 3);
     });
   });
 }


### PR DESCRIPTION
Apply same change as here: https://github.com/serverpod/serverpod/pull/2073

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
