### PR TITLE
Add missing await _webSocket!.ready after WebSocketChannel.connect

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -256,6 +256,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
       _firstMessageReceived = false;
       var host = await websocketHost;
       _webSocket = WebSocketChannel.connect(Uri.parse(host));
+      await _webSocket!.ready;
 
       // We are sending the ping message to the server, so that we are
       // guaranteed to get a first message in return. This will verify that we

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -256,7 +256,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
       _firstMessageReceived = false;
       var host = await websocketHost;
       _webSocket = WebSocketChannel.connect(Uri.parse(host));
-      await _webSocket!.ready;
+      await _webSocket?.ready;
 
       // We are sending the ping message to the server, so that we are
       // guaranteed to get a first message in return. This will verify that we


### PR DESCRIPTION
Add missing `await _webSocket!.ready` after `WebSocketChannel.connect`.

(See docs for `WebSocketChannel.connect`)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
