### PR TITLE
Deprecated the Older Class's API and added the updated Class to use.

### DIFF
--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -394,7 +394,7 @@ class UserAuthentication {
 }
 
 /// Collects methods for authenticating users.
-@Deprecated('Will be Removed it 2.0.0, use UserAuthentication instead')
+@Deprecated('Will be removed in 2.0.0, use UserAuthentication instead')
 class UserAuthetication {
   final Session _session;
 


### PR DESCRIPTION
This Pull Request have fixed the typo 'UserAuthetication' -> 'UserAuthentication' in /serverpod/lib/src/server/session.dart (Line 356 & 359) and kept the deprecated API(It is removed in 2.0.0 by this [PR](https://github.com/serverpod/serverpod/pull/2088)). 

Created a dummy class with the old (incorrect) name and add a deprecated annotation, so it's easier to find the correct class when upgrading.

This solves issue: https://github.com/serverpod/serverpod/issues/1887

URL Link: https://github.com/serverpod/serverpod/blob/main/packages/serverpod/lib/src/server/session.dart in Line 356 and 359.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes
Since the Class Name has changed its spelling, which is a publically exposed API, it is a breaking change which could be easily fixed with correcting the spelling.