### PR TITLE
Add firebase service account key to gitignore

### DIFF
--- a/templates/serverpod_templates/projectname_server/gitignore
+++ b/templates/serverpod_templates/projectname_server/gitignore
@@ -10,3 +10,6 @@ doc/api/
 
 # Passwords file
 config/passwords.yaml
+
+# Firebase service account key for Firebase auth
+config/firebase_service_account_key.json


### PR DESCRIPTION
This adds the firebase service account key file to the templates gitignore. Since the name is a serverpod convention it is safe to assume that adding it to gitignore should also be a convention similar to the passwords.yaml.

Closes #2085 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I listed at least one issue that this PR fixes in the description above.
