### PR TITLE
Add missing `_storeSharedPrefs` in `logOut()`

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
@@ -92,6 +92,7 @@ class SessionManager with ChangeNotifier {
       await caller.client.updateStreamingConnectionAuthenticationKey(null);
 
       _signedInUser = null;
+      await _storeSharedPrefs();
       await keyManager.remove();
 
       notifyListeners();


### PR DESCRIPTION
Currently on logout, the signed in user id is not being removed from stored prefs, which makes Serverpod flutter apps think they are signed in when they are restarted after logout (during session manager initialization).

This fixes this by calling `_storeSharedPrefs` (which is obviously missing from the code).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
