### PR TITLE
fix typo in filename mentioning "password.yaml" to "passwords.yaml"

### DIFF
--- a/examples/auth_example/auth_example_server/README.md
+++ b/examples/auth_example/auth_example_server/README.md
@@ -18,7 +18,7 @@ database: auth_example
 password: 9S8rYW7XeIA8bmGY9FBzOSLwQZtQEFNr
 ```
 
-Create the local `password.yaml` file in the server `config` directory. `auth_example/auth_example_server/config/password.yaml` with the following content:
+Create the local `passwords.yaml` file in the server `config` directory. `auth_example/auth_example_server/config/passwords.yaml` with the following content:
 
 ```yaml
 development:

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/cloud_storage/google_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/cloud_storage/google_cloud_storage.dart
@@ -24,9 +24,9 @@ class GoogleCloudStorage extends CloudStorage {
     required this.bucket,
     String? publicHost,
   })  : assert(serverpod.getPassword('HMACAccessKeyId') != null,
-            'HMACAccessKeyId must be present in your password.yaml file'),
+            'HMACAccessKeyId must be present in your passwords.yaml file'),
         assert(serverpod.getPassword('HMACSecretKey') != null,
-            'HMACSecretKey must be present in your password.yaml file'),
+            'HMACSecretKey must be present in your passwords.yaml file'),
         _hmacAccessKeyId = serverpod.getPassword('HMACAccessKeyId')!,
         _hmacSecretKey = serverpod.getPassword('HMACSecretKey')!,
         super(storageId) {

--- a/integrations/serverpod_cloud_storage_s3/lib/src/cloud_storage.dart/s3_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/cloud_storage.dart/s3_cloud_storage.dart
@@ -24,9 +24,9 @@ class S3CloudStorage extends CloudStorage {
     required this.bucket,
     String? publicHost,
   })  : assert(serverpod.getPassword('AWSAccessKeyId') != null,
-            'AWSAccessKeyId must be present in your password.yaml file'),
+            'AWSAccessKeyId must be present in your passwords.yaml file'),
         assert(serverpod.getPassword('AWSSecretKey') != null,
-            'AWSSecretKey must be present in your password.yaml file'),
+            'AWSSecretKey must be present in your passwords.yaml file'),
         _awsAccessKeyId = serverpod.getPassword('AWSAccessKeyId')!,
         _awsSecretKey = serverpod.getPassword('AWSSecretKey')!,
         super(storageId) {


### PR DESCRIPTION
Small typo fix 

wrong: `password.yaml`
right: `passwords.yaml`


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes 
