### PR TITLE
adding e2e tests for exceptions

### DIFF
--- a/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
@@ -178,4 +178,50 @@ void main() {
       );
     },
   );
+
+  group(
+      "Given a Serverpod server when calling an endpoint which throws a normal exception, ",
+      () {
+    late http.Response response;
+
+    setUpAll(() async {
+      response = await http.post(
+        Uri.parse("${serverUrl}exceptionTest"),
+        body: jsonEncode({"method": "throwNormalException"}),
+      );
+      print(response.body);
+    });
+
+    test('then it should return status code 500', () {
+      expect(response.statusCode, 500);
+    });
+  });
+
+  group(
+      "Given a Serverpod server when calling an endpoint which throws a exception with data, ",
+      () {
+    late http.Response response;
+
+    setUpAll(() async {
+      response = await http.post(
+        Uri.parse("${serverUrl}exceptionTest"),
+        body: jsonEncode({"method": "throwExceptionWithData"}),
+      );
+    });
+
+    test('then it should return status code 500', () {
+      expect(response.statusCode, 500);
+    });
+
+    test('then the serialized response body should contain the "className" key',
+        () {
+      Map jsonMap = jsonDecode(response.body);
+      expect(jsonMap, contains('className'));
+    });
+
+    test('then the serialized response body should contain the "data" key', () {
+      Map jsonMap = jsonDecode(response.body);
+      expect(jsonMap, contains('data'));
+    });
+  });
 }

--- a/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
@@ -223,5 +223,13 @@ void main() {
       Map jsonMap = jsonDecode(response.body);
       expect(jsonMap, contains('data'));
     });
+
+    test('then the serialized "data" object inside response body contain all the fields', () {
+      Map jsonMap = jsonDecode(response.body)["data"];
+      expect(jsonMap, contains('message'));
+      expect(jsonMap, contains('creationDate'));
+      expect(jsonMap, contains('errorFields'));
+      expect(jsonMap, contains('someNullableField'));
+    });
   });
 }

--- a/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
@@ -224,7 +224,9 @@ void main() {
       expect(jsonMap, contains('data'));
     });
 
-    test('then the serialized "data" object inside response body contain all the fields', () {
+    test(
+        'then the serialized "data" object inside response body contain all the fields',
+        () {
       Map jsonMap = jsonDecode(response.body)["data"];
       expect(jsonMap, contains('message'));
       expect(jsonMap, contains('creationDate'));


### PR DESCRIPTION
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Changes:
This PR introduces end-to-end tests specifically for endpoints that generate runtime exceptions.