### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/examples/auth_example/auth_example_server/aws/terraform/config.auto.tfvars
+++ b/examples/auth_example/auth_example_server/aws/terraform/config.auto.tfvars
@@ -56,7 +56,7 @@ use_top_domain_for_web = false
 # The definition of the server instances to deploy. Note that if you change the
 # region, you will have to change the AMI as they are bound to specific regions.
 # Serverpod is tested with Amazon Linux 2 Kernel 5.x (You can find the AMI ids
-# for a specifc region under EC2 > AMI Catalog in your AWS console.)
+# for a specific region under EC2 > AMI Catalog in your AWS console.)
 # Note: For some regions the t2.micro is not available. If so, consult the AWS
 # documentation to find another instance type that suits your needs.
 instance_type                = "t2.micro"

--- a/examples/auth_example/auth_example_server/aws/terraform/init-script.sh
+++ b/examples/auth_example/auth_example_server/aws/terraform/init-script.sh
@@ -14,7 +14,7 @@ wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/2.18
 unzip -q dartsdk-linux-x64-release.zip
 sudo mv dart-sdk/ /usr/lib/dart/
 sudo chmod -R 755 /usr/lib/dart/
-echo 'export PATH="$PATH:/usr/lib/dart/bin"' >>/etc/profile.d/script.sh
+echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> /etc/profile.d/script.sh
 
 # Install CodeDeploy agent
 echo "Installing CodeDeploy agent"
@@ -26,7 +26,7 @@ rm install
 
 # Set runmode
 echo "Setting runmode"
-echo ${runmode} >/home/ec2-user/runmode
+echo ${runmode} > /home/ec2-user/runmode
 chown ec2-user:ec2-user /home/ec2-user/runmode
 
 echo "Setup done"

--- a/examples/auth_example/auth_example_server/aws/terraform/init-script.sh
+++ b/examples/auth_example/auth_example_server/aws/terraform/init-script.sh
@@ -5,7 +5,7 @@ yum update -y
 # Install yum packages
 echo "Installing ruby"
 yum install ruby -y
-ehco "Installing wget"
+echo "Installing wget"
 yum install wget -y
 
 # Install Dart
@@ -14,7 +14,7 @@ wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/2.18
 unzip -q dartsdk-linux-x64-release.zip
 sudo mv dart-sdk/ /usr/lib/dart/
 sudo chmod -R 755 /usr/lib/dart/
-echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> /etc/profile.d/script.sh
+echo 'export PATH="$PATH:/usr/lib/dart/bin"' >>/etc/profile.d/script.sh
 
 # Install CodeDeploy agent
 echo "Installing CodeDeploy agent"
@@ -26,7 +26,7 @@ rm install
 
 # Set runmode
 echo "Setting runmode"
-echo ${runmode} > /home/ec2-user/runmode
+echo ${runmode} >/home/ec2-user/runmode
 chown ec2-user:ec2-user /home/ec2-user/runmode
 
 echo "Setup done"

--- a/examples/auth_example/auth_example_server/aws/terraform/variables.tf
+++ b/examples/auth_example/auth_example_server/aws/terraform/variables.tf
@@ -193,6 +193,6 @@ variable "DATABASE_PASSWORD_PRODUCTION" {
 }
 
 variable "DATABASE_PASSWORD_STAGING" {
-  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deployning a staging environment)."
+  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deploying a staging environment)."
   type        = string
 }

--- a/examples/chat/chat_server/aws/terraform/config.auto.tfvars
+++ b/examples/chat/chat_server/aws/terraform/config.auto.tfvars
@@ -56,7 +56,7 @@ use_top_domain_for_web = false
 # The definition of the server instances to deploy. Note that if you change the
 # region, you will have to change the AMI as they are bound to specific regions.
 # Serverpod is tested with Amazon Linux 2 Kernel 5.x (You can find the AMI ids
-# for a specifc region under EC2 > AMI Catalog in your AWS console.)
+# for a specific region under EC2 > AMI Catalog in your AWS console.)
 # Note: For some regions the t2.micro is not available. If so, consult the AWS
 # documentation to find another instance type that suits your needs.
 instance_type                = "t2.micro"

--- a/examples/chat/chat_server/aws/terraform/init-script.sh
+++ b/examples/chat/chat_server/aws/terraform/init-script.sh
@@ -14,7 +14,7 @@ wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/2.18
 unzip -q dartsdk-linux-x64-release.zip
 sudo mv dart-sdk/ /usr/lib/dart/
 sudo chmod -R 755 /usr/lib/dart/
-echo 'export PATH="$PATH:/usr/lib/dart/bin"' >>/etc/profile.d/script.sh
+echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> /etc/profile.d/script.sh
 
 # Install CodeDeploy agent
 echo "Installing CodeDeploy agent"
@@ -26,7 +26,7 @@ rm install
 
 # Set runmode
 echo "Setting runmode"
-echo ${runmode} >/home/ec2-user/runmode
+echo ${runmode} > /home/ec2-user/runmode
 chown ec2-user:ec2-user /home/ec2-user/runmode
 
 echo "Setup done"

--- a/examples/chat/chat_server/aws/terraform/init-script.sh
+++ b/examples/chat/chat_server/aws/terraform/init-script.sh
@@ -5,7 +5,7 @@ yum update -y
 # Install yum packages
 echo "Installing ruby"
 yum install ruby -y
-ehco "Installing wget"
+echo "Installing wget"
 yum install wget -y
 
 # Install Dart
@@ -14,7 +14,7 @@ wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/2.18
 unzip -q dartsdk-linux-x64-release.zip
 sudo mv dart-sdk/ /usr/lib/dart/
 sudo chmod -R 755 /usr/lib/dart/
-echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> /etc/profile.d/script.sh
+echo 'export PATH="$PATH:/usr/lib/dart/bin"' >>/etc/profile.d/script.sh
 
 # Install CodeDeploy agent
 echo "Installing CodeDeploy agent"
@@ -26,7 +26,7 @@ rm install
 
 # Set runmode
 echo "Setting runmode"
-echo ${runmode} > /home/ec2-user/runmode
+echo ${runmode} >/home/ec2-user/runmode
 chown ec2-user:ec2-user /home/ec2-user/runmode
 
 echo "Setup done"

--- a/examples/chat/chat_server/aws/terraform/variables.tf
+++ b/examples/chat/chat_server/aws/terraform/variables.tf
@@ -193,6 +193,6 @@ variable "DATABASE_PASSWORD_PRODUCTION" {
 }
 
 variable "DATABASE_PASSWORD_STAGING" {
-  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deployning a staging environment)."
+  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deploying a staging environment)."
   type        = string
 }

--- a/integrations/serverpod_cloud_storage_gcp/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_gcp/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/client/exceptions.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/client/exceptions.dart
@@ -22,5 +22,5 @@ class NoPermissionsException extends S3Exception {
 
   @override
   String get devDebugHint =>
-      "S3 returned a 403 status code. Please make sure you have the right permissons for this request";
+      "S3 returned a 403 status code. Please make sure you have the right permissions for this request";
 }

--- a/integrations/serverpod_cloud_storage_s3/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_s3/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/client/exceptions.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/client/exceptions.dart
@@ -22,5 +22,5 @@ class NoPermissionsException extends S3Exception {
 
   @override
   String get devDebugHint =>
-      "S3 returned a 403 status code. Please make sure you have the right permissons for this request";
+      "S3 returned a 403 status code. Please make sure you have the right permissions for this request";
 }

--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/lib/src/signin_button.dart
@@ -46,7 +46,7 @@ class SignInWithAppleButtonState extends State<SignInWithAppleButton> {
           ),
       onPressed: () {
         // Open a dialog with just the progress indicator that isn't
-        // dismissable.
+        // dismissible.
         showLoadingBarrier(context: context);
         var navigator = Navigator.of(context, rootNavigator: true);
 

--- a/modules/serverpod_auth/serverpod_auth_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_client/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/google_refresh_token.dart
@@ -40,7 +40,7 @@ abstract class GoogleRefreshToken extends _i1.SerializableEntity {
   /// The user id associated with the token.
   int userId;
 
-  /// The token iteself.
+  /// The token itself.
   String refreshToken;
 
   GoogleRefreshToken copyWith({

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
@@ -10,7 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
-/// Information about a user that can safely be publically accessible.
+/// Information about a user that can safely be publicly accessible.
 abstract class UserInfoPublic extends _i1.SerializableEntity {
   UserInfoPublic._({
     this.id,

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/google/google_sign_in_web_service.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/google/google_sign_in_web_service.dart
@@ -92,7 +92,7 @@ class _SignInSession {
     });
   }
 
-  // Called when we recieve the code from open window.
+  // Called when we receive the code from open window.
   void completeWithCode(String code) {
     if (!isClosed) {
       codeCompleter.complete(code);

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/google/sign_in_with_google_platform.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/google/sign_in_with_google_platform.dart
@@ -1,10 +1,10 @@
 /// An object for internal use to pass along the idToken or serverAuthCode
-/// recieved from google during the sign in process.
+/// received from google during the sign in process.
 class ClientAuthTokens {
-  /// The auth token recieved from google.
+  /// The auth token received from google.
   final String? idToken;
 
-  /// The server auth code recieved from google.
+  /// The server auth code received from google.
   final String? serverAuthCode;
 
   /// Creates a new [ClientAuthTokens] object.

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/signin_button.dart
@@ -69,7 +69,7 @@ class SignInWithGoogleButtonState extends State<SignInWithGoogleButton> {
           ),
       onPressed: () {
         // Open a dialog with just the progress indicator that isn't
-        // dismissable.
+        // dismissible.
         showLoadingBarrier(context: context);
         var navigator = Navigator.of(context, rootNavigator: true);
 

--- a/modules/serverpod_auth/serverpod_auth_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_server/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_auth/serverpod_auth_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_server/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -40,7 +40,7 @@ abstract class GoogleRefreshToken extends _i1.TableRow
   /// The user id associated with the token.
   int userId;
 
-  /// The token iteself.
+  /// The token itself.
   String refreshToken;
 
   @override
@@ -137,7 +137,7 @@ class GoogleRefreshTokenTable extends _i1.Table {
   /// The user id associated with the token.
   late final _i1.ColumnInt userId;
 
-  /// The token iteself.
+  /// The token itself.
   late final _i1.ColumnString refreshToken;
 
   @override

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
@@ -11,7 +11,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-/// Information about a user that can safely be publically accessible.
+/// Information about a user that can safely be publicly accessible.
 abstract class UserInfoPublic extends _i1.SerializableEntity
     implements _i1.ProtocolSerialization {
   UserInfoPublic._({

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/models/google_refresh_token.spy.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/models/google_refresh_token.spy.yaml
@@ -5,7 +5,7 @@ fields:
   ### The user id associated with the token.
   userId: int
 
-  ### The token iteself.
+  ### The token itself.
   refreshToken: String
 indexes:
   serverpod_google_refresh_token_userId_idx:

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/models/user_info_public.spy.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/models/user_info_public.spy.yaml
@@ -1,4 +1,4 @@
-### Information about a user that can safely be publically accessible.
+### Information about a user that can safely be publicly accessible.
 class: UserInfoPublic
 fields:
   ### Id of the user, if known.

--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/modules/serverpod_chat/serverpod_chat_client/CHANGELOG.md
+++ b/modules/serverpod_chat/serverpod_chat_client/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_chat/serverpod_chat_client/CHANGELOG.md
+++ b/modules/serverpod_chat/serverpod_chat_client/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment.dart
@@ -10,7 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
-/// An attachement to a chat message. Typically an image or a file.
+/// An attachment to a chat message. Typically an image or a file.
 abstract class ChatMessageAttachment extends _i1.SerializableEntity {
   ChatMessageAttachment._({
     required this.fileName,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment_upload_description.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment_upload_description.dart
@@ -10,7 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
-/// A description for uploading an attachement.
+/// A description for uploading an attachment.
 abstract class ChatMessageAttachmentUploadDescription
     extends _i1.SerializableEntity {
   ChatMessageAttachmentUploadDescription._({

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_read_message.dart
@@ -10,7 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 
-/// Message to notifiy the server that messages have been read.
+/// Message to notify the server that messages have been read.
 abstract class ChatReadMessage extends _i1.SerializableEntity {
   ChatReadMessage._({
     this.id,

--- a/modules/serverpod_chat/serverpod_chat_flutter/CHANGELOG.md
+++ b/modules/serverpod_chat/serverpod_chat_flutter/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_controller.dart
+++ b/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_controller.dart
@@ -14,7 +14,7 @@ typedef ChatControllerReceivedMessageCallback = void Function(
 
 /// Handles all interaction with a chat channel.
 class ChatController {
-  /// The identifiying channel name of chat this controller is handling.
+  /// The identifying channel name of chat this controller is handling.
   late final String channel;
 
   /// Reference to the module.
@@ -26,7 +26,7 @@ class ChatController {
   /// True if the chat is ephemeral and shouldn't be saved to the database.
   final bool ephemeral;
 
-  /// Name of an autheticated user.
+  /// Name of an authenticated user.
   final String? unauthenticatedUserName;
 
   /// Reference to the dispatch that handles multiple chat channels.
@@ -316,7 +316,7 @@ class ChatController {
     }
   }
 
-  // Listeners for recevied message chunks
+  // Listeners for received message chunks
 
   /// Adds a listener for received chunks of messages.
   void addReceivedMessageChunkListener(VoidCallback listener) {

--- a/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_dispatch.dart
+++ b/modules/serverpod_chat/serverpod_chat_flutter/lib/src/chat_dispatch.dart
@@ -26,7 +26,7 @@ class ChatDispatch {
     _handleStreamMessages();
   }
 
-  /// Adds a listener to a specifiec chat channel. It's only allowed to add one
+  /// Adds a listener to a specific chat channel. It's only allowed to add one
   /// listener per channel.
   void addListener(String channel, ChatMessageListener listener,
       {String? unauthenticatedUserName}) {

--- a/modules/serverpod_chat/serverpod_chat_server/CHANGELOG.md
+++ b/modules/serverpod_chat/serverpod_chat_server/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/modules/serverpod_chat/serverpod_chat_server/CHANGELOG.md
+++ b/modules/serverpod_chat/serverpod_chat_server/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment.dart
@@ -10,7 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-/// An attachement to a chat message. Typically an image or a file.
+/// An attachment to a chat message. Typically an image or a file.
 abstract class ChatMessageAttachment extends _i1.SerializableEntity
     implements _i1.ProtocolSerialization {
   ChatMessageAttachment._({

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment_upload_description.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment_upload_description.dart
@@ -10,7 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-/// A description for uploading an attachement.
+/// A description for uploading an attachment.
 abstract class ChatMessageAttachmentUploadDescription
     extends _i1.SerializableEntity implements _i1.ProtocolSerialization {
   ChatMessageAttachmentUploadDescription._({

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -10,7 +10,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-/// Message to notifiy the server that messages have been read.
+/// Message to notify the server that messages have been read.
 abstract class ChatReadMessage extends _i1.TableRow
     implements _i1.ProtocolSerialization {
   ChatReadMessage._({

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/models/chat_message_attachment.spy.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/models/chat_message_attachment.spy.yaml
@@ -1,4 +1,4 @@
-### An attachement to a chat message. Typically an image or a file.
+### An attachment to a chat message. Typically an image or a file.
 class: ChatMessageAttachment
 fields:
   ### The name of the file.

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/models/chat_message_attachment_upload_description.spy.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/models/chat_message_attachment_upload_description.spy.yaml
@@ -1,4 +1,4 @@
-### A description for uploading an attachement.
+### A description for uploading an attachment.
 class: ChatMessageAttachmentUploadDescription
 fields:
   ### The path where the file should be uploaded.

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/models/chat_read_message.spy.yaml
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/models/chat_read_message.spy.yaml
@@ -1,4 +1,4 @@
-### Message to notifiy the server that messages have been read.
+### Message to notify the server that messages have been read.
 class: ChatReadMessage
 table: serverpod_chat_read_message
 fields:

--- a/packages/serverpod/CHANGELOG.md
+++ b/packages/serverpod/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/packages/serverpod/CHANGELOG.md
+++ b/packages/serverpod/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/packages/serverpod/lib/src/cloud_storage/cloud_storage.dart
+++ b/packages/serverpod/lib/src/cloud_storage/cloud_storage.dart
@@ -17,7 +17,7 @@ abstract class CloudStorage {
   String storageId;
 
   /// Creates a [CloudStorage] with the specified [storageId]. By default,
-  /// two storages are used by Serverepod `public` and `private`. The public
+  /// two storages are used by Serverpod `public` and `private`. The public
   /// should be accessible to everyone (usually through a web interface),
   /// while the private is accessed internally only.
   CloudStorage(this.storageId);

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -667,7 +667,7 @@ class DatabaseConnection {
       Column<dynamic>? orderBy, bool orderDescending) {
     assert(orderByList == null || orderBy == null);
     if (orderBy != null) {
-      // If order by is set then order by list is overriden.
+      // If order by is set then order by list is overridden.
       return [Order(column: orderBy, orderDescending: orderDescending)];
     }
     return orderByList;

--- a/packages/serverpod/lib/src/generated/database/foreign_key_match_type.dart
+++ b/packages/serverpod/lib/src/generated/database/foreign_key_match_type.dart
@@ -16,7 +16,7 @@ enum ForeignKeyMatchType with _i1.SerializableEntity {
   /// to be null unless all foreign key columns are null.
   full,
 
-  /// [partial] is not yet implemented in postges. Don't use this.
+  /// [partial] is not yet implemented in postgres. Don't use this.
   partial,
 
   /// [simple] allows any of the foreign key columns to be null.

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -75,7 +75,7 @@ abstract class LogEntry extends _i1.TableRow
   /// The id of the server which created this log entry.
   String serverId;
 
-  /// Timpstamp of this log entry.
+  /// Timestamp of this log entry.
   DateTime time;
 
   /// The log level of this entry.
@@ -284,7 +284,7 @@ class LogEntryTable extends _i1.Table {
   /// The id of the server which created this log entry.
   late final _i1.ColumnString serverId;
 
-  /// Timpstamp of this log entry.
+  /// Timestamp of this log entry.
   late final _i1.ColumnDateTime time;
 
   /// The log level of this entry.

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -70,7 +70,7 @@ abstract class MessageLogEntry extends _i1.TableRow
   /// The id of the message this entry is associated with.
   int messageId;
 
-  /// The entpoint this message is associated with.
+  /// The endpoint this message is associated with.
   String endpoint;
 
   /// The class name of the message this entry is associated with.
@@ -281,7 +281,7 @@ class MessageLogEntryTable extends _i1.Table {
   /// The id of the message this entry is associated with.
   late final _i1.ColumnInt messageId;
 
-  /// The entpoint this message is associated with.
+  /// The endpoint this message is associated with.
   late final _i1.ColumnString endpoint;
 
   /// The class name of the message this entry is associated with.

--- a/packages/serverpod/lib/src/models/database/foreign_key_match_type.spy.yaml
+++ b/packages/serverpod/lib/src/models/database/foreign_key_match_type.spy.yaml
@@ -4,7 +4,7 @@ values:
   ### [full] will not allow one column of a multicolumn foreign key
   ### to be null unless all foreign key columns are null.
   - full
-  ### [partial] is not yet implemented in postges. Don't use this.
+  ### [partial] is not yet implemented in postgres. Don't use this.
   - partial
   ### [simple] allows any of the foreign key columns to be null.
   ### If any of them are null, the row is not required to have a

--- a/packages/serverpod/lib/src/models/log_entry.spy.yaml
+++ b/packages/serverpod/lib/src/models/log_entry.spy.yaml
@@ -14,7 +14,7 @@ fields:
   ### The id of the server which created this log entry.
   serverId: String
 
-  ### Timpstamp of this log entry.
+  ### Timestamp of this log entry.
   time: DateTime
 
   ### The log level of this entry.

--- a/packages/serverpod/lib/src/models/message_log_entry.spy.yaml
+++ b/packages/serverpod/lib/src/models/message_log_entry.spy.yaml
@@ -11,7 +11,7 @@ fields:
   ### The id of the message this entry is associated with.
   messageId: int
 
-  ### The entpoint this message is associated with.
+  ### The endpoint this message is associated with.
   endpoint: String
 
   ### The class name of the message this entry is associated with.

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -219,7 +219,7 @@ abstract class Route {
     headers.contentType = ContentType('text', 'html', charset: 'utf-8');
   }
 
-  /// Handles a call to this route. This method is repsonsible for setting
+  /// Handles a call to this route. This method is responsible for setting
   /// a correct response headers, status code, and write the response body to
   /// `request.response`.
   Future<bool> handleCall(Session session, HttpRequest request);
@@ -279,7 +279,7 @@ abstract class Route {
   }
 }
 
-/// A [WidgetRoute] is the most convienient way to create routes in your server.
+/// A [WidgetRoute] is the most convenient way to create routes in your server.
 /// Override the [build] method and return an appropriate [Widget].
 abstract class WidgetRoute extends Route {
   /// Override this method to build your web [Widget] from the current [session]

--- a/packages/serverpod/lib/src/serialization/serialization_manager.dart
+++ b/packages/serverpod/lib/src/serialization/serialization_manager.dart
@@ -3,7 +3,7 @@ import 'package:serverpod/serverpod.dart';
 
 /// The [SerializationManager] is responsible for creating objects from a
 /// serialization, but also for serializing objects. This class is typically
-/// overriden by generated code. [SerializationManagerServer] is an extension to
+/// overridden by generated code. [SerializationManagerServer] is an extension to
 /// also handle [Table]s.
 abstract class SerializationManagerServer extends SerializationManager {
   /// The name of the module that defines the serialization.

--- a/packages/serverpod/lib/src/server/command_line_args.dart
+++ b/packages/serverpod/lib/src/server/command_line_args.dart
@@ -22,7 +22,7 @@ enum ServerpodRole {
   maintenance,
 }
 
-/// The overaching logging mode of the server. This can be set to either
+/// The overarching logging mode of the server. This can be set to either
 /// [normal] or [verbose]. In [normal] mode, only important messages are logged,
 /// which is the default.
 enum ServerpodLoggingMode {

--- a/packages/serverpod/lib/src/server/endpoint.dart
+++ b/packages/serverpod/lib/src/server/endpoint.dart
@@ -51,7 +51,7 @@ abstract class Endpoint {
 
   final Map<Session, dynamic> _userObjects = {};
 
-  /// Retrieves a custom object assiciated with this [Endpoint] and [Session].
+  /// Retrieves a custom object associated with this [Endpoint] and [Session].
   dynamic getUserObject(Session session) {
     return _userObjects[session];
   }

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -262,7 +262,7 @@ class ResultInvalidParams extends Result {
   /// Description of the error.
   final String errorDescription;
 
-  /// Creates a new [ResutInvalidParams] object.
+  /// Creates a new [ResultInvalidParams] object.
   ResultInvalidParams(this.errorDescription);
 
   @override

--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -126,7 +126,7 @@ class HealthCheckManager {
   Future<void> _optimizeHealthCheckData(int numHealthChecks) async {
     var session = await _pod.createSession(enableLogging: false);
     try {
-      // Optimize connection info entreis.
+      // Optimize connection info entries.
       var didOptimizeMinutes = await _optimizeConnectionInfoEntries(
         session,
         1,

--- a/packages/serverpod/lib/src/server/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager.dart
@@ -364,7 +364,7 @@ class LogManager {
   /// Logs an entry, depending on the session type it will be logged directly
   /// to the database or stored in the temporary cache until the session is
   /// closed. Call [shouldLogEntry] to check if the entry should be logged
-  /// before calling this method. This method can be called asyncronously.
+  /// before calling this method. This method can be called asynchronously.
   @internal
   Future<void> logEntry(Session session, LogEntry entry) async {
     await _internalLogger(
@@ -380,7 +380,7 @@ class LogManager {
   /// Logs a query, depending on the session type it will be logged directly
   /// to the database or stored in the temporary cache until the session is
   /// closed. Call [shouldLogQuery] to check if the entry should be logged
-  /// before calling this method. This method can be called asyncronously.
+  /// before calling this method. This method can be called asynchronously.
   @internal
   Future<void> logQuery(Session session, QueryLogEntry entry) async {
     await _internalLogger(
@@ -397,7 +397,7 @@ class LogManager {
   /// logged directly to the database or stored in the temporary cache until the
   /// session is closed. Call [shouldLogMessage] to check if the entry should be
   /// logged before calling this method. This method can be called
-  /// asyncronously.
+  /// asynchronously.
   @internal
   Future<void> logMessage(Session session, MessageLogEntry entry) async {
     await _internalLogger(

--- a/packages/serverpod/test/database/expressions/expression_test.dart
+++ b/packages/serverpod/test/database/expressions/expression_test.dart
@@ -285,7 +285,7 @@ void main() {
     Expression expression = firstColumn.equals('test 1') &
         (secondColumn.like('test 2') | firstColumn.equals('test 1'));
 
-    group('when retrieveing columns', () {
+    group('when retrieving columns', () {
       List<Column> columns = expression.columns;
 
       test('then all columns are represented.', () {

--- a/packages/serverpod_client/CHANGELOG.md
+++ b/packages/serverpod_client/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/packages/serverpod_client/lib/src/file_uploader.dart
+++ b/packages/serverpod_client/lib/src/file_uploader.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
-/// The file uploader uploads files to Serverpods cloud storage. On the server
+/// The file uploader uploads files to Serverpod's cloud storage. On the server
 /// you can setup a custom storage service, such as S3 or Google Cloud. To
 /// directly upload a file, you first need to retrieve an upload description
 /// from your server. After the file is uploaded, make sure to notify the server

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -246,7 +246,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
     if (disconnectOnLostInternetConnection) {
       assert(
         _connectivityMonitor != null,
-        'To enable automatic disconnect on lost internet connection, you need to set the connectivityMonitor propery.',
+        'To enable automatic disconnect on lost internet connection, you need to set the connectivityMonitor property.',
       );
     }
     _disconnectOnLostInternetConnection = disconnectOnLostInternetConnection;

--- a/packages/serverpod_client/lib/src/streaming_connection_handler.dart
+++ b/packages/serverpod_client/lib/src/streaming_connection_handler.dart
@@ -5,7 +5,7 @@ import 'serverpod_client_shared.dart';
 /// Represents the state of the connection handler.
 class StreamingConnectionHandlerState {
   /// Time in seconds until next connection attempt. Only set if the connection
-  /// [status] is StreaminConnectionStatus.waitingToRetry.
+  /// [status] is StreamingConnectionStatus.waitingToRetry.
   final int? retryInSeconds;
 
   /// The status of the connection.
@@ -19,12 +19,12 @@ class StreamingConnectionHandlerState {
 
 /// The StreamingConnection handler manages the web socket connection and its
 /// state. It will automatically reconnect to the server if the connection is
-/// lost. The [listener] will be notfied whenever the connection state changes
+/// lost. The [listener] will be notified whenever the connection state changes
 /// and once every second when counting down to reconnect. The time between
 /// reconnection attempts is specified with [retryEverySeconds], default is 5
 /// seconds.
 class StreamingConnectionHandler {
-  /// The Serverpod client this StremingConnectionHandler is managing.
+  /// The Serverpod client this StreamingConnectionHandler is managing.
   final ServerpodClientShared client;
 
   /// Time in seconds between connection attempts. Default is 5 seconds.

--- a/packages/serverpod_flutter/CHANGELOG.md
+++ b/packages/serverpod_flutter/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/packages/serverpod_lints/CHANGELOG.md
+++ b/packages/serverpod_lints/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/packages/serverpod_serialization/CHANGELOG.md
+++ b/packages/serverpod_serialization/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/packages/serverpod_service_client/CHANGELOG.md
+++ b/packages/serverpod_service_client/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_match_type.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_match_type.dart
@@ -16,7 +16,7 @@ enum ForeignKeyMatchType with _i1.SerializableEntity {
   /// to be null unless all foreign key columns are null.
   full,
 
-  /// [partial] is not yet implemented in postges. Don't use this.
+  /// [partial] is not yet implemented in postgres. Don't use this.
   partial,
 
   /// [simple] allows any of the foreign key columns to be null.

--- a/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
@@ -74,7 +74,7 @@ abstract class LogEntry extends _i1.SerializableEntity {
   /// The id of the server which created this log entry.
   String serverId;
 
-  /// Timpstamp of this log entry.
+  /// Timestamp of this log entry.
   DateTime time;
 
   /// The log level of this entry.

--- a/packages/serverpod_service_client/lib/src/protocol/message_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/message_log_entry.dart
@@ -70,7 +70,7 @@ abstract class MessageLogEntry extends _i1.SerializableEntity {
   /// The id of the message this entry is associated with.
   int messageId;
 
-  /// The entpoint this message is associated with.
+  /// The endpoint this message is associated with.
   String endpoint;
 
   /// The class name of the message this entry is associated with.

--- a/packages/serverpod_shared/CHANGELOG.md
+++ b/packages/serverpod_shared/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/packages/serverpod_shared/CHANGELOG.md
+++ b/packages/serverpod_shared/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/templates/serverpod_templates/CHANGELOG.md
+++ b/templates/serverpod_templates/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/templates/serverpod_templates/CHANGELOG.md
+++ b/templates/serverpod_templates/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/templates/serverpod_templates/modulename_client/gitignore
+++ b/templates/serverpod_templates/modulename_client/gitignore
@@ -2,7 +2,7 @@
     .dart_tool/
     .packages
 
-# Omit commiting pubspec.lock for library packages:
+# Omit committing pubspec.lock for library packages:
 # https://dart.dev/guides/libraries/private-files#pubspeclock
 pubspec.lock
 

--- a/templates/serverpod_templates/modulename_server/gitignore
+++ b/templates/serverpod_templates/modulename_server/gitignore
@@ -2,7 +2,7 @@
 .dart_tool/
 .packages
 
-# Omit commiting pubspec.lock for library packages:
+# Omit committing pubspec.lock for library packages:
 # https://dart.dev/guides/libraries/private-files#pubspeclock
 pubspec.lock
 

--- a/templates/serverpod_templates/projectname_client/gitignore
+++ b/templates/serverpod_templates/projectname_client/gitignore
@@ -2,7 +2,7 @@
 .dart_tool/
 .packages
 
-# Omit commiting pubspec.lock for library packages:
+# Omit committing pubspec.lock for library packages:
 # https://dart.dev/guides/libraries/private-files#pubspeclock
 pubspec.lock
 

--- a/templates/serverpod_templates/projectname_flutter/gitignore
+++ b/templates/serverpod_templates/projectname_flutter/gitignore
@@ -34,7 +34,7 @@
 # Web related
 lib/generated_plugin_registrant.dart
 
-# Symbolication related
+# Symbolization related
 app.*.symbols
 
 # Obfuscation related

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/config.auto.tfvars
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/config.auto.tfvars
@@ -56,7 +56,7 @@ use_top_domain_for_web = false
 # The definition of the server instances to deploy. Note that if you change the
 # region, you will have to change the AMI as they are bound to specific regions.
 # Serverpod is tested with Amazon Linux 2 Kernel 5.x (You can find the AMI ids
-# for a specifc region under EC2 > AMI Catalog in your AWS console.)
+# for a specific region under EC2 > AMI Catalog in your AWS console.)
 # Note: For some regions the t2.micro is not available. If so, consult the AWS
 # documentation to find another instance type that suits your needs.
 instance_type                = "t2.micro"

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/init-script.sh
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/init-script.sh
@@ -14,7 +14,7 @@ wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/2.18
 unzip -q dartsdk-linux-x64-release.zip
 sudo mv dart-sdk/ /usr/lib/dart/
 sudo chmod -R 755 /usr/lib/dart/
-echo 'export PATH="$PATH:/usr/lib/dart/bin"' >>/etc/profile.d/script.sh
+echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> /etc/profile.d/script.sh
 
 # Install CodeDeploy agent
 echo "Installing CodeDeploy agent"
@@ -26,7 +26,7 @@ rm install
 
 # Set runmode
 echo "Setting runmode"
-echo ${runmode} >/home/ec2-user/runmode
+echo ${runmode} > /home/ec2-user/runmode
 chown ec2-user:ec2-user /home/ec2-user/runmode
 
 echo "Setup done"

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/init-script.sh
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/init-script.sh
@@ -5,7 +5,7 @@ yum update -y
 # Install yum packages
 echo "Installing ruby"
 yum install ruby -y
-ehco "Installing wget"
+echo "Installing wget"
 yum install wget -y
 
 # Install Dart
@@ -14,7 +14,7 @@ wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/2.18
 unzip -q dartsdk-linux-x64-release.zip
 sudo mv dart-sdk/ /usr/lib/dart/
 sudo chmod -R 755 /usr/lib/dart/
-echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> /etc/profile.d/script.sh
+echo 'export PATH="$PATH:/usr/lib/dart/bin"' >>/etc/profile.d/script.sh
 
 # Install CodeDeploy agent
 echo "Installing CodeDeploy agent"
@@ -26,7 +26,7 @@ rm install
 
 # Set runmode
 echo "Setting runmode"
-echo ${runmode} > /home/ec2-user/runmode
+echo ${runmode} >/home/ec2-user/runmode
 chown ec2-user:ec2-user /home/ec2-user/runmode
 
 echo "Setup done"

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/variables.tf
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/variables.tf
@@ -193,6 +193,6 @@ variable "DATABASE_PASSWORD_PRODUCTION" {
 }
 
 variable "DATABASE_PASSWORD_STAGING" {
-  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deployning a staging environment)."
+  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deploying a staging environment)."
   type        = string
 }

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/gcp/terraform_gce/variables.tf
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/gcp/terraform_gce/variables.tf
@@ -34,6 +34,6 @@ variable "DATABASE_PASSWORD_PRODUCTION" {
 }
 
 variable "DATABASE_PASSWORD_STAGING" {
-  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deployning a staging environment)."
+  description = "The staging database password, you can find it in the config/passwords.yaml file (no need to specify if you aren't deploying a staging environment)."
   type        = string
 }

--- a/tests/serverpod_test_client/CHANGELOG.md
+++ b/tests/serverpod_test_client/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
+++ b/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
+++ b/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: handles invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.

--- a/tests/serverpod_test_module/serverpod_test_module_server/CHANGELOG.md
+++ b/tests/serverpod_test_module/serverpod_test_module_server/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/tests/serverpod_test_server/CHANGELOG.md
+++ b/tests/serverpod_test_server/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/tests/serverpod_test_server/test/generated_methods/from_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/from_json_test.dart
@@ -143,7 +143,7 @@ void main() {
 
   group('Given a class with a nullable DateTime field, ', () {
     test(
-        'when deserializing from a JSON string representing a DateTime, then the result matches the expected valuee',
+        'when deserializing from a JSON string representing a DateTime, then the result matches the expected value',
         () {
       expect(
         Types.fromJson({'aDateTime': '2024-01-01T00:00:00.000Z'}).aDateTime,

--- a/tests/serverpod_test_server/test_e2e/connection_test.dart
+++ b/tests/serverpod_test_server/test_e2e/connection_test.dart
@@ -1116,7 +1116,7 @@ void main() {
       expect(clientException!.statusCode, equals(500));
     });
 
-    test('Exception in call from database being caugt', () async {
+    test('Exception in call from database being caught', () async {
       var result =
           await client.failedCalls.failedDatabaseQueryCaughtException();
       expect(result, equals(true));

--- a/tests/serverpod_test_server/test_e2e/method_path.dart
+++ b/tests/serverpod_test_server/test_e2e/method_path.dart
@@ -20,7 +20,7 @@ void main() {
 
     test('fail if method name is incorrect', () async {
       var result = await http.post(
-        Uri.parse('${serverUrl}simple?method=helloNonExistant&name=Bob'),
+        Uri.parse('${serverUrl}simple?method=helloNonExistent&name=Bob'),
       );
 
       expect(result.statusCode, equals(400));
@@ -39,7 +39,7 @@ void main() {
 
     test('fail if method name is incorrect', () async {
       var result = await http.post(
-        Uri.parse('${serverUrl}simple/helloNonExistant?name=Andy'),
+        Uri.parse('${serverUrl}simple/helloNonExistent?name=Andy'),
       );
 
       expect(result.statusCode, equals(400));
@@ -60,7 +60,7 @@ void main() {
     test('fail if method name is incorrect', () async {
       var result = await http.post(
         Uri.parse(
-            '${serverUrl}serverpod_test_module.module?method=helloNonExistant&name=Bob'),
+            '${serverUrl}serverpod_test_module.module?method=helloNonExistent&name=Bob'),
       );
 
       expect(result.statusCode, equals(400));
@@ -80,7 +80,7 @@ void main() {
     test('fail if method name is incorrect', () async {
       var result = await http.post(
         Uri.parse(
-            '${serverUrl}serverpod_test_module.module/helloNonExistant?name=Andy'),
+            '${serverUrl}serverpod_test_module.module/helloNonExistent?name=Andy'),
       );
 
       expect(result.statusCode, equals(400));

--- a/tests/serverpod_test_server/test_e2e/module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/module_test.dart
@@ -41,7 +41,7 @@ void main() {
 
   group('Nested modules classes.', () {
     test(
-      'Given a generated protocol class with a custom class, then serialze the internal data.',
+      'Given a generated protocol class with a custom class, then serialize the internal data.',
       () async {
         var result =
             await client.moduleSerialization.serializeNestedModuleObject();

--- a/tests/serverpod_test_server/test_e2e/redis_test.dart
+++ b/tests/serverpod_test_server/test_e2e/redis_test.dart
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('Get non-existing', () async {
-      var retrievedData = await client.redis.getSimpleData('test-nonexistant');
+      var retrievedData = await client.redis.getSimpleData('test-nonexistent');
       expect(retrievedData, isNull);
     });
 

--- a/tests/serverpod_test_server/test_e2e/service_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/service_protocol_test.dart
@@ -291,7 +291,7 @@ void main() {
       }
 
       // This test failed some times due to some kind of race condition.
-      // Idealy we would not use a hard coded delay here.
+      // Ideally we would not use a hard coded delay here.
       // Ticket: https://github.com/serverpod/serverpod/issues/773
       await Future.delayed(const Duration(seconds: 5));
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/list_include_test.dart
@@ -414,7 +414,7 @@ void main() async {
   });
 
   test(
-      'Given a list relation when quering with a where clause in the included list then the result only includes the rows satisfying the where clause.',
+      'Given a list relation when querying with a where clause in the included list then the result only includes the rows satisfying the where clause.',
       () async {
     var stockholm = await City.db.insertRow(session, City(name: 'Stockholm'));
 
@@ -455,7 +455,7 @@ void main() async {
   });
 
   test(
-      'Given a list relation when quering with a orderBy clause in the included list then the result is ordered by the orderBy clause.',
+      'Given a list relation when querying with a orderBy clause in the included list then the result is ordered by the orderBy clause.',
       () async {
     var stockholm = await City.db.insertRow(session, City(name: 'Stockholm'));
 
@@ -490,7 +490,7 @@ void main() async {
   });
 
   test(
-      'Given a list relation when quering with a orderBy in descending order clause in the included list then the result is ordered by the orderBy clause.',
+      'Given a list relation when querying with a orderBy in descending order clause in the included list then the result is ordered by the orderBy clause.',
       () async {
     var stockholm = await City.db.insertRow(session, City(name: 'Stockholm'));
 
@@ -525,7 +525,7 @@ void main() async {
   });
 
   test(
-      'Given a list relation when quering with multiple orderBy clauses in the included list then the the result is ordered by all the orderedBy clauses.',
+      'Given a list relation when querying with multiple orderBy clauses in the included list then the the result is ordered by all the orderedBy clauses.',
       () async {
     var stockholm = await City.db.insertRow(session, City(name: 'Stockholm'));
 

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/order_by_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/entities_with_list_relations/find/order_by_test.dart
@@ -31,7 +31,7 @@ void main() async {
         Person(name: 'Isak'),
         Person(name: 'Alex'),
       ]);
-      // Attach Tom, Jane and John to San Fransisco
+      // Attach Tom, Jane and John to San Francisco
       await City.db.attach.citizens(session, cities[1], people.sublist(0, 3));
       // Attach Viktor, Isak and Alex to Stockholm
       await City.db.attach.citizens(session, cities[0], people.sublist(3, 6));
@@ -47,7 +47,7 @@ void main() async {
       // Attach Serverpod to Stockholm
       await City.db.attachRow
           .organizations(session, cities[0], organizations[2]);
-      // Attach Apple and Google to San Fransisco
+      // Attach Apple and Google to San Francisco
       await City.db.attach
           .organizations(session, cities[1], organizations.sublist(0, 2));
       // Attach Barclays and BBC to London

--- a/tests/serverpod_test_server/test_integration/database_operations/entity_relations/long_identifiers_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/entity_relations/long_identifiers_test.dart
@@ -7,7 +7,7 @@ void main() async {
   var session = await IntegrationTestServer().session();
 
   group(
-      'Given a model with a list relation to model with max lenght named fields',
+      'Given a model with a list relation to model with max length named fields',
       () {
     tearDown(() async {
       await MultipleMaxFieldName.db

--- a/tools/serverpod_cli/CHANGELOG.md
+++ b/tools/serverpod_cli/CHANGELOG.md
@@ -66,7 +66,7 @@
 - fix: Makes it possible to create modules from templates in developer mode.
 - fix: Correctly marks nested enum types in the analyzer.
 - fix: Adds support for all Serverpod's supported types as keys in Maps.
-- fix: Restric fields with scopes other than all to be nullable.
+- fix: Restrict fields with scopes other than all to be nullable.
 - fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
 - fix: Less restrictive enum naming rules.
 - fix: Pins Dart and Busybox docker image versions (only for new projects).
@@ -80,9 +80,9 @@
 - fix: Removes old generated folder from Dockerfile.
 - fix: Prevents database analyzer from crashing when missing table.
 - fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
-- fix: Ingores all null fields in JSON map serialization.
+- fix: Ignores all null fields in JSON map serialization.
 - fix: Improved error message if port is in use when starting server.
-- chore: Bumbs `vm_service` version to support latest version.
+- chore: Bumps `vm_service` version to support latest version.
 
 ## 1.2.0
 This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
@@ -92,7 +92,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Adds Visual Studio Code extension.
 - feat: Syntax highlighting in model files.
 - feat: Adds LSP server for analyzing model files.
-- feat: CLI automatically detects modules withouth the need to modify the generator file.
+- feat: CLI automatically detects modules without the need to modify the generator file.
 - feat: Validates project names on `serverpod create`.
 - feat: Validates Serverpod packages and CLI version in `serverpod generate`.
 - feat: Prompts user to update Serverpod when running an old version of the CLI.
@@ -111,7 +111,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
 - fix: Makes endpoint classes public to enable Dart doc.
 - fix: Serializable exceptions now work with modules.
-- fix: Handels invalid return types when parsing endpoint methods.
+- fix: Handles invalid return types when parsing endpoint methods.
 - fix: Fixes localhost on Android emulator.
 - fix: Use explicit version for all Serverpod packages.
 - fix: Uses git version of CLI in local tests.
@@ -124,7 +124,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - docs: Many improvements to API documentation.
 - chore: Updates to latest version of Flutter.
 - chore: Updates dependencies.
-- chore: Fixes deprected methods.
+- chore: Fixes deprecated methods.
 - chore: Makes Dart & Flutter version requirements consistent across packages.
 - chore: Adds serverpod_lints package.
 - ci: Now runs tests on multiple Flutter versions.
@@ -183,7 +183,7 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 - fix: Deprecate `database` and `api` keywords.
 - fix: Stop generator from getting stuck on circular dependencies.
 - fix: Handle invalid YAML errors and report them.
-- fix: Only report duplicated and invald negations once.
+- fix: Only report duplicated and invalid negations once.
 - fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
 - fix: Deserialization of `DateTime` handles `null` explicitly.
 - fix: Only return valid entries from analyzer.
@@ -228,20 +228,20 @@ This is a summary of the new features in version 1.2.0. For the full list, pleas
 ## 1.1.0
 - feat: Lightweight run mode and support for serverless platforms.
 - feat: Support for Google Cloud Platform deployments, including Terraform module.
-- feat: Adds serializable exeptions that can be passed from the server to the client.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
 - feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
 - feat: Support for `UUID` in serialization.
 - feat: New supported static file types in Relic.
 - feat: Allows endpoints in sub directories.
 - feat: Support for GCP Cloud Storage.
 - feat: Support for connecting to Postgres through a UNIX socket.
-- feat: Adds database maintanance methods to Insights APIs (still experimental and API may change).
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
 - docs: Improved documentation.
 - fix: Better output on startup to aid in debugging connectivity issues.
 - fix: Prevents self referencing table to cause `serverpod generate` to hang.
 - fix: Adds email from Firebase to UserInfo in auth module.
 - fix: Don't print stack trace when Google signin disconnect fails.
-- fix: Return bool from `SessionManager.initizlize()` to indicate if server was reached.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
 - fix: Better recovery when parsing yaml-files.
 - chore: Migrates Firebase to new Flutter APIs.
 - chore: Updates dependencies.

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -386,12 +386,12 @@ extension ForeignKeyDefinitionPgSqlGeneration on ForeignKeyDefinition {
   }) {
     var out = '';
 
-    var refColumsFmt = referenceColumns.map((e) => '"$e"');
+    var refColumnsFmt = referenceColumns.map((e) => '"$e"');
 
     out += 'ALTER TABLE ONLY "$tableName"\n';
     out += '    ADD CONSTRAINT "$constraintName"\n';
     out += '    FOREIGN KEY("${columns.join(', ')}")\n';
-    out += '    REFERENCES "$referenceTable"(${refColumsFmt.join(', ')})';
+    out += '    REFERENCES "$referenceTable"(${refColumnsFmt.join(', ')})';
 
     String? delete = onDelete?.toPgSqlAction();
     if (delete != null) {

--- a/tools/serverpod_cli/lib/src/database/migration.dart
+++ b/tools/serverpod_cli/lib/src/database/migration.dart
@@ -251,7 +251,7 @@ TableMigration? generateTableMigration(
     }
   }
 
-  // Check that all added columns can be created in a modfication of the table
+  // Check that all added columns can be created in a modification of the table
   for (var column in addColumns) {
     if (!column.canBeCreatedInTableMigration) {
       warnings.add(

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -218,9 +218,9 @@ class TypeDefinition {
     );
   }
 
-  /// Get the qgsql type that represents this [TypeDefinition] in the database.
+  /// Get the pgsql type that represents this [TypeDefinition] in the database.
   String get databaseType {
-    // TODO: add all suported types here
+    // TODO: add all supported types here
     var enumSerialization = serializeEnum;
     if (enumSerialization != null && isEnumType) {
       switch (enumSerialization) {
@@ -250,7 +250,7 @@ class TypeDefinition {
 
   /// Get the [Column] extending class name representing this [TypeDefinition].
   String get columnType {
-    // TODO: add all suported types here
+    // TODO: add all supported types here
     if (isEnumType) return 'ColumnEnum';
     if (className == 'int') return 'ColumnInt';
     if (className == 'double') return 'ColumnDouble';

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -81,7 +81,7 @@ class ExampleEndpoint extends Endpoint {
   });
 
   group(
-      'Given an endpoint with excluded method name (overriden method from Endpoint class)',
+      'Given an endpoint with excluded method name (overridden method from Endpoint class)',
       () {
     var collector = CodeGenerationCollector();
     var testDirectory =

--- a/util/run_tests_update_pubspecs
+++ b/util/run_tests_update_pubspecs
@@ -6,7 +6,7 @@ set -e
 echo "### Run serverpod generate test"
 echo "### If this test fails, make sure that you have run serverpod generate"
 echo "### on all packages with util/generate_all"
-echo "### Also check that dependency versions are consistant across packages."
+echo "### Also check that dependency versions are consistent across packages."
 
 # Install the serverpod command
 echo "### Installing CLI tools"


### PR DESCRIPTION
One PR to rule them all! 
This PR tries to close #2276. All mentioned typos where fixed but one:

`import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'`, I could only find this reference but not where this relation_to_mutiple_max_field_name.dart is defined. 


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes
