### PR TITLE
Handle bad websocket upgrade requests

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -228,7 +228,15 @@ class Server {
       await request.response.close();
       return;
     } else if (uri.path == '/websocket') {
-      var webSocket = await WebSocketTransformer.upgrade(request);
+      WebSocket webSocket;
+      try {
+        webSocket = await WebSocketTransformer.upgrade(request);
+      } catch (e) {
+        // Handle "WebSocketException: Invalid WebSocket upgrade request"
+        request.response.statusCode = HttpStatus.badRequest;
+        await request.response.close();
+        return;
+      }
       webSocket.pingInterval = const Duration(seconds: 30);
       unawaited(_handleWebsocket(webSocket, request));
       return;

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -232,9 +232,15 @@ class Server {
       try {
         webSocket = await WebSocketTransformer.upgrade(request);
       } catch (e) {
-        // Handle "WebSocketException: Invalid WebSocket upgrade request"
-        request.response.statusCode = HttpStatus.badRequest;
-        await request.response.close();
+        // Handle "WebSocketException: Invalid WebSocket upgrade request".
+        stderr.writeln('Failed to upgrade connection to websocket: $e');
+        try {
+          request.response.statusCode = HttpStatus.badRequest;
+          await request.response.close();
+        } catch (e) {
+          // The statusCode setter throws StateException if the the header has
+          // already been sent. Ignore this.
+        }
         return;
       }
       webSocket.pingInterval = const Duration(seconds: 30);

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -231,16 +231,8 @@ class Server {
       WebSocket webSocket;
       try {
         webSocket = await WebSocketTransformer.upgrade(request);
-      } catch (e) {
-        // Handle "WebSocketException: Invalid WebSocket upgrade request".
-        stderr.writeln('Failed to upgrade connection to websocket: $e');
-        try {
-          request.response.statusCode = HttpStatus.badRequest;
-          await request.response.close();
-        } catch (e) {
-          // The statusCode setter throws StateException if the the header has
-          // already been sent. Ignore this.
-        }
+      } on WebSocketException {
+        stderr.writeln('Failed to upgrade connection to websocket');
         return;
       }
       webSocket.pingInterval = const Duration(seconds: 30);


### PR DESCRIPTION
Once you expose a server to the Internet, you get all sorts of crawlers hitting your site. This small change properly handles a bad websocket upgrade request by sending back BadRequest rather than throwing an exception (which causes the server debugger process to stop on uncaught exception).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
