### PR TITLE
fix!: Return object removed from database delete methods.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -282,7 +282,7 @@ class ChannelRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Channel>> delete(
     _i1.Session session,
     List<Channel> rows, {
     _i1.Transaction? transaction,
@@ -293,7 +293,7 @@ class ChannelRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Channel> deleteRow(
     _i1.Session session,
     Channel row, {
     _i1.Transaction? transaction,
@@ -304,7 +304,7 @@ class ChannelRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Channel>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ChannelTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -305,7 +305,7 @@ class EmailAuthRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<EmailAuth>> delete(
     _i1.Session session,
     List<EmailAuth> rows, {
     _i1.Transaction? transaction,
@@ -316,7 +316,7 @@ class EmailAuthRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<EmailAuth> deleteRow(
     _i1.Session session,
     EmailAuth row, {
     _i1.Transaction? transaction,
@@ -327,7 +327,7 @@ class EmailAuthRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<EmailAuth>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailAuthTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -328,7 +328,7 @@ class EmailCreateAccountRequestRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<EmailCreateAccountRequest>> delete(
     _i1.Session session,
     List<EmailCreateAccountRequest> rows, {
     _i1.Transaction? transaction,
@@ -339,7 +339,7 @@ class EmailCreateAccountRequestRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<EmailCreateAccountRequest> deleteRow(
     _i1.Session session,
     EmailCreateAccountRequest row, {
     _i1.Transaction? transaction,
@@ -350,7 +350,7 @@ class EmailCreateAccountRequestRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<EmailCreateAccountRequest>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -308,7 +308,7 @@ class EmailFailedSignInRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<EmailFailedSignIn>> delete(
     _i1.Session session,
     List<EmailFailedSignIn> rows, {
     _i1.Transaction? transaction,
@@ -319,7 +319,7 @@ class EmailFailedSignInRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<EmailFailedSignIn> deleteRow(
     _i1.Session session,
     EmailFailedSignIn row, {
     _i1.Transaction? transaction,
@@ -330,7 +330,7 @@ class EmailFailedSignInRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<EmailFailedSignIn>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailFailedSignInTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -307,7 +307,7 @@ class EmailResetRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<EmailReset>> delete(
     _i1.Session session,
     List<EmailReset> rows, {
     _i1.Transaction? transaction,
@@ -318,7 +318,7 @@ class EmailResetRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<EmailReset> deleteRow(
     _i1.Session session,
     EmailReset row, {
     _i1.Transaction? transaction,
@@ -329,7 +329,7 @@ class EmailResetRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<EmailReset>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailResetTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -284,7 +284,7 @@ class GoogleRefreshTokenRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<GoogleRefreshToken>> delete(
     _i1.Session session,
     List<GoogleRefreshToken> rows, {
     _i1.Transaction? transaction,
@@ -295,7 +295,7 @@ class GoogleRefreshTokenRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<GoogleRefreshToken> deleteRow(
     _i1.Session session,
     GoogleRefreshToken row, {
     _i1.Transaction? transaction,
@@ -306,7 +306,7 @@ class GoogleRefreshTokenRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<GoogleRefreshToken>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<GoogleRefreshTokenTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -305,7 +305,7 @@ class UserImageRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<UserImage>> delete(
     _i1.Session session,
     List<UserImage> rows, {
     _i1.Transaction? transaction,
@@ -316,7 +316,7 @@ class UserImageRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<UserImage> deleteRow(
     _i1.Session session,
     UserImage row, {
     _i1.Transaction? transaction,
@@ -327,7 +327,7 @@ class UserImageRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<UserImage>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserImageTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -423,7 +423,7 @@ class UserInfoRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<UserInfo>> delete(
     _i1.Session session,
     List<UserInfo> rows, {
     _i1.Transaction? transaction,
@@ -434,7 +434,7 @@ class UserInfoRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<UserInfo> deleteRow(
     _i1.Session session,
     UserInfo row, {
     _i1.Transaction? transaction,
@@ -445,7 +445,7 @@ class UserInfoRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<UserInfo>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserInfoTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -424,7 +424,7 @@ class ChatMessageRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ChatMessage>> delete(
     _i1.Session session,
     List<ChatMessage> rows, {
     _i1.Transaction? transaction,
@@ -435,7 +435,7 @@ class ChatMessageRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ChatMessage> deleteRow(
     _i1.Session session,
     ChatMessage row, {
     _i1.Transaction? transaction,
@@ -446,7 +446,7 @@ class ChatMessageRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ChatMessage>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ChatMessageTable> where,
     _i1.Transaction? transaction,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -306,7 +306,7 @@ class ChatReadMessageRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ChatReadMessage>> delete(
     _i1.Session session,
     List<ChatReadMessage> rows, {
     _i1.Transaction? transaction,
@@ -317,7 +317,7 @@ class ChatReadMessageRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ChatReadMessage> deleteRow(
     _i1.Session session,
     ChatReadMessage row, {
     _i1.Transaction? transaction,
@@ -328,7 +328,7 @@ class ChatReadMessageRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ChatReadMessage>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ChatReadMessageTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -243,7 +243,7 @@ class DatabaseConnection {
   }
 
   /// For most cases use the corresponding method in [Database] instead.
-  Future<List<int>> delete<T extends TableRow>(
+  Future<List<T>> delete<T extends TableRow>(
     Session session,
     List<T> rows, {
     Transaction? transaction,
@@ -263,7 +263,7 @@ class DatabaseConnection {
   }
 
   /// For most cases use the corresponding method in [Database] instead.
-  Future<int> deleteRow<T extends TableRow>(
+  Future<T> deleteRow<T extends TableRow>(
     Session session,
     T row, {
     Transaction? transaction,
@@ -284,7 +284,7 @@ class DatabaseConnection {
   }
 
   /// For most cases use the corresponding method in [Database] instead.
-  Future<List<int>> deleteWhere<T extends TableRow>(
+  Future<List<T>> deleteWhere<T extends TableRow>(
     Session session,
     Expression where, {
     Transaction? transaction,
@@ -292,13 +292,11 @@ class DatabaseConnection {
     var table = _getTableOrAssert<T>(session, operation: 'deleteWhere');
 
     var query = DeleteQueryBuilder(table: table)
-        .withReturn(Returning.id)
+        .withReturn(Returning.all)
         .withWhere(where)
         .build();
 
-    var result = await _query(session, query, transaction: transaction);
-
-    return result.toList().map((r) => r.first as int).toList();
+    return await _deserializedMappedQuery(session, query, table: table);
   }
 
   /// For most cases use the corresponding method in [Database] instead.

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -150,10 +150,10 @@ class Database {
     );
   }
 
-  /// Deletes all [TableRow]s in the list and returns the deleted ids.
+  /// Deletes all [TableRow]s in the list and returns the deleted rows.
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
-  Future<List<int>> delete<T extends TableRow>(
+  Future<List<T>> delete<T extends TableRow>(
     List<T> rows, {
     Transaction? transaction,
   }) async {
@@ -165,7 +165,7 @@ class Database {
   }
 
   /// Deletes a single [TableRow].
-  Future<int> deleteRow<T extends TableRow>(
+  Future<T> deleteRow<T extends TableRow>(
     T row, {
     Transaction? transaction,
   }) async {
@@ -177,7 +177,7 @@ class Database {
   }
 
   /// Deletes all rows matching the [where] expression.
-  Future<List<int>> deleteWhere<T extends TableRow>({
+  Future<List<T>> deleteWhere<T extends TableRow>({
     required Expression where,
     Transaction? transaction,
   }) async {

--- a/packages/serverpod/lib/src/database/sql_query_builder.dart
+++ b/packages/serverpod/lib/src/database/sql_query_builder.dart
@@ -399,7 +399,8 @@ class DeleteQueryBuilder {
   DeleteQueryBuilder withReturn(Returning returning) {
     switch (returning) {
       case Returning.all:
-        _returningStatement = ' RETURNING *';
+        _returningStatement =
+            ' RETURNING ${_buildColumnAliases(_table.columns)}';
         break;
       case Returning.id:
         _returningStatement = ' RETURNING "${_table.tableName}".id';
@@ -443,12 +444,7 @@ String _buildSelectStatement(
   List<Column> selectColumns, {
   TableRelation? countTableRelation,
 }) {
-  var selectStatements = selectColumns
-      .map((column) => '$column AS "${truncateIdentifier(
-            column.queryAlias,
-            DatabaseConstants.pgsqlMaxNameLimitation,
-          )}"')
-      .join(', ');
+  var selectStatements = _buildColumnAliases(selectColumns);
 
   if (countTableRelation != null) {
     selectStatements +=
@@ -456,6 +452,15 @@ String _buildSelectStatement(
   }
 
   return selectStatements;
+}
+
+String _buildColumnAliases(List<Column> columns) {
+  return columns
+      .map((column) => '$column AS "${truncateIdentifier(
+            column.queryAlias,
+            DatabaseConstants.pgsqlMaxNameLimitation,
+          )}"')
+      .join(', ');
 }
 
 List<Column> _gatherIncludeColumns(Include? include) {

--- a/packages/serverpod/lib/src/generated/auth_key.dart
+++ b/packages/serverpod/lib/src/generated/auth_key.dart
@@ -342,7 +342,7 @@ class AuthKeyRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<AuthKey>> delete(
     _i1.Session session,
     List<AuthKey> rows, {
     _i1.Transaction? transaction,
@@ -353,7 +353,7 @@ class AuthKeyRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<AuthKey> deleteRow(
     _i1.Session session,
     AuthKey row, {
     _i1.Transaction? transaction,
@@ -364,7 +364,7 @@ class AuthKeyRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<AuthKey>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<AuthKeyTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -373,7 +373,7 @@ class CloudStorageEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<CloudStorageEntry>> delete(
     _i1.Session session,
     List<CloudStorageEntry> rows, {
     _i1.Transaction? transaction,
@@ -384,7 +384,7 @@ class CloudStorageEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<CloudStorageEntry> deleteRow(
     _i1.Session session,
     CloudStorageEntry row, {
     _i1.Transaction? transaction,
@@ -395,7 +395,7 @@ class CloudStorageEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<CloudStorageEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CloudStorageEntryTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -328,7 +328,7 @@ class CloudStorageDirectUploadEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<CloudStorageDirectUploadEntry>> delete(
     _i1.Session session,
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.Transaction? transaction,
@@ -339,7 +339,7 @@ class CloudStorageDirectUploadEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<CloudStorageDirectUploadEntry> deleteRow(
     _i1.Session session,
     CloudStorageDirectUploadEntry row, {
     _i1.Transaction? transaction,
@@ -350,7 +350,7 @@ class CloudStorageDirectUploadEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<CloudStorageDirectUploadEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>
         where,

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -307,7 +307,7 @@ class DatabaseMigrationVersionRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<DatabaseMigrationVersion>> delete(
     _i1.Session session,
     List<DatabaseMigrationVersion> rows, {
     _i1.Transaction? transaction,
@@ -318,7 +318,7 @@ class DatabaseMigrationVersionRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<DatabaseMigrationVersion> deleteRow(
     _i1.Session session,
     DatabaseMigrationVersion row, {
     _i1.Transaction? transaction,
@@ -329,7 +329,7 @@ class DatabaseMigrationVersionRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<DatabaseMigrationVersion>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<DatabaseMigrationVersionTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -352,7 +352,7 @@ class FutureCallEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<FutureCallEntry>> delete(
     _i1.Session session,
     List<FutureCallEntry> rows, {
     _i1.Transaction? transaction,
@@ -363,7 +363,7 @@ class FutureCallEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<FutureCallEntry> deleteRow(
     _i1.Session session,
     FutureCallEntry row, {
     _i1.Transaction? transaction,
@@ -374,7 +374,7 @@ class FutureCallEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<FutureCallEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<FutureCallEntryTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -461,7 +461,7 @@ class LogEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<LogEntry>> delete(
     _i1.Session session,
     List<LogEntry> rows, {
     _i1.Transaction? transaction,
@@ -472,7 +472,7 @@ class LogEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<LogEntry> deleteRow(
     _i1.Session session,
     LogEntry row, {
     _i1.Transaction? transaction,
@@ -483,7 +483,7 @@ class LogEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<LogEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<LogEntryTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -462,7 +462,7 @@ class MessageLogEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<MessageLogEntry>> delete(
     _i1.Session session,
     List<MessageLogEntry> rows, {
     _i1.Transaction? transaction,
@@ -473,7 +473,7 @@ class MessageLogEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<MessageLogEntry> deleteRow(
     _i1.Session session,
     MessageLogEntry row, {
     _i1.Transaction? transaction,
@@ -484,7 +484,7 @@ class MessageLogEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<MessageLogEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<MessageLogEntryTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -284,7 +284,7 @@ class MethodInfoRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<MethodInfo>> delete(
     _i1.Session session,
     List<MethodInfo> rows, {
     _i1.Transaction? transaction,
@@ -295,7 +295,7 @@ class MethodInfoRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<MethodInfo> deleteRow(
     _i1.Session session,
     MethodInfo row, {
     _i1.Transaction? transaction,
@@ -306,7 +306,7 @@ class MethodInfoRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<MethodInfo>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<MethodInfoTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -462,7 +462,7 @@ class QueryLogEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<QueryLogEntry>> delete(
     _i1.Session session,
     List<QueryLogEntry> rows, {
     _i1.Transaction? transaction,
@@ -473,7 +473,7 @@ class QueryLogEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<QueryLogEntry> deleteRow(
     _i1.Session session,
     QueryLogEntry row, {
     _i1.Transaction? transaction,
@@ -484,7 +484,7 @@ class QueryLogEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<QueryLogEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<QueryLogEntryTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -263,7 +263,7 @@ class ReadWriteTestEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ReadWriteTestEntry>> delete(
     _i1.Session session,
     List<ReadWriteTestEntry> rows, {
     _i1.Transaction? transaction,
@@ -274,7 +274,7 @@ class ReadWriteTestEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ReadWriteTestEntry> deleteRow(
     _i1.Session session,
     ReadWriteTestEntry row, {
     _i1.Transaction? transaction,
@@ -285,7 +285,7 @@ class ReadWriteTestEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ReadWriteTestEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ReadWriteTestEntryTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -334,7 +334,7 @@ class RuntimeSettingsRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<RuntimeSettings>> delete(
     _i1.Session session,
     List<RuntimeSettings> rows, {
     _i1.Transaction? transaction,
@@ -345,7 +345,7 @@ class RuntimeSettingsRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<RuntimeSettings> deleteRow(
     _i1.Session session,
     RuntimeSettings row, {
     _i1.Transaction? transaction,
@@ -356,7 +356,7 @@ class RuntimeSettingsRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<RuntimeSettings>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<RuntimeSettingsTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -376,7 +376,7 @@ class ServerHealthConnectionInfoRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ServerHealthConnectionInfo>> delete(
     _i1.Session session,
     List<ServerHealthConnectionInfo> rows, {
     _i1.Transaction? transaction,
@@ -387,7 +387,7 @@ class ServerHealthConnectionInfoRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ServerHealthConnectionInfo> deleteRow(
     _i1.Session session,
     ServerHealthConnectionInfo row, {
     _i1.Transaction? transaction,
@@ -398,7 +398,7 @@ class ServerHealthConnectionInfoRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ServerHealthConnectionInfo>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -376,7 +376,7 @@ class ServerHealthMetricRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ServerHealthMetric>> delete(
     _i1.Session session,
     List<ServerHealthMetric> rows, {
     _i1.Transaction? transaction,
@@ -387,7 +387,7 @@ class ServerHealthMetricRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ServerHealthMetric> deleteRow(
     _i1.Session session,
     ServerHealthMetric row, {
     _i1.Transaction? transaction,
@@ -398,7 +398,7 @@ class ServerHealthMetricRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ServerHealthMetric>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ServerHealthMetricTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -538,7 +538,7 @@ class SessionLogEntryRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<SessionLogEntry>> delete(
     _i1.Session session,
     List<SessionLogEntry> rows, {
     _i1.Transaction? transaction,
@@ -549,7 +549,7 @@ class SessionLogEntryRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<SessionLogEntry> deleteRow(
     _i1.Session session,
     SessionLogEntry row, {
     _i1.Transaction? transaction,
@@ -560,7 +560,7 @@ class SessionLogEntryRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<SessionLogEntry>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<SessionLogEntryTable> where,
     _i1.Transaction? transaction,

--- a/packages/serverpod/test/database/sql_query_builder_test.dart
+++ b/packages/serverpod/test/database/sql_query_builder_test.dart
@@ -637,7 +637,8 @@ void main() {
           .withReturn(Returning.all)
           .build();
 
-      expect(query, 'DELETE FROM "citizen" RETURNING *');
+      expect(query,
+          'DELETE FROM "citizen" RETURNING "citizen"."id" AS "citizen.id"');
     });
 
     test('when query return id is build then the output is a return id query.',
@@ -718,7 +719,7 @@ void main() {
           .build();
 
       expect(query,
-          'DELETE FROM "citizen" USING "company" AS "citizen_company_company" WHERE "citizen_company_company"."name" = \'Serverpod\' AND "citizen"."companyId" = "citizen_company_company"."id" RETURNING *');
+          'DELETE FROM "citizen" USING "company" AS "citizen_company_company" WHERE "citizen_company_company"."name" = \'Serverpod\' AND "citizen"."companyId" = "citizen_company_company"."id" RETURNING "citizen"."id" AS "citizen.id"');
     });
 
     test(

--- a/tests/serverpod_test_server/lib/src/endpoints/database_basic.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_basic.dart
@@ -101,19 +101,23 @@ class BasicDatabase extends Endpoint {
     Session session,
     SimpleData simpleData,
   ) async {
-    return SimpleData.db.deleteRow(
+    var result = await SimpleData.db.deleteRow(
       session,
       simpleData,
     );
+
+    return result.id!;
   }
 
   Future<List<int>> deleteWhereSimpleData(
     Session session,
   ) async {
-    return SimpleData.db.deleteWhere(
+    var result = await SimpleData.db.deleteWhere(
       where: (t) => Constant.bool(true),
       session,
     );
+
+    return result.map((e) => e.id!).toList();
   }
 
   Future<int> countSimpleData(Session session) async {
@@ -142,8 +146,10 @@ class BasicDatabase extends Endpoint {
   }
 
   Future<List<int>> deleteAllInTypes(Session session) async {
-    return await Types.db
-        .deleteWhere(session, where: (t) => Constant.bool(true));
+    var result =
+        await Types.db.deleteWhere(session, where: (t) => Constant.bool(true));
+
+    return result.map((e) => e.id!).toList();
   }
 
   Future<Types?> getTypes(Session session, int id) async {

--- a/tests/serverpod_test_server/lib/src/endpoints/database_batch.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_batch.dart
@@ -34,7 +34,9 @@ class DatabaseBatch extends Endpoint {
     Session session,
     List<UniqueData> value,
   ) async {
-    return session.db.delete<UniqueData>(value);
+    var result = await session.db.delete<UniqueData>(value);
+
+    return result.map((e) => e.id!).toList();
   }
 
   Future<RelatedUniqueData> insertRelatedUniqueData(

--- a/tests/serverpod_test_server/lib/src/endpoints/database_batch_generated.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/database_batch_generated.dart
@@ -34,7 +34,9 @@ class DatabaseBatchGenerated extends Endpoint {
     Session session,
     List<UniqueData> value,
   ) async {
-    return UniqueData.db.delete(session, value);
+    var result = await UniqueData.db.delete(session, value);
+
+    return result.map((e) => e.id!).toList();
   }
 
   Future<RelatedUniqueData> insertRelatedUniqueData(

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -415,7 +415,7 @@ class CityWithLongTableNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<CityWithLongTableName>> delete(
     _i1.Session session,
     List<CityWithLongTableName> rows, {
     _i1.Transaction? transaction,
@@ -426,7 +426,7 @@ class CityWithLongTableNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<CityWithLongTableName> deleteRow(
     _i1.Session session,
     CityWithLongTableName row, {
     _i1.Transaction? transaction,
@@ -437,7 +437,7 @@ class CityWithLongTableNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<CityWithLongTableName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CityWithLongTableNameTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -407,7 +407,7 @@ class OrganizationWithLongTableNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<OrganizationWithLongTableName>> delete(
     _i1.Session session,
     List<OrganizationWithLongTableName> rows, {
     _i1.Transaction? transaction,
@@ -418,7 +418,7 @@ class OrganizationWithLongTableNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<OrganizationWithLongTableName> deleteRow(
     _i1.Session session,
     OrganizationWithLongTableName row, {
     _i1.Transaction? transaction,
@@ -429,7 +429,7 @@ class OrganizationWithLongTableNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<OrganizationWithLongTableName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>
         where,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -392,7 +392,7 @@ class PersonWithLongTableNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<PersonWithLongTableName>> delete(
     _i1.Session session,
     List<PersonWithLongTableName> rows, {
     _i1.Transaction? transaction,
@@ -403,7 +403,7 @@ class PersonWithLongTableNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<PersonWithLongTableName> deleteRow(
     _i1.Session session,
     PersonWithLongTableName row, {
     _i1.Transaction? transaction,
@@ -414,7 +414,7 @@ class PersonWithLongTableNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<PersonWithLongTableName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<PersonWithLongTableNameTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -269,7 +269,7 @@ class MaxFieldNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<MaxFieldName>> delete(
     _i1.Session session,
     List<MaxFieldName> rows, {
     _i1.Transaction? transaction,
@@ -280,7 +280,7 @@ class MaxFieldNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<MaxFieldName> deleteRow(
     _i1.Session session,
     MaxFieldName row, {
     _i1.Transaction? transaction,
@@ -291,7 +291,7 @@ class MaxFieldNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<MaxFieldName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<MaxFieldNameTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -308,7 +308,7 @@ class LongImplicitIdFieldRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<LongImplicitIdField>> delete(
     _i1.Session session,
     List<LongImplicitIdField> rows, {
     _i1.Transaction? transaction,
@@ -319,7 +319,7 @@ class LongImplicitIdFieldRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<LongImplicitIdField> deleteRow(
     _i1.Session session,
     LongImplicitIdField row, {
     _i1.Transaction? transaction,
@@ -330,7 +330,7 @@ class LongImplicitIdFieldRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<LongImplicitIdField>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -380,7 +380,7 @@ class LongImplicitIdFieldCollectionRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<LongImplicitIdFieldCollection>> delete(
     _i1.Session session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.Transaction? transaction,
@@ -391,7 +391,7 @@ class LongImplicitIdFieldCollectionRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<LongImplicitIdFieldCollection> deleteRow(
     _i1.Session session,
     LongImplicitIdFieldCollection row, {
     _i1.Transaction? transaction,
@@ -402,7 +402,7 @@ class LongImplicitIdFieldCollectionRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<LongImplicitIdFieldCollection>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>
         where,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -349,7 +349,7 @@ class RelationToMultipleMaxFieldNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<RelationToMultipleMaxFieldName>> delete(
     _i1.Session session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
@@ -360,7 +360,7 @@ class RelationToMultipleMaxFieldNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<RelationToMultipleMaxFieldName> deleteRow(
     _i1.Session session,
     RelationToMultipleMaxFieldName row, {
     _i1.Transaction? transaction,
@@ -371,7 +371,7 @@ class RelationToMultipleMaxFieldNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<RelationToMultipleMaxFieldName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>
         where,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -307,7 +307,7 @@ class UserNoteRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<UserNote>> delete(
     _i1.Session session,
     List<UserNote> rows, {
     _i1.Transaction? transaction,
@@ -318,7 +318,7 @@ class UserNoteRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<UserNote> deleteRow(
     _i1.Session session,
     UserNote row, {
     _i1.Transaction? transaction,
@@ -329,7 +329,7 @@ class UserNoteRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<UserNote>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -347,7 +347,7 @@ class UserNoteCollectionRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<UserNoteCollection>> delete(
     _i1.Session session,
     List<UserNoteCollection> rows, {
     _i1.Transaction? transaction,
@@ -358,7 +358,7 @@ class UserNoteCollectionRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<UserNoteCollection> deleteRow(
     _i1.Session session,
     UserNoteCollection row, {
     _i1.Transaction? transaction,
@@ -369,7 +369,7 @@ class UserNoteCollectionRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<UserNoteCollection>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -344,7 +344,7 @@ class UserNoteCollectionWithALongNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<UserNoteCollectionWithALongName>> delete(
     _i1.Session session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.Transaction? transaction,
@@ -355,7 +355,7 @@ class UserNoteCollectionWithALongNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<UserNoteCollectionWithALongName> deleteRow(
     _i1.Session session,
     UserNoteCollectionWithALongName row, {
     _i1.Transaction? transaction,
@@ -366,7 +366,7 @@ class UserNoteCollectionWithALongNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<UserNoteCollectionWithALongName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>
         where,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -308,7 +308,7 @@ class UserNoteWithALongNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<UserNoteWithALongName>> delete(
     _i1.Session session,
     List<UserNoteWithALongName> rows, {
     _i1.Transaction? transaction,
@@ -319,7 +319,7 @@ class UserNoteWithALongNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<UserNoteWithALongName> deleteRow(
     _i1.Session session,
     UserNoteWithALongName row, {
     _i1.Transaction? transaction,
@@ -330,7 +330,7 @@ class UserNoteWithALongNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<UserNoteWithALongName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteWithALongNameTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -360,7 +360,7 @@ class MultipleMaxFieldNameRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<MultipleMaxFieldName>> delete(
     _i1.Session session,
     List<MultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
@@ -371,7 +371,7 @@ class MultipleMaxFieldNameRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<MultipleMaxFieldName> deleteRow(
     _i1.Session session,
     MultipleMaxFieldName row, {
     _i1.Transaction? transaction,
@@ -382,7 +382,7 @@ class MultipleMaxFieldNameRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<MultipleMaxFieldName>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -407,7 +407,7 @@ class CityRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<City>> delete(
     _i1.Session session,
     List<City> rows, {
     _i1.Transaction? transaction,
@@ -418,7 +418,7 @@ class CityRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<City> deleteRow(
     _i1.Session session,
     City row, {
     _i1.Transaction? transaction,
@@ -429,7 +429,7 @@ class CityRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<City>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -401,7 +401,7 @@ class OrganizationRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Organization>> delete(
     _i1.Session session,
     List<Organization> rows, {
     _i1.Transaction? transaction,
@@ -412,7 +412,7 @@ class OrganizationRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Organization> deleteRow(
     _i1.Session session,
     Organization row, {
     _i1.Transaction? transaction,
@@ -423,7 +423,7 @@ class OrganizationRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Organization>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -379,7 +379,7 @@ class PersonRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Person>> delete(
     _i1.Session session,
     List<Person> rows, {
     _i1.Transaction? transaction,
@@ -390,7 +390,7 @@ class PersonRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Person> deleteRow(
     _i1.Session session,
     Person row, {
     _i1.Transaction? transaction,
@@ -401,7 +401,7 @@ class PersonRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Person>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -337,7 +337,7 @@ class CourseRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Course>> delete(
     _i1.Session session,
     List<Course> rows, {
     _i1.Transaction? transaction,
@@ -348,7 +348,7 @@ class CourseRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Course> deleteRow(
     _i1.Session session,
     Course row, {
     _i1.Transaction? transaction,
@@ -359,7 +359,7 @@ class CourseRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Course>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -373,7 +373,7 @@ class EnrollmentRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Enrollment>> delete(
     _i1.Session session,
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
@@ -384,7 +384,7 @@ class EnrollmentRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Enrollment> deleteRow(
     _i1.Session session,
     Enrollment row, {
     _i1.Transaction? transaction,
@@ -395,7 +395,7 @@ class EnrollmentRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Enrollment>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -333,7 +333,7 @@ class StudentRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Student>> delete(
     _i1.Session session,
     List<Student> rows, {
     _i1.Transaction? transaction,
@@ -344,7 +344,7 @@ class StudentRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Student> deleteRow(
     _i1.Session session,
     Student row, {
     _i1.Transaction? transaction,
@@ -355,7 +355,7 @@ class StudentRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Student>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -328,7 +328,7 @@ class ObjectUserRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectUser>> delete(
     _i1.Session session,
     List<ObjectUser> rows, {
     _i1.Transaction? transaction,
@@ -339,7 +339,7 @@ class ObjectUserRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectUser> deleteRow(
     _i1.Session session,
     ObjectUser row, {
     _i1.Transaction? transaction,
@@ -350,7 +350,7 @@ class ObjectUserRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectUser>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectUserTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -278,7 +278,7 @@ class ParentUserRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ParentUser>> delete(
     _i1.Session session,
     List<ParentUser> rows, {
     _i1.Transaction? transaction,
@@ -289,7 +289,7 @@ class ParentUserRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ParentUser> deleteRow(
     _i1.Session session,
     ParentUser row, {
     _i1.Transaction? transaction,
@@ -300,7 +300,7 @@ class ParentUserRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ParentUser>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ParentUserTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -308,7 +308,7 @@ class ArenaRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Arena>> delete(
     _i1.Session session,
     List<Arena> rows, {
     _i1.Transaction? transaction,
@@ -319,7 +319,7 @@ class ArenaRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Arena> deleteRow(
     _i1.Session session,
     Arena row, {
     _i1.Transaction? transaction,
@@ -330,7 +330,7 @@ class ArenaRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Arena>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -328,7 +328,7 @@ class PlayerRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Player>> delete(
     _i1.Session session,
     List<Player> rows, {
     _i1.Transaction? transaction,
@@ -339,7 +339,7 @@ class PlayerRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Player> deleteRow(
     _i1.Session session,
     Player row, {
     _i1.Transaction? transaction,
@@ -350,7 +350,7 @@ class PlayerRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Player>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -401,7 +401,7 @@ class TeamRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Team>> delete(
     _i1.Session session,
     List<Team> rows, {
     _i1.Transaction? transaction,
@@ -412,7 +412,7 @@ class TeamRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Team> deleteRow(
     _i1.Session session,
     Team row, {
     _i1.Transaction? transaction,
@@ -423,7 +423,7 @@ class TeamRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Team>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -327,7 +327,7 @@ class CommentRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Comment>> delete(
     _i1.Session session,
     List<Comment> rows, {
     _i1.Transaction? transaction,
@@ -338,7 +338,7 @@ class CommentRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Comment> deleteRow(
     _i1.Session session,
     Comment row, {
     _i1.Transaction? transaction,
@@ -349,7 +349,7 @@ class CommentRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Comment>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -335,7 +335,7 @@ class CustomerRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Customer>> delete(
     _i1.Session session,
     List<Customer> rows, {
     _i1.Transaction? transaction,
@@ -346,7 +346,7 @@ class CustomerRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Customer> deleteRow(
     _i1.Session session,
     Customer row, {
     _i1.Transaction? transaction,
@@ -357,7 +357,7 @@ class CustomerRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Customer>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -400,7 +400,7 @@ class OrderRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Order>> delete(
     _i1.Session session,
     List<Order> rows, {
     _i1.Transaction? transaction,
@@ -411,7 +411,7 @@ class OrderRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Order> deleteRow(
     _i1.Session session,
     Order row, {
     _i1.Transaction? transaction,
@@ -422,7 +422,7 @@ class OrderRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Order>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -330,7 +330,7 @@ class AddressRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Address>> delete(
     _i1.Session session,
     List<Address> rows, {
     _i1.Transaction? transaction,
@@ -341,7 +341,7 @@ class AddressRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Address> deleteRow(
     _i1.Session session,
     Address row, {
     _i1.Transaction? transaction,
@@ -352,7 +352,7 @@ class AddressRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Address>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -433,7 +433,7 @@ class CitizenRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Citizen>> delete(
     _i1.Session session,
     List<Citizen> rows, {
     _i1.Transaction? transaction,
@@ -444,7 +444,7 @@ class CitizenRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Citizen> deleteRow(
     _i1.Session session,
     Citizen row, {
     _i1.Transaction? transaction,
@@ -455,7 +455,7 @@ class CitizenRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Citizen>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -326,7 +326,7 @@ class CompanyRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Company>> delete(
     _i1.Session session,
     List<Company> rows, {
     _i1.Transaction? transaction,
@@ -337,7 +337,7 @@ class CompanyRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Company> deleteRow(
     _i1.Session session,
     Company row, {
     _i1.Transaction? transaction,
@@ -348,7 +348,7 @@ class CompanyRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Company>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -328,7 +328,7 @@ class TownRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Town>> delete(
     _i1.Session session,
     List<Town> rows, {
     _i1.Transaction? transaction,
@@ -339,7 +339,7 @@ class TownRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Town> deleteRow(
     _i1.Session session,
     Town row, {
     _i1.Transaction? transaction,
@@ -350,7 +350,7 @@ class TownRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Town>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -374,7 +374,7 @@ class BlockingRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Blocking>> delete(
     _i1.Session session,
     List<Blocking> rows, {
     _i1.Transaction? transaction,
@@ -385,7 +385,7 @@ class BlockingRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Blocking> deleteRow(
     _i1.Session session,
     Blocking row, {
     _i1.Transaction? transaction,
@@ -396,7 +396,7 @@ class BlockingRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Blocking>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -402,7 +402,7 @@ class MemberRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Member>> delete(
     _i1.Session session,
     List<Member> rows, {
     _i1.Transaction? transaction,
@@ -413,7 +413,7 @@ class MemberRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Member> deleteRow(
     _i1.Session session,
     Member row, {
     _i1.Transaction? transaction,
@@ -424,7 +424,7 @@ class MemberRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Member>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -401,7 +401,7 @@ class CatRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Cat>> delete(
     _i1.Session session,
     List<Cat> rows, {
     _i1.Transaction? transaction,
@@ -412,7 +412,7 @@ class CatRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Cat> deleteRow(
     _i1.Session session,
     Cat row, {
     _i1.Transaction? transaction,
@@ -423,7 +423,7 @@ class CatRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Cat>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -375,7 +375,7 @@ class PostRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Post>> delete(
     _i1.Session session,
     List<Post> rows, {
     _i1.Transaction? transaction,
@@ -386,7 +386,7 @@ class PostRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Post> deleteRow(
     _i1.Session session,
     Post row, {
     _i1.Transaction? transaction,
@@ -397,7 +397,7 @@ class PostRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Post>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -290,7 +290,7 @@ class ObjectFieldScopesRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectFieldScopes>> delete(
     _i1.Session session,
     List<ObjectFieldScopes> rows, {
     _i1.Transaction? transaction,
@@ -301,7 +301,7 @@ class ObjectFieldScopesRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectFieldScopes> deleteRow(
     _i1.Session session,
     ObjectFieldScopes row, {
     _i1.Transaction? transaction,
@@ -312,7 +312,7 @@ class ObjectFieldScopesRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectFieldScopes>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectFieldScopesTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -261,7 +261,7 @@ class ObjectWithByteDataRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithByteData>> delete(
     _i1.Session session,
     List<ObjectWithByteData> rows, {
     _i1.Transaction? transaction,
@@ -272,7 +272,7 @@ class ObjectWithByteDataRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithByteData> deleteRow(
     _i1.Session session,
     ObjectWithByteData row, {
     _i1.Transaction? transaction,
@@ -283,7 +283,7 @@ class ObjectWithByteDataRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithByteData>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithByteDataTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -260,7 +260,7 @@ class ObjectWithDurationRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithDuration>> delete(
     _i1.Session session,
     List<ObjectWithDuration> rows, {
     _i1.Transaction? transaction,
@@ -271,7 +271,7 @@ class ObjectWithDurationRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithDuration> deleteRow(
     _i1.Session session,
     ObjectWithDuration row, {
     _i1.Transaction? transaction,
@@ -282,7 +282,7 @@ class ObjectWithDurationRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithDuration>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithDurationTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -348,7 +348,7 @@ class ObjectWithEnumRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithEnum>> delete(
     _i1.Session session,
     List<ObjectWithEnum> rows, {
     _i1.Transaction? transaction,
@@ -359,7 +359,7 @@ class ObjectWithEnumRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithEnum> deleteRow(
     _i1.Session session,
     ObjectWithEnum row, {
     _i1.Transaction? transaction,
@@ -370,7 +370,7 @@ class ObjectWithEnumRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithEnum>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -279,7 +279,7 @@ class ObjectWithIndexRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithIndex>> delete(
     _i1.Session session,
     List<ObjectWithIndex> rows, {
     _i1.Transaction? transaction,
@@ -290,7 +290,7 @@ class ObjectWithIndexRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithIndex> deleteRow(
     _i1.Session session,
     ObjectWithIndex row, {
     _i1.Transaction? transaction,
@@ -301,7 +301,7 @@ class ObjectWithIndexRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithIndex>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithIndexTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -381,7 +381,7 @@ class ObjectWithObjectRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithObject>> delete(
     _i1.Session session,
     List<ObjectWithObject> rows, {
     _i1.Transaction? transaction,
@@ -392,7 +392,7 @@ class ObjectWithObjectRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithObject> deleteRow(
     _i1.Session session,
     ObjectWithObject row, {
     _i1.Transaction? transaction,
@@ -403,7 +403,7 @@ class ObjectWithObjectRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithObject>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithObjectTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -258,7 +258,7 @@ class ObjectWithParentRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithParent>> delete(
     _i1.Session session,
     List<ObjectWithParent> rows, {
     _i1.Transaction? transaction,
@@ -269,7 +269,7 @@ class ObjectWithParentRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithParent> deleteRow(
     _i1.Session session,
     ObjectWithParent row, {
     _i1.Transaction? transaction,
@@ -280,7 +280,7 @@ class ObjectWithParentRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithParent>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithParentTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -258,7 +258,7 @@ class ObjectWithSelfParentRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithSelfParent>> delete(
     _i1.Session session,
     List<ObjectWithSelfParent> rows, {
     _i1.Transaction? transaction,
@@ -269,7 +269,7 @@ class ObjectWithSelfParentRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithSelfParent> deleteRow(
     _i1.Session session,
     ObjectWithSelfParent row, {
     _i1.Transaction? transaction,
@@ -280,7 +280,7 @@ class ObjectWithSelfParentRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithSelfParent>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithSelfParentTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -281,7 +281,7 @@ class ObjectWithUuidRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ObjectWithUuid>> delete(
     _i1.Session session,
     List<ObjectWithUuid> rows, {
     _i1.Transaction? transaction,
@@ -292,7 +292,7 @@ class ObjectWithUuidRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ObjectWithUuid> deleteRow(
     _i1.Session session,
     ObjectWithUuid row, {
     _i1.Transaction? transaction,
@@ -303,7 +303,7 @@ class ObjectWithUuidRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ObjectWithUuid>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithUuidTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -330,7 +330,7 @@ class RelatedUniqueDataRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<RelatedUniqueData>> delete(
     _i1.Session session,
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
@@ -341,7 +341,7 @@ class RelatedUniqueDataRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<RelatedUniqueData> deleteRow(
     _i1.Session session,
     RelatedUniqueData row, {
     _i1.Transaction? transaction,
@@ -352,7 +352,7 @@ class RelatedUniqueDataRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<RelatedUniqueData>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -258,7 +258,7 @@ class ScopeNoneFieldsRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<ScopeNoneFields>> delete(
     _i1.Session session,
     List<ScopeNoneFields> rows, {
     _i1.Transaction? transaction,
@@ -269,7 +269,7 @@ class ScopeNoneFieldsRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<ScopeNoneFields> deleteRow(
     _i1.Session session,
     ScopeNoneFields row, {
     _i1.Transaction? transaction,
@@ -280,7 +280,7 @@ class ScopeNoneFieldsRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<ScopeNoneFields>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<ScopeNoneFieldsTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -264,7 +264,7 @@ class SimpleDataRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<SimpleData>> delete(
     _i1.Session session,
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
@@ -275,7 +275,7 @@ class SimpleDataRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<SimpleData> deleteRow(
     _i1.Session session,
     SimpleData row, {
     _i1.Transaction? transaction,
@@ -286,7 +286,7 @@ class SimpleDataRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<SimpleData>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -263,7 +263,7 @@ class SimpleDateTimeRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<SimpleDateTime>> delete(
     _i1.Session session,
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
@@ -274,7 +274,7 @@ class SimpleDateTimeRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<SimpleDateTime> deleteRow(
     _i1.Session session,
     SimpleDateTime row, {
     _i1.Transaction? transaction,
@@ -285,7 +285,7 @@ class SimpleDateTimeRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<SimpleDateTime>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -448,7 +448,7 @@ class TypesRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<Types>> delete(
     _i1.Session session,
     List<Types> rows, {
     _i1.Transaction? transaction,
@@ -459,7 +459,7 @@ class TypesRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<Types> deleteRow(
     _i1.Session session,
     Types row, {
     _i1.Transaction? transaction,
@@ -470,7 +470,7 @@ class TypesRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<Types>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -278,7 +278,7 @@ class UniqueDataRepository {
     );
   }
 
-  Future<List<int>> delete(
+  Future<List<UniqueData>> delete(
     _i1.Session session,
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
@@ -289,7 +289,7 @@ class UniqueDataRepository {
     );
   }
 
-  Future<int> deleteRow(
+  Future<UniqueData> deleteRow(
     _i1.Session session,
     UniqueData row, {
     _i1.Transaction? transaction,
@@ -300,7 +300,7 @@ class UniqueDataRepository {
     );
   }
 
-  Future<List<int>> deleteWhere(
+  Future<List<UniqueData>> deleteWhere(
     _i1.Session session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/delete_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/delete_test.dart
@@ -1,0 +1,88 @@
+import 'package:serverpod/database.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+
+  tearDown(() async {
+    await SimpleData.db.deleteWhere(session, where: (_) => Constant.bool(true));
+  });
+
+  group('Given a list of entries', () {
+    late List<SimpleData> data;
+
+    setUp(() async {
+      data = await SimpleData.db.insert(session, [
+        SimpleData(num: 1),
+        SimpleData(num: 2),
+        SimpleData(num: 3),
+      ]);
+    });
+
+    group('when deleting row', () {
+      late SimpleData deleteResult;
+      setUp(() async {
+        deleteResult = await SimpleData.db.deleteRow(session, data[0]);
+      });
+
+      test('then the row is removed', () async {
+        var result = await SimpleData.db.find(session);
+
+        expect(result, hasLength(2));
+        var numbers = result.map((e) => e.num).toList();
+        expect(numbers, [data[1].num, data[2].num]);
+      });
+
+      test('then removed row is returned', () async {
+        expect(deleteResult.num, data[0].num);
+      });
+    });
+
+    group('when deleting multiple rows', () {
+      late List<SimpleData> deleteResult;
+
+      setUp(() async {
+        deleteResult = await SimpleData.db.delete(session, data.sublist(1));
+      });
+
+      test('then the rows are removed', () async {
+        var result = await SimpleData.db.find(session);
+
+        expect(result, hasLength(1));
+        expect(result.firstOrNull?.num, data[0].num);
+      });
+
+      test('then removed rows are returned', () async {
+        expect(deleteResult, hasLength(2));
+        var numbers = deleteResult.map((e) => e.num).toList();
+        expect(numbers, [data[1].num, data[2].num]);
+      });
+    });
+
+    group('when deleting based on filter', () {
+      late List<SimpleData> deleteResult;
+
+      setUp(() async {
+        deleteResult = await SimpleData.db.deleteWhere(
+          session,
+          where: (t) => t.num.inSet({data[0].num, data[2].num}),
+        );
+      });
+
+      test('then the rows are removed', () async {
+        var result = await SimpleData.db.find(session);
+
+        expect(result, hasLength(1));
+        expect(result.firstOrNull?.num, data[1].num);
+      });
+
+      test('then removed rows are returned', () async {
+        expect(deleteResult, hasLength(2));
+        var numbers = deleteResult.map((e) => e.num).toList();
+        expect(numbers, [data[0].num, data[2].num]);
+      });
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_any_test.dart
@@ -34,13 +34,14 @@ void main() async {
         Enrollment(studentId: students[1].id!, courseId: courses[1].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to any course.
         where: (s) => s.enrollments.any(),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -79,14 +80,15 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to any level 2 course.
         where: (s) =>
             s.enrollments.any((e) => e.course.name.ilike('level 2:%')),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -122,13 +124,14 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to any course or is named Alex.
         where: (s) => (s.enrollments.any()) | s.name.equals('Alex'),
       );
 
-      expect(deletedStudentIds, hasLength(3));
+      expect(deletedStudents, hasLength(3));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -168,7 +171,7 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to any level 2 course or a any math course.
         where: (s) =>
@@ -176,7 +179,8 @@ void main() async {
             (s.enrollments.any((e) => e.course.name.ilike('%math%'))),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_count_test.dart
@@ -39,13 +39,14 @@ void main() async {
         Enrollment(studentId: students[2].id!, courseId: courses[1].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to more than one course.
         where: (s) => s.enrollments.count() > 1,
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -86,16 +87,18 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // Fetch all students enrolled to more than one level 2 course.
         where: (s) =>
             s.enrollments.count((e) => e.course.name.ilike('level 2:%')) > 1,
       );
 
-      expect(deletedStudentIds, [
+      expect(deletedStudents, hasLength(1));
+      expect(
+        deletedStudents.firstOrNull?.id,
         students[3].id, // Lisa
-      ]);
+      );
     });
 
     test(
@@ -130,13 +133,14 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to more than two courses or is named Alex.
         where: (s) => (s.enrollments.count() > 2) | s.name.equals('Alex'),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -174,13 +178,14 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[2].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to more than one course but less than three courses.
         where: (s) => (s.enrollments.count() > 1) & (s.enrollments.count() < 3),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -225,7 +230,7 @@ void main() async {
         Enrollment(studentId: students[4].id!, courseId: courses[3].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to more than one level 2 course or more than two level 1 courses.
         where: (s) =>
@@ -233,7 +238,8 @@ void main() async {
             (s.enrollments.count((e) => e.course.name.ilike('level 1:%')) > 2),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_every_test.dart
@@ -44,16 +44,18 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to only level 2 courses.
         where: (s) =>
             s.enrollments.every((e) => e.course.name.ilike('level 2:%')),
       );
 
-      expect(deletedStudentIds, [
+      expect(deletedStudents, hasLength(1));
+      expect(
+        deletedStudents.firstOrNull?.id,
         students[3].id, // Lisa
-      ]);
+      );
     });
 
     test(
@@ -84,7 +86,7 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[3].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to only math courses or is named Alex.
         where: (s) =>
@@ -92,7 +94,8 @@ void main() async {
             s.name.equals('Alex'),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -131,7 +134,7 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to only level 2 courses or only math courses.
         where: (s) =>
@@ -139,7 +142,8 @@ void main() async {
             (s.enrollments.every((e) => e.course.name.ilike('%math%'))),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_none_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/many_to_many/deleteWhere/where_none_test.dart
@@ -34,15 +34,17 @@ void main() async {
         Enrollment(studentId: students[1].id!, courseId: courses[1].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled no courses.
         where: (s) => s.enrollments.none(),
       );
 
-      expect(deletedStudentIds, [
+      expect(deletedStudents, hasLength(1));
+      expect(
+        deletedStudents.firstOrNull?.id,
         students[2].id, // Lisa
-      ]);
+      );
     });
 
     test(
@@ -74,13 +76,14 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students not enrolled to no math courses.
         where: (s) => s.enrollments.none((e) => e.course.name.ilike('%math%')),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -109,13 +112,14 @@ void main() async {
         Enrollment(studentId: students[1].id!, courseId: courses[1].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // All students enrolled to no course or is named Alex.
         where: (s) => (s.enrollments.none()) | s.name.equals('Alex'),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([
@@ -152,7 +156,7 @@ void main() async {
         Enrollment(studentId: students[3].id!, courseId: courses[5].id!),
       ]);
 
-      var deletedStudentIds = await Student.db.deleteWhere(
+      var deletedStudents = await Student.db.deleteWhere(
         session,
         // Fetch all students enrolled to no level 2 course and no math course.
         where: (s) =>
@@ -160,7 +164,8 @@ void main() async {
             (s.enrollments.none((e) => e.course.name.ilike('%math%'))),
       );
 
-      expect(deletedStudentIds, hasLength(2));
+      expect(deletedStudents, hasLength(2));
+      var deletedStudentIds = deletedStudents.map((c) => c.id).toList();
       expect(
           deletedStudentIds,
           containsAll([

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_any_test.dart
@@ -42,13 +42,14 @@ void main() async {
       // Attach Isak to Bulls
       await Team.db.attachRow.players(session, teams[1], players[2]);
 
-      var deletedArenaIds = await Arena.db.deleteWhere(
+      var deletedArenas = await Arena.db.deleteWhere(
         session,
         // Delete all arenas with teams that have any player.
         where: (a) => a.team.players.any(),
       );
 
-      expect(deletedArenaIds, hasLength(2));
+      expect(deletedArenas, hasLength(2));
+      var deletedArenaIds = deletedArenas.map((c) => c.id).toList();
       expect(
           deletedArenaIds,
           containsAll([
@@ -83,15 +84,17 @@ void main() async {
       // Attach Isak to Bulls
       await Team.db.attachRow.players(session, teams[1], players[2]);
 
-      var deletedArenaIds = await Arena.db.deleteWhere(
+      var deletedArenas = await Arena.db.deleteWhere(
         session,
         // Delete all arenas with teams that have any player with a name starting with a.
         where: (a) => a.team.players.any((p) => p.name.ilike('a%')),
       );
 
-      expect(deletedArenaIds, [
+      expect(deletedArenas, hasLength(1));
+      expect(
+        deletedArenas.firstOrNull?.id,
         arenas[0].id, // Eagle Stadium
-      ]);
+      );
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_count_test.dart
@@ -42,15 +42,17 @@ void main() async {
       // Attach Isak to Bulls
       await Team.db.attachRow.players(session, teams[1], players[2]);
 
-      var deletedArenaIds = await Arena.db.deleteWhere(
+      var deletedArenas = await Arena.db.deleteWhere(
         session,
         // Delete all arenas with teams that have more than one player.
         where: (a) => a.team.players.count() > 1,
       );
 
-      expect(deletedArenaIds, [
+      expect(deletedArenas, hasLength(1));
+      expect(
+        deletedArenas.firstOrNull?.id,
         arenas[0].id, // Eagle Stadium
-      ]);
+      );
     });
 
     test(
@@ -81,15 +83,17 @@ void main() async {
       // Attach Isak And Alice to Bulls
       await Team.db.attach.players(session, teams[1], players.sublist(3, 5));
 
-      var deletedArenaIds = await Arena.db.deleteWhere(
+      var deletedArenas = await Arena.db.deleteWhere(
         session,
         // Delete all arenas with teams that have more than one player with a name starting with a.
         where: (a) => a.team.players.count((p) => p.name.ilike('a%')) > 1,
       );
 
-      expect(deletedArenaIds, [
+      expect(deletedArenas, hasLength(1));
+      expect(
+        deletedArenas.firstOrNull?.id,
         arenas[0].id, // Eagle Stadium
-      ]);
+      );
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_every_test.dart
@@ -47,15 +47,17 @@ void main() async {
       // Attach Anna to Sharks
       await Team.db.attachRow.players(session, teams[2], players[3]);
 
-      var deletedArenaIds = await Arena.db.deleteWhere(
+      var deletedArenas = await Arena.db.deleteWhere(
         session,
         // Delete arenas where all players in the team have a name starting with 'a' or 'A'.
         where: (a) => a.team.players.every((p) => p.name.ilike('a%')),
       );
 
-      expect(deletedArenaIds, [
+      expect(deletedArenas, hasLength(1));
+      expect(
+        deletedArenas.firstOrNull?.id,
         arenas[2].id, // Shark Tank
-      ]);
+      );
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_none_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/nested_one_to_many/deleteWhere/where_none_test.dart
@@ -42,15 +42,17 @@ void main() async {
       // Attach Isak to Bulls
       await Team.db.attachRow.players(session, teams[1], players[2]);
 
-      var deletedArenaIds = await Arena.db.deleteWhere(
+      var deletedArenas = await Arena.db.deleteWhere(
         session,
         // Delete all arenas with teams that have no players.
         where: (a) => a.team.players.none(),
       );
 
-      expect(deletedArenaIds, [
+      expect(deletedArenas, hasLength(1));
+      expect(
+        deletedArenas.firstOrNull?.id,
         arenas[2].id, // Shark Tank
-      ]);
+      );
     });
 
     test(
@@ -79,13 +81,14 @@ void main() async {
       // Attach Isak to Bulls
       await Team.db.attachRow.players(session, teams[1], players[2]);
 
-      var deletedArenaIds = await Arena.db.deleteWhere(
+      var deletedArenas = await Arena.db.deleteWhere(
         session,
         // Delete all arenas with teams that have no players with a name starting with a.
         where: (a) => a.team.players.none((p) => p.name.ilike('a%')),
       );
 
-      expect(deletedArenaIds, hasLength(2));
+      expect(deletedArenas, hasLength(2));
+      var deletedArenaIds = deletedArenas.map((c) => c.id).toList();
       expect(
           deletedArenaIds,
           containsAll([

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_any_test.dart
@@ -31,13 +31,14 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with any order.
         where: (c) => c.orders.any(),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -64,13 +65,14 @@ void main() async {
         Order(description: 'Prem: Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with any order with a description starting with 'prem'.
         where: (c) => c.orders.any((o) => o.description.ilike('prem%')),
       );
 
-      expect(deletedCustomerIds, [customers[2].id]);
+      expect(deletedCustomers, hasLength(1));
+      expect(deletedCustomers.firstOrNull?.id, customers[2].id);
     });
 
     test(
@@ -86,13 +88,14 @@ void main() async {
         Order(description: 'Order 1', customerId: customers[0].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with any order or name 'Isak'
         where: (c) => c.orders.any() | c.name.equals('Isak'),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -119,7 +122,7 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deleteCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with any order with a description starting with 'prem'
         // or 'basic'.
@@ -127,8 +130,9 @@ void main() async {
             o.description.ilike('prem%') | o.description.ilike('basic%')),
       );
 
-      expect(deleteCustomerIds, hasLength(2));
-      expect(deleteCustomerIds, [
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
+      expect(deletedCustomerIds, [
         customers[0].id, // Alex
         customers[2].id, // Viktor
       ]);
@@ -153,7 +157,7 @@ void main() async {
         Order(description: 'Basic: Order 7', customerId: customers[2].id!),
       ]);
 
-      var deleteCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with any order with a description starting with 'prem'
         // and any order with a description starting with 'basic'.
@@ -162,9 +166,11 @@ void main() async {
             c.orders.any((o) => o.description.ilike('basic%')),
       );
 
-      expect(deleteCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[2].id, // Viktor
-      ]);
+      );
     });
   });
 
@@ -204,15 +210,17 @@ void main() async {
         Comment(description: 'Comment 11', orderId: orders[3].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with any order that have any comment.
         where: (c) => c.orders.any((o) => o.comments.any()),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[1].id, // Isak
-      ]);
+      );
     });
 
     test(
@@ -249,7 +257,7 @@ void main() async {
         Comment(description: 'Comment 11', orderId: orders[3].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         where: (c) => c.orders.any(
 
@@ -257,9 +265,11 @@ void main() async {
             (o) => o.comments.any((c) => c.description.ilike('del%'))),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[1].id, // Isak
-      ]);
+      );
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_count_test.dart
@@ -32,13 +32,14 @@ void main() async {
         Order(description: 'Order 6', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with more than one order
         where: (c) => c.orders.count() > 1,
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
         deletedCustomerIds,
         containsAll([
@@ -65,15 +66,17 @@ void main() async {
         Order(description: 'Prem: Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with more than one order starting with 'prem'
         where: (c) => c.orders.count((o) => o.description.ilike('prem%')) > 1,
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[2].id, // Viktor
-      ]);
+      );
     });
 
     test(
@@ -94,13 +97,14 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with more than two orders or name 'Isak'
         where: (c) => (c.orders.count() > 2) | c.name.equals('Isak'),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -127,15 +131,17 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with more than one orders but less than three
         where: (c) => (c.orders.count() > 1) & (c.orders.count() < 3),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[2].id, // Viktor
-      ]);
+      );
     });
 
     test(
@@ -158,7 +164,7 @@ void main() async {
         Order(description: 'Basic: Order 7', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with more than one premium order and one basic order
         where: (c) =>
@@ -166,9 +172,11 @@ void main() async {
             (c.orders.count((o) => o.description.ilike('basic%')) > 1),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[2].id, // Viktor
-      ]);
+      );
     });
   });
 
@@ -221,15 +229,17 @@ void main() async {
         Comment(description: 'Comment 14', orderId: orders[4].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with more than one order with more than two comments
         where: (c) => c.orders.count((o) => o.comments.count() > 2) > 1,
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[1].id, // Isak
-      ]);
+      );
     });
 
     test(
@@ -272,16 +282,18 @@ void main() async {
         Comment(description: 'Comment 14', orderId: orders[4].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         where: (c) => c.orders.count(
             // All customers with more than one order with more than one comment starting with 'del'
             (o) => o.comments.count((c) => c.description.ilike('del%')) > 1) > 1,
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[1].id, // Isak
-      ]);
+      );
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_every_test.dart
@@ -31,15 +31,17 @@ void main() async {
         Order(description: 'Prem: Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers where every order has a description starting with 'prem'.
         where: (c) => c.orders.every((o) => o.description.ilike('prem%')),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[2].id, // Viktor
-      ]);
+      );
     });
 
     test(
@@ -60,7 +62,7 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers where every order has a description starting with 'prem' or customer name is 'Viktor'
         where: (c) =>
@@ -68,7 +70,8 @@ void main() async {
             c.name.equals('Isak'),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -95,7 +98,7 @@ void main() async {
         Order(description: 'Basic: Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers where every order has a description starting with 'prem'
         // or 'basic'.
@@ -103,9 +106,11 @@ void main() async {
             o.description.ilike('prem%') | o.description.ilike('basic%')),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[2].id, // Viktor
-      ]);
+      );
     });
 
     test(
@@ -130,7 +135,7 @@ void main() async {
         Order(description: 'Basic: Order 7', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers where every order has a description starting with 'prem'
         // or every order has a description starting with 'basic'.
@@ -139,7 +144,8 @@ void main() async {
             c.orders.every((o) => o.description.ilike('basic%')),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -198,14 +204,15 @@ void main() async {
         Comment(description: 'Del: Comment 14', orderId: orders[4].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers where every comment for every order starts with del.
         where: (c) => c.orders
             .every((o) => o.comments.every((c) => c.description.ilike('del%'))),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(deletedCustomerIds, [
         customers[0].id, // Alex
         customers[2].id, // Viktor
@@ -249,7 +256,7 @@ void main() async {
         Comment(description: 'Del: Comment 9', orderId: orders[3].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers where every comment for every order starts with 'del' or every order starts with 'prem'.
         where: (c) => c.orders.every((o) =>
@@ -257,7 +264,8 @@ void main() async {
             o.description.ilike('prem%')),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_none_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/one_to_many/deleteWhere/where_none_test.dart
@@ -31,15 +31,17 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with no order.
         where: (c) => c.orders.none(),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[1].id, // Isak
-      ]);
+      );
     });
 
     test(
@@ -60,13 +62,14 @@ void main() async {
         Order(description: 'Prem: Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with no orders with a description starting with 'prem'.
         where: (c) => c.orders.none((o) => o.description.ilike('prem%')),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -93,13 +96,14 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with no orders or name 'Viktor'
         where: (c) => c.orders.none() | c.name.equals('Viktor'),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -126,7 +130,7 @@ void main() async {
         Order(description: 'Order 5', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with no orders with a description starting with 'prem'
         // or 'basic'.
@@ -134,9 +138,11 @@ void main() async {
             o.description.ilike('prem%') | o.description.ilike('basic%')),
       );
 
-      expect(deletedCustomerIds, [
+      expect(deletedCustomers, hasLength(1));
+      expect(
+        deletedCustomers.firstOrNull?.id,
         customers[1].id, // Isak
-      ]);
+      );
     });
 
     test(
@@ -158,7 +164,7 @@ void main() async {
         Order(description: 'Basic: Order 7', customerId: customers[2].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers with no orders with a description starting with 'prem'
         // or no orders with a description starting with 'basic'.
@@ -167,7 +173,8 @@ void main() async {
             c.orders.none((o) => o.description.ilike('basic%')),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -216,13 +223,14 @@ void main() async {
         Comment(description: 'Comment 11', orderId: orders[3].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         // All customers without orders that have no comments.
         where: (c) => c.orders.none((o) => o.comments.none()),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([
@@ -265,7 +273,7 @@ void main() async {
         Comment(description: 'Comment 11', orderId: orders[3].id!),
       ]);
 
-      var deletedCustomerIds = await Customer.db.deleteWhere(
+      var deletedCustomers = await Customer.db.deleteWhere(
         session,
         where: (c) => c.orders.none(
 
@@ -273,7 +281,8 @@ void main() async {
             (o) => o.comments.none((c) => c.description.ilike('del%'))),
       );
 
-      expect(deletedCustomerIds, hasLength(2));
+      expect(deletedCustomers, hasLength(2));
+      var deletedCustomerIds = deletedCustomers.map((c) => c.id).toList();
       expect(
           deletedCustomerIds,
           containsAll([

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_any_test.dart
@@ -36,10 +36,11 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db
+        var deleted = await Member.db
             .deleteWhere(session, where: (t) => t.blocking.any());
 
-        expect(deletedIds, hasLength(3));
+        expect(deleted, hasLength(3));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(
           deletedIds,
           containsAll(
@@ -73,14 +74,15 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => t.blocking.any(
             (c) => c.blockedId.equals(member[0].id!),
           ),
         );
 
-        expect(deletedIds, hasLength(2));
+        expect(deleted, hasLength(2));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, [member[1].id, member[2].id]);
       },
     );
@@ -106,12 +108,13 @@ void main() async {
         Blocking(blockedById: member[1].id!, blockedId: member[2].id!),
       ]);
 
-      var deletedIds = await Member.db.deleteWhere(
+      var deleted = await Member.db.deleteWhere(
         session,
         where: (t) => t.blocking.any() | t.name.equals('Member3'),
       );
 
-      expect(deletedIds, hasLength(3));
+      expect(deleted, hasLength(3));
+      var deletedIds = deleted.map((c) => c.id).toList();
       expect(
         deletedIds,
         containsAll(
@@ -144,14 +147,15 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) =>
               t.blocking.any((o) => o.blocked.name.ilike('%3')) &
               t.blockedBy.any((o) => o.blockedBy.name.ilike('%1')),
         );
 
-        expect(deletedIds, [member[1].id!]);
+        expect(deleted, hasLength(1));
+        expect(deleted.firstOrNull?.id, member[1].id!);
       },
     );
   });

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_count_test.dart
@@ -36,10 +36,11 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db
+        var deleted = await Member.db
             .deleteWhere(session, where: (t) => t.blocking.count() > 1);
 
-        expect(deletedIds, hasLength(2));
+        expect(deleted, hasLength(2));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, containsAll([member[0].id!, member[1].id!]));
       },
     );
@@ -68,7 +69,7 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => t.blocking
               .count(
@@ -77,7 +78,8 @@ void main() async {
               .equals(1),
         );
 
-        expect(deletedIds, hasLength(2));
+        expect(deleted, hasLength(2));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, containsAll([member[1].id!, member[2].id!]));
       },
     );
@@ -103,12 +105,13 @@ void main() async {
           Blocking(blockedById: member[1].id!, blockedId: member[2].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => (t.blocking.count() > 1) | t.name.equals('Member3'),
         );
 
-        expect(deletedIds, hasLength(3));
+        expect(deleted, hasLength(3));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(
           deletedIds,
           containsAll(
@@ -142,12 +145,13 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => (t.blocking.count() > 1) & (t.blocking.count() < 3),
         );
 
-        expect(deletedIds, [member[1].id!]);
+        expect(deleted, hasLength(1));
+        expect(deleted.firstOrNull?.id, member[1].id!);
       },
     );
 
@@ -175,14 +179,15 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) =>
               t.blocking.count((o) => o.blocked.name.ilike('%3')).equals(1) &
               t.blockedBy.count((o) => o.blockedBy.name.ilike('%1')).equals(1),
         );
 
-        expect(deletedIds, [member[1].id!]);
+        expect(deleted, hasLength(1));
+        expect(deleted.firstOrNull?.id, member[1].id!);
       },
     );
   });

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_every_test.dart
@@ -36,14 +36,15 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => t.blocking.every(
             (c) => c.blockedId.equals(member[0].id!),
           ),
         );
 
-        expect(deletedIds, [member[2].id!]);
+        expect(deleted, hasLength(1));
+        expect(deleted.firstOrNull?.id, member[2].id!);
       },
     );
 
@@ -68,14 +69,15 @@ void main() async {
           Blocking(blockedById: member[1].id!, blockedId: member[2].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) =>
               t.blocking.every((o) => o.blockedBy.name.equals('Member1')) |
               t.name.equals('Member3'),
         );
 
-        expect(deletedIds, hasLength(2));
+        expect(deleted, hasLength(2));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, containsAll([member[0].id!, member[2].id!]));
       },
     );
@@ -104,14 +106,15 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) =>
               t.blocking.every((o) => o.blockedBy.name.equals('Member1')) |
               t.blocking.every((o) => o.blockedBy.name.equals('Member2')),
         );
 
-        expect(deletedIds, hasLength(2));
+        expect(deleted, hasLength(2));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, [member[0].id!, member[1].id!]);
       },
     );

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_none_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/many_to_many/deleteWhere/where_none_test.dart
@@ -36,12 +36,13 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => t.blocking.none(),
         );
 
-        expect(deletedIds, containsAll([member[3].id!]));
+        expect(deleted, hasLength(1));
+        expect(deleted.firstOrNull?.id, member[3].id!);
       },
     );
 
@@ -69,14 +70,15 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => t.blocking.none(
             (c) => c.blockedId.equals(member[0].id!),
           ),
         );
 
-        expect(deletedIds, hasLength(2));
+        expect(deleted, hasLength(2));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, [member[0].id!, member[3].id!]);
       },
     );
@@ -102,12 +104,13 @@ void main() async {
           Blocking(blockedById: member[1].id!, blockedId: member[2].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) => t.blocking.none() | t.name.equals('Member3'),
         );
 
-        expect(deletedIds, hasLength(2));
+        expect(deleted, hasLength(2));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, containsAll([member[2].id!, member[3].id!]));
       },
     );
@@ -136,14 +139,15 @@ void main() async {
           Blocking(blockedById: member[2].id!, blockedId: member[0].id!),
         ]);
 
-        var deletedIds = await Member.db.deleteWhere(
+        var deleted = await Member.db.deleteWhere(
           session,
           where: (t) =>
               t.blocking.none((o) => o.blocked.name.ilike('%3')) |
               t.blockedBy.none((o) => o.blockedBy.name.ilike('%1')),
         );
 
-        expect(deletedIds, hasLength(3));
+        expect(deleted, hasLength(3));
+        var deletedIds = deleted.map((c) => c.id).toList();
         expect(deletedIds, [member[0].id!, member[2].id!, member[3].id!]);
       },
     );

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_any_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_any_test.dart
@@ -23,12 +23,13 @@ void main() async {
           Cat(name: 'Kitten3', motherId: zelda.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.any(),
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
 
@@ -45,12 +46,13 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.any((t) => t.name.ilike('smul%')),
         );
 
-        expect(deletedCatIds, [smulan.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, smulan.id);
       },
     );
 
@@ -67,12 +69,13 @@ void main() async {
         Cat(name: 'Smulan II', motherId: smulan.id),
       ]);
 
-      var deletedCatIds = await Cat.db.deleteWhere(
+      var deletedCats = await Cat.db.deleteWhere(
         session,
         where: (t) => t.kittens.any() | t.name.equals('Zelda'),
       );
 
-      expect(deletedCatIds, hasLength(2));
+      expect(deletedCats, hasLength(2));
+      var deletedCatIds = deletedCats.map((c) => c.id).toList();
       expect(deletedCatIds, containsAll([zelda.id, smulan.id]));
     });
 
@@ -89,14 +92,15 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.any(
             (t) => t.name.ilike('kitt%') | t.name.equals('Smulan II'),
           ),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, [zelda.id, smulan.id]);
       },
     );
@@ -114,14 +118,15 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) =>
               t.kittens.any((t) => t.name.ilike('kitt%')) &
               t.kittens.any((t) => t.name.equals('Zelda II')),
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
   });
@@ -150,12 +155,13 @@ void main() async {
           Cat(name: 'Nested Kitten3', motherId: kittens.last.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.any((o) => o.kittens.any()),
         );
 
-        expect(deletedCatIds, [smulan.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, smulan.id);
       },
     );
 
@@ -179,14 +185,15 @@ void main() async {
           Cat(name: 'Nested Kitten4', motherId: kittens.first.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.any(
             (o) => o.kittens.any((o) => o.name.equals('Nested Kitten1')),
           ),
         );
 
-        expect(deletedCatIds, [smulan.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, smulan.id);
       },
     );
   });

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_count_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_count_test.dart
@@ -23,12 +23,13 @@ void main() async {
           Cat(name: 'Kitten4', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.count() > 1,
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
 
@@ -45,12 +46,13 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.count((t) => t.name.ilike('kitt%')) > 1,
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
 
@@ -67,12 +69,13 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => (t.kittens.count() > 2) | t.name.equals('Smulan'),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll([zelda.id, smulan.id]));
       },
     );
@@ -91,12 +94,13 @@ void main() async {
           Cat(name: 'Kitten4', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => (t.kittens.count() > 1) & (t.kittens.count() < 3),
         );
 
-        expect(deletedCatIds, [smulan.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, smulan.id);
       },
     );
 
@@ -114,14 +118,15 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) =>
               (t.kittens.count((t) => t.name.ilike('kitt%')) > 1) &
               (t.kittens.count((t) => t.name.ilike('Zelda%')) > 1),
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
   });
@@ -159,12 +164,13 @@ void main() async {
           Cat(name: 'Nested Kitten9', motherId: kittens[1].id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.count((o) => o.kittens.count() > 2) > 1,
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
 
@@ -196,14 +202,15 @@ void main() async {
           Cat(name: 'Nested Kitten9', motherId: kittens[1].id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.count(
               // All cats with more than 1 kitten with more than 1 kittens named Zelda
               (o) => o.kittens.count((c) => c.name.ilike('zelda%')) > 1) > 1,
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
   });

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_every_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_every_test.dart
@@ -24,12 +24,13 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.every((o) => o.name.ilike('kitt%')),
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
 
@@ -46,14 +47,15 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) =>
               t.kittens.every((o) => o.name.ilike('kitt%')) |
               t.name.equals('Smulan'),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll([zelda.id, smulan.id]));
       },
     );
@@ -71,13 +73,14 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens
               .every((t) => t.name.ilike('kitt%') | t.name.equals('Smulan II')),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll([zelda.id, smulan.id]));
       },
     );
@@ -95,14 +98,15 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) =>
               t.kittens.every((t) => t.name.ilike('kitt%')) |
               t.kittens.every((t) => t.name.ilike('smul%')),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll([zelda.id, smulan.id]));
       },
     );
@@ -132,14 +136,15 @@ void main() async {
           Cat(name: 'Nested Kitten3', motherId: kittens.last.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.every(
               // All cats where all kittens has kittens with name starting with 'Nest'
               (o) => o.kittens.every((c) => c.name.ilike('nest%'))),
         );
 
-        expect(deletedCatIds, [smulan.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, smulan.id);
       },
     );
 
@@ -161,14 +166,15 @@ void main() async {
           Cat(name: 'Smulan III', motherId: kittens.last.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.every(
             (o) => o.kittens.every((o) => o.name.ilike('%kitten%')),
           ),
         );
 
-        expect(deletedCatIds, [zelda.id]);
+        expect(deletedCats, hasLength(1));
+        expect(deletedCats.firstOrNull?.id, zelda.id);
       },
     );
   });

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_none_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/self/one_to_many/deleteWhere/where_none_test.dart
@@ -23,12 +23,13 @@ void main() async {
           Cat(name: 'Kitten3', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.none(),
         );
 
-        expect(deletedCatIds, hasLength(3));
+        expect(deletedCats, hasLength(3));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll(kittens.map((e) => e.id)));
       },
     );
@@ -44,12 +45,13 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.none((t) => t.name.ilike('smul%')),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll(kittens.map((e) => e.id)));
       },
     );
@@ -65,12 +67,13 @@ void main() async {
           Cat(name: 'Kitten2', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.none() | t.name.equals('Zelda'),
         );
 
-        expect(deletedCatIds, hasLength(3));
+        expect(deletedCats, hasLength(3));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(
           deletedCatIds,
           containsAll([zelda.id, kittens.first.id!, kittens.last.id!]),
@@ -89,14 +92,15 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.none(
             (o) => o.name.ilike('kitt%') | o.name.ilike('smul%'),
           ),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll(kittens.map((e) => e.id)));
       },
     );
@@ -112,14 +116,15 @@ void main() async {
           Cat(name: 'Smulan II', motherId: smulan.id),
         ]);
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) =>
               t.kittens.none((o) => o.name.ilike('kitt%')) &
               t.kittens.none((o) => o.name.ilike('smul%')),
         );
 
-        expect(deletedCatIds, hasLength(2));
+        expect(deletedCats, hasLength(2));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(deletedCatIds, containsAll(kittens.map((e) => e.id)));
       },
     );
@@ -146,12 +151,13 @@ void main() async {
           Cat(name: 'Kitten2', motherId: kittens.first.id),
         );
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.none((o) => o.kittens.none()),
         );
 
-        expect(deletedCatIds, hasLength(3));
+        expect(deletedCats, hasLength(3));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(
           deletedCatIds,
           containsAll([zelda.id!, kittens.last.id!, kitten2.id!]),
@@ -175,14 +181,15 @@ void main() async {
           Cat(name: 'Kitten2', motherId: kittens.first.id),
         );
 
-        var deletedCatIds = await Cat.db.deleteWhere(
+        var deletedCats = await Cat.db.deleteWhere(
           session,
           where: (t) => t.kittens.none(
             (o) => o.kittens.none((o) => o.name.ilike('kitt%')),
           ),
         );
 
-        expect(deletedCatIds, hasLength(3));
+        expect(deletedCats, hasLength(3));
+        var deletedCatIds = deletedCats.map((c) => c.id).toList();
         expect(
           deletedCatIds,
           containsAll([zelda.id!, kittens.last.id!, kitten2.id!]),

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -639,7 +639,15 @@ class BuildRepositoryClass {
         ..returns = TypeReference(
           (r) => r
             ..symbol = 'Future'
-            ..types.add((refer('List<int>'))),
+            ..types.add(TypeReference(
+              (r) => r
+                ..symbol = 'List'
+                ..types.add(
+                  TypeReference(
+                    (r) => r..symbol = className,
+                  ),
+                ),
+            )),
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
@@ -681,7 +689,9 @@ class BuildRepositoryClass {
         ..returns = TypeReference(
           (r) => r
             ..symbol = 'Future'
-            ..types.add((refer('int'))),
+            ..types.add(TypeReference(
+              (r) => r..symbol = className,
+            )),
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
@@ -723,7 +733,15 @@ class BuildRepositoryClass {
         ..returns = TypeReference(
           (r) => r
             ..symbol = 'Future'
-            ..types.add((refer('List<int>'))),
+            ..types.add(TypeReference(
+              (r) => r
+                ..symbol = 'List'
+                ..types.add(
+                  TypeReference(
+                    (r) => r..symbol = className,
+                  ),
+                ),
+            )),
         )
         ..requiredParameters.addAll([
           Parameter((p) => p

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
@@ -486,7 +486,7 @@ void main() {
         test('that returns a future with the base class', () {
           expect(
             deleteMethod?.returnType?.toSource(),
-            contains('Future<List<int>>'),
+            contains('Future<List<$testClassName>>'),
           );
         });
 
@@ -535,7 +535,7 @@ void main() {
 
           expect(
             deleteRowMethod?.returnType?.toSource(),
-            contains('int'),
+            contains(testClassName),
           );
         });
 
@@ -584,7 +584,7 @@ void main() {
 
           expect(
             deleteWhereMethod?.returnType?.toSource(),
-            contains('List<int>'),
+            contains('List<$testClassName>'),
           );
         });
 


### PR DESCRIPTION
### Change
- Changes the return type of all delete methods to return the object that is deleted.

This change ensures that our find and delete methods have the same return type and enables the possibility to "pop" an entry form the database in a single transaction.

Documentation update: https://github.com/serverpod/serverpod_docs/pull/89

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Yes - Changes the return type for the delete methods.
