### PR TITLE
fix!: Remove customConstructor map from protocol class.

### DIFF
--- a/examples/auth_example/auth_example_client/lib/src/protocol/protocol.dart
+++ b/examples/auth_example/auth_example_client/lib/src/protocol/protocol.dart
@@ -20,8 +20,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -30,9 +28,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.Example) {
       return _i2.Example.fromJson(data) as T;
     }

--- a/examples/auth_example/auth_example_server/lib/src/generated/protocol.dart
+++ b/examples/auth_example/auth_example_server/lib/src/generated/protocol.dart
@@ -20,8 +20,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
@@ -35,9 +33,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i4.Example) {
       return _i4.Example.fromJson(data) as T;
     }

--- a/examples/chat/chat_client/lib/src/protocol/protocol.dart
+++ b/examples/chat/chat_client/lib/src/protocol/protocol.dart
@@ -22,8 +22,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -32,9 +30,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.Channel) {
       return _i2.Channel.fromJson(data) as T;
     }

--- a/examples/chat/chat_server/lib/src/generated/protocol.dart
+++ b/examples/chat/chat_server/lib/src/generated/protocol.dart
@@ -22,8 +22,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
@@ -82,9 +80,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i5.Channel) {
       return _i5.Channel.fromJson(data) as T;
     }

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
@@ -45,8 +45,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -55,9 +53,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.AppleAuthInfo) {
       return _i2.AppleAuthInfo.fromJson(data) as T;
     }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -45,8 +45,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
@@ -631,9 +629,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i3.AppleAuthInfo) {
       return _i3.AppleAuthInfo.fromJson(data) as T;
     }

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
@@ -41,8 +41,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -51,9 +49,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.ChatJoinChannel) {
       return _i2.ChatJoinChannel.fromJson(data) as T;
     }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
@@ -41,8 +41,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
@@ -204,9 +202,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i4.ChatJoinChannel) {
       return _i4.ChatJoinChannel.fromJson(data) as T;
     }

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -129,8 +129,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
@@ -1304,9 +1302,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i3.CacheInfo) {
       return _i3.CacheInfo.fromJson(data) as T;
     }

--- a/packages/serverpod_serialization/lib/src/serialization.dart
+++ b/packages/serverpod_serialization/lib/src/serialization.dart
@@ -5,11 +5,6 @@ import 'dart:typed_data';
 
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-/// The constructor takes JSON structure and turns it into a decoded
-/// [SerializableEntity].
-typedef constructor<T> = T Function(
-    dynamic jsonSerialization, SerializationManager serializationManager);
-
 /// Exception thrown when no deserialization type was found during
 /// protocol deserialization
 class DeserializationTypeNotFoundException implements Exception {

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -130,8 +130,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -140,9 +138,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.CacheInfo) {
       return _i2.CacheInfo.fromJson(data) as T;
     }

--- a/templates/serverpod_templates/modulename_client/lib/src/protocol/protocol.dart
+++ b/templates/serverpod_templates/modulename_client/lib/src/protocol/protocol.dart
@@ -19,8 +19,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -29,9 +27,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.ModuleClass) {
       return _i2.ModuleClass.fromJson(data) as T;
     }

--- a/templates/serverpod_templates/modulename_server/lib/src/generated/protocol.dart
+++ b/templates/serverpod_templates/modulename_server/lib/src/generated/protocol.dart
@@ -19,8 +19,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [];
@@ -31,9 +29,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i3.ModuleClass) {
       return _i3.ModuleClass.fromJson(data) as T;
     }

--- a/templates/serverpod_templates/projectname_client/lib/src/protocol/protocol.dart
+++ b/templates/serverpod_templates/projectname_client/lib/src/protocol/protocol.dart
@@ -19,8 +19,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -29,9 +27,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.Example) {
       return _i2.Example.fromJson(data) as T;
     }

--- a/templates/serverpod_templates/projectname_server/lib/src/generated/protocol.dart
+++ b/templates/serverpod_templates/projectname_server/lib/src/generated/protocol.dart
@@ -19,8 +19,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
@@ -33,9 +31,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i3.Example) {
       return _i3.Example.fromJson(data) as T;
     }

--- a/tests/serverpod_test_client/lib/serverpod_test_client.dart
+++ b/tests/serverpod_test_client/lib/serverpod_test_client.dart
@@ -1,16 +1,2 @@
-import 'package:serverpod_client/serverpod_client.dart';
-import 'package:serverpod_test_client/src/custom_classes.dart';
-import 'package:serverpod_test_client/src/protocol/protocol.dart';
-
 export 'src/protocol/protocol.dart';
 export 'package:serverpod_client/serverpod_client.dart';
-
-extension CustomProtocol on Protocol {
-  void registerCustomConstructors() {
-    Protocol.customConstructors[CustomClass2] =
-        (data, serializationManager) => CustomClass2(data['text']);
-    Protocol.customConstructors[getType<CustomClass2?>()] =
-        (data, serializationManager) =>
-            data == null ? null : CustomClass2(data['text']);
-  }
-}

--- a/tests/serverpod_test_client/lib/src/custom_classes.dart
+++ b/tests/serverpod_test_client/lib/src/custom_classes.dart
@@ -24,5 +24,9 @@ class CustomClass2 {
 
   const CustomClass2(this.value);
 
+  factory CustomClass2.fromJson(dynamic data) {
+    return CustomClass2(data['text']);
+  }
+
   dynamic toJson() => {'text': value};
 }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -184,8 +184,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -194,9 +192,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.ExceptionWithData) {
       return _i2.ExceptionWithData.fromJson(data) as T;
     }

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -1507,6 +1507,9 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i83.CustomClass) {
       return _i83.CustomClass.fromJson(data) as T;
     }
+    if (t == _i83.CustomClass2) {
+      return _i83.CustomClass2.fromJson(data) as T;
+    }
     if (t == _i84.ProtocolCustomClass) {
       return _i84.ProtocolCustomClass.fromJson(data) as T;
     }
@@ -1518,6 +1521,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (t == _i1.getType<_i83.CustomClass?>()) {
       return (data != null ? _i83.CustomClass.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i83.CustomClass2?>()) {
+      return (data != null ? _i83.CustomClass2.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i84.ProtocolCustomClass?>()) {
       return (data != null ? _i84.ProtocolCustomClass.fromJson(data) : null)
@@ -1553,6 +1559,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (data is _i83.CustomClass) {
       return 'CustomClass';
+    }
+    if (data is _i83.CustomClass2) {
+      return 'CustomClass2';
     }
     if (data is _i84.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
@@ -1776,6 +1785,9 @@ class Protocol extends _i1.SerializationManager {
     }
     if (data['className'] == 'CustomClass') {
       return deserialize<_i83.CustomClass>(data['data']);
+    }
+    if (data['className'] == 'CustomClass2') {
+      return deserialize<_i83.CustomClass2>(data['data']);
     }
     if (data['className'] == 'ProtocolCustomClass') {
       return deserialize<_i84.ProtocolCustomClass>(data['data']);

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
@@ -19,8 +19,6 @@ class Protocol extends _i1.SerializationManager {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   @override
@@ -29,9 +27,6 @@ class Protocol extends _i1.SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i2.ModuleClass) {
       return _i2.ModuleClass.fromJson(data) as T;
     }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -19,8 +19,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [];
@@ -31,9 +29,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i3.ModuleClass) {
       return _i3.ModuleClass.fromJson(data) as T;
     }

--- a/tests/serverpod_test_server/config/generator.yaml
+++ b/tests/serverpod_test_server/config/generator.yaml
@@ -8,6 +8,7 @@ modules:
 
 extraClasses:
   - project:src/custom_classes.dart:CustomClass
+  - project:src/custom_classes.dart:CustomClass2
   - project:src/protocol_custom_classes.dart:ProtocolCustomClass
   - package:serverpod_test_shared/serverpod_test_shared.dart:ExternalCustomClass
   - package:serverpod_test_shared/serverpod_test_shared.dart:FreezedCustomClass

--- a/tests/serverpod_test_server/lib/server.dart
+++ b/tests/serverpod_test_server/lib/server.dart
@@ -2,7 +2,6 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as auth;
 import 'package:serverpod_cloud_storage_s3/serverpod_cloud_storage_s3.dart'
     as s3;
-import 'package:serverpod_test_server/src/custom_classes.dart';
 import 'package:serverpod_test_server/src/web/routes/root.dart';
 
 import 'src/futureCalls/test_call.dart';
@@ -17,12 +16,6 @@ void run(List<String> args) async {
     Endpoints(),
     authenticationHandler: auth.authenticationHandler,
   );
-
-  Protocol.customConstructors[CustomClass2] =
-      (data, serializationManager) => CustomClass2(data['text']);
-  Protocol.customConstructors[getType<CustomClass2?>()] =
-      (data, serializationManager) =>
-          data == null ? null : CustomClass2(data['text']);
 
   // Add future calls
   pod.registerFutureCall(TestCall(), 'testCall');

--- a/tests/serverpod_test_server/lib/src/custom_classes.dart
+++ b/tests/serverpod_test_server/lib/src/custom_classes.dart
@@ -24,5 +24,9 @@ class CustomClass2 {
 
   const CustomClass2(this.value);
 
+  factory CustomClass2.fromJson(dynamic data) {
+    return CustomClass2(data['text']);
+  }
+
   dynamic toJson() => {'text': value};
 }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -188,8 +188,6 @@ class Protocol extends _i1.SerializationManagerServer {
 
   factory Protocol() => _instance;
 
-  static final Map<Type, _i1.constructor> customConstructors = {};
-
   static final Protocol _instance = Protocol._();
 
   static final List<_i2.TableDefinition> targetTableDefinitions = [
@@ -2817,9 +2815,6 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (customConstructors.containsKey(t)) {
-      return customConstructors[t]!(data, this) as T;
-    }
     if (t == _i5.ExceptionWithData) {
       return _i5.ExceptionWithData.fromJson(data) as T;
     }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -4155,6 +4155,9 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i87.CustomClass) {
       return _i87.CustomClass.fromJson(data) as T;
     }
+    if (t == _i87.CustomClass2) {
+      return _i87.CustomClass2.fromJson(data) as T;
+    }
     if (t == _i88.ProtocolCustomClass) {
       return _i88.ProtocolCustomClass.fromJson(data) as T;
     }
@@ -4166,6 +4169,9 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (t == _i1.getType<_i87.CustomClass?>()) {
       return (data != null ? _i87.CustomClass.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i87.CustomClass2?>()) {
+      return (data != null ? _i87.CustomClass2.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<_i88.ProtocolCustomClass?>()) {
       return (data != null ? _i88.ProtocolCustomClass.fromJson(data) : null)
@@ -4204,6 +4210,9 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (data is _i87.CustomClass) {
       return 'CustomClass';
+    }
+    if (data is _i87.CustomClass2) {
+      return 'CustomClass2';
     }
     if (data is _i88.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
@@ -4433,6 +4442,9 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (data['className'] == 'CustomClass') {
       return deserialize<_i87.CustomClass>(data['data']);
+    }
+    if (data['className'] == 'CustomClass2') {
+      return deserialize<_i87.CustomClass2>(data['data']);
     }
     if (data['className'] == 'ProtocolCustomClass') {
       return deserialize<_i88.ProtocolCustomClass>(data['data']);

--- a/tests/serverpod_test_server/test_e2e/connection_test.dart
+++ b/tests/serverpod_test_server/test_e2e/connection_test.dart
@@ -22,10 +22,6 @@ ByteData createByteData() {
 void main() {
   var client = Client(serverUrl);
 
-  setUp(() {
-    Protocol().registerCustomConstructors();
-  });
-
   group('Calls', () {
     test('Named parameters basic call', () async {
       var result = await client.namedParameters.namedParametersMethod(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -54,17 +54,6 @@ class LibraryGenerator {
 
     protocol.fields.addAll([
       Field((f) => f
-        ..name = 'customConstructors'
-        ..static = true
-        ..type = TypeReference((t) => t
-          ..symbol = 'Map'
-          ..types.addAll([
-            refer('Type'),
-            refer('constructor', serverpodUrl(serverCode)),
-          ]))
-        ..modifier = FieldModifier.final$
-        ..assignment = literalMap({}).code),
-      Field((f) => f
         ..name = '_instance'
         ..static = true
         ..type = refer('Protocol')
@@ -116,8 +105,6 @@ class LibraryGenerator {
           ..type = refer('Type?')))
         ..body = Block.of([
           const Code('t ??= T;'),
-          const Code(
-              'if(customConstructors.containsKey(t)){return customConstructors[t]!(data, this) as T;}'),
           ...(<Expression, Code>{
             for (var classInfo in models)
               refer(classInfo.className, classInfo.fileRef()): Code.scope(


### PR DESCRIPTION
# Changes

Removes unnecessary code

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

customConstructor is no longer available on the Protocol class.

Custom classes should instead be registered the way we have documented.
