### PR TITLE
add timestamp to generate --watch log output 1.2

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
@@ -1,10 +1,12 @@
 import 'dart:io';
 
 import 'package:async/async.dart';
+import 'package:intl/intl.dart';
+import 'package:path/path.dart' as p;
+import 'package:watcher/watcher.dart';
+
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/logger/logger.dart';
-import 'package:watcher/watcher.dart';
-import 'package:path/path.dart' as p;
 
 import 'generator.dart';
 
@@ -26,9 +28,10 @@ Future<bool> performGenerateContinuously({
 
   await for (WatchEvent event in watchers) {
     log.info(
-      'File changed: $event',
+      DateFormat('MMM dd - HH:mm:ss:SS').format(DateTime.now()),
       newParagraph: true,
     );
+    log.info('File changed: $event');
     success = await _performSafeGenerate(
       config: config,
       endpointsAnalyzer: endpointsAnalyzer,


### PR DESCRIPTION
Like #2198, this PR adds a timestamp to the log output when "serverpod generate --watch" detects changes

closes: #971

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

no breaking changes