### PR TITLE
fix: Remove redirect from relic.

### DIFF
--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -16,9 +16,6 @@ class WebServer {
   /// The port the webserver is running on.
   late final int _port;
 
-  /// The hostname of the webserver.
-  late final String _hostname;
-
   /// A list of [Route] which defines how to handle path passed to the server.
   final List<Route> routes = <Route>[];
 
@@ -35,7 +32,6 @@ class WebServer {
     }
 
     _port = config.port;
-    _hostname = config.publicHost;
   }
 
   bool _running = false;
@@ -119,14 +115,6 @@ class WebServer {
           'Malformed call, invalid uri from ${request.connectionInfo?.remoteAddress.address}');
 
       request.response.statusCode = HttpStatus.badRequest;
-      await request.response.close();
-      return;
-    }
-
-    if (uri.host != _hostname) {
-      var redirect = uri.replace(host: _hostname);
-      request.response.headers.add('Location', redirect.toString());
-      request.response.statusCode = HttpStatus.movedPermanently;
       await request.response.close();
       return;
     }


### PR DESCRIPTION
# Changes

Removes the redirect path on host name match from relic. 

Reasoning: This makes more sense to configure in the loadbalancer and simplifies the setup when configuring health checks and doing more complex internal traffic etc.

Since you are not able to disable this feature today you will have to set the `host` in the header of the request to work around this limitation which you may or may not be able to do.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none