### PR TITLE
Firebase login fixes

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
@@ -23,6 +23,10 @@ Future<UserInfo?> signInWithFirebase({
           return SignInScreen(
             providers: authProviders,
             actions: [
+              AuthCancelledAction((context) {
+                completer.complete(null);
+                Navigator.of(context).pop();
+              }),
               AuthStateChangeAction<SignedIn>((context, state) async {
                 try {
                   if (state.user == null) {

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/src/auth.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:serverpod_auth_client/serverpod_auth_client.dart';
 import 'package:serverpod_auth_shared_flutter/serverpod_auth_shared_flutter.dart';
-import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 /// Attempts to Sign in with Firebase. If successful, a [UserInfo] is returned.
 /// If the attempt is not a success, null is returned.
@@ -59,6 +59,10 @@ Future<UserInfo?> signInWithFirebase({
                     completer.complete(serverResponse.userInfo);
                     return;
                   } catch (e) {
+                    if (kDebugMode) {
+                      print('serverpod_auth_firebase: Failed to authenticate '
+                          'with Serverpod backend: $e');
+                    }
                     completer.complete(null);
                     return;
                   }


### PR DESCRIPTION
* Adds a missing `Navigator.of(context).pop()` on exit (the dialog stays open after login success/failure). (Although I had to capture the navigator instance before pushing the route, because `context` is not available across an async gap.)
* Uses the return value of the route to return the `UserInfo?` (which is what it's designed for) rather than a `Completer`.
* If Firebase login fails due to exception, nothing is reported to the terminal. This prints the exception details.
* Also pops on `AuthCanceledAction`. This may also need to be added for `SignedOutAction` and/or `AccountDeletedAction`, I'm not sure. Please take a look at the Firebase docs to ensure that whatever action is taken, the route that is pushed is always popped at the end.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.
