### PR TITLE
fix!: Change default values for auth config.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -171,7 +171,7 @@ class AuthConfig {
   }) {
     if (validationCodeLength < 8) {
       stderr.writeln(
-        'WARNING: Validation code length is less than 8. This is not recommended.',
+        'WARNING: Validation code length is less than 8. This makes the validation code more susceptible to brute force attacks.',
       );
     }
 

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/config.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:image/image.dart';
 import 'package:serverpod/server.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart';
@@ -113,7 +114,7 @@ class AuthConfig {
   /// This value determines the number of digits in the validation code. Default is 8.
   final int validationCodeLength;
 
-  /// The time for password resets to be valid. Default is one day.
+  /// The time for password resets to be valid. Default is 15 minutes.
   final Duration passwordResetExpirationTime;
 
   /// True if the server should use the accounts email address as part of the
@@ -160,7 +161,7 @@ class AuthConfig {
     this.sendPasswordResetEmail,
     this.sendValidationEmail,
     this.validationCodeLength = 8,
-    this.passwordResetExpirationTime = const Duration(hours: 24),
+    this.passwordResetExpirationTime = const Duration(minutes: 15),
     this.extraSaltyHash = true,
     this.firebaseServiceAccountKeyJson =
         'config/firebase_service_account_key.json',
@@ -168,11 +169,17 @@ class AuthConfig {
     this.minPasswordLength = 8,
     this.allowUnsecureRandom = false,
   }) {
-    if (validationCodeLength < 1) {
+    if (validationCodeLength < 8) {
+      stderr.writeln(
+        'WARNING: Validation code length is less than 8. This is not recommended.',
+      );
+    }
+
+    if (validationCodeLength < 4) {
       throw ArgumentError.value(
         validationCodeLength,
         'validationCodeLength',
-        'must be at least 1',
+        'must be at least 4',
       );
     }
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -582,7 +582,7 @@ class Emails {
   static String _generateVerificationCode() {
     return Random().nextString(
       length: AuthConfig.current.validationCodeLength,
-      chars: '0123456789',
+      chars: '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -582,7 +582,6 @@ class Emails {
   static String _generateVerificationCode() {
     return Random().nextString(
       length: AuthConfig.current.validationCodeLength,
-      chars: '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
     );
   }
 

--- a/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
+++ b/tests/serverpod_test_server/test_integration/authentication/auth_config_changes_test.dart
@@ -53,7 +53,7 @@ void main() async {
         throwsA(isA<ArgumentError>().having(
           (e) => e.toString(),
           'message',
-          contains('must be at least 1'),
+          contains('must be at least 4'),
         )));
   });
 
@@ -65,7 +65,7 @@ void main() async {
         throwsA(isA<ArgumentError>().having(
           (e) => e.toString(),
           'message',
-          contains('must be at least 1'),
+          contains('must be at least 4'),
         )));
   });
 }


### PR DESCRIPTION
# Changes

* The default expiration time for the validation code is now 15 minutes (down from 24 hours).
* A warning is printed if the validation code is less than 8 chars.
* The minimum validation code length is now 4 chars.
* The validation now contains a-z, A-Z, 0-9.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

The default values of the auth module has been change, and the minimum validation code length has been increase from 1 to 4.