### PR TITLE
Print streaming message handler exceptions to console

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -437,6 +437,10 @@ class Server {
             } catch (e, s) {
               messageError = e;
               messageStackTrace = s;
+              stderr.writeln('${DateTime.now().toUtc()} Internal server error. '
+                  'Uncaught exception in handleStreamMessage.');
+              stderr.writeln('$e');
+              stderr.writeln('$s');
             }
 
             var duration =


### PR DESCRIPTION
Fixes #2188.

Reports exceptions in the streaming message handler the same way that exceptions are reported in the endpoint handler.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
