### PR TITLE
chore: Bump postgres version to 16.3.

### DIFF
--- a/examples/auth_example/auth_example_server/aws/terraform/database.tf
+++ b/examples/auth_example/auth_example_server/aws/terraform/database.tf
@@ -2,7 +2,7 @@ resource "aws_db_instance" "postgres" {
   identifier          = var.project_name
   allocated_storage   = 10
   engine              = "postgres"
-  engine_version      = "14.2"
+  engine_version      = "16.3"
   instance_class      = "db.t3.micro"
   db_name             = "serverpod"
   username            = "postgres"
@@ -41,7 +41,7 @@ resource "aws_db_instance" "postgres_staging" {
   identifier          = "${var.project_name}-staging"
   allocated_storage   = 10
   engine              = "postgres"
-  engine_version      = "14.2"
+  engine_version      = "16.3"
   instance_class      = "db.t3.micro"
   db_name             = "serverpod"
   username            = "postgres"

--- a/examples/auth_example/auth_example_server/docker-compose.yaml
+++ b/examples/auth_example/auth_example_server/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   postgres:
-    image: postgres:14.1
+    image: postgres:16.3
     ports:
       - '8090:5432'
     environment:

--- a/examples/chat/chat_server/aws/terraform/database.tf
+++ b/examples/chat/chat_server/aws/terraform/database.tf
@@ -2,7 +2,7 @@ resource "aws_db_instance" "postgres" {
   identifier          = var.project_name
   allocated_storage   = 10
   engine              = "postgres"
-  engine_version      = "14.2"
+  engine_version      = "16.3"
   instance_class      = "db.t3.micro"
   db_name             = "serverpod"
   username            = "postgres"
@@ -41,7 +41,7 @@ resource "aws_db_instance" "postgres_staging" {
   identifier          = "${var.project_name}-staging"
   allocated_storage   = 10
   engine              = "postgres"
-  engine_version      = "14.2"
+  engine_version      = "16.3"
   instance_class      = "db.t3.micro"
   db_name             = "serverpod"
   username            = "postgres"

--- a/examples/chat/chat_server/docker-compose.yaml
+++ b/examples/chat/chat_server/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   postgres:
-    image: postgres:14.1
+    image: postgres:16.3
     ports:
       - '8090:5432'
     environment:

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/database.tf
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/database.tf
@@ -2,7 +2,7 @@ resource "aws_db_instance" "postgres" {
   identifier          = var.project_name
   allocated_storage   = 10
   engine              = "postgres"
-  engine_version      = "14.2"
+  engine_version      = "16.3"
   instance_class      = "db.t3.micro"
   db_name             = "serverpod"
   username            = "postgres"
@@ -41,7 +41,7 @@ resource "aws_db_instance" "postgres_staging" {
   identifier          = "${var.project_name}-staging"
   allocated_storage   = 10
   engine              = "postgres"
-  engine_version      = "14.2"
+  engine_version      = "16.3"
   instance_class      = "db.t3.micro"
   db_name             = "serverpod"
   username            = "postgres"

--- a/templates/serverpod_templates/projectname_server_upgrade/docker-compose.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   postgres:
-    image: postgres:14.1
+    image: postgres:16.3
     ports:
       - '8090:5432'
     environment:

--- a/tests/docker/tests_e2e/docker-compose.yml
+++ b/tests/docker/tests_e2e/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - 'serverpod_test_server'
   postgres:
-    image: postgres:14.1
+    image: postgres:16.3
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: serverpod_test

--- a/tests/docker/tests_e2e_migrations/docker-compose.yml
+++ b/tests/docker/tests_e2e_migrations/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - 'serverpod_test_server'
   postgres:
-    image: postgres:14.1
+    image: postgres:16.3
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: serverpod_test

--- a/tests/docker/tests_integration/docker-compose.yml
+++ b/tests/docker/tests_integration/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 'postgres'
       - 'redis'
   postgres:
-    image: postgres:14.1
+    image: postgres:16.3
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: serverpod_test

--- a/tests/serverpod_test_server/docker-local/docker-compose.yml
+++ b/tests/serverpod_test_server/docker-local/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   postgres:
-    image: postgres:14.1
+    image: postgres:16.3
     ports:
       - '8090:5432'
       - '5432:5432'


### PR DESCRIPTION
An issue reported that Postgres version 14.2 is no longer available from Amazon RDS making the supplied terraform script fail when used.

### Changes
- Bumps the Postgres version used in the aws terraform scripts from 14.2 -> 16.3: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html#postgresql-versions-version163.
- Bumps the Postgres version in all docker composes.

Closes: #2375 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple configuration change that will affect users creating new projects.