### PR TITLE
Update connectivity_plus version

### DIFF
--- a/packages/serverpod_flutter/lib/src/flutter_connectivity_monitor.dart
+++ b/packages/serverpod_flutter/lib/src/flutter_connectivity_monitor.dart
@@ -6,7 +6,7 @@ import 'package:serverpod_client/serverpod_client.dart';
 
 /// Concrete implementation of [ConnectivityMonitor] for use with Flutter.
 class FlutterConnectivityMonitor extends ConnectivityMonitor {
-  late StreamSubscription<ConnectivityResult> _connectivitySubscription;
+  late StreamSubscription<List<ConnectivityResult>> _connectivitySubscription;
   bool _receivedFirstEvent = false;
 
   /// Creates a new connectivity monitor.
@@ -17,18 +17,19 @@ class FlutterConnectivityMonitor extends ConnectivityMonitor {
 
     // Start listening to connection status changes.
     _connectivitySubscription =
-        Connectivity().onConnectivityChanged.listen((event) {
+        Connectivity().onConnectivityChanged.listen((connectivityResultList) {
+      var connected = !connectivityResultList.any((connectivityResult) =>
+          connectivityResult == ConnectivityResult.none);
       if (!_receivedFirstEvent) {
         // Skip the first event if it happens immediately on launch as it may
         // not be correct on some platforms.
         _receivedFirstEvent = true;
         var durationSinceStart = DateTime.now().difference(connectionTime);
-        if (event == ConnectivityResult.none &&
-            durationSinceStart < warmupDuration) {
+        if (!connected && durationSinceStart < warmupDuration) {
           return;
         }
       }
-      notifyListeners(event != ConnectivityResult.none);
+      notifyListeners(connected);
     });
   }
 

--- a/packages/serverpod_flutter/lib/src/flutter_connectivity_monitor.dart
+++ b/packages/serverpod_flutter/lib/src/flutter_connectivity_monitor.dart
@@ -18,8 +18,8 @@ class FlutterConnectivityMonitor extends ConnectivityMonitor {
     // Start listening to connection status changes.
     _connectivitySubscription =
         Connectivity().onConnectivityChanged.listen((connectivityResultList) {
-      var connected = !connectivityResultList.any((connectivityResult) =>
-          connectivityResult == ConnectivityResult.none);
+      var connected = connectivityResultList.any((connectivityResult) =>
+          connectivityResult != ConnectivityResult.none);
       if (!_receivedFirstEvent) {
         // Skip the first event if it happens immediately on launch as it may
         // not be correct on some platforms.

--- a/packages/serverpod_flutter/pubspec.yaml
+++ b/packages/serverpod_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   flutter: '>=3.13.0'
 
 dependencies:
-  connectivity_plus: ^5.0.0
+  connectivity_plus: ^6.0.0
   serverpod_client: 2.0.0-alpha.2
   flutter:
     sdk: flutter

--- a/templates/pubspecs/packages/serverpod_flutter/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_flutter/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   flutter: FLUTTER_VERSION
 
 dependencies:
-  connectivity_plus: ^5.0.0
+  connectivity_plus: ^6.0.0
   serverpod_client: SERVERPOD_VERSION
   flutter:
     sdk: flutter


### PR DESCRIPTION
This updates `connectivity_plus` to `^6.0.0` (which has a new API).

(My iOS app crashes on launch with a segfault in `connectivity_plus ^5.0.0` -- this doesn't fix it, but it's still probably good to get updated since the API has changed, and other bugs have been fixed.)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
