### PR TITLE
Bump sign_in_with_apple dep version: 5.0.0 -> 6.2.0

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
   serverpod_auth_client: 2.0.0-alpha.2
   serverpod_auth_shared_flutter: 2.0.0-alpha.2
-  sign_in_with_apple: ^5.0.0
+  sign_in_with_apple: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
   serverpod_auth_client: SERVERPOD_VERSION
   serverpod_auth_shared_flutter: SERVERPOD_VERSION
-  sign_in_with_apple: ^5.0.0
+  sign_in_with_apple: ^6.1.0
 
 dev_dependencies:
   flutter_test:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
   serverpod_auth_client: SERVERPOD_VERSION
   serverpod_auth_shared_flutter: SERVERPOD_VERSION
-  sign_in_with_apple: ^6.1.0
+  sign_in_with_apple: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
A lot of libraries in Serverpod are getting out of date... This increases the version of the Apple sign-in library.
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
