### PR TITLE
fix: Bump cli tools dependency.

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: ^0.0.2
+  cli_tools: ^0.1.0
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
@@ -1,14 +1,10 @@
-import 'package:args/args.dart';
-import 'package:args/command_runner.dart';
+import 'package:cli_tools/cli_tools.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
-abstract class ServerpodCommand extends Command {
-  @override
-  void printUsage() {
-    log.info(usage);
-  }
-
-  @override
-  ArgParser get argParser => _argParser;
-  final ArgParser _argParser = ArgParser(usageLineLength: log.wrapTextColumn);
+abstract class ServerpodCommand extends BetterCommand {
+  ServerpodCommand()
+      : super(
+          logInfo: (String message) => log.info(message),
+          wrapTextColumn: log.wrapTextColumn,
+        );
 }

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: ^0.0.2
+  cli_tools: ^0.1.0
 
 dev_dependencies:
   serverpod_lints: 2.0.0


### PR DESCRIPTION
### Changes
- Updates the usage of Pub API client to use exceptions instead of callbacks to handle errors.
- Updates the usage of Local Storage Manager to use exceptions instead of callbacks to handle errors.
- Uses the BetterCommand abstract class to do correct terminal width print bindings.
- Bumps the cli_tools dependency to 0.1.0.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - just a dependency bump.
