### PR TITLE
removing SerializationManager as parameter from fromJson factory consructor on the code generator for custom classes

### DIFF
--- a/tests/serverpod_test_client/lib/src/custom_classes.dart
+++ b/tests/serverpod_test_client/lib/src/custom_classes.dart
@@ -14,8 +14,7 @@ class CustomClass extends SerializableEntity {
   @override
   String toJson() => value;
 
-  static CustomClass fromJson(
-      dynamic data, SerializationManager serializationManager) {
+  static CustomClass fromJson(dynamic data) {
     return CustomClass(data);
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -1505,34 +1505,31 @@ class Protocol extends _i1.SerializationManager {
           as dynamic;
     }
     if (t == _i83.CustomClass) {
-      return _i83.CustomClass.fromJson(data, this) as T;
+      return _i83.CustomClass.fromJson(data) as T;
     }
     if (t == _i84.ProtocolCustomClass) {
-      return _i84.ProtocolCustomClass.fromJson(data, this) as T;
+      return _i84.ProtocolCustomClass.fromJson(data) as T;
     }
     if (t == _i85.ExternalCustomClass) {
-      return _i85.ExternalCustomClass.fromJson(data, this) as T;
+      return _i85.ExternalCustomClass.fromJson(data) as T;
     }
     if (t == _i85.FreezedCustomClass) {
-      return _i85.FreezedCustomClass.fromJson(data, this) as T;
+      return _i85.FreezedCustomClass.fromJson(data) as T;
     }
     if (t == _i1.getType<_i83.CustomClass?>()) {
-      return (data != null ? _i83.CustomClass.fromJson(data, this) : null) as T;
+      return (data != null ? _i83.CustomClass.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i84.ProtocolCustomClass?>()) {
-      return (data != null
-          ? _i84.ProtocolCustomClass.fromJson(data, this)
-          : null) as T;
+      return (data != null ? _i84.ProtocolCustomClass.fromJson(data) : null)
+          as T;
     }
     if (t == _i1.getType<_i85.ExternalCustomClass?>()) {
-      return (data != null
-          ? _i85.ExternalCustomClass.fromJson(data, this)
-          : null) as T;
+      return (data != null ? _i85.ExternalCustomClass.fromJson(data) : null)
+          as T;
     }
     if (t == _i1.getType<_i85.FreezedCustomClass?>()) {
-      return (data != null
-          ? _i85.FreezedCustomClass.fromJson(data, this)
-          : null) as T;
+      return (data != null ? _i85.FreezedCustomClass.fromJson(data) : null)
+          as T;
     }
     try {
       return _i86.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_client/lib/src/protocol_custom_classes.dart
+++ b/tests/serverpod_test_client/lib/src/protocol_custom_classes.dart
@@ -10,7 +10,6 @@ class ProtocolCustomClass extends SerializableEntity {
 
   factory ProtocolCustomClass.fromJson(
     Map<String, dynamic> json,
-    SerializationManager manager,
   ) {
     return ProtocolCustomClass(
       value: json["value"] as String?,

--- a/tests/serverpod_test_server/lib/src/custom_classes.dart
+++ b/tests/serverpod_test_server/lib/src/custom_classes.dart
@@ -14,8 +14,7 @@ class CustomClass extends SerializableEntity {
   @override
   String toJson() => value;
 
-  static CustomClass fromJson(
-      dynamic data, SerializationManager serializationManager) {
+  static CustomClass fromJson(dynamic data) {
     return CustomClass(data);
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -4153,34 +4153,31 @@ class Protocol extends _i1.SerializationManagerServer {
           as dynamic;
     }
     if (t == _i87.CustomClass) {
-      return _i87.CustomClass.fromJson(data, this) as T;
+      return _i87.CustomClass.fromJson(data) as T;
     }
     if (t == _i88.ProtocolCustomClass) {
-      return _i88.ProtocolCustomClass.fromJson(data, this) as T;
+      return _i88.ProtocolCustomClass.fromJson(data) as T;
     }
     if (t == _i89.ExternalCustomClass) {
-      return _i89.ExternalCustomClass.fromJson(data, this) as T;
+      return _i89.ExternalCustomClass.fromJson(data) as T;
     }
     if (t == _i89.FreezedCustomClass) {
-      return _i89.FreezedCustomClass.fromJson(data, this) as T;
+      return _i89.FreezedCustomClass.fromJson(data) as T;
     }
     if (t == _i1.getType<_i87.CustomClass?>()) {
-      return (data != null ? _i87.CustomClass.fromJson(data, this) : null) as T;
+      return (data != null ? _i87.CustomClass.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i88.ProtocolCustomClass?>()) {
-      return (data != null
-          ? _i88.ProtocolCustomClass.fromJson(data, this)
-          : null) as T;
+      return (data != null ? _i88.ProtocolCustomClass.fromJson(data) : null)
+          as T;
     }
     if (t == _i1.getType<_i89.ExternalCustomClass?>()) {
-      return (data != null
-          ? _i89.ExternalCustomClass.fromJson(data, this)
-          : null) as T;
+      return (data != null ? _i89.ExternalCustomClass.fromJson(data) : null)
+          as T;
     }
     if (t == _i1.getType<_i89.FreezedCustomClass?>()) {
-      return (data != null
-          ? _i89.FreezedCustomClass.fromJson(data, this)
-          : null) as T;
+      return (data != null ? _i89.FreezedCustomClass.fromJson(data) : null)
+          as T;
     }
     try {
       return _i3.Protocol().deserialize<T>(data, t);

--- a/tests/serverpod_test_server/lib/src/protocol_custom_classes.dart
+++ b/tests/serverpod_test_server/lib/src/protocol_custom_classes.dart
@@ -13,7 +13,6 @@ class ProtocolCustomClass extends SerializableEntity
 
   factory ProtocolCustomClass.fromJson(
     Map<String, dynamic> json,
-    SerializationManager manager,
   ) {
     return ProtocolCustomClass(
       value: json["value"] as String?,

--- a/tests/serverpod_test_shared/lib/src/external_custom_class.dart
+++ b/tests/serverpod_test_shared/lib/src/external_custom_class.dart
@@ -1,6 +1,6 @@
 // TODO: Put public facing types in this file.
 
-import 'package:serverpod_serialization/serverpod_serialization.dart';
+
 
 class ExternalCustomClass {
   final String value;
@@ -9,8 +9,7 @@ class ExternalCustomClass {
 
   String toJson() => value;
 
-  static ExternalCustomClass fromJson(
-      dynamic data, SerializationManager serializationManager) {
+  static ExternalCustomClass fromJson(dynamic data) {
     return ExternalCustomClass(data);
   }
 }

--- a/tests/serverpod_test_shared/lib/src/external_custom_class.dart
+++ b/tests/serverpod_test_shared/lib/src/external_custom_class.dart
@@ -1,7 +1,5 @@
 // TODO: Put public facing types in this file.
 
-
-
 class ExternalCustomClass {
   final String value;
 

--- a/tests/serverpod_test_shared/lib/src/freezed_custom_class.dart
+++ b/tests/serverpod_test_shared/lib/src/freezed_custom_class.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 part 'freezed_custom_class.freezed.dart';
 part 'freezed_custom_class.g.dart';
@@ -14,7 +13,6 @@ class FreezedCustomClass with _$FreezedCustomClass {
 
   factory FreezedCustomClass.fromJson(
     Map<String, Object?> json,
-    SerializationManager serializationManager,
   ) =>
       _$FreezedCustomClassFromJson(json);
 }

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -388,9 +388,9 @@ class TypeDefinition {
             Code.scope((a) => nullable
                 ? '(data!=null?'
                     '${a(reference(serverCode, config: config))}'
-                    '.fromJson(data,this):null)as T'
+                    '.fromJson(data):null)as T'
                 : '${a(reference(serverCode, config: config))}'
-                    '.fromJson(data,this) as T'))
+                    '.fromJson(data) as T'))
       ];
     } else {
       return [];


### PR DESCRIPTION
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Changes:
This PR continues the work started in [PR #2102](https://github.com/serverpod/serverpod/pull/2102) by removing the `SerializationManager` parameter from the `fromJson` factory constructor in custom classes. The previous PR successfully eliminated this parameter from all serverpod-generated classes and models, and this change extends that simplification to include custom classes as well.