### PR TITLE
Report websocket errors to stderr

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:serverpod_client/serverpod_client.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -274,6 +275,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
         }
       });
     } catch (e) {
+      stderr.writeln('Failed to open streaming connection: $e');
       _webSocket = null;
       _cancelConnectionTimer();
       rethrow;
@@ -309,6 +311,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
       _webSocket = null;
       _cancelConnectionTimer();
     } catch (e) {
+      stderr.writeln('Error while listening to websocket stream: $e');
       _webSocket = null;
       _cancelConnectionTimer();
     }


### PR DESCRIPTION
Currently web socket errors are not reported to stderr in most cases (although in one strange case, they are reported and not caught by the caller: https://github.com/dart-lang/sdk/issues/55664 )

This PR prints websocket errs to stderr.

Solves #1679.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
