### PR TITLE
SignInWithEmailDialog allow to toggle obscure password

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -59,6 +59,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   _Page _page = _Page.createAccount;
 
   bool _enabled = true;
+  bool _isPasswordObscured = true;
 
   @override
   void initState() {
@@ -105,11 +106,21 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         TextField(
           enabled: _enabled,
           controller: _passwordController,
-          obscureText: true,
+          obscureText: _isPasswordObscured,
           decoration: InputDecoration(
             hintText: 'Password',
             helperText: ' ',
             errorText: _passwordIssue,
+            suffixIcon: IconButton(
+              icon: Icon(
+                _isPasswordObscured ? Icons.visibility : Icons.visibility_off,
+              ),
+              onPressed: () {
+                setState(() {
+                  _isPasswordObscured = !_isPasswordObscured;
+                });
+              },
+            ),
           ),
           onChanged: (_) {
             setState(() {
@@ -155,11 +166,21 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         TextField(
           enabled: _enabled,
           controller: _passwordController,
-          obscureText: true,
+          obscureText: _isPasswordObscured,
           decoration: InputDecoration(
             hintText: 'Password',
             helperText: ' ',
             errorText: _passwordIssue,
+            suffixIcon: IconButton(
+              icon: Icon(
+                _isPasswordObscured ? Icons.visibility : Icons.visibility_off,
+              ),
+              onPressed: () {
+                setState(() {
+                  _isPasswordObscured = !_isPasswordObscured;
+                });
+              },
+            ),
           ),
           onChanged: (_) {
             setState(() {


### PR DESCRIPTION
This PR adds the option to show/hide the password on the SignInWithEmailDialog. 

Tries to close #1707 

I wanted to add some WidgetTests, but got an error, when tapping "I have an account" within the test. 
This error appears in debug mode when the screen is not wide enough. 

```
The overflowing RenderFlex has an orientation of Axis.horizontal.
The edge of the RenderFlex that is overflowing has been marked in the
rendering with a yellow and
black striped pattern. This is usually caused by the contents being too big
for the RenderFlex.
Consider applying a flex factor (e.g. using an Expanded widget) to force the
children of the
RenderFlex to fit within the available space instead of being sized to their
natural size.
This is considered an error condition because it indicates that there is
content that cannot be
seen. If the content is legitimately bigger than the available space, consider
clipping it with a
ClipRect widget before putting it in the flex, or using a scrollable container
rather than a Flex,
like a ListView.
The specific RenderFlex in question is: RenderFlex#edd35 relayoutBoundary=up8
OVERFLOWING:
  creator: Row ← Column ← Padding ← ConstrainedBox ← Container ←
```

It is pointing towards the last Row of this part holding "Forgot Pass" and "Create Account":
![signin](https://github.com/serverpod/serverpod/assets/136239531/951d289a-fe00-4e0d-994d-ffb64475e6f5)


Let me know if I should look into resolving the error and add tests

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes
