### PR TITLE
fix: Docker template support x86 and dynamic flags.

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/Dockerfile
+++ b/templates/serverpod_templates/projectname_server_upgrade/Dockerfile
@@ -6,18 +6,20 @@ COPY . .
 RUN dart pub get
 RUN dart compile exe bin/main.dart -o bin/server
 
-FROM scratch
+FROM alpine:latest
+
+ENV runmode=production
+ENV serverid=default
+ENV logging=normal
+ENV role=monolith
 
 COPY --from=build /runtime/ /
 COPY --from=build /app/bin/server server
 COPY --from=build /app/config/ config/
 COPY --from=build /app/web/ web/
-COPY --from=build /app/migrations/ migrations/
-
 
 EXPOSE 8080
 EXPOSE 8081
 EXPOSE 8082
 
-# The default flags used when starting the server, can be manually overridden by passing flags to the docker run command
-ENTRYPOINT ["./server", "--mode=production", "--server-id=default", "--logging=normal", "--role=monolith"]
+ENTRYPOINT ./server --mode=$runmode --server-id=$serverid --logging=$logging --role=$role

--- a/templates/serverpod_templates/projectname_server_upgrade/Dockerfile
+++ b/templates/serverpod_templates/projectname_server_upgrade/Dockerfile
@@ -12,6 +12,7 @@ COPY --from=build /runtime/ /
 COPY --from=build /app/bin/server server
 COPY --from=build /app/config/ config/
 COPY --from=build /app/web/ web/
+COPY --from=build /app/migrations/ migrations/
 
 
 EXPOSE 8080

--- a/templates/serverpod_templates/projectname_server_upgrade/Dockerfile
+++ b/templates/serverpod_templates/projectname_server_upgrade/Dockerfile
@@ -1,29 +1,22 @@
-# If you update the dart version, make sure the image is
-# compatible with the busybox image.
 FROM dart:3.2.5 AS build
 
 WORKDIR /app
 COPY . .
 
 RUN dart pub get
-RUN dart compile exe bin/main.dart -o bin/main
+RUN dart compile exe bin/main.dart -o bin/server
 
-# If you update the busybox version, make sure the image is
-# compatible with the dart image.
-FROM busybox:1.36.1-glibc
-
-ENV runmode=development
-ENV serverid=default
-ENV logging=normal
-ENV role=monolith
+FROM scratch
 
 COPY --from=build /runtime/ /
-COPY --from=build /app/bin/main /app/bin/main
+COPY --from=build /app/bin/server server
 COPY --from=build /app/config/ config/
 COPY --from=build /app/web/ web/
+
 
 EXPOSE 8080
 EXPOSE 8081
 EXPOSE 8082
 
-CMD app/bin/main --mode $runmode --server-id $serverid --logging $logging --role $role
+# The default flags used when starting the server, can be manually overridden by passing flags to the docker run command
+ENTRYPOINT ["./server", "--mode=production", "--server-id=default", "--logging=normal", "--role=monolith"]


### PR DESCRIPTION
# Fix

**Edit:**

Reverting back some of the changes here with the effect that the `--apply-migrations` feature described will not work.

The reason for this decision is that we have terraform modules and bash scripts that require the environment variable input to exist. These deployment scripts are today pinned to the main branch and has no versioning reference. This means we are not able to update the scripts without breaking old docker images. 

The solution we want to implement in the future is to have proper environment variable support in Serverpod so that they can be parsed natively by the framework. This way we would be able to to allow both env configurations as well as command line args, even outside a docker environment. 

The current image is based on alpine as we need sh in the execution env. But in the future we should go back to scratch as it is about 5mb smaller in size.

---
Old docker file did not work when compiling on x86 architecture and you where not able to override / add any flag you wanted.

* New docker file supports all all architectures supported by dart.
* Any flag can be overridden or added

Example flag:
`docker run <my-image> --apply-migrations` 
Will run the container with the default flags and `--apply-migrations`

`docker run <my-image> --mode=development`
Will run the container with the default flags but with mode overridden to development. 

Closes: https://github.com/serverpod/serverpod/issues/1729
Closes: https://github.com/serverpod/serverpod/issues/1081

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ x I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).
