### PR TITLE
fix: Allow usage of user related google api calls in onUserCreated callback.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -11,25 +11,29 @@ class Users {
     Session session,
     UserInfo userInfo, [
     String? authMethod,
-    bool manageOnUserCreated = true,
+    UserInfoCreationCallback? onUserWillBeCreatedOverride,
+    UserInfoUpdateCallback? onUserCreatedOverride,
   ]) async {
-    if (AuthConfig.current.onUserWillBeCreated != null) {
-      var approved = await AuthConfig.current.onUserWillBeCreated!(
-        session,
-        userInfo,
-        authMethod,
-      );
-      if (!approved) return null;
-    }
+    bool approved = switch (onUserWillBeCreatedOverride) {
+      null => await AuthConfig.current.onUserWillBeCreated?.call(
+            session,
+            userInfo,
+            authMethod,
+          ) ??
+          true,
+      _ => await onUserWillBeCreatedOverride.call(session, userInfo, authMethod)
+    };
+    if (!approved) return null;
 
     userInfo = await UserInfo.db.insertRow(session, userInfo);
-    if (userInfo.id != null) {
-      if (AuthConfig.current.onUserCreated != null && manageOnUserCreated) {
-        await AuthConfig.current.onUserCreated!(session, userInfo);
-      }
-      return userInfo;
+
+    if (onUserCreatedOverride == null) {
+      await AuthConfig.current.onUserCreated?.call(session, userInfo);
+    } else {
+      await onUserCreatedOverride(session, userInfo);
     }
-    return null;
+
+    return userInfo;
   }
 
   /// Finds a user by its email address. Returns null if no user is found.

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -11,6 +11,7 @@ class Users {
     Session session,
     UserInfo userInfo, [
     String? authMethod,
+    bool manageOnUserCreated = true,
   ]) async {
     if (AuthConfig.current.onUserWillBeCreated != null) {
       var approved = await AuthConfig.current.onUserWillBeCreated!(
@@ -23,7 +24,7 @@ class Users {
 
     userInfo = await UserInfo.db.insertRow(session, userInfo);
     if (userInfo.id != null) {
-      if (AuthConfig.current.onUserCreated != null) {
+      if (AuthConfig.current.onUserCreated != null && manageOnUserCreated) {
         await AuthConfig.current.onUserCreated!(session, userInfo);
       }
       return userInfo;


### PR DESCRIPTION
# Fix

Delay the call to `onUserCreated` if signing up with google and we request additional access to the google apis. This makes it possible to use the google API in the `onUserCreated` callback.

Additional thoughts for the future: 
 * The session object does not contain the userId when the callback is made. It would not be too hard to add this but the problem is that the email auth flow is not signing in users when we create the account. Hence the session object could be populated with some providers but not with others.
 * If the callback throws (user code) we don't catch that. This might be reasonable, but we are in a half complete state in some situations where the user is created but we have not created any refresh tokens. This may be the desired behavior but could be a problem, I'm not convinced either way right now.

Closes: #2321 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none