### PR TITLE
fix: Prevent generating empty endpoints variable when no endpoints are defined.

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -316,8 +316,11 @@ class LibraryGenerator {
                   ..name = 'server'
                   ..type = refer('Server', serverpodUrl(true)))))
                 ..body = Block.of([
-                  _buildEndpointLookupMap(protocolDefinition.endpoints),
-                  _buildEndpointConnectors(protocolDefinition.endpoints),
+                  if (protocolDefinition.endpoints.isNotEmpty) ...[
+                    _buildEndpointLookupMap(protocolDefinition.endpoints),
+                    _buildEndpointConnectors(protocolDefinition.endpoints),
+                  ],
+
                   // Connectors
                   // Hook up modules
                   for (var module in config.modules)

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -300,16 +300,6 @@ class LibraryGenerator {
   Library generateServerEndpointDispatch() {
     var library = LibraryBuilder();
 
-    /// Get the path to a endpoint.
-    String endpointPath(EndpointDefinition endpoint) {
-      return p.posix.joinAll([
-        '..',
-        'endpoints',
-        ...endpoint.subDirParts,
-        p.basename(endpoint.filePath),
-      ]);
-    }
-
     // Endpoint class
     library.body.add(
       Class(
@@ -326,103 +316,9 @@ class LibraryGenerator {
                   ..name = 'server'
                   ..type = refer('Server', serverpodUrl(true)))))
                 ..body = Block.of([
-                  // Endpoints lookup map
-                  refer('var endpoints')
-                      .assign(literalMap({
-                        for (var endpoint in protocolDefinition.endpoints)
-                          endpoint.name:
-                              refer(endpoint.className, endpointPath(endpoint))
-                                  .call([])
-                                  .cascade('initialize')
-                                  .call([
-                                    refer('server'),
-                                    literalString(endpoint.name),
-                                    config.type != PackageType.module
-                                        ? refer('null')
-                                        : literalString(config.name)
-                                  ])
-                      }, refer('String'),
-                          refer('Endpoint', serverpodUrl(true))))
-                      .statement,
+                  _buildEndpointLookupMap(protocolDefinition.endpoints),
+                  _buildEndpointConnectors(protocolDefinition.endpoints),
                   // Connectors
-                  for (var endpoint in protocolDefinition.endpoints)
-                    refer('connectors')
-                        .index(literalString(endpoint.name))
-                        .assign(refer('EndpointConnector', serverpodUrl(true))
-                            .call([], {
-                          'name': literalString(endpoint.name),
-                          'endpoint': refer('endpoints')
-                              .index(literalString(endpoint.name))
-                              .nullChecked,
-                          'methodConnectors': literalMap({
-                            for (var method in endpoint.methods)
-                              literalString(method.name):
-                                  refer('MethodConnector', serverpodUrl(true))
-                                      .call([], {
-                                'name': literalString(method.name),
-                                'params': literalMap({
-                                  for (var param in [
-                                    ...method.parameters,
-                                    ...method.parametersPositional,
-                                    ...method.parametersNamed,
-                                  ])
-                                    literalString(param.name): refer(
-                                            'ParameterDescription',
-                                            serverpodUrl(true))
-                                        .call([], {
-                                      'name': literalString(param.name),
-                                      'type':
-                                          refer('getType', serverpodUrl(true))
-                                              .call([], {}, [
-                                        param.type
-                                            .reference(true, config: config)
-                                      ]),
-                                      'nullable':
-                                          literalBool(param.type.nullable),
-                                    })
-                                }),
-                                'call': Method(
-                                  (m) => m
-                                    ..requiredParameters.addAll([
-                                      Parameter((p) => p
-                                        ..name = 'session'
-                                        ..type = refer(
-                                            'Session', serverpodUrl(true))),
-                                      Parameter((p) => p
-                                        ..name = 'params'
-                                        ..type = TypeReference((t) => t
-                                          ..symbol = 'Map'
-                                          ..types.addAll([
-                                            refer('String'),
-                                            refer('dynamic'),
-                                          ])))
-                                    ])
-                                    ..modifier = MethodModifier.async
-                                    ..body = refer('endpoints')
-                                        .index(literalString(endpoint.name))
-                                        .asA(refer(endpoint.className,
-                                            endpointPath(endpoint)))
-                                        .property(method.name)
-                                        .call([
-                                      refer('session'),
-                                      for (var param in [
-                                        ...method.parameters,
-                                        ...method.parametersPositional
-                                      ])
-                                        refer('params')
-                                            .index(literalString(param.name)),
-                                    ], {
-                                      for (var param in [
-                                        ...method.parametersNamed
-                                      ])
-                                        param.name: refer('params')
-                                            .index(literalString(param.name)),
-                                    }).code,
-                                ).closure,
-                              }),
-                          })
-                        }))
-                        .statement,
                   // Hook up modules
                   for (var module in config.modules)
                     refer('modules')
@@ -732,6 +628,104 @@ class LibraryGenerator {
     );
 
     return library.build();
+  }
+
+  String _endpointPath(EndpointDefinition endpoint) {
+    return p.posix.joinAll([
+      '..',
+      'endpoints',
+      ...endpoint.subDirParts,
+      p.basename(endpoint.filePath),
+    ]);
+  }
+
+  Code _buildEndpointLookupMap(List<EndpointDefinition> endpoints) {
+    return refer('var endpoints')
+        .assign(literalMap({
+          for (var endpoint in endpoints)
+            endpoint.name: refer(endpoint.className, _endpointPath(endpoint))
+                .call([])
+                .cascade('initialize')
+                .call([
+                  refer('server'),
+                  literalString(endpoint.name),
+                  config.type != PackageType.module
+                      ? refer('null')
+                      : literalString(config.name)
+                ])
+        }, refer('String'), refer('Endpoint', serverpodUrl(true))))
+        .statement;
+  }
+
+  Code _buildEndpointConnectors(List<EndpointDefinition> endpoints) {
+    return Block.of([
+      for (var endpoint in endpoints)
+        refer('connectors')
+            .index(literalString(endpoint.name))
+            .assign(refer('EndpointConnector', serverpodUrl(true)).call([], {
+              'name': literalString(endpoint.name),
+              'endpoint': refer('endpoints')
+                  .index(literalString(endpoint.name))
+                  .nullChecked,
+              'methodConnectors': literalMap({
+                for (var method in endpoint.methods)
+                  literalString(method.name):
+                      refer('MethodConnector', serverpodUrl(true)).call([], {
+                    'name': literalString(method.name),
+                    'params': literalMap({
+                      for (var param in [
+                        ...method.parameters,
+                        ...method.parametersPositional,
+                        ...method.parametersNamed,
+                      ])
+                        literalString(param.name):
+                            refer('ParameterDescription', serverpodUrl(true))
+                                .call([], {
+                          'name': literalString(param.name),
+                          'type': refer('getType', serverpodUrl(true)).call([],
+                              {}, [param.type.reference(true, config: config)]),
+                          'nullable': literalBool(param.type.nullable),
+                        })
+                    }),
+                    'call': Method(
+                      (m) => m
+                        ..requiredParameters.addAll([
+                          Parameter((p) => p
+                            ..name = 'session'
+                            ..type = refer('Session', serverpodUrl(true))),
+                          Parameter((p) => p
+                            ..name = 'params'
+                            ..type = TypeReference((t) => t
+                              ..symbol = 'Map'
+                              ..types.addAll([
+                                refer('String'),
+                                refer('dynamic'),
+                              ])))
+                        ])
+                        ..modifier = MethodModifier.async
+                        ..body = refer('endpoints')
+                            .index(literalString(endpoint.name))
+                            .asA(refer(
+                                endpoint.className, _endpointPath(endpoint)))
+                            .property(method.name)
+                            .call([
+                          refer('session'),
+                          for (var param in [
+                            ...method.parameters,
+                            ...method.parametersPositional
+                          ])
+                            refer('params').index(literalString(param.name)),
+                        ], {
+                          for (var param in [...method.parametersNamed])
+                            param.name: refer('params')
+                                .index(literalString(param.name)),
+                        }).code,
+                    ).closure,
+                  }),
+              })
+            }))
+            .statement
+    ]);
   }
 }
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
@@ -1,0 +1,137 @@
+import 'package:recase/recase.dart';
+import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    'lib',
+    'src',
+    'generated',
+    'endpoints.dart',
+  );
+  group(
+      'Given protocol definition without endpoints when generating endpoints file',
+      () {
+    var protocolDefinition = const ProtocolDefinition(
+      endpoints: [],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test('then endpoints file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+
+    var endpointsFile = codeMap[expectedFileName];
+    group(
+      'then endpoints file',
+      () {
+        test('has no endpoints defined.', () {
+          expect(endpointsFile, isNot(contains('var endpoints =')));
+        });
+
+        test('has no endpoint connectors defined.', () {
+          expect(endpointsFile, isNot(contains('connectors')));
+        });
+      },
+      skip: endpointsFile == null,
+    );
+  });
+
+  group(
+      'Given protocol definition with endpoint when generating endpoints file',
+      () {
+    var endpointName = 'testing';
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('${endpointName.pascalCase}Endpoint')
+            .withName(endpointName)
+            .build(),
+      ],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test('then endpoints file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+
+    var endpointsFile = codeMap[expectedFileName];
+    group(
+      'then endpoints file',
+      () {
+        test('has endpoints map defined.', () {
+          expect(endpointsFile, contains('var endpoints ='));
+        });
+
+        test('has endpoint connectors for endpoint defined defined.', () {
+          expect(endpointsFile, contains('connectors[\'$endpointName\']'));
+        });
+      },
+      skip: endpointsFile == null,
+    );
+  });
+
+  group(
+      'Given protocol definition with multiple endpoints when generating endpoints file',
+      () {
+    var firstEndpointName = 'testing1';
+    var secondEndpointName = 'testing2';
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('${firstEndpointName.pascalCase}Endpoint')
+            .withName(firstEndpointName)
+            .build(),
+        EndpointDefinitionBuilder()
+            .withClassName('${secondEndpointName.pascalCase}Endpoint')
+            .withName(secondEndpointName)
+            .build(),
+      ],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test('then endpoints file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+    var endpointsFile = codeMap[expectedFileName];
+
+    group(
+      'then endpoints file',
+      () {
+        test('has endpoint defined.', () {
+          expect(endpointsFile, contains('var endpoints ='));
+        });
+
+        test('has endpoint connectors for both endpoints defined defined.', () {
+          expect(endpointsFile, contains('connectors[\'$firstEndpointName\']'));
+          expect(
+              endpointsFile, contains('connectors[\'$secondEndpointName\']'));
+        });
+      },
+      skip: endpointsFile == null,
+    );
+  });
+}


### PR DESCRIPTION

### Changes
- It prevents generating an unused variable if no endpoints are defined.

Without this fix, the analyzer will give a warning if no endpoints are defined.

Fixes: #2154


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple bug fix.
