### PR TITLE
fix!: Remove endpoint to validate validation code.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -289,50 +289,6 @@ class Emails {
     );
   }
 
-  /// Verifies a password reset code, returns a [EmailPasswordReset] object if
-  /// successful, null otherwise.
-  static Future<EmailPasswordReset?> verifyEmailPasswordReset(
-    Session session,
-    String verificationCode,
-  ) async {
-    session.log('verificationCode: $verificationCode', level: LogLevel.debug);
-
-    var passwordReset = await EmailReset.db.findFirstRow(session, where: (t) {
-      return t.verificationCode.equals(verificationCode) &
-          (t.expiration > DateTime.now().toUtc());
-    });
-
-    if (passwordReset == null) {
-      session.log(
-        'Verification code is invalid or has expired!',
-        level: LogLevel.debug,
-      );
-      return null;
-    }
-
-    var userInfo = await Users.findUserByUserId(session, passwordReset.userId);
-    if (userInfo == null) {
-      session.log(
-        "User with id: '${passwordReset.userId}' is not found!",
-        level: LogLevel.debug,
-      );
-      return null;
-    }
-
-    if (userInfo.email == null) {
-      session.log(
-        "User with id: '${passwordReset.userId}' has no email address!",
-        level: LogLevel.debug,
-      );
-      return null;
-    }
-
-    return EmailPasswordReset(
-      userName: userInfo.userName,
-      email: userInfo.email!,
-    );
-  }
-
   /// Resets a users password using a password reset verification code.
   static Future<bool> resetPassword(
     Session session,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/email_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/email_endpoint.dart
@@ -34,15 +34,6 @@ class EmailEndpoint extends Endpoint {
     return Emails.initiatePasswordReset(session, email);
   }
 
-  /// Verifies a password reset code, if successful returns an
-  /// [EmailPasswordReset] object, otherwise returns null.
-  Future<EmailPasswordReset?> verifyEmailPasswordReset(
-    Session session,
-    String verificationCode,
-  ) {
-    return Emails.verifyEmailPasswordReset(session, verificationCode);
-  }
-
   /// Resets a users password using the reset code.
   Future<bool> resetPassword(
       Session session, String verificationCode, String password) {


### PR DESCRIPTION
# Fix

Removes the `verifyEmailPasswordReset` endpoint.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

`verifyEmailPasswordReset` is no longer accessible.