### PR TITLE
feat: SignInWithEmailDialog allow label localization/customization

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/serverpod_auth_email_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/serverpod_auth_email_flutter.dart
@@ -1,2 +1,3 @@
 export 'src/signin_button.dart';
 export 'src/auth.dart';
+export 'src/signin_labels.dart';

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:serverpod_auth_client/serverpod_auth_client.dart';
 import 'package:serverpod_auth_email_flutter/src/signin_dialog.dart';
+import 'package:serverpod_auth_email_flutter/src/signin_labels.dart';
 
 /// Sign in with Email button. When pressed, a pop-up window appears with fields for entering login, email and password.
 class SignInWithEmailButton extends StatefulWidget {
@@ -29,6 +30,10 @@ class SignInWithEmailButton extends StatefulWidget {
   /// If this value is modified, the server must be updated to match.
   final int? minPasswordLength;
 
+  /// Labels for the sign in dialog.
+  /// If [null], the default/english labels will be used.
+  final SignInWithEmailDialogLabels? labels;
+
   /// Creates a new Sign in with Email button.
   const SignInWithEmailButton({
     required this.caller,
@@ -38,6 +43,7 @@ class SignInWithEmailButton extends StatefulWidget {
     this.icon,
     this.maxPasswordLength,
     this.minPasswordLength,
+    this.labels,
     super.key,
   });
 
@@ -63,6 +69,7 @@ class SignInWithEmailButtonState extends State<SignInWithEmailButton> {
           caller: widget.caller,
           maxPasswordLength: widget.maxPasswordLength,
           minPasswordLength: widget.minPasswordLength,
+          labels: widget.labels,
           onSignedIn: () {
             if (widget.onSignedIn != null) {
               widget.onSignedIn!();

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_button.dart
@@ -32,7 +32,7 @@ class SignInWithEmailButton extends StatefulWidget {
 
   /// Labels for the sign in dialog.
   /// If [null], the default/english labels will be used.
-  final SignInWithEmailDialogLabels? labels;
+  final SignInWithEmailDialogLabels? localization;
 
   /// Creates a new Sign in with Email button.
   const SignInWithEmailButton({
@@ -43,7 +43,7 @@ class SignInWithEmailButton extends StatefulWidget {
     this.icon,
     this.maxPasswordLength,
     this.minPasswordLength,
-    this.labels,
+    this.localization,
     super.key,
   });
 
@@ -69,7 +69,7 @@ class SignInWithEmailButtonState extends State<SignInWithEmailButton> {
           caller: widget.caller,
           maxPasswordLength: widget.maxPasswordLength,
           minPasswordLength: widget.minPasswordLength,
-          labels: widget.labels,
+          localization: widget.localization,
           onSignedIn: () {
             if (widget.onSignedIn != null) {
               widget.onSignedIn!();

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -2,6 +2,7 @@ import 'package:email_validator/email_validator.dart';
 import 'package:flutter/material.dart';
 import 'package:serverpod_auth_client/serverpod_auth_client.dart';
 import 'package:serverpod_auth_email_flutter/src/auth.dart';
+import 'package:serverpod_auth_email_flutter/src/signin_labels.dart';
 
 const _defaultMaxPasswordLength = 128;
 const _defaultMinPasswordLength = 8;
@@ -28,6 +29,9 @@ class SignInWithEmailDialog extends StatefulWidget {
   /// The minimum length of the password.
   final int minPasswordLength;
 
+  /// Optional labels for the sign in with email dialog.
+  final SignInWithEmailDialogLabels? labels;
+
   /// Creates a new sign in with email dialog.
   const SignInWithEmailDialog({
     super.key,
@@ -35,6 +39,7 @@ class SignInWithEmailDialog extends StatefulWidget {
     required this.onSignedIn,
     this.maxPasswordLength = _defaultMaxPasswordLength,
     this.minPasswordLength = _defaultMinPasswordLength,
+    this.labels,
   });
 
   @override
@@ -78,7 +83,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _usernameController,
           keyboardType: TextInputType.name,
           decoration: InputDecoration(
-            hintText: 'User name',
+            hintText: widget.labels?.userName ?? 'User name',
             helperText: ' ',
             errorText: _userNameIssue,
           ),
@@ -93,7 +98,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: 'Email',
+            hintText: widget.labels?.email ?? 'Email',
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -108,7 +113,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: _isPasswordObscured,
           decoration: InputDecoration(
-            hintText: 'Password',
+            hintText: widget.labels?.password ?? 'Password',
             helperText: ' ',
             errorText: _passwordIssue,
             suffixIcon: IconButton(
@@ -133,7 +138,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _createAccount : null,
-          child: const Text('Create Account'),
+          child: Text(widget.labels?.createAccount ?? 'Create Account'),
         ),
         TextButton(
           onPressed: _enabled
@@ -143,7 +148,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: const Text('I have an account'),
+          child: Text(widget.labels?.iHaveAnAccount ?? 'I have an account'),
         ),
       ];
     } else if (_page == _Page.signIn) {
@@ -153,7 +158,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: 'Email',
+            hintText: widget.labels?.email ?? 'Email',
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -168,7 +173,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: _isPasswordObscured,
           decoration: InputDecoration(
-            hintText: 'Password',
+            hintText: widget.labels?.password ?? 'Password',
             helperText: ' ',
             errorText: _passwordIssue,
             suffixIcon: IconButton(
@@ -193,7 +198,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _signIn : null,
-          child: const Text('Sign In'),
+          child: Text(widget.labels?.signIn ?? 'Sign In'),
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
@@ -204,7 +209,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   _page = _Page.forgotPassword;
                 });
               },
-              child: const Text('Forgot Pass'),
+              child: Text(widget.labels?.forgotPassword ?? 'Forgot Pass'),
             ),
             const Spacer(),
             TextButton(
@@ -215,7 +220,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                       });
                     }
                   : null,
-              child: const Text('Create Account'),
+              child: Text(widget.labels?.createAccount ?? 'Create Account'),
             ),
           ],
         ),
@@ -227,7 +232,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: 'Email',
+            hintText: widget.labels?.email ?? 'Email',
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -242,7 +247,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _initiatePasswordReset : null,
-          child: const Text('Reset Password'),
+          child: Text(widget.labels?.resetPassword ?? 'Reset Password'),
         ),
         TextButton(
           onPressed: _enabled
@@ -252,13 +257,14 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: const Text('Back'),
+          child: Text(widget.labels?.back ?? 'Back'),
         ),
       ];
     } else if (_page == _Page.confirmEmail) {
       widgets = [
-        const Text(
-          'Please check your email. We have sent you a code to verify your address.',
+        Text(
+          widget.labels?.confirmEmailMessage ??
+              'Please check your email. We have sent you a code to verify your address.',
         ),
         const SizedBox(
           height: 16,
@@ -268,7 +274,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _validationCodeController,
           keyboardType: TextInputType.text,
           decoration: InputDecoration(
-            hintText: 'Validation code',
+            hintText: widget.labels?.validationCode ?? 'Validation code',
             helperText: ' ',
             errorText: _validationCodeIssue,
           ),
@@ -283,7 +289,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _validateAccount : null,
-          child: const Text('Sign In'),
+          child: Text(widget.labels?.signIn ?? 'Sign In'),
         ),
         TextButton(
           onPressed: _enabled
@@ -293,13 +299,14 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: const Text('Back'),
+          child: Text(widget.labels?.back ?? 'Back'),
         ),
       ];
     } else if (_page == _Page.confirmPasswordReset) {
       widgets = [
-        const Text(
-          'Please check your email. We have sent you a code to verify your account.',
+        Text(
+          widget.labels?.confirmPasswordResetMessage ??
+              'Please check your email. We have sent you a code to verify your account.',
         ),
         const SizedBox(
           height: 16,
@@ -309,7 +316,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _validationCodeController,
           keyboardType: TextInputType.text,
           decoration: InputDecoration(
-            hintText: 'Validation code',
+            hintText: widget.labels?.validationCode ?? 'Validation code',
             helperText: ' ',
             errorText: _validationCodeIssue,
           ),
@@ -325,7 +332,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: true,
           decoration: InputDecoration(
-            hintText: 'New password',
+            hintText: widget.labels?.newPassword ?? 'New password',
             helperText: ' ',
             errorText: _passwordIssue,
           ),
@@ -340,7 +347,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _resetPassword : null,
-          child: const Text('Sign In'),
+          child: Text(widget.labels?.signIn ?? 'Sign In'),
         ),
         TextButton(
           onPressed: _enabled
@@ -350,7 +357,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: const Text('Back'),
+          child: Text(widget.labels?.back ?? 'Back'),
         ),
       ];
     } else {
@@ -375,7 +382,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var userName = _usernameController.text.trim();
     if (userName.isEmpty) {
       setState(() {
-        _userNameIssue = 'Please enter a user name';
+        _userNameIssue =
+            widget.labels?.userNameRequired ?? 'Please enter a user name';
       });
       return;
     }
@@ -383,7 +391,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue = 'Invalid email';
+        _emailIssue = widget.labels?.invalidEmail ?? 'Invalid email';
       });
       return;
     }
@@ -391,13 +399,19 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var password = _passwordController.text;
     if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = 'Minimum ${widget.minPasswordLength} characters';
+        _passwordIssue = widget.labels?.minimum != null &&
+                widget.labels?.characters != null
+            ? '${widget.labels?.minimum} ${widget.minPasswordLength} ${widget.labels?.characters}'
+            : 'Minimum ${widget.minPasswordLength} characters';
       });
       return;
     }
     if (password.length > widget.maxPasswordLength) {
       setState(() {
-        _passwordIssue = 'Maximum ${widget.maxPasswordLength} characters';
+        _passwordIssue = widget.labels?.maximum != null &&
+                widget.labels?.characters != null
+            ? '${widget.labels?.maximum} ${widget.maxPasswordLength} ${widget.labels?.characters}'
+            : 'Maximum ${widget.maxPasswordLength} characters';
       });
       return;
     }
@@ -418,7 +432,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
       if (success) {
         _page = _Page.confirmEmail;
       } else {
-        _emailIssue = 'Email already in use';
+        _emailIssue = widget.labels?.emailInUse ?? 'Email already in use';
       }
     });
   }
@@ -427,7 +441,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     _resetIssues();
     if (_validationCodeController.text.isEmpty) {
       setState(() {
-        _validationCodeIssue = 'Enter your code';
+        _validationCodeIssue = widget.labels?.enterCode ?? 'Enter your code';
       });
       return;
     }
@@ -444,7 +458,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
     if (userInfo == null) {
       setState(() {
-        _validationCodeIssue = 'Incorrect code';
+        _validationCodeIssue = widget.labels?.incorrectCode ?? 'Incorrect code';
         _enabled = true;
       });
       return;
@@ -473,7 +487,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue = 'Invalid email';
+        _emailIssue = widget.labels?.invalidEmail ?? 'Invalid email';
       });
       return;
     }
@@ -481,7 +495,10 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var password = _passwordController.text;
     if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = 'Minimum ${widget.minPasswordLength} characters';
+        _passwordIssue = widget.labels?.minimum != null &&
+                widget.labels?.characters != null
+            ? '${widget.labels?.minimum} ${widget.minPasswordLength} ${widget.labels?.characters}'
+            : 'Minimum ${widget.minPasswordLength} characters';
       });
       return;
     }
@@ -494,7 +511,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     if (result == null) {
       // Something went wrong, start over
       setState(() {
-        _passwordIssue = 'Incorrect password';
+        _passwordIssue = widget.labels?.incorrectCode ?? 'Incorrect password';
         _enabled = true;
       });
       return;
@@ -512,7 +529,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue = 'Invalid email';
+        _emailIssue = widget.labels?.invalidEmail ?? 'Invalid email';
       });
       return;
     }
@@ -533,7 +550,10 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     _resetIssues();
     if (_passwordController.text.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = 'Min ${widget.minPasswordLength} characters';
+        _passwordIssue = widget.labels?.minimum != null &&
+                widget.labels?.characters != null
+            ? '${widget.labels?.minimum} ${widget.minPasswordLength} ${widget.labels?.characters}'
+            : 'Min ${widget.minPasswordLength} characters';
       });
       return;
     }
@@ -552,7 +572,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
     if (!success) {
       setState(() {
-        _validationCodeIssue = 'Incorrect code';
+        _validationCodeIssue = widget.labels?.incorrectCode ?? 'Incorrect code';
         _enabled = true;
       });
       return;
@@ -602,6 +622,7 @@ void showSignInWithEmailDialog({
   required VoidCallback onSignedIn,
   int? maxPasswordLength,
   int? minPasswordLength,
+  SignInWithEmailDialogLabels? labels,
 }) {
   showDialog(
     context: context,
@@ -611,6 +632,7 @@ void showSignInWithEmailDialog({
         onSignedIn: onSignedIn,
         maxPasswordLength: maxPasswordLength ?? _defaultMaxPasswordLength,
         minPasswordLength: minPasswordLength ?? _defaultMinPasswordLength,
+        labels: labels,
       );
     },
   );

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -83,7 +83,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _usernameController,
           keyboardType: TextInputType.name,
           decoration: InputDecoration(
-            hintText: widget.labels?.userName ?? 'User name',
+            hintText: widget.localization?.inputLabelUserName ?? 'User name',
             helperText: ' ',
             errorText: _userNameIssue,
           ),
@@ -98,7 +98,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: widget.labels?.email ?? 'Email',
+            hintText: widget.localization?.inputLabelEmail ?? 'Email',
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -113,7 +113,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: _isPasswordObscured,
           decoration: InputDecoration(
-            hintText: widget.labels?.password ?? 'Password',
+            hintText: widget.localization?.inputLabelPassword ?? 'Password',
             helperText: ' ',
             errorText: _passwordIssue,
             suffixIcon: IconButton(
@@ -138,7 +138,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _createAccount : null,
-          child: Text(widget.labels?.createAccount ?? 'Create Account'),
+          child: Text(widget.localization?.buttonTitleCreateAccount ??
+              'Create Account'),
         ),
         TextButton(
           onPressed: _enabled
@@ -148,7 +149,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.labels?.iHaveAnAccount ?? 'I have an account'),
+          child: Text(widget.localization?.buttonTitleIHaveAccount ??
+              'I have an account'),
         ),
       ];
     } else if (_page == _Page.signIn) {
@@ -158,7 +160,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: widget.labels?.email ?? 'Email',
+            hintText: widget.localization?.inputLabelEmail ?? 'Email',
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -173,7 +175,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: _isPasswordObscured,
           decoration: InputDecoration(
-            hintText: widget.labels?.password ?? 'Password',
+            hintText: widget.localization?.inputLabelPassword ?? 'Password',
             helperText: ' ',
             errorText: _passwordIssue,
             suffixIcon: IconButton(
@@ -198,7 +200,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _signIn : null,
-          child: Text(widget.labels?.signIn ?? 'Sign In'),
+          child: Text(widget.localization?.buttonTitleSignIn ?? 'Sign In'),
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
@@ -209,7 +211,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   _page = _Page.forgotPassword;
                 });
               },
-              child: Text(widget.labels?.forgotPassword ?? 'Forgot Pass'),
+              child: Text(widget.localization?.buttonTitleForgotPassword ??
+                  'Forgot Pass'),
             ),
             const Spacer(),
             TextButton(
@@ -220,7 +223,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                       });
                     }
                   : null,
-              child: Text(widget.labels?.createAccount ?? 'Create Account'),
+              child: Text(widget.localization?.buttonTitleCreateAccount ??
+                  'Create Account'),
             ),
           ],
         ),
@@ -232,7 +236,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: widget.labels?.email ?? 'Email',
+            hintText: widget.localization?.inputLabelEmail ?? 'Email',
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -247,7 +251,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _initiatePasswordReset : null,
-          child: Text(widget.labels?.resetPassword ?? 'Reset Password'),
+          child: Text(widget.localization?.buttonTitleResetPassword ??
+              'Reset Password'),
         ),
         TextButton(
           onPressed: _enabled
@@ -257,13 +262,13 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.labels?.back ?? 'Back'),
+          child: Text(widget.localization?.buttonTitleBack ?? 'Back'),
         ),
       ];
     } else if (_page == _Page.confirmEmail) {
       widgets = [
         Text(
-          widget.labels?.confirmEmailMessage ??
+          widget.localization?.messageEmailVerificationSent ??
               'Please check your email. We have sent you a code to verify your address.',
         ),
         const SizedBox(
@@ -274,7 +279,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _validationCodeController,
           keyboardType: TextInputType.text,
           decoration: InputDecoration(
-            hintText: widget.labels?.validationCode ?? 'Validation code',
+            hintText: widget.localization?.inputLabelValidationCode ??
+                'Validation code',
             helperText: ' ',
             errorText: _validationCodeIssue,
           ),
@@ -289,7 +295,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _validateAccount : null,
-          child: Text(widget.labels?.signIn ?? 'Sign In'),
+          child: Text(widget.localization?.buttonTitleSignIn ?? 'Sign In'),
         ),
         TextButton(
           onPressed: _enabled
@@ -299,13 +305,13 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.labels?.back ?? 'Back'),
+          child: Text(widget.localization?.buttonTitleBack ?? 'Back'),
         ),
       ];
     } else if (_page == _Page.confirmPasswordReset) {
       widgets = [
         Text(
-          widget.labels?.confirmPasswordResetMessage ??
+          widget.localization?.messagePasswordResetSent ??
               'Please check your email. We have sent you a code to verify your account.',
         ),
         const SizedBox(
@@ -316,7 +322,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _validationCodeController,
           keyboardType: TextInputType.text,
           decoration: InputDecoration(
-            hintText: widget.labels?.validationCode ?? 'Validation code',
+            hintText: widget.localization?.inputLabelValidationCode ??
+                'Validation code',
             helperText: ' ',
             errorText: _validationCodeIssue,
           ),
@@ -332,7 +339,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: true,
           decoration: InputDecoration(
-            hintText: widget.labels?.newPassword ?? 'New password',
+            hintText:
+                widget.localization?.inputLabelNewPassword ?? 'New password',
             helperText: ' ',
             errorText: _passwordIssue,
           ),
@@ -347,7 +355,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _resetPassword : null,
-          child: Text(widget.labels?.signIn ?? 'Sign In'),
+          child: Text(widget.localization?.buttonTitleSignIn ?? 'Sign In'),
         ),
         TextButton(
           onPressed: _enabled
@@ -357,7 +365,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.labels?.back ?? 'Back'),
+          child: Text(widget.localization?.buttonTitleBack ?? 'Back'),
         ),
       ];
     } else {
@@ -382,8 +390,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var userName = _usernameController.text.trim();
     if (userName.isEmpty) {
       setState(() {
-        _userNameIssue =
-            widget.labels?.userNameRequired ?? 'Please enter a user name';
+        _userNameIssue = widget.localization?.errorMessageUserNameRequired ??
+            'Please enter a user name';
       });
       return;
     }
@@ -391,7 +399,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue = widget.labels?.invalidEmail ?? 'Invalid email';
+        _emailIssue =
+            widget.localization?.errorMessageInvalidEmail ?? 'Invalid email';
       });
       return;
     }
@@ -399,19 +408,17 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var password = _passwordController.text;
     if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = widget.labels?.minimum != null &&
-                widget.labels?.characters != null
-            ? '${widget.labels?.minimum} ${widget.minPasswordLength} ${widget.labels?.characters}'
-            : 'Minimum ${widget.minPasswordLength} characters';
+        _passwordIssue = widget.localization?.minimumLengthMessage
+                ?.call(widget.minPasswordLength) ??
+            'Minimum ${widget.minPasswordLength} characters';
       });
       return;
     }
     if (password.length > widget.maxPasswordLength) {
       setState(() {
-        _passwordIssue = widget.labels?.maximum != null &&
-                widget.labels?.characters != null
-            ? '${widget.labels?.maximum} ${widget.maxPasswordLength} ${widget.labels?.characters}'
-            : 'Maximum ${widget.maxPasswordLength} characters';
+        _passwordIssue = widget.localization?.maximumLengthMessage
+                ?.call(widget.maxPasswordLength) ??
+            'Maximum ${widget.maxPasswordLength} characters';
       });
       return;
     }
@@ -432,7 +439,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
       if (success) {
         _page = _Page.confirmEmail;
       } else {
-        _emailIssue = widget.labels?.emailInUse ?? 'Email already in use';
+        _emailIssue = widget.localization?.errorMessageEmailInUse ??
+            'Email already in use';
       }
     });
   }
@@ -441,7 +449,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     _resetIssues();
     if (_validationCodeController.text.isEmpty) {
       setState(() {
-        _validationCodeIssue = widget.labels?.enterCode ?? 'Enter your code';
+        _validationCodeIssue =
+            widget.localization?.messageEnterCode ?? 'Enter your code';
       });
       return;
     }
@@ -458,7 +467,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
     if (userInfo == null) {
       setState(() {
-        _validationCodeIssue = widget.labels?.incorrectCode ?? 'Incorrect code';
+        _validationCodeIssue =
+            widget.localization?.errorMessageIncorrectCode ?? 'Incorrect code';
         _enabled = true;
       });
       return;
@@ -487,7 +497,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue = widget.labels?.invalidEmail ?? 'Invalid email';
+        _emailIssue =
+            widget.localization?.errorMessageInvalidEmail ?? 'Invalid email';
       });
       return;
     }
@@ -495,10 +506,9 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var password = _passwordController.text;
     if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = widget.labels?.minimum != null &&
-                widget.labels?.characters != null
-            ? '${widget.labels?.minimum} ${widget.minPasswordLength} ${widget.labels?.characters}'
-            : 'Minimum ${widget.minPasswordLength} characters';
+        _passwordIssue = widget.localization?.minimumLengthMessage
+                ?.call(widget.minPasswordLength) ??
+            'Minimum ${widget.minPasswordLength} characters';
       });
       return;
     }
@@ -511,7 +521,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     if (result == null) {
       // Something went wrong, start over
       setState(() {
-        _passwordIssue = widget.labels?.incorrectCode ?? 'Incorrect password';
+        _passwordIssue = widget.localization?.errorMessageIncorrectPassword ??
+            'Incorrect password';
         _enabled = true;
       });
       return;
@@ -529,7 +540,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue = widget.labels?.invalidEmail ?? 'Invalid email';
+        _emailIssue =
+            widget.localization?.errorMessageInvalidEmail ?? 'Invalid email';
       });
       return;
     }
@@ -550,10 +562,9 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     _resetIssues();
     if (_passwordController.text.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = widget.labels?.minimum != null &&
-                widget.labels?.characters != null
-            ? '${widget.labels?.minimum} ${widget.minPasswordLength} ${widget.labels?.characters}'
-            : 'Min ${widget.minPasswordLength} characters';
+        _passwordIssue = widget.localization?.minimumLengthMessage
+                ?.call(widget.minPasswordLength) ??
+            'Minimum ${widget.minPasswordLength} characters';
       });
       return;
     }
@@ -572,7 +583,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
     if (!success) {
       setState(() {
-        _validationCodeIssue = widget.labels?.incorrectCode ?? 'Incorrect code';
+        _validationCodeIssue =
+            widget.localization?.errorMessageIncorrectCode ?? 'Incorrect code';
         _enabled = true;
       });
       return;
@@ -622,7 +634,7 @@ void showSignInWithEmailDialog({
   required VoidCallback onSignedIn,
   int? maxPasswordLength,
   int? minPasswordLength,
-  SignInWithEmailDialogLabels? labels,
+  SignInWithEmailDialogLabels? localization,
 }) {
   showDialog(
     context: context,
@@ -632,7 +644,7 @@ void showSignInWithEmailDialog({
         onSignedIn: onSignedIn,
         maxPasswordLength: maxPasswordLength ?? _defaultMaxPasswordLength,
         minPasswordLength: minPasswordLength ?? _defaultMinPasswordLength,
-        labels: labels,
+        localization: localization,
       );
     },
   );

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -30,6 +30,7 @@ class SignInWithEmailDialog extends StatefulWidget {
   final int minPasswordLength;
 
   /// Optional labels for the sign in with email dialog.
+  /// If null, default English labels will be used.
   final SignInWithEmailDialogLabels? localization;
 
   /// Creates a new sign in with email dialog.
@@ -60,6 +61,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   String? _validationCodeIssue;
 
   late final EmailAuthController _emailAuth;
+  late final SignInWithEmailDialogLabels _localization;
 
   _Page _page = _Page.createAccount;
 
@@ -70,6 +72,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
   void initState() {
     super.initState();
     _emailAuth = EmailAuthController(widget.caller);
+    _localization = widget.localization ?? SignInWithEmailDialogLabels.enUS();
   }
 
   @override
@@ -83,7 +86,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _usernameController,
           keyboardType: TextInputType.name,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelUserName ?? 'User name',
+            hintText: _localization.inputHintUserName,
             helperText: ' ',
             errorText: _userNameIssue,
           ),
@@ -98,7 +101,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelEmail ?? 'Email',
+            hintText: _localization.inputHintEmail,
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -113,7 +116,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: _isPasswordObscured,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelPassword ?? 'Password',
+            hintText: _localization.inputHintPassword,
             helperText: ' ',
             errorText: _passwordIssue,
             suffixIcon: IconButton(
@@ -138,8 +141,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _createAccount : null,
-          child: Text(widget.localization?.buttonTitleCreateAccount ??
-              'Create Account'),
+          child: Text(_localization.buttonTitleCreateAccount),
         ),
         TextButton(
           onPressed: _enabled
@@ -149,8 +151,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.localization?.buttonTitleIHaveAccount ??
-              'I have an account'),
+          child: Text(_localization.buttonTitleIHaveAccount),
         ),
       ];
     } else if (_page == _Page.signIn) {
@@ -160,7 +161,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelEmail ?? 'Email',
+            hintText: _localization.inputHintEmail,
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -175,7 +176,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: _isPasswordObscured,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelPassword ?? 'Password',
+            hintText: _localization.inputHintPassword,
             helperText: ' ',
             errorText: _passwordIssue,
             suffixIcon: IconButton(
@@ -200,7 +201,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _signIn : null,
-          child: Text(widget.localization?.buttonTitleSignIn ?? 'Sign In'),
+          child: Text(_localization.buttonTitleSignIn),
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
@@ -211,8 +212,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   _page = _Page.forgotPassword;
                 });
               },
-              child: Text(widget.localization?.buttonTitleForgotPassword ??
-                  'Forgot Pass'),
+              child: Text(_localization.buttonTitleForgotPassword),
             ),
             const Spacer(),
             TextButton(
@@ -223,8 +223,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                       });
                     }
                   : null,
-              child: Text(widget.localization?.buttonTitleCreateAccount ??
-                  'Create Account'),
+              child: Text(_localization.buttonTitleCreateAccount),
             ),
           ],
         ),
@@ -236,7 +235,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _emailController,
           keyboardType: TextInputType.emailAddress,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelEmail ?? 'Email',
+            hintText: _localization.inputHintEmail,
             helperText: ' ',
             errorText: _emailIssue,
           ),
@@ -251,8 +250,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _initiatePasswordReset : null,
-          child: Text(widget.localization?.buttonTitleResetPassword ??
-              'Reset Password'),
+          child: Text(_localization.buttonTitleResetPassword),
         ),
         TextButton(
           onPressed: _enabled
@@ -262,14 +260,13 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.localization?.buttonTitleBack ?? 'Back'),
+          child: Text(_localization.buttonTitleBack),
         ),
       ];
     } else if (_page == _Page.confirmEmail) {
       widgets = [
         Text(
-          widget.localization?.messageEmailVerificationSent ??
-              'Please check your email. We have sent you a code to verify your address.',
+          _localization.messageEmailVerificationSent,
         ),
         const SizedBox(
           height: 16,
@@ -279,8 +276,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _validationCodeController,
           keyboardType: TextInputType.text,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelValidationCode ??
-                'Validation code',
+            hintText: _localization.inputHintValidationCode,
             helperText: ' ',
             errorText: _validationCodeIssue,
           ),
@@ -295,7 +291,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _validateAccount : null,
-          child: Text(widget.localization?.buttonTitleSignIn ?? 'Sign In'),
+          child: Text(_localization.buttonTitleSignIn),
         ),
         TextButton(
           onPressed: _enabled
@@ -305,14 +301,13 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.localization?.buttonTitleBack ?? 'Back'),
+          child: Text(_localization.buttonTitleBack),
         ),
       ];
     } else if (_page == _Page.confirmPasswordReset) {
       widgets = [
         Text(
-          widget.localization?.messagePasswordResetSent ??
-              'Please check your email. We have sent you a code to verify your account.',
+          _localization.messagePasswordResetSent,
         ),
         const SizedBox(
           height: 16,
@@ -322,8 +317,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _validationCodeController,
           keyboardType: TextInputType.text,
           decoration: InputDecoration(
-            hintText: widget.localization?.inputLabelValidationCode ??
-                'Validation code',
+            hintText: _localization.inputHintValidationCode,
             helperText: ' ',
             errorText: _validationCodeIssue,
           ),
@@ -339,8 +333,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
           controller: _passwordController,
           obscureText: true,
           decoration: InputDecoration(
-            hintText:
-                widget.localization?.inputLabelNewPassword ?? 'New password',
+            hintText: _localization.inputHintNewPassword,
             helperText: ' ',
             errorText: _passwordIssue,
           ),
@@ -355,7 +348,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _resetPassword : null,
-          child: Text(widget.localization?.buttonTitleSignIn ?? 'Sign In'),
+          child: Text(_localization.buttonTitleSignIn),
         ),
         TextButton(
           onPressed: _enabled
@@ -365,7 +358,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(widget.localization?.buttonTitleBack ?? 'Back'),
+          child: Text(_localization.buttonTitleBack),
         ),
       ];
     } else {
@@ -390,8 +383,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var userName = _usernameController.text.trim();
     if (userName.isEmpty) {
       setState(() {
-        _userNameIssue = widget.localization?.errorMessageUserNameRequired ??
-            'Please enter a user name';
+        _userNameIssue = _localization.errorMessageUserNameRequired;
       });
       return;
     }
@@ -399,8 +391,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue =
-            widget.localization?.errorMessageInvalidEmail ?? 'Invalid email';
+        _emailIssue = _localization.errorMessageInvalidEmail;
       });
       return;
     }
@@ -408,17 +399,15 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var password = _passwordController.text;
     if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = widget.localization?.minimumLengthMessage
-                ?.call(widget.minPasswordLength) ??
-            'Minimum ${widget.minPasswordLength} characters';
+        _passwordIssue =
+            _localization.minimumLengthMessage(widget.minPasswordLength);
       });
       return;
     }
     if (password.length > widget.maxPasswordLength) {
       setState(() {
-        _passwordIssue = widget.localization?.maximumLengthMessage
-                ?.call(widget.maxPasswordLength) ??
-            'Maximum ${widget.maxPasswordLength} characters';
+        _passwordIssue =
+            _localization.maximumLengthMessage(widget.maxPasswordLength);
       });
       return;
     }
@@ -439,8 +428,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
       if (success) {
         _page = _Page.confirmEmail;
       } else {
-        _emailIssue = widget.localization?.errorMessageEmailInUse ??
-            'Email already in use';
+        _emailIssue = _localization.errorMessageEmailInUse;
       }
     });
   }
@@ -449,8 +437,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     _resetIssues();
     if (_validationCodeController.text.isEmpty) {
       setState(() {
-        _validationCodeIssue =
-            widget.localization?.messageEnterCode ?? 'Enter your code';
+        _validationCodeIssue = _localization.messageEnterCode;
       });
       return;
     }
@@ -467,8 +454,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
     if (userInfo == null) {
       setState(() {
-        _validationCodeIssue =
-            widget.localization?.errorMessageIncorrectCode ?? 'Incorrect code';
+        _validationCodeIssue = _localization.errorMessageIncorrectCode;
         _enabled = true;
       });
       return;
@@ -497,8 +483,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue =
-            widget.localization?.errorMessageInvalidEmail ?? 'Invalid email';
+        _emailIssue = _localization.errorMessageInvalidEmail;
       });
       return;
     }
@@ -506,9 +491,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var password = _passwordController.text;
     if (password.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = widget.localization?.minimumLengthMessage
-                ?.call(widget.minPasswordLength) ??
-            'Minimum ${widget.minPasswordLength} characters';
+        _passwordIssue =
+            _localization.minimumLengthMessage(widget.minPasswordLength);
       });
       return;
     }
@@ -521,8 +505,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     if (result == null) {
       // Something went wrong, start over
       setState(() {
-        _passwordIssue = widget.localization?.errorMessageIncorrectPassword ??
-            'Incorrect password';
+        _passwordIssue = _localization.errorMessageIncorrectPassword;
         _enabled = true;
       });
       return;
@@ -540,8 +523,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     var email = _emailController.text.trim().toLowerCase();
     if (!EmailValidator.validate(email)) {
       setState(() {
-        _emailIssue =
-            widget.localization?.errorMessageInvalidEmail ?? 'Invalid email';
+        _emailIssue = _localization.errorMessageInvalidEmail;
       });
       return;
     }
@@ -562,9 +544,8 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
     _resetIssues();
     if (_passwordController.text.length < widget.minPasswordLength) {
       setState(() {
-        _passwordIssue = widget.localization?.minimumLengthMessage
-                ?.call(widget.minPasswordLength) ??
-            'Minimum ${widget.minPasswordLength} characters';
+        _passwordIssue =
+            _localization.minimumLengthMessage(widget.minPasswordLength);
       });
       return;
     }
@@ -583,8 +564,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
     if (!success) {
       setState(() {
-        _validationCodeIssue =
-            widget.localization?.errorMessageIncorrectCode ?? 'Incorrect code';
+        _validationCodeIssue = _localization.errorMessageIncorrectCode;
         _enabled = true;
       });
       return;

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -141,7 +141,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         ),
         ElevatedButton(
           onPressed: _enabled ? _createAccount : null,
-          child: Text(_localization.buttonTitleCreateAccount),
+          child: Text(_localization.buttonTitleSignUp),
         ),
         TextButton(
           onPressed: _enabled
@@ -151,7 +151,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                   });
                 }
               : null,
-          child: Text(_localization.buttonTitleIHaveAccount),
+          child: Text(_localization.buttonTitleOpenSignIn),
         ),
       ];
     } else if (_page == _Page.signIn) {
@@ -223,7 +223,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
                       });
                     }
                   : null,
-              child: Text(_localization.buttonTitleCreateAccount),
+              child: Text(_localization.buttonTitleOpenSignUp),
             ),
           ],
         ),

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -30,7 +30,7 @@ class SignInWithEmailDialog extends StatefulWidget {
   final int minPasswordLength;
 
   /// Optional labels for the sign in with email dialog.
-  final SignInWithEmailDialogLabels? labels;
+  final SignInWithEmailDialogLabels? localization;
 
   /// Creates a new sign in with email dialog.
   const SignInWithEmailDialog({
@@ -39,7 +39,7 @@ class SignInWithEmailDialog extends StatefulWidget {
     required this.onSignedIn,
     this.maxPasswordLength = _defaultMaxPasswordLength,
     this.minPasswordLength = _defaultMinPasswordLength,
-    this.labels,
+    this.localization,
   });
 
   @override

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
@@ -1,0 +1,95 @@
+/// A collection of [String] used in the `SignInWithEmailDialog`.
+/// When [null] the default/english labels will be used.
+class SignInWithEmailDialogLabels {
+  /// [TextField] label for `User name`.
+  String? userName;
+
+  /// [TextField] label for `Email`.
+  String? email;
+
+  /// [TextField] label for `Password`.
+  String? password;
+
+  /// [Button] text for `Create Account`.
+  String? createAccount;
+
+  /// [Button] text for `I have an account`.
+  String? iHaveAnAccount;
+
+  /// [Button] text for `Sign In`.
+  String? signIn;
+
+  /// [Button] text for `Forgot Pass`.
+  String? forgotPassword;
+
+  /// [Button] text for `Reset Password`.
+  String? resetPassword;
+
+  /// [TextField] label for `New Password`.
+  String? newPassword;
+
+  /// [Button] text for `Back`.
+  String? back;
+
+  /// [Text] for `Please check your email. We have sent you a code to verify your address.`.
+  String? confirmEmailMessage;
+
+  /// [TextField] label for `Validation Code`.
+  String? validationCode;
+
+  /// [Text] for `Please check your email. We have sent you a code to verify your account.`.
+  String? confirmPasswordResetMessage;
+
+  /// [Text] for `Please enter a user name`.
+  String? userNameRequired;
+
+  /// [Text] for `Invalid email`.
+  String? invalidEmail;
+
+  /// [Text] for `Minimum`. Used in `Minimum ${passwordLength} characters`.
+  String? minimum;
+
+  /// [Text] for `Maximum`. Used in `Maximum ${passwordLength} characters`.
+  String? maximum;
+
+  /// [Text] for `characters`. Used in `Minimum ${passwordLength} characters` and `Maximum ${passwordLength} characters`.
+  String? characters;
+
+  /// [Text] for `Email already in use`.
+  String? emailInUse;
+
+  /// [Text] for `Enter your code`.
+  String? enterCode;
+
+  /// [Text] for `Incorrect code`.
+  String? incorrectCode;
+
+  /// [Text] for `Incorrect password`.
+  String? incorrectPassword;
+
+  /// Optional labels for the `SignInWithEmailDialog`.
+  SignInWithEmailDialogLabels({
+    this.userName,
+    this.email,
+    this.password,
+    this.createAccount,
+    this.iHaveAnAccount,
+    this.signIn,
+    this.forgotPassword,
+    this.resetPassword,
+    this.newPassword,
+    this.back,
+    this.confirmEmailMessage,
+    this.validationCode,
+    this.confirmPasswordResetMessage,
+    this.userNameRequired,
+    this.invalidEmail,
+    this.minimum,
+    this.maximum,
+    this.characters,
+    this.emailInUse,
+    this.enterCode,
+    this.incorrectCode,
+    this.incorrectPassword,
+  });
+}

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
@@ -13,16 +13,20 @@ class SignInWithEmailDialogLabels {
   /// Used in both sign-in and sign-up forms TextField.
   final String inputHintPassword;
 
-  /// Button text for creating a new account.
-  /// Used in the main dialog when in sign-up mode.
-  final String buttonTitleCreateAccount;
+  /// Button text for the sign-up submit button.
+  /// Used in the sign-up form to create a new account.
+  final String buttonTitleSignUp;
 
-  /// Button text for switching to sign-in mode.
-  /// Used in the sign-up form to switch back to sign-in.
-  final String buttonTitleIHaveAccount;
+  /// Button text for navigating to sign-up form.
+  /// Used in the sign-in form to switch to account creation.
+  final String buttonTitleOpenSignUp;
 
-  /// Button text for signing in.
-  /// Used in the main dialog when in sign-in mode.
+  /// Button text for navigating to sign-in form.
+  /// Used in the sign-up form to return to sign-in.
+  final String buttonTitleOpenSignIn;
+
+  /// Button text for the sign-in submit button.
+  /// Used in the sign-in form to authenticate the user.
   final String buttonTitleSignIn;
 
   /// Button text for the forgot password option.
@@ -93,8 +97,9 @@ class SignInWithEmailDialogLabels {
     required this.inputHintUserName,
     required this.inputHintEmail,
     required this.inputHintPassword,
-    required this.buttonTitleCreateAccount,
-    required this.buttonTitleIHaveAccount,
+    required this.buttonTitleSignUp,
+    required this.buttonTitleOpenSignUp,
+    required this.buttonTitleOpenSignIn,
     required this.buttonTitleSignIn,
     required this.buttonTitleForgotPassword,
     required this.buttonTitleResetPassword,
@@ -119,8 +124,9 @@ class SignInWithEmailDialogLabels {
     String? inputHintUserName,
     String? inputHintEmail,
     String? inputHintPassword,
-    String? buttonTitleCreateAccount,
-    String? buttonTitleIHaveAccount,
+    String? buttonTitleSignUp,
+    String? buttonTitleOpenSignUp,
+    String? buttonTitleOpenSignIn,
     String? buttonTitleSignIn,
     String? buttonTitleForgotPassword,
     String? buttonTitleResetPassword,
@@ -142,8 +148,9 @@ class SignInWithEmailDialogLabels {
       inputHintUserName: inputHintUserName ?? 'User name',
       inputHintEmail: inputHintEmail ?? 'Email',
       inputHintPassword: inputHintPassword ?? 'Password',
-      buttonTitleCreateAccount: buttonTitleCreateAccount ?? 'Create Account',
-      buttonTitleIHaveAccount: buttonTitleIHaveAccount ?? 'I have an account',
+      buttonTitleSignUp: buttonTitleSignUp ?? 'Sign Up',
+      buttonTitleOpenSignUp: buttonTitleOpenSignUp ?? 'Create Account',
+      buttonTitleOpenSignIn: buttonTitleOpenSignIn ?? 'I have an account',
       buttonTitleSignIn: buttonTitleSignIn ?? 'Sign In',
       buttonTitleForgotPassword: buttonTitleForgotPassword ?? 'Forgot Pass',
       buttonTitleResetPassword: buttonTitleResetPassword ?? 'Reset Password',

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
@@ -1,114 +1,171 @@
 /// A collection of [String] used in the `SignInWithEmailDialog`.
 /// When [null] the default/english labels will be used.
 class SignInWithEmailDialogLabels {
-  /// Label text for the username input field.
+  /// Hint text for the username input field.
   /// Used in the sign-up form TextField.
-  String? inputLabelUserName;
+  final String inputHintUserName;
 
-  /// Label text for the email input field.
+  /// Hint text for the email input field.
   /// Used in both sign-in and sign-up forms TextField.
-  String? inputLabelEmail;
+  final String inputHintEmail;
 
-  /// Label text for the password input field.
+  /// Hint text for the password input field.
   /// Used in both sign-in and sign-up forms TextField.
-  String? inputLabelPassword;
+  final String inputHintPassword;
 
   /// Button text for creating a new account.
   /// Used in the main dialog when in sign-up mode.
-  String? buttonTitleCreateAccount;
+  final String buttonTitleCreateAccount;
 
   /// Button text for switching to sign-in mode.
   /// Used in the sign-up form to switch back to sign-in.
-  String? buttonTitleIHaveAccount;
+  final String buttonTitleIHaveAccount;
 
   /// Button text for signing in.
   /// Used in the main dialog when in sign-in mode.
-  String? buttonTitleSignIn;
+  final String buttonTitleSignIn;
 
   /// Button text for the forgot password option.
   /// Used in the sign-in form below the password field.
-  String? buttonTitleForgotPassword;
+  final String buttonTitleForgotPassword;
 
   /// Button text for initiating password reset.
   /// Used in the password reset form.
-  String? buttonTitleResetPassword;
+  final String buttonTitleResetPassword;
 
-  /// Label text for the new password input field.
+  /// Hint text for the new password input field.
   /// Used in the password reset form TextField.
-  String? inputLabelNewPassword;
+  final String inputHintNewPassword;
 
   /// Button text for navigating back.
   /// Used in various forms to return to the previous screen.
-  String? buttonTitleBack;
+  final String buttonTitleBack;
 
   /// Message shown after sending email verification code.
   /// Displayed in the email verification screen.
-  String? messageEmailVerificationSent;
+  final String messageEmailVerificationSent;
 
-  /// Label text for the validation code input field.
+  /// Hint text for the validation code input field.
   /// Used in both email verification and password reset forms TextField.
-  String? inputLabelValidationCode;
+  final String inputHintValidationCode;
 
   /// Message shown after sending password reset code.
   /// Displayed in the password reset verification screen.
-  String? messagePasswordResetSent;
+  final String messagePasswordResetSent;
 
   /// Error message shown when username is empty.
   /// Displayed under the username field in sign-up form.
-  String? errorMessageUserNameRequired;
+  final String errorMessageUserNameRequired;
 
   /// Error message shown for invalid email format.
   /// Displayed under the email field in both sign-in and sign-up forms.
-  String? errorMessageInvalidEmail;
+  final String errorMessageInvalidEmail;
 
   /// Callback function that returns a formatted string for minimum length validation.
   /// Takes the required length as a parameter.
   /// Used for password length validation messages.
-  String Function(int length)? minimumLengthMessage;
+  final String Function(int length) minimumLengthMessage;
 
   /// Callback function that returns a formatted string for maximum length validation.
   /// Takes the maximum allowed length as a parameter.
   /// Used for password length validation messages.
-  String Function(int length)? maximumLengthMessage;
+  final String Function(int length) maximumLengthMessage;
 
   /// Error message shown when email is already registered.
   /// Displayed under the email field in sign-up form.
-  String? errorMessageEmailInUse;
+  final String errorMessageEmailInUse;
 
   /// Message prompting to enter verification code.
   /// Used in both email verification and password reset screens.
-  String? messageEnterCode;
+  final String messageEnterCode;
 
   /// Error message shown when verification code is incorrect.
   /// Displayed in both email verification and password reset forms.
-  String? errorMessageIncorrectCode;
+  final String errorMessageIncorrectCode;
 
   /// Error message shown when password is incorrect.
   /// Displayed under the password field in sign-in form.
-  String? errorMessageIncorrectPassword;
+  final String errorMessageIncorrectPassword;
 
-  /// Optional labels for the `SignInWithEmailDialog`.
+  /// Constructor for the `SignInWithEmailDialog` labels.
+  /// All parameters are required to ensure complete localization.
   SignInWithEmailDialogLabels({
-    this.inputLabelUserName,
-    this.inputLabelEmail,
-    this.inputLabelPassword,
-    this.buttonTitleCreateAccount,
-    this.buttonTitleIHaveAccount,
-    this.buttonTitleSignIn,
-    this.buttonTitleForgotPassword,
-    this.buttonTitleResetPassword,
-    this.inputLabelNewPassword,
-    this.buttonTitleBack,
-    this.messageEmailVerificationSent,
-    this.inputLabelValidationCode,
-    this.messagePasswordResetSent,
-    this.errorMessageUserNameRequired,
-    this.errorMessageInvalidEmail,
-    this.minimumLengthMessage,
-    this.maximumLengthMessage,
-    this.errorMessageEmailInUse,
-    this.messageEnterCode,
-    this.errorMessageIncorrectCode,
-    this.errorMessageIncorrectPassword,
+    required this.inputHintUserName,
+    required this.inputHintEmail,
+    required this.inputHintPassword,
+    required this.buttonTitleCreateAccount,
+    required this.buttonTitleIHaveAccount,
+    required this.buttonTitleSignIn,
+    required this.buttonTitleForgotPassword,
+    required this.buttonTitleResetPassword,
+    required this.inputHintNewPassword,
+    required this.buttonTitleBack,
+    required this.messageEmailVerificationSent,
+    required this.inputHintValidationCode,
+    required this.messagePasswordResetSent,
+    required this.errorMessageUserNameRequired,
+    required this.errorMessageInvalidEmail,
+    required this.minimumLengthMessage,
+    required this.maximumLengthMessage,
+    required this.errorMessageEmailInUse,
+    required this.messageEnterCode,
+    required this.errorMessageIncorrectCode,
+    required this.errorMessageIncorrectPassword,
   });
+
+  /// Factory constructor that creates a new instance with default English labels.
+  /// Individual values can be overridden by providing them as parameters.
+  factory SignInWithEmailDialogLabels.enUS({
+    String? inputHintUserName,
+    String? inputHintEmail,
+    String? inputHintPassword,
+    String? buttonTitleCreateAccount,
+    String? buttonTitleIHaveAccount,
+    String? buttonTitleSignIn,
+    String? buttonTitleForgotPassword,
+    String? buttonTitleResetPassword,
+    String? inputHintNewPassword,
+    String? buttonTitleBack,
+    String? messageEmailVerificationSent,
+    String? inputHintValidationCode,
+    String? messagePasswordResetSent,
+    String? errorMessageUserNameRequired,
+    String? errorMessageInvalidEmail,
+    String Function(int length)? minimumLengthMessage,
+    String Function(int length)? maximumLengthMessage,
+    String? errorMessageEmailInUse,
+    String? messageEnterCode,
+    String? errorMessageIncorrectCode,
+    String? errorMessageIncorrectPassword,
+  }) {
+    return SignInWithEmailDialogLabels(
+      inputHintUserName: inputHintUserName ?? 'User name',
+      inputHintEmail: inputHintEmail ?? 'Email',
+      inputHintPassword: inputHintPassword ?? 'Password',
+      buttonTitleCreateAccount: buttonTitleCreateAccount ?? 'Create Account',
+      buttonTitleIHaveAccount: buttonTitleIHaveAccount ?? 'I have an account',
+      buttonTitleSignIn: buttonTitleSignIn ?? 'Sign In',
+      buttonTitleForgotPassword: buttonTitleForgotPassword ?? 'Forgot Pass',
+      buttonTitleResetPassword: buttonTitleResetPassword ?? 'Reset Password',
+      inputHintNewPassword: inputHintNewPassword ?? 'New password',
+      buttonTitleBack: buttonTitleBack ?? 'Back',
+      messageEmailVerificationSent: messageEmailVerificationSent ??
+          'Please check your email. We have sent you a code to verify your address.',
+      inputHintValidationCode: inputHintValidationCode ?? 'Validation code',
+      messagePasswordResetSent: messagePasswordResetSent ??
+          'Please check your email. We have sent you a code to verify your account.',
+      errorMessageUserNameRequired:
+          errorMessageUserNameRequired ?? 'Please enter a user name',
+      errorMessageInvalidEmail: errorMessageInvalidEmail ?? 'Invalid email',
+      minimumLengthMessage:
+          minimumLengthMessage ?? ((length) => 'Minimum $length characters'),
+      maximumLengthMessage:
+          maximumLengthMessage ?? ((length) => 'Maximum $length characters'),
+      errorMessageEmailInUse: errorMessageEmailInUse ?? 'Email already in use',
+      messageEnterCode: messageEnterCode ?? 'Enter your code',
+      errorMessageIncorrectCode: errorMessageIncorrectCode ?? 'Incorrect code',
+      errorMessageIncorrectPassword:
+          errorMessageIncorrectPassword ?? 'Incorrect password',
+    );
+  }
 }

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_labels.dart
@@ -1,95 +1,114 @@
 /// A collection of [String] used in the `SignInWithEmailDialog`.
 /// When [null] the default/english labels will be used.
 class SignInWithEmailDialogLabels {
-  /// [TextField] label for `User name`.
-  String? userName;
+  /// Label text for the username input field.
+  /// Used in the sign-up form TextField.
+  String? inputLabelUserName;
 
-  /// [TextField] label for `Email`.
-  String? email;
+  /// Label text for the email input field.
+  /// Used in both sign-in and sign-up forms TextField.
+  String? inputLabelEmail;
 
-  /// [TextField] label for `Password`.
-  String? password;
+  /// Label text for the password input field.
+  /// Used in both sign-in and sign-up forms TextField.
+  String? inputLabelPassword;
 
-  /// [Button] text for `Create Account`.
-  String? createAccount;
+  /// Button text for creating a new account.
+  /// Used in the main dialog when in sign-up mode.
+  String? buttonTitleCreateAccount;
 
-  /// [Button] text for `I have an account`.
-  String? iHaveAnAccount;
+  /// Button text for switching to sign-in mode.
+  /// Used in the sign-up form to switch back to sign-in.
+  String? buttonTitleIHaveAccount;
 
-  /// [Button] text for `Sign In`.
-  String? signIn;
+  /// Button text for signing in.
+  /// Used in the main dialog when in sign-in mode.
+  String? buttonTitleSignIn;
 
-  /// [Button] text for `Forgot Pass`.
-  String? forgotPassword;
+  /// Button text for the forgot password option.
+  /// Used in the sign-in form below the password field.
+  String? buttonTitleForgotPassword;
 
-  /// [Button] text for `Reset Password`.
-  String? resetPassword;
+  /// Button text for initiating password reset.
+  /// Used in the password reset form.
+  String? buttonTitleResetPassword;
 
-  /// [TextField] label for `New Password`.
-  String? newPassword;
+  /// Label text for the new password input field.
+  /// Used in the password reset form TextField.
+  String? inputLabelNewPassword;
 
-  /// [Button] text for `Back`.
-  String? back;
+  /// Button text for navigating back.
+  /// Used in various forms to return to the previous screen.
+  String? buttonTitleBack;
 
-  /// [Text] for `Please check your email. We have sent you a code to verify your address.`.
-  String? confirmEmailMessage;
+  /// Message shown after sending email verification code.
+  /// Displayed in the email verification screen.
+  String? messageEmailVerificationSent;
 
-  /// [TextField] label for `Validation Code`.
-  String? validationCode;
+  /// Label text for the validation code input field.
+  /// Used in both email verification and password reset forms TextField.
+  String? inputLabelValidationCode;
 
-  /// [Text] for `Please check your email. We have sent you a code to verify your account.`.
-  String? confirmPasswordResetMessage;
+  /// Message shown after sending password reset code.
+  /// Displayed in the password reset verification screen.
+  String? messagePasswordResetSent;
 
-  /// [Text] for `Please enter a user name`.
-  String? userNameRequired;
+  /// Error message shown when username is empty.
+  /// Displayed under the username field in sign-up form.
+  String? errorMessageUserNameRequired;
 
-  /// [Text] for `Invalid email`.
-  String? invalidEmail;
+  /// Error message shown for invalid email format.
+  /// Displayed under the email field in both sign-in and sign-up forms.
+  String? errorMessageInvalidEmail;
 
-  /// [Text] for `Minimum`. Used in `Minimum ${passwordLength} characters`.
-  String? minimum;
+  /// Callback function that returns a formatted string for minimum length validation.
+  /// Takes the required length as a parameter.
+  /// Used for password length validation messages.
+  String Function(int length)? minimumLengthMessage;
 
-  /// [Text] for `Maximum`. Used in `Maximum ${passwordLength} characters`.
-  String? maximum;
+  /// Callback function that returns a formatted string for maximum length validation.
+  /// Takes the maximum allowed length as a parameter.
+  /// Used for password length validation messages.
+  String Function(int length)? maximumLengthMessage;
 
-  /// [Text] for `characters`. Used in `Minimum ${passwordLength} characters` and `Maximum ${passwordLength} characters`.
-  String? characters;
+  /// Error message shown when email is already registered.
+  /// Displayed under the email field in sign-up form.
+  String? errorMessageEmailInUse;
 
-  /// [Text] for `Email already in use`.
-  String? emailInUse;
+  /// Message prompting to enter verification code.
+  /// Used in both email verification and password reset screens.
+  String? messageEnterCode;
 
-  /// [Text] for `Enter your code`.
-  String? enterCode;
+  /// Error message shown when verification code is incorrect.
+  /// Displayed in both email verification and password reset forms.
+  String? errorMessageIncorrectCode;
 
-  /// [Text] for `Incorrect code`.
-  String? incorrectCode;
-
-  /// [Text] for `Incorrect password`.
-  String? incorrectPassword;
+  /// Error message shown when password is incorrect.
+  /// Displayed under the password field in sign-in form.
+  String? errorMessageIncorrectPassword;
 
   /// Optional labels for the `SignInWithEmailDialog`.
   SignInWithEmailDialogLabels({
-    this.userName,
-    this.email,
-    this.password,
-    this.createAccount,
-    this.iHaveAnAccount,
-    this.signIn,
-    this.forgotPassword,
-    this.resetPassword,
-    this.newPassword,
-    this.back,
-    this.confirmEmailMessage,
-    this.validationCode,
-    this.confirmPasswordResetMessage,
-    this.userNameRequired,
-    this.invalidEmail,
-    this.minimum,
-    this.maximum,
-    this.characters,
-    this.emailInUse,
-    this.enterCode,
-    this.incorrectCode,
-    this.incorrectPassword,
+    this.inputLabelUserName,
+    this.inputLabelEmail,
+    this.inputLabelPassword,
+    this.buttonTitleCreateAccount,
+    this.buttonTitleIHaveAccount,
+    this.buttonTitleSignIn,
+    this.buttonTitleForgotPassword,
+    this.buttonTitleResetPassword,
+    this.inputLabelNewPassword,
+    this.buttonTitleBack,
+    this.messageEmailVerificationSent,
+    this.inputLabelValidationCode,
+    this.messagePasswordResetSent,
+    this.errorMessageUserNameRequired,
+    this.errorMessageInvalidEmail,
+    this.minimumLengthMessage,
+    this.maximumLengthMessage,
+    this.errorMessageEmailInUse,
+    this.messageEnterCode,
+    this.errorMessageIncorrectCode,
+    this.errorMessageIncorrectPassword,
   });
 }


### PR DESCRIPTION
This PR adds the functionality to localize/internationalize the labels in the `SignInWithEmailDialog`.

The `SignInWithEmailButton` now accepts a (nullable) parameter `localization` of type `SignInWithEmailLabels` consisting of nullable `Strings` or `String Function(int length)?`.


![Selection_037](https://github.com/user-attachments/assets/f837806a-ec12-400b-a07e-b7685c1d19c3)

![Selection_038](https://github.com/user-attachments/assets/e5479bb7-c543-49c5-9e22-f71f1d5799a5)



When passed with valid strings this shows in the UI: 

![spanish-log-in](https://github.com/serverpod/serverpod/assets/136239531/c7113138-7be4-4e4e-a30b-88423ca44259)

If a individual String is `null`, the english fallback is used.

![auth-half-spanish](https://github.com/serverpod/serverpod/assets/136239531/5aea59e6-1a7f-44b2-8b7a-dd9dc46a0e68)



closes #2291 


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

no breaking changes