### PR TITLE
set hostname for tests to localhost

### DIFF
--- a/tests/serverpod_test_server/config/production.yaml
+++ b/tests/serverpod_test_server/config/production.yaml
@@ -17,12 +17,12 @@ webServer:
   publicScheme: http
 
 database:
-  host: postgres
+  host: localhost
   port: 5432
   name: serverpod_test
   user: postgres
 
 redis:
   enabled: true
-  host: redis
+  host: localhost
   port: 6379


### PR DESCRIPTION
In serverpod_test_server the host for database and redis was set to "postgres" and "redis" respectively. 
This resulted in the tests failing wherever `var session = await IntegrationTestServer().session();` was called.

After changing the host to localhost on both all tests run as expected

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._
