### PR TITLE
fix: Prevent crash when missing web or template directory (Stable 1.2)

### DIFF
--- a/packages/serverpod/lib/src/relic/templates.dart
+++ b/packages/serverpod/lib/src/relic/templates.dart
@@ -12,6 +12,8 @@ class Templates {
 
   /// Loads all templates from web/templates
   Future<void> loadAll(Directory templateDirectory) async {
+    if (!await templateDirectory.exists()) return;
+
     for (var entity in await templateDirectory.list().toList()) {
       if (entity is File && extension(entity.path).toLowerCase() == '.html') {
         var file = entity;

--- a/packages/serverpod/lib/src/relic/templates.dart
+++ b/packages/serverpod/lib/src/relic/templates.dart
@@ -31,4 +31,7 @@ class Templates {
   Template? operator [](String name) {
     return _templates[name];
   }
+
+  /// Returns true if no templates are loaded.
+  bool get isEmpty => _templates.isEmpty;
 }

--- a/packages/serverpod/lib/src/relic/templates.dart
+++ b/packages/serverpod/lib/src/relic/templates.dart
@@ -11,9 +11,8 @@ class Templates {
   final Map<String, Template> _templates = {};
 
   /// Loads all templates from web/templates
-  Future<void> loadAll() async {
-    var dir = Directory('web/templates');
-    for (var entity in await dir.list().toList()) {
+  Future<void> loadAll(Directory templateDirectory) async {
+    for (var entity in await templateDirectory.list().toList()) {
       if (entity is File && extension(entity.path).toLowerCase() == '.html') {
         var file = entity;
         var name = basenameWithoutExtension(file.path);

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:serverpod/serverpod.dart';
+import 'package:path/path.dart' as path;
 
 /// The Serverpod webserver.
 class WebServer {
@@ -49,7 +50,7 @@ class WebServer {
   /// Starts the webserver.
   /// Returns true if the webserver was started successfully.
   Future<bool> start() async {
-    await templates.loadAll();
+    await templates.loadAll(Directory(path.joinAll(['web', 'templates'])));
 
     try {
       _httpServer = await HttpServer.bind(InternetAddress.anyIPv6, _port);

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -50,7 +50,12 @@ class WebServer {
   /// Starts the webserver.
   /// Returns true if the webserver was started successfully.
   Future<bool> start() async {
-    await templates.loadAll(Directory(path.joinAll(['web', 'templates'])));
+    var templatesDirectory = Directory(path.joinAll(['web', 'templates']));
+    await templates.loadAll(templatesDirectory);
+    if (templates.isEmpty) {
+      logDebug(
+          'No webserver relic templates found, template directory path: "${templatesDirectory.path}".');
+    }
 
     try {
       _httpServer = await HttpServer.bind(InternetAddress.anyIPv6, _port);

--- a/packages/serverpod/test/relic/templates_test.dart
+++ b/packages/serverpod/test/relic/templates_test.dart
@@ -1,0 +1,12 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given missing templates folder when loading templates then no templates are loaded',
+      () async {
+    await templates.loadAll();
+
+    expect(templates, isEmpty);
+  });
+}

--- a/packages/serverpod/test/relic/templates_test.dart
+++ b/packages/serverpod/test/relic/templates_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
 import 'package:serverpod/serverpod.dart';
 import 'package:test/test.dart';
 
@@ -5,7 +8,11 @@ void main() {
   test(
       'Given missing templates folder when loading templates then no templates are loaded',
       () async {
-    await templates.loadAll();
+    var uniqueUuid = const Uuid().v4();
+    var nonExistingDirectory =
+        Directory(path.joinAll([uniqueUuid, 'non-existing-directory']));
+
+    await templates.loadAll(nonExistingDirectory);
 
     expect(templates, isEmpty);
   });


### PR DESCRIPTION
Same fix as here: https://github.com/serverpod/serverpod/pull/2138

Connected to #2101 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.
