### PR TITLE
Typo fix 'UserAuthetication' -> 'UserAuthentication' 

### DIFF
--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -353,7 +353,6 @@ class FutureCallSession extends Session {
 }
 
 /// Collects methods for authenticating users.
-@Deprecated('Will be Removed it 2.0.0, use UserAuthentication instead')
 class UserAuthentication {
   final Session _session;
 
@@ -408,6 +407,7 @@ class UserAuthentication {
 }
 
 /// Collects methods for authenticating users.
+@Deprecated('Will be Removed it 2.0.0, use UserAuthentication instead')
 class UserAuthetication {
   final Session _session;
 

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -2,10 +2,10 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/server/features.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
-import 'package:meta/meta.dart';
 
 import '../authentication/util.dart';
 import '../cache/caches.dart';
@@ -63,7 +63,7 @@ abstract class Session {
   Map<String, String> get passwords => server.passwords;
 
   /// Methods related to user authentication.
-  late final UserAuthetication auth;
+  late final UserAuthentication auth;
 
   /// Provides access to the cloud storages used by this [Serverpod].
   late final StorageAccess storage;
@@ -88,7 +88,7 @@ abstract class Session {
   }) {
     _startTime = DateTime.now();
 
-    auth = UserAuthetication._(this);
+    auth = UserAuthentication._(this);
     storage = StorageAccess._(this);
     messages = MessageCentralAccess._(this);
 
@@ -353,10 +353,10 @@ class FutureCallSession extends Session {
 }
 
 /// Collects methods for authenticating users.
-class UserAuthetication {
+class UserAuthentication {
   final Session _session;
 
-  UserAuthetication._(this._session);
+  UserAuthentication._(this._session);
 
   /// Returns the id of an authenticated user or null if the user isn't signed
   /// in.

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -406,61 +406,6 @@ class UserAuthentication {
   }
 }
 
-/// Collects methods for authenticating users.
-@Deprecated('Will be Removed it 2.0.0, use UserAuthentication instead')
-class UserAuthetication {
-  final Session _session;
-
-  UserAuthetication._(this._session);
-
-  /// Returns the id of an authenticated user or null if the user isn't signed
-  /// in.
-  Future<int?> get authenticatedUserId async {
-    if (!_session._initialized) await _session._initialize();
-    return _session._authenticatedUser;
-  }
-
-  /// Signs in an user to the server. The user should have been authenticated
-  /// before signing them in. Send the AuthKey.id and key to the client and
-  /// use that to authenticate in future calls. In most cases, it's more
-  /// convenient to use the serverpod_auth module for authentication.
-  Future<AuthKey> signInUser(int userId, String method,
-      {Set<Scope> scopes = const {}}) async {
-    var signInSalt = _session.passwords['authKeySalt'] ?? defaultAuthKeySalt;
-
-    var key = generateRandomString();
-    var hash = hashString(signInSalt, key);
-
-    var scopeNames = <String>[];
-    for (var scope in scopes) {
-      if (scope.name != null) scopeNames.add(scope.name!);
-    }
-
-    var authKey = AuthKey(
-      userId: userId,
-      hash: hash,
-      key: key,
-      scopeNames: scopeNames,
-      method: method,
-    );
-
-    _session._authenticatedUser = userId;
-    var result = await AuthKey.db.insertRow(_session, authKey);
-    return result.copyWith(key: key);
-  }
-
-  /// Signs out a user from the server and deletes all authentication keys.
-  /// This means that the user will be signed out from all connected devices.
-  Future<void> signOutUser({int? userId}) async {
-    userId ??= await authenticatedUserId;
-    if (userId == null) return;
-
-    await _session.db
-        .deleteWhere<AuthKey>(where: AuthKey.t.userId.equals(userId));
-    _session._authenticatedUser = null;
-  }
-}
-
 /// Collects methods for accessing cloud storage.
 class StorageAccess {
   final Session _session;

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -353,10 +353,65 @@ class FutureCallSession extends Session {
 }
 
 /// Collects methods for authenticating users.
+@Deprecated('Will be Removed it 2.0.0, use UserAuthentication instead')
 class UserAuthentication {
   final Session _session;
 
   UserAuthentication._(this._session);
+
+  /// Returns the id of an authenticated user or null if the user isn't signed
+  /// in.
+  Future<int?> get authenticatedUserId async {
+    if (!_session._initialized) await _session._initialize();
+    return _session._authenticatedUser;
+  }
+
+  /// Signs in an user to the server. The user should have been authenticated
+  /// before signing them in. Send the AuthKey.id and key to the client and
+  /// use that to authenticate in future calls. In most cases, it's more
+  /// convenient to use the serverpod_auth module for authentication.
+  Future<AuthKey> signInUser(int userId, String method,
+      {Set<Scope> scopes = const {}}) async {
+    var signInSalt = _session.passwords['authKeySalt'] ?? defaultAuthKeySalt;
+
+    var key = generateRandomString();
+    var hash = hashString(signInSalt, key);
+
+    var scopeNames = <String>[];
+    for (var scope in scopes) {
+      if (scope.name != null) scopeNames.add(scope.name!);
+    }
+
+    var authKey = AuthKey(
+      userId: userId,
+      hash: hash,
+      key: key,
+      scopeNames: scopeNames,
+      method: method,
+    );
+
+    _session._authenticatedUser = userId;
+    var result = await AuthKey.db.insertRow(_session, authKey);
+    return result.copyWith(key: key);
+  }
+
+  /// Signs out a user from the server and deletes all authentication keys.
+  /// This means that the user will be signed out from all connected devices.
+  Future<void> signOutUser({int? userId}) async {
+    userId ??= await authenticatedUserId;
+    if (userId == null) return;
+
+    await _session.db
+        .deleteWhere<AuthKey>(where: AuthKey.t.userId.equals(userId));
+    _session._authenticatedUser = null;
+  }
+}
+
+/// Collects methods for authenticating users.
+class UserAuthetication {
+  final Session _session;
+
+  UserAuthetication._(this._session);
 
   /// Returns the id of an authenticated user or null if the user isn't signed
   /// in.


### PR DESCRIPTION
This Pull Request have fixed the typo 'UserAuthetication' -> 'UserAuthentication' in /serverpod/lib/src/server/session.dart (Line 356 & 359)

Also Created a dummy class with the old (incorrect) name and add a deprecated annotation, so it's easier to find the correct class when upgrading.

This solves issue: https://github.com/serverpod/serverpod/issues/1887

URL Link: https://github.com/serverpod/serverpod/blob/main/packages/serverpod/lib/src/server/session.dart in Line 356 and 359.

Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with ///), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.


Breaking changes - 
Since the Class Name has changed its spelling, which is a publically exposed API, it is a breaking change which could be easily fixed with correcting the spelling.