### PR TITLE
chore: Modify pub get all to support offline mode.

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
       - name: Install dependencies
-        run: util/pub_get_all
+        run: bash util/pub_get_all
       - name: Analyze
         run: bash util/run_tests_analyze
 
@@ -56,7 +56,7 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
       - name: Install dependencies
-        run: util/pub_get_all
+        run: bash util/pub_get_all
       - name: Analyze
         run: bash util/run_tests_analyze --allow-infos
 
@@ -86,7 +86,7 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
       - name: Run serverpod update pubspecs
-        run: util/run_tests_update_pubspecs
+        run: bash util/run_tests_update_pubspecs
 
   unit_tests:
     name: Unit tests

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
       - name: Run serverpod generate
-        run: util/run_tests_serverpod_generate
+        run: bash util/run_tests_serverpod_generate
 
   update_pubspecs:
     name: update pubspecs

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -71,6 +71,8 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
+      - name: Install dependencies
+        run: bash util/pub_get_all
       - name: Run serverpod generate
         run: bash util/run_tests_serverpod_generate
 

--- a/util/pub_get_all
+++ b/util/pub_get_all
@@ -8,165 +8,63 @@ fi
 
 set -e
 
-BASE=`pwd`
+BASE=$(pwd)
+OFFLINE_MODE=""
+
+# Check for --offline parameter
+if [ "$1" == "--offline" ]; then
+    OFFLINE_MODE="--offline"
+    echo "Running in offline mode"
+fi
 
 echo "PUB UPGRADE ALL"
 
-echo "\n### serverpod"
-cd $BASE/packages/serverpod
-dart pub upgrade
+declare -a paths=(
+  "packages/serverpod"
+  "examples/auth_example/auth_example_client"
+  "examples/auth_example/auth_example_flutter"
+  "examples/auth_example/auth_example_server"
+  "examples/chat/chat_client"
+  "examples/chat/chat_flutter"
+  "examples/chat/chat_server"
+  "packages/serverpod_client"
+  "packages/serverpod_serialization"
+  "packages/serverpod_service_client"
+  "packages/serverpod_shared"
+  "packages/serverpod_flutter"
+  "tests/serverpod_test_client"
+  "tests/serverpod_test_server"
+  "tests/serverpod_test_shared"
+  "tests/serverpod_test_module/serverpod_test_module_client"
+  "tests/serverpod_test_module/serverpod_test_module_server"
+  "tests/bootstrap_project"
+  "tests/serverpod_cli_e2e_test"
+  "templates/serverpod_templates/projectname_server"
+  "templates/serverpod_templates/projectname_client"
+  "templates/serverpod_templates/projectname_flutter"
+  "templates/serverpod_templates/modulename_server"
+  "templates/serverpod_templates/modulename_client"
+  "modules/serverpod_auth/serverpod_auth_server"
+  "modules/serverpod_auth/serverpod_auth_client"
+  "modules/serverpod_auth/serverpod_auth_shared_flutter"
+  "modules/serverpod_auth/serverpod_auth_apple_flutter"
+  "modules/serverpod_auth/serverpod_auth_google_flutter"
+  "modules/serverpod_auth/serverpod_auth_email_flutter"
+  "modules/serverpod_auth/serverpod_auth_firebase_flutter"
+  "modules/serverpod_chat/serverpod_chat_server"
+  "modules/serverpod_chat/serverpod_chat_client"
+  "modules/serverpod_chat/serverpod_chat_flutter"
+  "integrations/serverpod_cloud_storage_s3"
+  "integrations/serverpod_cloud_storage_gcp"
+  "tools/serverpod_cli"
+)
 
-echo "\n### examples/auth_example/auth_example_client"
-cd $BASE/examples/auth_example/auth_example_client
-dart pub upgrade
-
-echo "\n### examples/auth_example/auth_example_flutter"
-cd $BASE/examples/auth_example/auth_example_flutter
-flutter pub upgrade
-
-echo "\n### examples/auth_example/auth_example_server"
-cd $BASE/examples/auth_example/auth_example_server
-dart pub upgrade
-
-echo "\n### examples/chat/chat_client"
-cd $BASE/examples/chat/chat_client
-dart pub upgrade
-
-echo "\n### examples/chat/chat_flutter"
-cd $BASE/examples/chat/chat_flutter
-flutter pub upgrade
-
-echo "\n### examples/chat/chat_server"
-cd $BASE/examples/chat/chat_server
-dart pub upgrade
-
-echo "\n### serverpod_client"
-cd $BASE/packages/serverpod_client
-dart pub upgrade
-
-echo "\n### serverpod_serialization"
-cd $BASE/packages/serverpod_serialization
-dart pub upgrade
-
-echo "\n### serverpod_service_client"
-cd $BASE/packages/serverpod_service_client
-dart pub upgrade
-
-echo "\n### serverpod_shared"
-cd $BASE/packages/serverpod_shared
-dart pub upgrade
-
-echo "\n### serverpod_flutter"
-cd $BASE/packages/serverpod_flutter
-flutter pub upgrade
-
-# Tests
-
-echo "\n### serverpod_test_client"
-cd $BASE/tests/serverpod_test_client
-dart pub upgrade
-
-echo "\n### serverpod_test_server"
-cd $BASE/tests/serverpod_test_server
-dart pub upgrade
-
-echo "\n### serverpod_test_shared"
-cd $BASE/tests/serverpod_test_shared
-dart pub upgrade
-
-echo "\n### serverpod_test_module_client"
-cd $BASE/tests/serverpod_test_module/serverpod_test_module_client
-dart pub upgrade
-
-echo "\n### serverpod_test_module_server"
-cd $BASE/tests/serverpod_test_module/serverpod_test_module_server
-dart pub upgrade
-
-echo "\n### bootstrap_project"
-cd $BASE/tests/bootstrap_project
-dart pub upgrade
-
-echo "\n### serverpod_cli_e2e_test"
-cd $BASE/tests/serverpod_cli_e2e_test
-dart pub upgrade
-
-# Templates
-
-echo "\n### projectname_server"
-cd $BASE/templates/serverpod_templates/projectname_server
-dart pub upgrade
-
-echo "\n### projectname_client"
-cd $BASE/templates/serverpod_templates/projectname_client
-dart pub upgrade
-
-echo "\n### projectname_flutter"
-cd $BASE/templates/serverpod_templates/projectname_flutter
-flutter pub upgrade
-
-echo "\n### modulename_server"
-cd $BASE/templates/serverpod_templates/modulename_server
-dart pub upgrade
-
-echo "\n### modulename_client"
-cd $BASE/templates/serverpod_templates/modulename_client
-dart pub upgrade
-
-# Auth module
-
-echo "\n### serverpod_auth_server"
-cd $BASE/modules/serverpod_auth/serverpod_auth_server
-dart pub upgrade
-
-echo "\n### serverpod_auth_client"
-cd $BASE/modules/serverpod_auth/serverpod_auth_client
-dart pub upgrade
-
-echo "\n### serverpod_auth_shared_flutter"
-cd $BASE/modules/serverpod_auth/serverpod_auth_shared_flutter
-flutter pub upgrade
-
-echo "\n### serverpod_auth_apple_flutter"
-cd $BASE/modules/serverpod_auth/serverpod_auth_apple_flutter
-flutter pub upgrade
-
-echo "\n### serverpod_auth_google_flutter"
-cd $BASE/modules/serverpod_auth/serverpod_auth_google_flutter
-flutter pub upgrade
-
-echo "\n### serverpod_auth_email_flutter"
-cd $BASE/modules/serverpod_auth/serverpod_auth_email_flutter
-flutter pub upgrade
-
-echo "\n### serverpod_auth_firebase_flutter"
-cd $BASE/modules/serverpod_auth/serverpod_auth_firebase_flutter
-flutter pub upgrade
-
-# Chat module
-
-echo "\n### serverpod_chat_server"
-cd $BASE/modules/serverpod_chat/serverpod_chat_server
-dart pub upgrade
-
-echo "\n### serverpod_chat_client"
-cd $BASE/modules/serverpod_chat/serverpod_chat_client
-dart pub upgrade
-
-echo "\n### serverpod_chat_flutter"
-cd $BASE/modules/serverpod_chat/serverpod_chat_flutter
-flutter pub upgrade
-
-# Integrations
-
-echo "\n### serverpod_cloud_storage_s3"
-cd $BASE/integrations/serverpod_cloud_storage_s3
-dart pub upgrade
-
-echo "\n### serverpod_cloud_storage_gcp"
-cd $BASE/integrations/serverpod_cloud_storage_gcp
-dart pub upgrade
-
-# Tooling
-echo "\n### serverpod_cli"
-cd $BASE/tools/serverpod_cli
-dart pub upgrade
+for path in "${paths[@]}"; do
+  echo "\n### $path"
+  cd "$BASE/$path"
+  if [[ "$path" == *flutter* ]]; then
+    flutter pub upgrade $OFFLINE_MODE
+  else
+    dart pub upgrade $OFFLINE_MODE
+  fi
+done

--- a/util/pub_get_all
+++ b/util/pub_get_all
@@ -19,19 +19,16 @@ fi
 
 echo "PUB UPGRADE ALL"
 
-declare -a paths=(
+declare -a dart_paths=(
   "packages/serverpod"
   "examples/auth_example/auth_example_client"
-  "examples/auth_example/auth_example_flutter"
   "examples/auth_example/auth_example_server"
   "examples/chat/chat_client"
-  "examples/chat/chat_flutter"
   "examples/chat/chat_server"
   "packages/serverpod_client"
   "packages/serverpod_serialization"
   "packages/serverpod_service_client"
   "packages/serverpod_shared"
-  "packages/serverpod_flutter"
   "tests/serverpod_test_client"
   "tests/serverpod_test_server"
   "tests/serverpod_test_shared"
@@ -41,30 +38,40 @@ declare -a paths=(
   "tests/serverpod_cli_e2e_test"
   "templates/serverpod_templates/projectname_server"
   "templates/serverpod_templates/projectname_client"
-  "templates/serverpod_templates/projectname_flutter"
   "templates/serverpod_templates/modulename_server"
   "templates/serverpod_templates/modulename_client"
   "modules/serverpod_auth/serverpod_auth_server"
   "modules/serverpod_auth/serverpod_auth_client"
-  "modules/serverpod_auth/serverpod_auth_shared_flutter"
-  "modules/serverpod_auth/serverpod_auth_apple_flutter"
-  "modules/serverpod_auth/serverpod_auth_google_flutter"
-  "modules/serverpod_auth/serverpod_auth_email_flutter"
-  "modules/serverpod_auth/serverpod_auth_firebase_flutter"
   "modules/serverpod_chat/serverpod_chat_server"
   "modules/serverpod_chat/serverpod_chat_client"
-  "modules/serverpod_chat/serverpod_chat_flutter"
   "integrations/serverpod_cloud_storage_s3"
   "integrations/serverpod_cloud_storage_gcp"
   "tools/serverpod_cli"
 )
 
-for path in "${paths[@]}"; do
+declare -a flutter_paths=(
+  "examples/auth_example/auth_example_flutter"
+  "examples/chat/chat_flutter"
+  "packages/serverpod_flutter"
+  "templates/serverpod_templates/projectname_flutter"
+  "modules/serverpod_auth/serverpod_auth_shared_flutter"
+  "modules/serverpod_auth/serverpod_auth_apple_flutter"
+  "modules/serverpod_auth/serverpod_auth_google_flutter"
+  "modules/serverpod_auth/serverpod_auth_email_flutter"
+  "modules/serverpod_auth/serverpod_auth_firebase_flutter"
+  "modules/serverpod_chat/serverpod_chat_flutter"
+)
+
+# Upgrade Dart packages
+for path in "${dart_paths[@]}"; do
   echo "\n### $path"
   cd "$BASE/$path"
-  if [[ "$path" == *flutter* ]]; then
-    flutter pub upgrade $OFFLINE_MODE
-  else
-    dart pub upgrade $OFFLINE_MODE
-  fi
+  dart pub upgrade $OFFLINE_MODE
+done
+
+# Upgrade Flutter packages
+for path in "${flutter_paths[@]}"; do
+  echo "\n### $path"
+  cd "$BASE/$path"
+  flutter pub upgrade $OFFLINE_MODE
 done

--- a/util/run_tests_serverpod_generate
+++ b/util/run_tests_serverpod_generate
@@ -25,8 +25,6 @@ dart pub global activate -s path .
 
 cd $SERVERPOD_HOME
 
-util/pub_get_all
-
 util/generate_all
 
 util/ensure_no_changes


### PR DESCRIPTION
# Modify

pub_get_all script is refactored to loop all packages instead and allow for an --offline flag to be passed (very useful in worktree repos).


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

