### PR TITLE
Add missing _notifyWebSocketConnectionStatusListeners

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -290,12 +290,12 @@ abstract class ServerpodClientShared extends EndpointCaller {
     _webSocket = null;
     _cancelConnectionTimer();
 
+    // Notify listeners that websocket has been closed
+    _notifyWebSocketConnectionStatusListeners();
+
     // Hack for dart:io version of websocket to get time to close the stream
     // in _listenToWebSocket
     await Future.delayed(const Duration(milliseconds: 100));
-
-    // Notify listeners that websocket has been closed
-    _notifyWebSocketConnectionStatusListeners();
   }
 
   Future<void> _listenToWebSocketStream() async {

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -293,6 +293,9 @@ abstract class ServerpodClientShared extends EndpointCaller {
     // Hack for dart:io version of websocket to get time to close the stream
     // in _listenToWebSocket
     await Future.delayed(const Duration(milliseconds: 100));
+
+    // Notify listeners that websocket has been closed
+    _notifyWebSocketConnectionStatusListeners();
   }
 
   Future<void> _listenToWebSocketStream() async {


### PR DESCRIPTION
Add missing `_notifyWebSocketConnectionStatusListeners` call when websocket is closed by client.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).
