### PR TITLE
chore: Allow latest lints, flutter_lints and intl dependency version.

### DIFF
--- a/examples/auth_example/auth_example_flutter/pubspec.yaml
+++ b/examples/auth_example/auth_example_flutter/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   cupertino_icons: ^1.0.5
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
   flutter_test:
     sdk: flutter
 

--- a/examples/auth_example/auth_example_server/pubspec.yaml
+++ b/examples/auth_example/auth_example_server/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   serverpod_auth_server: 2.0.0-alpha.3
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/examples/chat/chat_flutter/pubspec.yaml
+++ b/examples/chat/chat_flutter/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   cupertino_icons: ^1.0.5
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
   flutter_test:
     sdk: flutter
 

--- a/examples/chat/chat_server/pubspec.yaml
+++ b/examples/chat/chat_server/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   serverpod_chat_server: 2.0.0-alpha.3
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   xml2json: ^6.0.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   xml2json: ^6.0.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -10,9 +10,12 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 
 environment:
   sdk: '>=3.1.0 <4.0.0'
+
 dependencies:
-  lints: '>=3.0.0 <5.0.0'
   serverpod_client: 2.0.0-alpha.3
+
+dev_dependencies:
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod_client:

--- a/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -10,12 +10,9 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 
 environment:
   sdk: '>=3.1.0 <4.0.0'
-
 dependencies:
-  serverpod_client: 2.0.0-alpha.3
-
-dev_dependencies:
   lints: '>=3.0.0 <5.0.0'
+  serverpod_client: 2.0.0-alpha.3
 
 dependency_overrides:
   serverpod_client:

--- a/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -11,7 +11,7 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 environment:
   sdk: '>=3.1.0 <4.0.0'
 dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   serverpod_client: 2.0.0-alpha.3
 
 dependency_overrides:

--- a/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^8.0.0
-  intl: ^0.18.0
+  intl: '>=0.18.0 < 0.20.0'
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: 2.0.0-alpha.3

--- a/packages/serverpod_lints/pubspec.yaml
+++ b/packages/serverpod_lints/pubspec.yaml
@@ -10,5 +10,5 @@ environment:
   sdk: '>=3.1.0 <4.0.0'
 
 dependencies:
-  flutter_lints: ^3.0.0
-  lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
+  lints: '>=3.0.0 <5.0.0'

--- a/templates/pubspecs/examples/auth_example/auth_example_flutter/pubspec.yaml
+++ b/templates/pubspecs/examples/auth_example/auth_example_flutter/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   cupertino_icons: ^1.0.5
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
   flutter_test:
     sdk: flutter
 

--- a/templates/pubspecs/examples/auth_example/auth_example_server/pubspec.yaml
+++ b/templates/pubspecs/examples/auth_example/auth_example_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   serverpod_auth_server: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/examples/chat/chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/examples/chat/chat_flutter/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   cupertino_icons: ^1.0.5
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
   flutter_test:
     sdk: flutter
 

--- a/templates/pubspecs/examples/chat/chat_server/pubspec.yaml
+++ b/templates/pubspecs/examples/chat/chat_server/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   serverpod_chat_server: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   xml2json: ^6.0.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_s3/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   xml2json: ^6.0.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -9,12 +9,9 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 
 environment:
   sdk: DART_VERSION
-
 dependencies:
-  serverpod_client: SERVERPOD_VERSION
-
-dev_dependencies:
   lints: '>=3.0.0 <5.0.0'
+  serverpod_client: SERVERPOD_VERSION
 
 dependency_overrides:
   serverpod_client:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -10,7 +10,7 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 environment:
   sdk: DART_VERSION
 dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   serverpod_client: SERVERPOD_VERSION
 
 dependency_overrides:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_client/pubspec.yaml
@@ -9,9 +9,12 @@ issue_tracker: https://github.com/serverpod/serverpod/issues
 
 environment:
   sdk: DART_VERSION
+
 dependencies:
-  lints: '>=3.0.0 <5.0.0'
   serverpod_client: SERVERPOD_VERSION
+
+dev_dependencies:
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod_client:

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^8.0.0
-  intl: ^0.18.0
+  intl: '>=0.18.0 < 0.20.0'
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: SERVERPOD_VERSION

--- a/templates/pubspecs/packages/serverpod_lints/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_lints/pubspec.yaml
@@ -9,5 +9,5 @@ environment:
   sdk: DART_VERSION
 
 dependencies:
-  flutter_lints: ^3.0.0
-  lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
+  lints: '>=3.0.0 <5.0.0'

--- a/templates/pubspecs/templates/serverpod_templates/modulename_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/modulename_server/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   serverpod: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides: #--CONDITIONALLY_REMOVE_LINE--#
   serverpod: #--CONDITIONALLY_REMOVE_LINE--#

--- a/templates/pubspecs/templates/serverpod_templates/projectname_flutter/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_flutter/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   cupertino_icons: ^1.0.5
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
   flutter_test:
     sdk: flutter
 

--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   serverpod: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides: #--CONDITIONALLY_REMOVE_LINE--#
   serverpod: #--CONDITIONALLY_REMOVE_LINE--#

--- a/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
+++ b/templates/pubspecs/tests/bootstrap_project/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   uuid: ^4.0.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   test: ^1.24.2
   path: ^1.8.2
   serverpod_cli: SERVERPOD_VERSION

--- a/templates/pubspecs/tests/serverpod_cli_e2e_test/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_cli_e2e_test/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dev_dependencies:
   async: ^2.11.0
   collection: ^1.17.1
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   path: ^1.8.2
   test: ^1.24.2
   uuid: ^4.0.0

--- a/templates/pubspecs/tests/serverpod_test_module/serverpod_test_module_client/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_module/serverpod_test_module_client/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   serverpod_client: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod_client:

--- a/templates/pubspecs/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   serverpod: SERVERPOD_VERSION
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   test: ^1.24.2
   path: ^1.8.2
   serverpod_cli: SERVERPOD_VERSION

--- a/templates/pubspecs/tests/serverpod_test_shared/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_shared/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   build_runner: ^2.4.1
   freezed: ^2.3.2
   json_serializable: ^6.6.1
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   test: ^1.24.2
 
 dependency_overrides:

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   http: ">=0.13.0 <2.0.0"
-  intl: ^0.18.0
+  intl: '>=0.18.0 < 0.20.0'
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0

--- a/templates/serverpod_templates/modulename_server/pubspec.yaml
+++ b/templates/serverpod_templates/modulename_server/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   serverpod: 2.0.0-alpha.3
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides: 
   serverpod: 

--- a/templates/serverpod_templates/projectname_flutter/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_flutter/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   cupertino_icons: ^1.0.5
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: '>=3.0.0 <5.0.0'
   flutter_test:
     sdk: flutter
 

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   serverpod: 2.0.0-alpha.3
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides: 
   serverpod: 

--- a/tests/bootstrap_project/pubspec.yaml
+++ b/tests/bootstrap_project/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   uuid: ^4.0.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   test: ^1.24.2
   path: ^1.8.2
   serverpod_cli: 2.0.0-alpha.3

--- a/tests/serverpod_cli_e2e_test/pubspec.yaml
+++ b/tests/serverpod_cli_e2e_test/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dev_dependencies:
   async: ^2.11.0
   collection: ^1.17.1
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   path: ^1.8.2
   test: ^1.24.2
   uuid: ^4.0.0

--- a/tests/serverpod_test_module/serverpod_test_module_client/pubspec.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_client/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   serverpod_client: 2.0.0-alpha.3
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod_client:

--- a/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   serverpod: 2.0.0-alpha.3
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod:

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   test: ^1.24.2
   path: ^1.8.2
   serverpod_cli: 2.0.0-alpha.3

--- a/tests/serverpod_test_shared/pubspec.yaml
+++ b/tests/serverpod_test_shared/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   build_runner: ^2.4.1
   freezed: ^2.3.2
   json_serializable: ^6.6.1
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
   test: ^1.24.2
 
 dependency_overrides:

--- a/tools/serverpod_cli/lib/src/test_util/endpoint_validation_helpers.dart
+++ b/tools/serverpod_cli/lib/src/test_util/endpoint_validation_helpers.dart
@@ -23,7 +23,7 @@ dependencies:
     path: $pathToServerpodRoot/packages/serverpod
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: '>=3.0.0 <5.0.0'
 
 dependency_overrides:
   serverpod_shared:

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   code_builder: ^4.4.0
   dart_style: ^2.3.0
   http: ">=0.13.0 <2.0.0"
-  intl: ^0.18.0
+  intl: '>=0.18.0 < 0.20.0'
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0


### PR DESCRIPTION
### Changes:
**lints**
New 4.0.0 version removes `package_prefixed_library_names` from core which is not used by Serverpod.
It also removes  `library_names` from recommended which is also not used by Serverpod. Therefore we can allow the range.
Changelog: https://pub.dev/packages/lints/changelog

**flutter_lints**
Basically a bump of the lints package.
Changelog: https://pub.dev/packages/flutter_lints/changelog

**intl**
It has no deprecations, and we can, therefore, safely allow the range for the Serverpod package.
Changelog: https://pub.dev/packages/intl/changelog

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - only increases the range.
