### PR TITLE
sign_in_with_apple pacakge version update

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
   serverpod_auth_client: 2.0.0
   serverpod_auth_shared_flutter: 2.0.0
-  sign_in_with_apple: ^5.0.0
+  sign_in_with_apple: '>=5.0.0 <7.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   material_design_icons_flutter: ">=6.0.0 < 7.0.0"
   serverpod_auth_client: SERVERPOD_VERSION
   serverpod_auth_shared_flutter: SERVERPOD_VERSION
-  sign_in_with_apple: ^5.0.0
+  sign_in_with_apple: '>=5.0.0 <7.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Allows a range for the `sign_in_with_apple` package.
Since the Serverpod implementation does not directly depend on any changes between version 5 and 6 in the package we can allow a range there.

Version 6 has dart 3.3 as minimum required version, so opting for a range instead of a direct bump to allow users to still use dart 3.2 if they prefer.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.