### PR TITLE
fix: Endpoint requests can now respond with 401 or 403 on failed authentication.

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -521,8 +521,6 @@ class Server {
     Endpoint endpoint,
   ) async {
     try {
-      // TODO: We need to mark stream as accessbile (in endpoint?) and check
-      // future messages that are passed to this endpoint.
       var authFailed = await EndpointDispatch.canUserAccessEndpoint(
         () => session.authenticationInfo,
         endpoint.requireLogin,

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -294,6 +294,7 @@ class Server {
         // TODO: Log to database?
         stderr.writeln('Malformed call: $result');
       }
+
       request.response.statusCode = HttpStatus.badRequest;
       await request.response.close();
       return;
@@ -302,7 +303,11 @@ class Server {
         // TODO: Log to database?
         stderr.writeln('Access denied: $result');
       }
-      request.response.statusCode = HttpStatus.forbidden;
+
+      request.response.statusCode = switch (result.reason) {
+        AuthenticationFailureReason.unauthenticated => HttpStatus.unauthorized,
+        AuthenticationFailureReason.insufficientAccess => HttpStatus.forbidden,
+      };
       await request.response.close();
       return;
     } else if (result is ResultInternalServerError) {

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -426,8 +426,12 @@ class Server {
             throw Exception('Endpoint not found: $endpointName');
           }
 
-          var authFailed = await endpoints.canUserAccessEndpoint(
-              session, endpointConnector.endpoint);
+          var endpoint = endpointConnector.endpoint;
+          var authFailed = await EndpointDispatch.canUserAccessEndpoint(
+            () => session.authenticationInfo,
+            endpoint.requireLogin,
+            endpoint.requiredScopes,
+          );
 
           if (authFailed == null) {
             // Process the message.
@@ -513,11 +517,17 @@ class Server {
   }
 
   Future<void> _callStreamOpened(
-      StreamingSession session, Endpoint endpoint) async {
+    StreamingSession session,
+    Endpoint endpoint,
+  ) async {
     try {
       // TODO: We need to mark stream as accessbile (in endpoint?) and check
       // future messages that are passed to this endpoint.
-      var authFailed = await endpoints.canUserAccessEndpoint(session, endpoint);
+      var authFailed = await EndpointDispatch.canUserAccessEndpoint(
+        () => session.authenticationInfo,
+        endpoint.requireLogin,
+        endpoint.requiredScopes,
+      );
       if (authFailed == null) await endpoint.streamOpened(session);
     } catch (e) {
       return;
@@ -525,9 +535,15 @@ class Server {
   }
 
   Future<void> _callStreamClosed(
-      StreamingSession session, Endpoint endpoint) async {
+    StreamingSession session,
+    Endpoint endpoint,
+  ) async {
     try {
-      var authFailed = await endpoints.canUserAccessEndpoint(session, endpoint);
+      var authFailed = await EndpointDispatch.canUserAccessEndpoint(
+        () => session.authenticationInfo,
+        endpoint.requireLogin,
+        endpoint.requiredScopes,
+      );
       if (authFailed == null) await endpoint.streamClosed(session);
     } catch (e) {
       return;

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -32,6 +32,15 @@ abstract class Session {
   @internal
   late final SessionLogEntryCache sessionLogs;
 
+  AuthenticationInfo? _authenticationInfo;
+
+  /// The authentication information for the session.
+  /// This will be null if the session is not authenticated.
+  Future<AuthenticationInfo?> get authenticationInfo async {
+    if (!_initialized) await _initialize();
+    return _authenticationInfo;
+  }
+
   int? _authenticatedUser;
   Set<Scope>? _scopes;
 
@@ -112,10 +121,10 @@ abstract class Session {
     }
 
     if (server.authenticationHandler != null && _authenticationKey != null) {
-      var authenticationInfo =
+      _authenticationInfo =
           await server.authenticationHandler!(this, _authenticationKey!);
-      _scopes = authenticationInfo?.scopes;
-      _authenticatedUser = authenticationInfo?.authenticatedUserId;
+      _scopes = _authenticationInfo?.scopes;
+      _authenticatedUser = _authenticationInfo?.authenticatedUserId;
     }
 
     _initialized = true;
@@ -335,6 +344,7 @@ class StreamingSession extends Session {
   @internal
   void updateAuthenticationKey(String? authenticationKey) {
     _authenticationKey = authenticationKey;
+    _initialized = false;
   }
 }
 

--- a/packages/serverpod/test/endpoint/authentication_test.dart
+++ b/packages/serverpod/test/endpoint/authentication_test.dart
@@ -1,0 +1,250 @@
+import 'package:serverpod/src/authentication/authentication_info.dart';
+import 'package:serverpod/src/authentication/scope.dart';
+import 'package:serverpod/src/server/endpoint_dispatch.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given unauthenticated user', () {
+    Future<AuthenticationInfo?> unauthenticatedUserProvider() async => null;
+
+    test(
+        'when accessing endpoint that does not required login or scopes, then null is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = <Scope>{};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        unauthenticatedUserProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, null);
+    });
+
+    test(
+        'when accessing endpoint that requires login but no scopes, then authentication failure is returned.',
+        () async {
+      var requiresLogin = true;
+      var requiredScopes = <Scope>{};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        unauthenticatedUserProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, isNotNull);
+      expect(
+        (result as ResultAuthenticationFailed).reason,
+        AuthenticationFailureReason.unauthenticated,
+      );
+    });
+
+    test(
+        'when accessing endpoint that requires scopes but not login, then authentication failure is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = {Scope.admin};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        unauthenticatedUserProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, isNotNull);
+      expect(
+        (result as ResultAuthenticationFailed).reason,
+        AuthenticationFailureReason.unauthenticated,
+      );
+    });
+
+    test(
+        'when accessing endpoint that requires login and scopes, then authentication failure is returned.',
+        () async {
+      var requiresLogin = true;
+      var requiredScopes = {Scope.admin};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        unauthenticatedUserProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, isNotNull);
+      expect(
+        (result as ResultAuthenticationFailed).reason,
+        AuthenticationFailureReason.unauthenticated,
+      );
+    });
+  });
+
+  group('Given authenticated user with no scopes', () {
+    Future<AuthenticationInfo?> authenticatedUserWithNoScopesProvider() async =>
+        AuthenticationInfo(
+          1,
+          {},
+        );
+
+    test(
+        'when accessing endpoint that does not required login or scopes, then null is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = <Scope>{};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, null);
+    });
+
+    test(
+        'when accessing endpoint that requires login but no scopes, then null is returned.',
+        () async {
+      var requiresLogin = true;
+      var requiredScopes = <Scope>{};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, null);
+    });
+
+    test(
+        'when accessing endpoint that requires scopes but not login, then authentication failure is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = {Scope.admin};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, isNotNull);
+      expect(
+        (result as ResultAuthenticationFailed).reason,
+        AuthenticationFailureReason.insufficientAccess,
+      );
+    });
+
+    test(
+        'when accessing endpoint that requires login and scopes, then authentication failure is returned.',
+        () async {
+      var requiresLogin = true;
+      var requiredScopes = {Scope.admin};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, isNotNull);
+      expect(
+        (result as ResultAuthenticationFailed).reason,
+        AuthenticationFailureReason.insufficientAccess,
+      );
+    });
+  });
+
+  group('Given authenticated user with "admin" scope', () {
+    Future<AuthenticationInfo?> authenticatedUserWithNoScopesProvider() async =>
+        AuthenticationInfo(
+          1,
+          {Scope.admin},
+        );
+
+    test(
+        'when accessing endpoint that does not required login or scopes, then null is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = <Scope>{};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, null);
+    });
+
+    test(
+        'when accessing endpoint that requires login but no scopes, then null is returned.',
+        () async {
+      var requiresLogin = true;
+      var requiredScopes = <Scope>{};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, null);
+    });
+
+    test(
+        'when accessing endpoint that requires "admin" scope but not login, then null is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = {Scope.admin};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, null);
+    });
+
+    test(
+        'when accessing endpoint that requires "admin" and "other" scope but not login, then null authentication failure is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = {Scope.admin, const Scope('other')};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, isNotNull);
+      expect(
+        (result as ResultAuthenticationFailed).reason,
+        AuthenticationFailureReason.insufficientAccess,
+      );
+    });
+
+    test(
+        'when accessing endpoint that requires login and "admin" scope, then null is returned.',
+        () async {
+      var requiresLogin = true;
+      var requiredScopes = {Scope.admin};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, null);
+    });
+
+    test(
+        'when accessing endpoint that requires login and "admin" and "other" scopes, then null authentication failure is returned.',
+        () async {
+      var requiresLogin = false;
+      var requiredScopes = {Scope.admin, const Scope('other')};
+      var result = await EndpointDispatch.canUserAccessEndpoint(
+        authenticatedUserWithNoScopesProvider,
+        requiresLogin,
+        requiredScopes,
+      );
+
+      expect(result, isNotNull);
+      expect(
+        (result as ResultAuthenticationFailed).reason,
+        AuthenticationFailureReason.insufficientAccess,
+      );
+    });
+  });
+}

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -123,14 +123,16 @@ class EndpointAuthentication extends _i1.EndpointRef {
 
   _i2.Future<_i3.AuthenticationResponse> authenticate(
     String email,
-    String password,
-  ) =>
+    String password, [
+    List<String>? scopes,
+  ]) =>
       caller.callServerEndpoint<_i3.AuthenticationResponse>(
         'authentication',
         'authenticate',
         {
           'email': email,
           'password': password,
+          'scopes': scopes,
         },
       );
 
@@ -1984,6 +1986,20 @@ class EndpointSignInRequired extends _i1.EndpointRef {
       );
 }
 
+/// {@category Endpoint}
+class EndpointAdminScopeRequired extends _i1.EndpointRef {
+  EndpointAdminScopeRequired(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'adminScopeRequired';
+
+  _i2.Future<bool> testMethod() => caller.callServerEndpoint<bool>(
+        'adminScopeRequired',
+        'testMethod',
+        {},
+      );
+}
+
 /// A simple endpoint that modifies a global integer. This class is meant for
 /// testing and the documentation has multiple lines.
 /// {@category Endpoint}
@@ -2135,6 +2151,7 @@ class Client extends _i1.ServerpodClient {
     redis = EndpointRedis(this);
     serverOnlyScopedFieldModel = EndpointServerOnlyScopedFieldModel(this);
     signInRequired = EndpointSignInRequired(this);
+    adminScopeRequired = EndpointAdminScopeRequired(this);
     simple = EndpointSimple(this);
     streaming = EndpointStreaming(this);
     streamingLogging = EndpointStreamingLogging(this);
@@ -2201,6 +2218,8 @@ class Client extends _i1.ServerpodClient {
 
   late final EndpointSignInRequired signInRequired;
 
+  late final EndpointAdminScopeRequired adminScopeRequired;
+
   late final EndpointSimple simple;
 
   late final EndpointStreaming streaming;
@@ -2244,6 +2263,7 @@ class Client extends _i1.ServerpodClient {
         'redis': redis,
         'serverOnlyScopedFieldModel': serverOnlyScopedFieldModel,
         'signInRequired': signInRequired,
+        'adminScopeRequired': adminScopeRequired,
         'simple': simple,
         'streaming': streaming,
         'streamingLogging': streamingLogging,

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -1190,6 +1190,11 @@ class Protocol extends _i1.SerializationManager {
               deserialize<String>(k), deserialize<List<_i68.Types>>(v)))
           : null) as dynamic;
     }
+    if (t == _i1.getType<List<String>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<String>(e)).toList()
+          : null) as dynamic;
+    }
     if (t == List<_i71.SimpleData>) {
       return (data as List).map((e) => deserialize<_i71.SimpleData>(e)).toList()
           as dynamic;

--- a/tests/serverpod_test_server/lib/src/endpoints/authentication.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/authentication.dart
@@ -29,8 +29,9 @@ class AuthenticationEndpoint extends Endpoint {
   Future<AuthenticationResponse> authenticate(
     Session session,
     String email,
-    String password,
-  ) async {
+    String password, [
+    List<String>? scopes,
+  ]) async {
     if (email == 'test@foo.bar' && password == 'password') {
       var userInfo = await Users.findUserByEmail(session, 'test@foo.bar');
       if (userInfo == null) {
@@ -47,7 +48,11 @@ class AuthenticationEndpoint extends Endpoint {
 
       if (userInfo == null) return AuthenticationResponse(success: false);
 
-      var authKey = await session.auth.signInUser(userInfo.id!, 'test');
+      var authKey = await session.auth.signInUser(
+        userInfo.id!,
+        'test',
+        scopes: scopes?.map((e) => Scope(e)).toSet() ?? const {},
+      );
       return AuthenticationResponse(
         success: true,
         keyId: authKey.id,

--- a/tests/serverpod_test_server/lib/src/endpoints/signin_required.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/signin_required.dart
@@ -13,7 +13,30 @@ class SignInRequiredEndpoint extends Endpoint {
 
   @override
   Future<void> handleStreamMessage(
-      StreamingSession session, SerializableEntity message) async {
+    StreamingSession session,
+    SerializableEntity message,
+  ) async {
+    if (message is SimpleData) {
+      unawaited(Future.delayed(const Duration(seconds: 1)).then((value) async {
+        await sendStreamMessage(session, message);
+      }));
+    }
+  }
+}
+
+class AdminScopeRequiredEndpoint extends Endpoint {
+  @override
+  Set<Scope> get requiredScopes => {Scope.admin};
+
+  Future<bool> testMethod(Session session) async {
+    return true;
+  }
+
+  @override
+  Future<void> handleStreamMessage(
+    StreamingSession session,
+    SerializableEntity message,
+  ) async {
     if (message is SimpleData) {
       unawaited(Future.delayed(const Duration(seconds: 1)).then((value) async {
         await sendStreamMessage(session, message);

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -264,6 +264,12 @@ class Endpoints extends _i1.EndpointDispatch {
           'signInRequired',
           null,
         ),
+      'adminScopeRequired': _i30.AdminScopeRequiredEndpoint()
+        ..initialize(
+          server,
+          'adminScopeRequired',
+          null,
+        ),
       'simple': _i31.SimpleEndpoint()
         ..initialize(
           server,
@@ -407,6 +413,11 @@ class Endpoints extends _i1.EndpointDispatch {
               type: _i1.getType<String>(),
               nullable: false,
             ),
+            'scopes': _i1.ParameterDescription(
+              name: 'scopes',
+              type: _i1.getType<List<String>?>(),
+              nullable: true,
+            ),
           },
           call: (
             _i1.Session session,
@@ -417,6 +428,7 @@ class Endpoints extends _i1.EndpointDispatch {
             session,
             params['email'],
             params['password'],
+            params['scopes'],
           ),
         ),
         'signOut': _i1.MethodConnector(
@@ -4336,6 +4348,23 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['signInRequired'] as _i30.SignInRequiredEndpoint)
+                  .testMethod(session),
+        )
+      },
+    );
+    connectors['adminScopeRequired'] = _i1.EndpointConnector(
+      name: 'adminScopeRequired',
+      endpoint: endpoints['adminScopeRequired']!,
+      methodConnectors: {
+        'testMethod': _i1.MethodConnector(
+          name: 'testMethod',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['adminScopeRequired']
+                      as _i30.AdminScopeRequiredEndpoint)
                   .testMethod(session),
         )
       },

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -3838,6 +3838,11 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<String>(k), deserialize<List<_i73.Types>>(v)))
           : null) as dynamic;
     }
+    if (t == _i1.getType<List<String>?>()) {
+      return (data != null
+          ? (data as List).map((e) => deserialize<String>(e)).toList()
+          : null) as dynamic;
+    }
     if (t == List<_i75.SimpleData>) {
       return (data as List).map((e) => deserialize<_i75.SimpleData>(e)).toList()
           as dynamic;

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -243,6 +243,8 @@ serverOnlyScopedFieldModel:
   - getScopeServerOnlyField:
 signInRequired:
   - testMethod:
+adminScopeRequired:
+  - testMethod:
 simple:
   - setGlobalInt:
   - addToGlobalInt:

--- a/tests/serverpod_test_server/test_e2e/authentication_test.dart
+++ b/tests/serverpod_test_server/test_e2e/authentication_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:serverpod_test_server/test_util/config.dart';
 import 'package:serverpod_test_server/test_util/test_key_manager.dart';
@@ -106,6 +107,69 @@ void main() {
 
       // We should not have added any new users
       expect(newUserCount - oldUserCount, equals(0));
+    });
+  });
+
+  group('Given signed in user without "admin" scope', () {
+    setUp(() async {
+      var response = await client.authentication.authenticate(
+        'test@foo.bar',
+        'password',
+      );
+      assert(response.success, 'Failed to authenticate user');
+      await client.authenticationKeyManager
+          ?.put('${response.keyId}:${response.key}');
+      assert(
+          await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
+    });
+
+    tearDown(() async {
+      await client.authenticationKeyManager?.remove();
+      await client.authentication.removeAllUsers();
+      await client.authentication.signOut();
+      assert(
+        await client.modules.auth.status.isSignedIn() == false,
+        'Still signed in after teardown',
+      );
+    });
+    test(
+        'when accessing endpoint that requires "admin" scope then 403 is returned.',
+        () async {
+      expectLater(
+          client.adminScopeRequired.testMethod(),
+          throwsA(isA<ServerpodClientException>()
+              .having((e) => e.statusCode, 'statusCode', 403)));
+    });
+  });
+
+  group('Given signed in user with "admin" scope', () {
+    setUp(() async {
+      var response = await client.authentication.authenticate(
+        'test@foo.bar',
+        'password',
+        [Scope.admin.name!],
+      );
+      assert(response.success, 'Failed to authenticate user');
+      await client.authenticationKeyManager
+          ?.put('${response.keyId}:${response.key}');
+      assert(
+          await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
+    });
+
+    tearDown(() async {
+      await client.authenticationKeyManager?.remove();
+      await client.authentication.removeAllUsers();
+      await client.authentication.signOut();
+      assert(
+        await client.modules.auth.status.isSignedIn() == false,
+        'Still signed in after teardown',
+      );
+    });
+    test(
+        'when accessing endpoint that requires "admin" scope then request is successful.',
+        () async {
+      var result = await client.adminScopeRequired.testMethod();
+      expect(result, equals(true));
     });
   });
 }

--- a/tests/serverpod_test_server/test_e2e/authentication_test.dart
+++ b/tests/serverpod_test_server/test_e2e/authentication_test.dart
@@ -36,11 +36,7 @@ void main() {
         }
       }
 
-      // Only perform the check for dart:io. On web -1 will be returned as
-      // failing status codes cannot be detected.
-      if (!identical(0, 0.0)) {
-        expect(statusCode, equals(403));
-      }
+      expect(statusCode, equals(401));
     });
 
     test('Authenticate with incorrect credentials', () async {
@@ -87,11 +83,7 @@ void main() {
         }
       }
 
-      // Only perform the check for dart:io. On web -1 will be returned as
-      // failing status codes cannot be detected.
-      if (!identical(0, 0.0)) {
-        expect(statusCode, equals(403));
-      }
+      expect(statusCode, equals(401));
     });
   });
 


### PR DESCRIPTION
### Change:
- AuthenticationInfo is now accessible throug the `Session` object.
- During endpoint authentication:
  - If no authentication info is returned server will response with 401 on authenticated endpoints.
  - If authentication info is returned but the authenticated user is missing required endpoint scopes the server will respond with 403.
- (BREAKING) Removes `scopes` and `authenticatedUser` getter from `Session`.

This change is made to support Refresh and Access tokens in the future (JWT requires this).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

New response code can be sent from the server but this is treated the same in the client currently.
Removes scopes and authenticatedUser getter from `Session` since they are accessible through the `authenticationInfo` getter.
