### PR TITLE
Make Email Verification Code Length Customizable

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -167,5 +167,11 @@ class AuthConfig {
     this.maxPasswordLength = 128,
     this.minPasswordLength = 8,
     this.allowUnsecureRandom = false,
-  });
+  }) {
+    if (validationCodeLength < 1) {
+      throw Exception(
+        'Invalid validation code length: $validationCodeLength. Length must be at least 1.',
+      );
+    }
+  }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -109,6 +109,10 @@ class AuthConfig {
   /// Called when a user should be sent a validation code on account setup.
   final SendValidationEmailCallback? sendValidationEmail;
 
+  /// The length of the validation code used in the authentication process.
+  /// This value determines the number of digits in the validation code. Default is 8.
+  final int validationCodeLength;
+
   /// The time for password resets to be valid. Default is one day.
   final Duration passwordResetExpirationTime;
 
@@ -155,6 +159,7 @@ class AuthConfig {
     this.onUserUpdated,
     this.sendPasswordResetEmail,
     this.sendValidationEmail,
+    this.validationCodeLength = 8,
     this.passwordResetExpirationTime = const Duration(hours: 24),
     this.extraSaltyHash = true,
     this.firebaseServiceAccountKeyJson =

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -169,8 +169,10 @@ class AuthConfig {
     this.allowUnsecureRandom = false,
   }) {
     if (validationCodeLength < 1) {
-      throw Exception(
-        'Invalid validation code length: $validationCodeLength. Length must be at least 1.',
+      throw ArgumentError.value(
+        validationCodeLength,
+        'validationCodeLength',
+        'must be at least 1',
       );
     }
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -578,8 +578,16 @@ class Emails {
   }
 
   static String _generateVerificationCode() {
+    var lenValidationCode = AuthConfig.current.validationCodeLength;
+
+    if (lenValidationCode <= 0) {
+      throw Exception(
+        'Invalid validation code length: $lenValidationCode. Length must be at least 1.',
+      );
+    }
+
     return Random().nextString(
-      length: AuthConfig.current.validationCodeLength,
+      length: lenValidationCode,
       chars: '0123456789',
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -578,16 +578,8 @@ class Emails {
   }
 
   static String _generateVerificationCode() {
-    var lenValidationCode = AuthConfig.current.validationCodeLength;
-
-    if (lenValidationCode <= 0) {
-      throw Exception(
-        'Invalid validation code length: $lenValidationCode. Length must be at least 1.',
-      );
-    }
-
     return Random().nextString(
-      length: lenValidationCode,
+      length: AuthConfig.current.validationCodeLength,
       chars: '0123456789',
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -579,7 +579,7 @@ class Emails {
 
   static String _generateVerificationCode() {
     return Random().nextString(
-      length: 8,
+      length: AuthConfig.current.validationCodeLength,
       chars: '0123456789',
     );
   }

--- a/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
@@ -35,9 +35,28 @@ void main() async {
 
   test(
       'Given a positive integer as validation code length when creating an account then validation code has the specified length.',
-      () {
-    final auth = AuthConfig(validationCodeLength: 4);
-    expect(auth.validationCodeLength, 4);
+      () async {
+    String? generatedValidationCode;
+    AuthConfig.set(
+      AuthConfig(
+        validationCodeLength: 4,
+        sendValidationEmail: (session, email, validationCode) async {
+          generatedValidationCode = validationCode;
+          return true;
+        },
+      ),
+    );
+
+    var createAccountRequest =
+        await Emails.createAccountRequest(session, userName, email, password);
+
+    expect(
+      createAccountRequest,
+      isTrue,
+      reason: 'Generated validation code is 8 characters long, which is valid',
+    );
+
+    assert(generatedValidationCode?.length == 4);
   });
 
   test(

--- a/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
@@ -21,16 +21,9 @@ void main() async {
       ),
     );
 
-    var createAccountRequest =
-        await Emails.createAccountRequest(session, userName, email, password);
+    await Emails.createAccountRequest(session, userName, email, password);
 
-    expect(
-      createAccountRequest,
-      isTrue,
-      reason: 'Generated validation code is 8 characters long, which is valid',
-    );
-
-    assert(generatedValidationCode?.length == 8);
+    expect(generatedValidationCode, hasLength(8));
   });
 
   test(
@@ -47,16 +40,9 @@ void main() async {
       ),
     );
 
-    var createAccountRequest =
-        await Emails.createAccountRequest(session, userName, email, password);
+    await Emails.createAccountRequest(session, userName, email, password);
 
-    expect(
-      createAccountRequest,
-      isTrue,
-      reason: 'Generated validation code is 4 characters long, which is valid',
-    );
-
-    assert(generatedValidationCode?.length == 4);
+    expect(generatedValidationCode, hasLength(4));
   });
 
   test(
@@ -64,10 +50,10 @@ void main() async {
       () {
     expect(
         () => AuthConfig(validationCodeLength: 0),
-        throwsA(isA<Exception>().having(
+        throwsA(isA<ArgumentError>().having(
           (e) => e.toString(),
           'message',
-          contains('Invalid validation code length'),
+          contains('must be at least 1'),
         )));
   });
 
@@ -76,10 +62,10 @@ void main() async {
       () {
     expect(
         () => AuthConfig(validationCodeLength: -4),
-        throwsA(isA<Exception>().having(
+        throwsA(isA<ArgumentError>().having(
           (e) => e.toString(),
           'message',
-          contains('Invalid validation code length'),
+          contains('must be at least 1'),
         )));
   });
 }

--- a/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
@@ -1,0 +1,74 @@
+import 'package:serverpod_auth_server/module.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var userName = 'test';
+  var email = 'test@serverpod.dev';
+  var password = 'password';
+  var session = await IntegrationTestServer().session();
+
+  var codeLengthsToTest = [-16, -8, -4, -1, 0, 1, 4, 16];
+
+  test(
+      'Not setting validationCodeLength will generate a code with default length 8',
+      () async {
+    String? generatedValidationCode;
+    AuthConfig.set(
+      AuthConfig(
+        sendValidationEmail: (session, email, validationCode) async {
+          generatedValidationCode = validationCode;
+          return true;
+        },
+      ),
+    );
+
+    var createAccountRequest =
+        await Emails.createAccountRequest(session, userName, email, password);
+
+    expect(
+      createAccountRequest,
+      isTrue,
+      reason: 'Generated validation code is 8 characters long, which is valid',
+    );
+
+    assert(generatedValidationCode?.length == 8);
+  });
+
+  for (var length in codeLengthsToTest) {
+    final willPass = length >= 1;
+    test(
+        willPass
+            ? 'Setting validationCodeLength to $length will generate a code with the given length'
+            : 'Setting validationCodeLength to $length will return null',
+        () async {
+      String? generatedValidationCode;
+      AuthConfig.set(
+        AuthConfig(
+          validationCodeLength: length,
+          sendValidationEmail: (session, email, validationCode) async {
+            generatedValidationCode = validationCode;
+            return true;
+          },
+        ),
+      );
+
+      var createAccountRequest =
+          await Emails.createAccountRequest(session, userName, email, password);
+
+      expect(
+        createAccountRequest,
+        willPass ? isTrue : isFalse,
+        reason: willPass
+            ? 'Generated validation code is $length characters long, which is valid'
+            : 'Generated validation code is null, which is invalid',
+      );
+
+      if (willPass) {
+        assert(generatedValidationCode?.length == length);
+      } else {
+        assert(generatedValidationCode == null);
+      }
+    });
+  }
+}

--- a/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
@@ -53,7 +53,7 @@ void main() async {
     expect(
       createAccountRequest,
       isTrue,
-      reason: 'Generated validation code is 8 characters long, which is valid',
+      reason: 'Generated validation code is 4 characters long, which is valid',
     );
 
     assert(generatedValidationCode?.length == 4);

--- a/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
@@ -1,16 +1,40 @@
 import 'package:serverpod_auth_server/module.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
 import 'package:test/test.dart';
 
 void main() async {
+  var userName = 'test';
+  var email = 'test@serverpod.dev';
+  var password = 'password';
+  var session = await IntegrationTestServer().session();
+
   test(
-      'Given no validation code length when constructing AuthConfig then validation code has the default length of 8.',
-      () {
-    final auth = AuthConfig();
-    expect(auth.validationCodeLength, 8);
+      'Given no validation code length configuration when creating an account then validation code has the default length of 8.',
+      () async {
+    String? generatedValidationCode;
+    AuthConfig.set(
+      AuthConfig(
+        sendValidationEmail: (session, email, validationCode) async {
+          generatedValidationCode = validationCode;
+          return true;
+        },
+      ),
+    );
+
+    var createAccountRequest =
+        await Emails.createAccountRequest(session, userName, email, password);
+
+    expect(
+      createAccountRequest,
+      isTrue,
+      reason: 'Generated validation code is 8 characters long, which is valid',
+    );
+
+    assert(generatedValidationCode?.length == 8);
   });
 
   test(
-      'Given a positive integer as validation code length when constructing AuthConfig then validation code has the specified length.',
+      'Given a positive integer as validation code length when creating an account then validation code has the specified length.',
       () {
     final auth = AuthConfig(validationCodeLength: 4);
     expect(auth.validationCodeLength, 4);

--- a/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
@@ -1,74 +1,42 @@
 import 'package:serverpod_auth_server/module.dart';
-import 'package:serverpod_test_server/test_util/test_serverpod.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  var userName = 'test';
-  var email = 'test@serverpod.dev';
-  var password = 'password';
-  var session = await IntegrationTestServer().session();
-
-  var codeLengthsToTest = [-16, -8, -4, -1, 0, 1, 4, 16];
-
   test(
-      'Not setting validationCodeLength will generate a code with default length 8',
-      () async {
-    String? generatedValidationCode;
-    AuthConfig.set(
-      AuthConfig(
-        sendValidationEmail: (session, email, validationCode) async {
-          generatedValidationCode = validationCode;
-          return true;
-        },
-      ),
-    );
-
-    var createAccountRequest =
-        await Emails.createAccountRequest(session, userName, email, password);
-
-    expect(
-      createAccountRequest,
-      isTrue,
-      reason: 'Generated validation code is 8 characters long, which is valid',
-    );
-
-    assert(generatedValidationCode?.length == 8);
+      'Given no validation code length when constructing AuthConfig then validation code has the default length of 8.',
+      () {
+    final auth = AuthConfig();
+    expect(auth.validationCodeLength, 8);
   });
 
-  for (var length in codeLengthsToTest) {
-    final willPass = length >= 1;
-    test(
-        willPass
-            ? 'Setting validationCodeLength to $length will generate a code with the given length'
-            : 'Setting validationCodeLength to $length will return null',
-        () async {
-      String? generatedValidationCode;
-      AuthConfig.set(
-        AuthConfig(
-          validationCodeLength: length,
-          sendValidationEmail: (session, email, validationCode) async {
-            generatedValidationCode = validationCode;
-            return true;
-          },
-        ),
-      );
+  test(
+      'Given a positive integer as validation code length when constructing AuthConfig then validation code has the specified length.',
+      () {
+    final auth = AuthConfig(validationCodeLength: 4);
+    expect(auth.validationCodeLength, 4);
+  });
 
-      var createAccountRequest =
-          await Emails.createAccountRequest(session, userName, email, password);
+  test(
+      'Given 0 as validation code length when trying to construct AuthConfig then throws.',
+      () {
+    expect(
+        () => AuthConfig(validationCodeLength: 0),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('Invalid validation code length'),
+        )));
+  });
 
-      expect(
-        createAccountRequest,
-        willPass ? isTrue : isFalse,
-        reason: willPass
-            ? 'Generated validation code is $length characters long, which is valid'
-            : 'Generated validation code is null, which is invalid',
-      );
-
-      if (willPass) {
-        assert(generatedValidationCode?.length == length);
-      } else {
-        assert(generatedValidationCode == null);
-      }
-    });
-  }
+  test(
+      'Given a negative integer as validation code length when trying to construct AuthConfig then throws.',
+      () {
+    expect(
+        () => AuthConfig(validationCodeLength: -4),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('Invalid validation code length'),
+        )));
+  });
 }


### PR DESCRIPTION
This adds another field to the  `serverpod_auth_server` modules\` `AuthConfig`.
The length of the validation code  can now be configured by setting `validationCodeLength`  when declaring the `AuthConfig` in server.dart.

default is still 8.

When 0 or a negative value is passed an Exception is thrown. 

Tests were added to check:
- if valid lengths result in a code of that length being generated and Emails.createAccountRequest returns true
- if invalid lengths result in an exception being thrown in the constructor of AuthConfig 

![auth-config-with-validationCodeLength](https://github.com/serverpod/serverpod/assets/136239531/313d8428-2c1c-481a-bb82-e8a8daab50e6)



closes #2247

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes