### PR TITLE
Only notify listeners if connection status actually changes

### DIFF
--- a/packages/serverpod_client/lib/src/connectivity_monitor.dart
+++ b/packages/serverpod_client/lib/src/connectivity_monitor.dart
@@ -25,12 +25,18 @@ abstract class ConnectivityMonitor {
     _listeners.clear();
   }
 
+  /// Only notify listeners if the connectivity status has changed.
+  bool _prevConnected = false;
+
   /// Notifies listeners of changes in connectivity. This method should only
   /// be called by classes that inherits from [ConnectivityMonitor].
   @protected
   void notifyListeners(bool connected) {
-    for (var listener in _listeners) {
-      listener(connected);
+    if (connected != _prevConnected) {
+      _prevConnected = connected;
+      for (var listener in _listeners) {
+        listener(connected);
+      }
     }
   }
 }

--- a/packages/serverpod_client/lib/src/connectivity_monitor.dart
+++ b/packages/serverpod_client/lib/src/connectivity_monitor.dart
@@ -26,17 +26,17 @@ abstract class ConnectivityMonitor {
   }
 
   /// Only notify listeners if the connectivity status has changed.
-  bool _prevConnected = false;
+  bool? _prevConnected;
 
   /// Notifies listeners of changes in connectivity. This method should only
   /// be called by classes that inherits from [ConnectivityMonitor].
   @protected
   void notifyListeners(bool connected) {
-    if (connected != _prevConnected) {
-      _prevConnected = connected;
-      for (var listener in _listeners) {
-        listener(connected);
-      }
+    if (connected == _prevConnected) return;
+
+    _prevConnected = connected;
+    for (var listener in _listeners) {
+      listener(connected);
     }
   }
 }

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -326,6 +326,10 @@ abstract class ServerpodClientShared extends EndpointCaller {
     _websocketConnectionStatusListeners.remove(listener);
   }
 
+  /// The previous streaming connection status (used to detect changes in
+  /// connection status, so that listeners can be notified)
+  StreamingConnectionStatus? _prevStreamingConnectionStatus;
+
   /// Checks if the streaming connection status has changed, and if so,
   /// notifies listeners.
   void _notifyWebSocketConnectionStatusListeners() {
@@ -337,10 +341,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
       }
     }
   }
-
-  /// The previous streaming connection status (used to detect changes in
-  /// connection status, so that listeners can be notified)
-  StreamingConnectionStatus? _prevStreamingConnectionStatus;
 
   /// Returns the current status of the streaming connection. It can be one of
   /// connected, connecting, or disconnected. Use the

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -334,11 +334,11 @@ abstract class ServerpodClientShared extends EndpointCaller {
   /// notifies listeners.
   void _notifyWebSocketConnectionStatusListeners() {
     var currStreamingConnectionStatus = streamingConnectionStatus;
-    if (currStreamingConnectionStatus != _prevStreamingConnectionStatus) {
-      _prevStreamingConnectionStatus = currStreamingConnectionStatus;
-      for (var listener in _websocketConnectionStatusListeners) {
-        listener();
-      }
+    if (currStreamingConnectionStatus == _prevStreamingConnectionStatus) return;
+
+    _prevStreamingConnectionStatus = currStreamingConnectionStatus;
+    for (var listener in _websocketConnectionStatusListeners) {
+      listener();
     }
   }
 

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -326,11 +326,21 @@ abstract class ServerpodClientShared extends EndpointCaller {
     _websocketConnectionStatusListeners.remove(listener);
   }
 
+  /// Checks if the streaming connection status has changed, and if so,
+  /// notifies listeners.
   void _notifyWebSocketConnectionStatusListeners() {
-    for (var listener in _websocketConnectionStatusListeners) {
-      listener();
+    var currStreamingConnectionStatus = streamingConnectionStatus;
+    if (currStreamingConnectionStatus != prevStreamingConnectionStatus) {
+      prevStreamingConnectionStatus = currStreamingConnectionStatus;
+      for (var listener in _websocketConnectionStatusListeners) {
+        listener();
+      }
     }
   }
+
+  /// The previous streaming connection status (used to detect changes in
+  /// connection status, so that listeners can be notified)
+  StreamingConnectionStatus? prevStreamingConnectionStatus;
 
   /// Returns the current status of the streaming connection. It can be one of
   /// connected, connecting, or disconnected. Use the

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -330,8 +330,8 @@ abstract class ServerpodClientShared extends EndpointCaller {
   /// notifies listeners.
   void _notifyWebSocketConnectionStatusListeners() {
     var currStreamingConnectionStatus = streamingConnectionStatus;
-    if (currStreamingConnectionStatus != prevStreamingConnectionStatus) {
-      prevStreamingConnectionStatus = currStreamingConnectionStatus;
+    if (currStreamingConnectionStatus != _prevStreamingConnectionStatus) {
+      _prevStreamingConnectionStatus = currStreamingConnectionStatus;
       for (var listener in _websocketConnectionStatusListeners) {
         listener();
       }
@@ -340,7 +340,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
 
   /// The previous streaming connection status (used to detect changes in
   /// connection status, so that listeners can be notified)
-  StreamingConnectionStatus? prevStreamingConnectionStatus;
+  StreamingConnectionStatus? _prevStreamingConnectionStatus;
 
   /// Returns the current status of the streaming connection. It can be one of
   /// connected, connecting, or disconnected. Use the


### PR DESCRIPTION
Currently the client sends multiple notifications of `connecting` status. It should only notify listeners if the streaming connection status actually changes (which is what this PR does).

I also applied the same fix to `ConnectivityMonitor`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
