### PR TITLE
Fixing streaming connection handler duplicating the connection status…

### DIFF
--- a/packages/serverpod_client/lib/src/streaming_connection_handler.dart
+++ b/packages/serverpod_client/lib/src/streaming_connection_handler.dart
@@ -52,7 +52,7 @@ class StreamingConnectionHandler {
 
   /// Disposes the connection handler, but does not close the connection.
   void dispose() {
-    client.addStreamingConnectionStatusListener(_onConnectionStatusChanged);
+    client.removeStreamingConnectionStatusListener(_onConnectionStatusChanged);
     _countdownTimer?.cancel();
     _countdownTimer = null;
   }


### PR DESCRIPTION
I'm trying to dispose of a StreamingConnectionHandler, but it keeps adding another _onConnectionStatusChanged listener.

Now, we can use the dispose method in the StreamingConnectionHandler. This method correctly removes the streamingConnectionStatusListener, preventing the listener from duplicating.

I searched for the test file for the StreamingConnectionHandler but couldn't find any. Do I need to create one? If so, where should I place it?

Issue: https://github.com/serverpod/serverpod/issues/2261

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
