### PR TITLE
fix: Att offset checking of value encoder to bytedata.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/value_encoder.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/value_encoder.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 // ignore: implementation_imports
@@ -12,8 +11,7 @@ class ValueEncoder extends PostgresTextEncoder {
     if (input == null) {
       return 'NULL';
     } else if (input is ByteData) {
-      var encoded = base64Encode(input.buffer.asUint8List());
-      return 'decode(\'$encoded\', \'base64\')';
+      return input.base64encodedString();
     } else if (input is DateTime) {
       return super.convert(SerializationManager.encode(input),
           escapeStrings: escapeStrings);


### PR DESCRIPTION
# Changes

Change the value encoder to postgres to set the offset and length of byte data.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none
