### PR TITLE
fix: Replace asserts in auth module with throws / logs.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/email_auth.dart
@@ -159,8 +159,9 @@ class Emails {
     String? password, [
     String? hash,
   ]) async {
-    assert(password != null || hash != null,
-        'Either password or hash needs to be provided');
+    if (password == null && hash == null) {
+      throw Exception('Either password or hash needs to be provided');
+    }
     var userInfo = await Users.findUserByEmail(session, email);
 
     if (userInfo == null) {
@@ -256,10 +257,13 @@ class Emails {
     Session session,
     String email,
   ) async {
-    assert(
-      AuthConfig.current.sendPasswordResetEmail != null,
-      'ResetPasswordEmail is not configured, cannot send email.',
-    );
+    if (AuthConfig.current.sendPasswordResetEmail == null) {
+      session.log(
+        'ResetPasswordEmail is not configured, cannot send email.',
+        level: LogLevel.debug,
+      );
+      return false;
+    }
 
     email = email.trim().toLowerCase();
 
@@ -378,10 +382,13 @@ class Emails {
     String email,
     String password,
   ) async {
-    assert(
-      AuthConfig.current.sendValidationEmail != null,
-      'The sendValidationEmail property needs to be set in AuthConfig.',
-    );
+    if (AuthConfig.current.sendValidationEmail == null) {
+      session.log(
+        'SendValidationEmail is not configured, cannot send email.',
+        level: LogLevel.debug,
+      );
+      return false;
+    }
 
     try {
       // Check if user already has an account

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/google_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/google_auth.dart
@@ -36,10 +36,11 @@ class GoogleAuth {
     Session session,
     int userId,
   ) async {
-    assert(
-      clientSecret != null,
-      'Google client secret from $_configFilePath is not loaded',
-    );
+    if (clientSecret == null) {
+      throw StateError(
+        'Google client secret from $_configFilePath is not loaded',
+      );
+    }
 
     var refreshTokenData = await GoogleRefreshToken.db.findFirstRow(
       session,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
@@ -128,10 +128,12 @@ class GoogleEndpoint extends Endpoint {
   /// Authenticates a user using an id token.
   Future<AuthenticationResponse> authenticateWithIdToken(
       Session session, String idToken) async {
+    var clientSecret = GoogleAuth.clientSecret;
+    if (clientSecret == null) {
+      throw StateError('The server side Google client secret is not loaded.');
+    }
     try {
-      assert(GoogleAuth.clientSecret != null,
-          'Google client secret is not loaded');
-      String clientId = GoogleAuth.clientSecret!.clientId;
+      String clientId = clientSecret.clientId;
 
       // Verify the token with Google's servers.
       // TODO: This should probably be done on this server.


### PR DESCRIPTION
# Chnages

Removes `asserts` in the auth module in favor of throws and logs.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none