### PR TITLE
postgres package upgrade

### DIFF
--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2
-  postgres: ^3.0.0
+  postgres: ^3.0.1
   redis: ^4.0.0
   retry: ^3.1.1
   synchronized: ^3.1.0

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   meta: ^1.8.0
   mustache_template: ^2.0.0
   path: ^1.8.2
-  postgres: ^3.0.0
+  postgres: ^3.0.1
   redis: ^4.0.0
   retry: ^3.1.1
   synchronized: ^3.1.0


### PR DESCRIPTION
Changed because the `TxSession` object is not available in postgres 3.0.0.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.