### PR TITLE
Report firebase login errors to console

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/firebase_endpoint.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart';
 import 'package:serverpod_auth_server/src/business/firebase_auth.dart';
@@ -17,12 +19,15 @@ class FirebaseEndpoint extends Endpoint {
     try {
       authManager = await FirebaseAuth.authManager;
     } catch (e, stackTrace) {
+      var message = 'Failed to create Firebase app. '
+          'Have you correctly configured the service account key?';
       session.log(
-        'Failed to create Firebase app. Have you correctly configured the service account key?',
+        message,
         level: LogLevel.error,
         stackTrace: stackTrace,
         exception: e,
       );
+      stderr.writeln('$message: $e');
 
       return AuthenticationResponse(
         success: false,


### PR DESCRIPTION
Errors that indicate server or cloud misconfiguration should be written to stderr, not just to the Serverpod log, so that the GCP logs contain these sorts of errors.

I added this change only in the case of Firebase Auth misconfiguration errors, but really this pattern should be applied elsewhere too in cases of server or cloud misconfiguration.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
