### PR TITLE
fix: Use user scopes from UserInfo when authenticating in all providers.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/apple_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/apple_endpoint.dart
@@ -113,6 +113,7 @@ class AppleEndpoint extends Endpoint {
       session,
       userInfo.id!,
       _authMethod,
+      scopes: userInfo.scopes,
     );
 
     return AuthenticationResponse(

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
@@ -80,6 +80,7 @@ class FirebaseEndpoint extends Endpoint {
         session,
         userInfo.id!,
         _authMethod,
+        scopes: userInfo.scopes,
       );
 
       return AuthenticationResponse(

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
@@ -103,6 +103,7 @@ class GoogleEndpoint extends Endpoint {
       session,
       userInfo.id!,
       _authMethod,
+      scopes: userInfo.scopes,
     );
 
     authClient.close();
@@ -184,6 +185,7 @@ class GoogleEndpoint extends Endpoint {
         session,
         userInfo.id!,
         _authMethod,
+        scopes: userInfo.scopes,
       );
 
       return AuthenticationResponse(


### PR DESCRIPTION
### Changes
- Fixes an issue where the scopes configured for the user info would not be respected when creating authentication token though the apple, google or firebase providers.

Unfortunately, because of the code structure this code is extremely hard to add automated tests for and have therefore not been included in the PR.

Closes: #2164 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - fixes a scope propagation issue.
