### PR TITLE
fix: Retrieve and remove future call entries in one operation.

### DIFF
--- a/packages/serverpod/lib/src/server/future_call_manager.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager.dart
@@ -108,22 +108,10 @@ class FutureCallManager {
         enableLogging: false,
       );
 
-      var rows = await tempSession.db
-          .transaction<List<FutureCallEntry>>((transaction) async {
-        var activeFutureCalls = await FutureCallEntry.db.find(
-          tempSession,
-          where: (t) => t.time <= now,
-          transaction: transaction,
-        );
-
-        await FutureCallEntry.db.deleteWhere(
-          tempSession,
-          where: (t) => t.time <= now,
-          transaction: transaction,
-        );
-
-        return activeFutureCalls;
-      });
+      var rows = await FutureCallEntry.db.deleteWhere(
+        tempSession,
+        where: (t) => t.time <= now,
+      );
 
       await tempSession.close();
 


### PR DESCRIPTION
### Change:
- Utilize the delete where operation to retrieve and remove future call entries.

Since no policy is configured for transactions, multiple instance of Serverpod might read and process the same future call operations before where removed from the database.

This issue was introduced when the `deleteAndReturn` method was removed but has not been released in a stable release yet.

This PR depends on the changes in https://github.com/serverpod/serverpod/pull/2121

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - internal functionality.
