### PR TITLE
fix!: Remove support for implicit string to expression conversion.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -510,9 +510,9 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
   Future<void> _resetPassword() async {
     _resetIssues();
-    if (_passwordController.text.length < 8) {
+    if (_passwordController.text.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = 'Min 8 characters';
+        _passwordIssue = 'Min ${widget.minPasswordLength} characters';
       });
       return;
     }

--- a/packages/serverpod/lib/src/database/concepts/columns.dart
+++ b/packages/serverpod/lib/src/database/concepts/columns.dart
@@ -335,21 +335,25 @@ mixin _ColumnNumberOperations<T> on _ValueOperatorColumn<T> {
   }
 
   /// Database greater than operator.
+  /// Throws [ArgumentError] if [other] is not an [Expression], [T] or [Column].
   Expression operator >(dynamic other) {
     return _GreaterThanExpression(this, _createValueExpression(other));
   }
 
   /// Database greater or equal than operator.
+  /// Throws [ArgumentError] if [other] is not an [Expression], [T] or [Column].
   Expression operator >=(dynamic other) {
     return _GreaterOrEqualExpression(this, _createValueExpression(other));
   }
 
   /// Database less than operator.
+  /// Throws [ArgumentError] if [other] is not an [Expression], [T] or [Column].
   Expression operator <(dynamic other) {
     return _LessThanExpression(this, _createValueExpression(other));
   }
 
   /// Database less or equal than operator.
+  /// Throws [ArgumentError] if [other] is not an [Expression], [T] or [Column].
   Expression operator <=(dynamic other) {
     return _LessThanOrEqualExpression(this, _createValueExpression(other));
   }
@@ -367,7 +371,9 @@ mixin _ColumnNumberOperations<T> on _ValueOperatorColumn<T> {
       return Expression(other);
     }
 
-    return EscapedExpression(other);
+    throw ArgumentError(
+      'Invalid type for comparison: ${other.runtimeType}, allowed types are Expression, $T or Column',
+    );
   }
 }
 

--- a/packages/serverpod/lib/src/database/concepts/expressions.dart
+++ b/packages/serverpod/lib/src/database/concepts/expressions.dart
@@ -24,21 +24,13 @@ class Expression<T> {
   List<Column> get columns => [];
 
   /// Database AND operator.
-  Expression operator &(dynamic other) {
-    if (other is Expression) {
-      return _AndExpression(this, other);
-    }
-
-    return _AndExpression(this, EscapedExpression(other));
+  Expression operator &(Expression other) {
+    return _AndExpression(this, other);
   }
 
   /// Database OR operator.
-  Expression operator |(dynamic other) {
-    if (other is Expression) {
-      return _OrExpression(this, other);
-    }
-
-    return _OrExpression(this, EscapedExpression(other));
+  Expression operator |(Expression other) {
+    return _OrExpression(this, other);
   }
 
   /// Iterator for all [Expression]s in the expression.

--- a/packages/serverpod/test/database/columns/column_count_test.dart
+++ b/packages/serverpod/test/database/columns/column_count_test.dart
@@ -155,12 +155,18 @@ void main() {
       });
 
       test(
-          'when greater than compared to unhandled type then output is escaped operator expression.',
+          'when greater than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column > 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$countColumnInExpression > \'string is unhandled\'');
+        expect(
+          () => column > 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -191,12 +197,18 @@ void main() {
       });
 
       test(
-          'when greater or equal than compared to unhandled type then output is escaped operator expression.',
+          'when greater or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column >= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$countColumnInExpression >= \'string is unhandled\'');
+        expect(
+          () => column >= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -227,12 +239,18 @@ void main() {
       });
 
       test(
-          'when less than compared to unhandled type then output is escaped operator expression.',
+          'when less than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column < 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$countColumnInExpression < \'string is unhandled\'');
+        expect(
+          () => column < 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -263,12 +281,18 @@ void main() {
       });
 
       test(
-          'when less or equal than compared to unhandled type then output is escaped operator expression.',
+          'when less or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column <= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$countColumnInExpression <= \'string is unhandled\'');
+        expect(
+          () => column <= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
     });
   });

--- a/packages/serverpod/test/database/columns/column_date_time_test.dart
+++ b/packages/serverpod/test/database/columns/column_date_time_test.dart
@@ -148,12 +148,18 @@ void main() {
       });
 
       test(
-          'when greater than compared to unhandled type then output is escaped operator expression.',
+          'when greater than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column > 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column > \'string is unhandled\'');
+        expect(
+          () => column > 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, DateTime or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -182,12 +188,18 @@ void main() {
       });
 
       test(
-          'when greater or equal than compared to unhandled type then output is escaped operator expression.',
+          'when greater or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column >= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column >= \'string is unhandled\'');
+        expect(
+          () => column >= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, DateTime or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -216,12 +228,18 @@ void main() {
       });
 
       test(
-          'when less than compared to unhandled type then output is escaped operator expression.',
+          'when less than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column < 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column < \'string is unhandled\'');
+        expect(
+          () => column < 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, DateTime or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -250,12 +268,18 @@ void main() {
       });
 
       test(
-          'when less or equal than compared to unhandled type then output is escaped operator expression.',
+          'when less or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column <= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column <= \'string is unhandled\'');
+        expect(
+          () => column <= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, DateTime or Column',
+            ),
+          ),
+        );
       });
     });
   });

--- a/packages/serverpod/test/database/columns/column_double_test.dart
+++ b/packages/serverpod/test/database/columns/column_double_test.dart
@@ -150,12 +150,18 @@ void main() {
       });
 
       test(
-          'when greater than compared to unhandled type then output is escaped operator expression.',
+          'when greater than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column > 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column > \'string is unhandled\'');
+        expect(
+          () => column > 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, double or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -183,12 +189,18 @@ void main() {
       });
 
       test(
-          'when greater or equal than compared to unhandled type then output is escaped operator expression.',
+          'when greater or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column >= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column >= \'string is unhandled\'');
+        expect(
+          () => column >= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, double or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -216,12 +228,18 @@ void main() {
       });
 
       test(
-          'when less than compared to unhandled type then output is escaped operator expression.',
+          'when less than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column < 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column < \'string is unhandled\'');
+        expect(
+          () => column < 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, double or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -249,12 +267,18 @@ void main() {
       });
 
       test(
-          'when less or equal than compared to unhandled type then output is escaped operator expression.',
+          'when less or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column <= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column <= \'string is unhandled\'');
+        expect(
+          () => column <= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, double or Column',
+            ),
+          ),
+        );
       });
     });
   });

--- a/packages/serverpod/test/database/columns/column_duration_test.dart
+++ b/packages/serverpod/test/database/columns/column_duration_test.dart
@@ -142,12 +142,18 @@ void main() {
       });
 
       test(
-          'when greater than compared to unhandled type then output is escaped operator expression.',
+          'when greater than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column > 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column > \'string is unhandled\'');
+        expect(
+          () => column > 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, Duration or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -175,12 +181,18 @@ void main() {
       });
 
       test(
-          'when greater or equal than compared to unhandled type then output is escaped operator expression.',
+          'when greater or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column >= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column >= \'string is unhandled\'');
+        expect(
+          () => column >= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, Duration or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -208,12 +220,18 @@ void main() {
       });
 
       test(
-          'when less than compared to unhandled type then output is escaped operator expression.',
+          'when less than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column < 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column < \'string is unhandled\'');
+        expect(
+          () => column < 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, Duration or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -241,12 +259,18 @@ void main() {
       });
 
       test(
-          'when less or equal than compared to unhandled type then output is escaped operator expression.',
+          'when less or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column <= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column <= \'string is unhandled\'');
+        expect(
+          () => column <= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, Duration or Column',
+            ),
+          ),
+        );
       });
     });
   });

--- a/packages/serverpod/test/database/columns/column_int_test.dart
+++ b/packages/serverpod/test/database/columns/column_int_test.dart
@@ -147,12 +147,18 @@ void main() {
       });
 
       test(
-          'when greater than compared to unhandled type then output is escaped operator expression.',
+          'when greater than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column > 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column > \'string is unhandled\'');
+        expect(
+          () => column > 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -180,12 +186,18 @@ void main() {
       });
 
       test(
-          'when greater or equal than compared to unhandled type then output is escaped operator expression.',
+          'when greater or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column >= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column >= \'string is unhandled\'');
+        expect(
+          () => column >= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -213,12 +225,18 @@ void main() {
       });
 
       test(
-          'when less than compared to unhandled type then output is escaped operator expression.',
+          'when less than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column < 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column < \'string is unhandled\'');
+        expect(
+          () => column < 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
 
       test(
@@ -246,12 +264,18 @@ void main() {
       });
 
       test(
-          'when less or equal than compared to unhandled type then output is escaped operator expression.',
+          'when less or equal than compared to unhandled type then argument error is thrown.',
           () {
-        var comparisonExpression = column <= 'string is unhandled';
-
-        expect(comparisonExpression.toString(),
-            '$column <= \'string is unhandled\'');
+        expect(
+          () => column <= 'string is unhandled',
+          throwsA(
+            isA<ArgumentError>().having(
+              (e) => e.message,
+              'message',
+              'Invalid type for comparison: String, allowed types are Expression, int or Column',
+            ),
+          ),
+        );
       });
     });
   });


### PR DESCRIPTION
## Changes
- (BREAKING) Removes implicit `dynamic` to Expression conversion for `&`, `|`, `<`, `<=`, `>` and `>=`.
- (Bonus) Makes sure the authentication flutter widgets uses the min configured password length for client-side validation.

The motivation for this change is that if we would like to support more databases in the future, we might need to adapt the query language to fit their flavor.

By removing implicit casting of dynamic, we can move to a more tree based structure for the query operations that can then be translated in the database adapter layer to fit the running database.

Closes: #2254

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

YES - removes implicit support for dynamic to Expression conversion for `&`, `|`, `<`, `<=`, `>` and `>=`.

