### PR TITLE
Remove useless stacktrace print

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -8,11 +8,11 @@ import 'package:serverpod/src/config/version.dart';
 import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/database/migrations/migration_manager.dart';
 import 'package:serverpod/src/redis/controller.dart';
+import 'package:serverpod/src/server/command_line_args.dart';
 import 'package:serverpod/src/server/features.dart';
 import 'package:serverpod/src/server/future_call_manager.dart';
 import 'package:serverpod/src/server/health_check_manager.dart';
 import 'package:serverpod/src/server/log_manager.dart';
-import 'package:serverpod/src/server/command_line_args.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
 import '../authentication/default_authentication_handler.dart';
@@ -784,12 +784,11 @@ class Serverpod {
       try {
         await session.db.testConnection();
         return session;
-      } catch (e, stackTrace) {
+      } catch (e) {
         // Write connection error to stderr.
         stderr.writeln(
           'Failed to connect to the database. Retrying in 10 seconds. $e',
         );
-        stderr.writeln('$stackTrace');
         if (!printedDatabaseConnectionError) {
           stderr.writeln('Database configuration:');
           stderr.writeln(config.database.toString());


### PR DESCRIPTION
Removes a useless stacktrace that just fills up the log when the servers are not correctly configured. It looks like this, and it doesn't help diagnose anything, other than what's in the error message.

```
INFO 2024-05-20T23:26:57.791531610Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: Failed to connect to the database. Retrying in 10 seconds. SocketException: Connection timed out, host: database.clicksocial.app, port: 5432
INFO 2024-05-20T23:26:57.791677662Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #0 _NativeSocket.connect.<anonymous closure>.<anonymous closure> (dart:io-patch/socket_patch.dart:990)
INFO 2024-05-20T23:26:57.791713295Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #1 _rootRun (dart:async/zone.dart:1391)
INFO 2024-05-20T23:26:57.791743530Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #2 _CustomZone.run (dart:async/zone.dart:1301)
INFO 2024-05-20T23:26:57.791772539Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #3 Future.timeout.<anonymous closure> (dart:async/future_impl.dart:942)
INFO 2024-05-20T23:26:57.791804629Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #4 _rootRun (dart:async/zone.dart:1391)
INFO 2024-05-20T23:26:57.791832710Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #5 _CustomZone.run (dart:async/zone.dart:1301)
INFO 2024-05-20T23:26:57.791875781Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #6 _CustomZone.runGuarded (dart:async/zone.dart:1209)
INFO 2024-05-20T23:26:57.791899913Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #7 _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1249)
INFO 2024-05-20T23:26:57.791932362Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #8 _rootRun (dart:async/zone.dart:1399)
INFO 2024-05-20T23:26:57.791957326Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #9 _CustomZone.run (dart:async/zone.dart:1301)
INFO 2024-05-20T23:26:57.791987102Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #10 _CustomZone.bindCallback.<anonymous closure> (dart:async/zone.dart:1233)
INFO 2024-05-20T23:26:57.792024334Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #11 Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18)
INFO 2024-05-20T23:26:57.792048994Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #12 _Timer._runTimers (dart:isolate-patch/timer_impl.dart:398)
INFO 2024-05-20T23:26:57.792071651Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #13 _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:429)
INFO 2024-05-20T23:26:57.792095271Z [resource.labels.instanceId: serverpod-production-pbqx] startup-script: #14 _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:184)
```