### PR TITLE
fix: Misc serverpod fixes.

### DIFF
--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -124,7 +124,7 @@ class ServerpodCommandRunner extends CommandRunner {
       return super.parse(args);
     } on UsageException catch (e) {
       _analytics.track(event: 'invalid');
-      log.error(e.toString(), type: const RawLogType());
+      log.error(e.toString());
       throw ExitException(ExitCodeType.commandNotFound);
     }
   }
@@ -145,7 +145,7 @@ class ServerpodCommandRunner extends CommandRunner {
         _analytics.track(event: topLevelResults.command!.name!);
       }
     } on UsageException catch (e) {
-      log.error(e.toString(), type: const RawLogType());
+      log.error(e.toString());
       _analytics.track(event: 'invalid');
       throw ExitException(ExitCodeType.commandNotFound);
     }

--- a/tools/serverpod_cli/test/integration/downloads/resource_manager_test.dart
+++ b/tools/serverpod_cli/test/integration/downloads/resource_manager_test.dart
@@ -8,7 +8,8 @@ import 'package:test/test.dart';
 
 void main() {
   group('Latest Cli Version: ', () {
-    var testCacheFolderPath = p.join('test', 'downloads', 'localCache');
+    var testCacheFolderPath =
+        p.join('test', 'integration', 'downloads', 'localCache');
 
     tearDown(() {
       var directory = Directory(testCacheFolderPath);


### PR DESCRIPTION
Minor fixes encountered when working on a different feature.

These should also be applied to the stable 1.2 branch.

### Changes
- Removes a trailing `%` print for error messages (same fix as we applied before but for regulair messages)
- Moves the resource manager integration tests to the integration test folder.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - just minor fixes.