### PR TITLE
fix: Stop webserver when shutdown is called.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -753,7 +753,7 @@ class Serverpod {
   Future<void> shutdown({bool exitProcess = true}) async {
     await redisController?.stop();
     server.shutdown();
-    webServer.stop();
+    _webServer?.stop();
     _serviceServer?.shutdown();
     _futureCallManager?.stop();
     _healthCheckManager?.stop();

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -753,6 +753,7 @@ class Serverpod {
   Future<void> shutdown({bool exitProcess = true}) async {
     await redisController?.stop();
     server.shutdown();
+    webServer.stop();
     _serviceServer?.shutdown();
     _futureCallManager?.stop();
     _healthCheckManager?.stop();


### PR DESCRIPTION
# Fix

Call stop on the webserver when shutdown on the serverpod object is called.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._