### PR TITLE
fix: Remove password reset verification code onusage attempt.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -276,9 +276,11 @@ class Emails {
     var emailReset = EmailReset(
       userId: userInfo.id!,
       verificationCode: verificationCode,
-      expiration: DateTime.now().add(
-        AuthConfig.current.passwordResetExpirationTime,
-      ),
+      expiration: DateTime.now()
+          .add(
+            AuthConfig.current.passwordResetExpirationTime,
+          )
+          .toUtc(),
     );
     await EmailReset.db.insertRow(session, emailReset);
 
@@ -368,7 +370,7 @@ class Emails {
 
     if (emailAuth == null) {
       session.log(
-        "ser with id: '${passwordReset.userId}' has no email authentication!",
+        "User with id: '${passwordReset.userId}' has no email authentication!",
         level: LogLevel.debug,
       );
       return false;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -356,7 +356,7 @@ class Emails {
 
     var passwordReset = passwordResets.first;
 
-    if (passwordReset.expiration.isAfter(DateTime.now().toUtc())) {
+    if (passwordReset.expiration.isBefore(DateTime.now().toUtc())) {
       session.log(
         'Verification code has expired!',
         level: LogLevel.debug,


### PR DESCRIPTION
# Changes
Removes the verification code in db when resetPassword endpoint is called.

Closes: https://github.com/serverpod/serverpod/issues/2360

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None