### PR TITLE
fix: Websocket lifetime improvements

### DIFF
--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -184,9 +184,9 @@ class WebServer {
   }
 
   /// Stops the webserver.
-  void stop() {
+  Future<void> stop() async {
     if (_httpServer != null) {
-      _httpServer!.close();
+      await _httpServer!.close();
     }
     _running = false;
   }

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -185,8 +185,9 @@ class WebServer {
 
   /// Stops the webserver.
   Future<void> stop() async {
-    if (_httpServer != null) {
-      await _httpServer!.close();
+    var localHttpServer = _httpServer;
+    if (localHttpServer != null) {
+      await localHttpServer.close();
     }
     _running = false;
   }

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -388,12 +388,10 @@ class Server {
       );
 
       for (var endpointConnector in endpoints.connectors.values) {
-        session.sessionLogs.currentEndpoint = endpointConnector.endpoint.name;
         await _callStreamOpened(session, endpointConnector.endpoint);
       }
       for (var module in endpoints.modules.values) {
         for (var endpointConnector in module.connectors.values) {
-          session.sessionLogs.currentEndpoint = endpointConnector.endpoint.name;
           await _callStreamOpened(session, endpointConnector.endpoint);
         }
       }
@@ -531,6 +529,7 @@ class Server {
     Endpoint endpoint,
   ) async {
     try {
+      session.sessionLogs.currentEndpoint = endpoint.name;
       var authFailed = await EndpointDispatch.canUserAccessEndpoint(
         () => session.authenticated,
         endpoint.requireLogin,

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -546,6 +546,7 @@ class Server {
     Endpoint endpoint,
   ) async {
     try {
+      session.sessionLogs.currentEndpoint = endpoint.name;
       var authFailed = await EndpointDispatch.canUserAccessEndpoint(
         () => session.authenticated,
         endpoint.requireLogin,

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -3,11 +3,11 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/database/database.dart';
 import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/server/health_check.dart';
+import 'package:serverpod/src/server/websocket_request_handler.dart';
 
 import '../cache/caches.dart';
 
@@ -237,7 +237,8 @@ class Server {
         return;
       }
       webSocket.pingInterval = const Duration(seconds: 30);
-      unawaited(_handleWebsocket(this, webSocket, request));
+      unawaited(
+          WebsocketRequestHandler.handleWebsocket(this, webSocket, request));
       return;
     } else if (uri.path == '/serverpod_cloud_storage') {
       readBody = false;
@@ -373,191 +374,6 @@ class Server {
       Uri uri, String body, HttpRequest request) async {
     var path = uri.pathSegments.join('/');
     return endpoints.handleUriCall(this, path, uri, body, request);
-  }
-
-  static Future<void> _handleWebsocket(
-    Server server,
-    WebSocket webSocket,
-    HttpRequest request,
-  ) async {
-    try {
-      var session = StreamingSession(
-        server: server,
-        uri: request.uri,
-        httpRequest: request,
-        webSocket: webSocket,
-      );
-
-      for (var endpointConnector in server.endpoints.connectors.values) {
-        await _callStreamOpened(session, endpointConnector.endpoint);
-      }
-      for (var module in server.endpoints.modules.values) {
-        for (var endpointConnector in module.connectors.values) {
-          await _callStreamOpened(session, endpointConnector.endpoint);
-        }
-      }
-
-      dynamic error;
-      StackTrace? stackTrace;
-
-      try {
-        await for (String jsonData in webSocket) {
-          var data = jsonDecode(jsonData) as Map;
-
-          // Handle control commands.
-          var command = data['command'] as String?;
-          if (command != null) {
-            var args = data['args'] as Map;
-
-            if (command == 'ping') {
-              webSocket.add(
-                SerializationManager.encodeForProtocol(
-                  {'command': 'pong'},
-                ),
-              );
-            } else if (command == 'auth') {
-              var authKey = args['key'] as String?;
-              session.updateAuthenticationKey(authKey);
-            }
-            continue;
-          }
-
-          // Handle messages passed to endpoints.
-          var endpointName = data['endpoint'] as String;
-          var serialization = data['object'] as Map<String, dynamic>;
-
-          var endpointConnector =
-              server.endpoints.getConnectorByName(endpointName);
-          if (endpointConnector == null) {
-            throw Exception('Endpoint not found: $endpointName');
-          }
-
-          var endpoint = endpointConnector.endpoint;
-          var authFailed = await EndpointDispatch.canUserAccessEndpoint(
-            () => session.authenticated,
-            endpoint.requireLogin,
-            endpoint.requiredScopes,
-          );
-
-          if (authFailed == null) {
-            // Process the message.
-            var startTime = DateTime.now();
-            dynamic messageError;
-            StackTrace? messageStackTrace;
-
-            SerializableModel? message;
-            try {
-              session.sessionLogs.currentEndpoint = endpointName;
-
-              message = server.serializationManager
-                  .deserializeByClassName(serialization);
-
-              if (message == null) throw Exception('Streamed message was null');
-
-              await endpointConnector.endpoint
-                  .handleStreamMessage(session, message);
-            } catch (e, s) {
-              messageError = e;
-              messageStackTrace = s;
-              stderr.writeln('${DateTime.now().toUtc()} Internal server error. '
-                  'Uncaught exception in handleStreamMessage.');
-              stderr.writeln('$e');
-              stderr.writeln('$s');
-            }
-
-            var duration =
-                DateTime.now().difference(startTime).inMicroseconds / 1000000.0;
-            var logManager = session.serverpod.logManager;
-
-            var slow = duration >=
-                logManager
-                    .getLogSettingsForStreamingSession(
-                      endpoint: endpointName,
-                    )
-                    .slowSessionDuration;
-
-            var shouldLog = logManager.shouldLogMessage(
-              session: session,
-              endpoint: endpointName,
-              slow: slow,
-              failed: messageError != null,
-            );
-
-            if (shouldLog) {
-              var logEntry = MessageLogEntry(
-                sessionLogId: session.sessionLogs.temporarySessionId,
-                serverId: server.serverId,
-                messageId: session.currentMessageId,
-                endpoint: endpointName,
-                messageName: serialization['className'],
-                duration: duration,
-                order: session.sessionLogs.currentLogOrderId,
-                error: messageError?.toString(),
-                stackTrace: messageStackTrace?.toString(),
-                slow: slow,
-              );
-              unawaited(logManager.logMessage(session, logEntry));
-
-              session.sessionLogs.currentLogOrderId += 1;
-            }
-
-            session.currentMessageId += 1;
-          }
-        }
-      } catch (e, s) {
-        error = e;
-        stackTrace = s;
-      }
-
-      // TODO: Possibly keep a list of open streams instead
-      for (var endpointConnector in server.endpoints.connectors.values) {
-        await _callStreamClosed(session, endpointConnector.endpoint);
-      }
-      for (var module in server.endpoints.modules.values) {
-        for (var endpointConnector in module.connectors.values) {
-          await _callStreamClosed(session, endpointConnector.endpoint);
-        }
-      }
-      await session.close(error: error, stackTrace: stackTrace);
-    } catch (e, stackTrace) {
-      stderr.writeln('$e');
-      stderr.writeln('$stackTrace');
-      return;
-    }
-  }
-
-  static Future<void> _callStreamOpened(
-    StreamingSession session,
-    Endpoint endpoint,
-  ) async {
-    try {
-      session.sessionLogs.currentEndpoint = endpoint.name;
-      var authFailed = await EndpointDispatch.canUserAccessEndpoint(
-        () => session.authenticated,
-        endpoint.requireLogin,
-        endpoint.requiredScopes,
-      );
-      if (authFailed == null) await endpoint.streamOpened(session);
-    } catch (e) {
-      return;
-    }
-  }
-
-  static Future<void> _callStreamClosed(
-    StreamingSession session,
-    Endpoint endpoint,
-  ) async {
-    try {
-      session.sessionLogs.currentEndpoint = endpoint.name;
-      var authFailed = await EndpointDispatch.canUserAccessEndpoint(
-        () => session.authenticated,
-        endpoint.requireLogin,
-        endpoint.requiredScopes,
-      );
-      if (authFailed == null) await endpoint.streamClosed(session);
-    } catch (e) {
-      return;
-    }
   }
 
   /// Shuts the server down.

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -377,8 +377,9 @@ class Server {
   }
 
   /// Shuts the server down.
-  void shutdown() {
-    _httpServer.close();
+  /// Returns a [Future] that completes when the server is shut down.
+  Future<void> shutdown() async {
+    await _httpServer.close();
     _running = false;
   }
 }

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -233,7 +233,7 @@ class Server {
       try {
         webSocket = await WebSocketTransformer.upgrade(request);
       } on WebSocketException {
-        stderr.writeln('Failed to upgrade connection to websocket');
+        serverpod.logVerbose('Failed to upgrade connection to websocket');
         return;
       }
       webSocket.pingInterval = const Duration(seconds: 30);

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -415,6 +415,9 @@ class Serverpod {
   /// Starts the Serverpod and all [Server]s that it manages.
   Future<void> start() async {
     _startedTime = DateTime.now().toUtc();
+    // It is important that we start the database pool manager before
+    // attempting to connect to the database.
+    _databasePoolManager?.start();
 
     await runZonedGuarded(() async {
       // Register cloud store endpoint if we're using the database cloud store
@@ -757,6 +760,9 @@ class Serverpod {
     await _serviceServer?.shutdown();
     _futureCallManager?.stop();
     _healthCheckManager?.stop();
+
+    // This needs to be closed last as it is used by the other services.
+    await _databasePoolManager?.stop();
 
     if (exitProcess) {
       exit(0);

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -752,9 +752,9 @@ class Serverpod {
   /// Shuts down the Serverpod and all associated servers.
   Future<void> shutdown({bool exitProcess = true}) async {
     await redisController?.stop();
-    server.shutdown();
-    _webServer?.stop();
-    _serviceServer?.shutdown();
+    await server.shutdown();
+    await _webServer?.stop();
+    await _serviceServer?.shutdown();
     _futureCallManager?.stop();
     _healthCheckManager?.stop();
 

--- a/packages/serverpod/lib/src/server/websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handler.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:serverpod/protocol.dart';
+import 'package:serverpod/serverpod.dart';
+
+/// Handles incoming websocket requests for the provided [WebSocket].
+abstract class WebsocketRequestHandler {
+  /// Handles incoming websocket requests.
+  /// Returns a [Future] that completes when the websocket is closed.
+  static Future<void> handleWebsocket(
+    Server server,
+    WebSocket webSocket,
+    HttpRequest request,
+  ) async {
+    try {
+      var session = StreamingSession(
+        server: server,
+        uri: request.uri,
+        httpRequest: request,
+        webSocket: webSocket,
+      );
+
+      for (var endpointConnector in server.endpoints.connectors.values) {
+        await _callStreamOpened(session, endpointConnector.endpoint);
+      }
+      for (var module in server.endpoints.modules.values) {
+        for (var endpointConnector in module.connectors.values) {
+          await _callStreamOpened(session, endpointConnector.endpoint);
+        }
+      }
+
+      dynamic error;
+      StackTrace? stackTrace;
+
+      try {
+        await for (String jsonData in webSocket) {
+          var data = jsonDecode(jsonData) as Map;
+
+          // Handle control commands.
+          var command = data['command'] as String?;
+          if (command != null) {
+            var args = data['args'] as Map;
+
+            if (command == 'ping') {
+              webSocket.add(
+                SerializationManager.encodeForProtocol(
+                  {'command': 'pong'},
+                ),
+              );
+            } else if (command == 'auth') {
+              var authKey = args['key'] as String?;
+              session.updateAuthenticationKey(authKey);
+            }
+            continue;
+          }
+
+          // Handle messages passed to endpoints.
+          var endpointName = data['endpoint'] as String;
+          var serialization = data['object'] as Map<String, dynamic>;
+
+          var endpointConnector =
+              server.endpoints.getConnectorByName(endpointName);
+          if (endpointConnector == null) {
+            throw Exception('Endpoint not found: $endpointName');
+          }
+
+          var endpoint = endpointConnector.endpoint;
+          var authFailed = await EndpointDispatch.canUserAccessEndpoint(
+            () => session.authenticated,
+            endpoint.requireLogin,
+            endpoint.requiredScopes,
+          );
+
+          if (authFailed == null) {
+            // Process the message.
+            var startTime = DateTime.now();
+            dynamic messageError;
+            StackTrace? messageStackTrace;
+
+            SerializableModel? message;
+            try {
+              session.sessionLogs.currentEndpoint = endpointName;
+
+              message = server.serializationManager
+                  .deserializeByClassName(serialization);
+
+              if (message == null) throw Exception('Streamed message was null');
+
+              await endpointConnector.endpoint
+                  .handleStreamMessage(session, message);
+            } catch (e, s) {
+              messageError = e;
+              messageStackTrace = s;
+              stderr.writeln('${DateTime.now().toUtc()} Internal server error. '
+                  'Uncaught exception in handleStreamMessage.');
+              stderr.writeln('$e');
+              stderr.writeln('$s');
+            }
+
+            var duration =
+                DateTime.now().difference(startTime).inMicroseconds / 1000000.0;
+            var logManager = session.serverpod.logManager;
+
+            var slow = duration >=
+                logManager
+                    .getLogSettingsForStreamingSession(
+                      endpoint: endpointName,
+                    )
+                    .slowSessionDuration;
+
+            var shouldLog = logManager.shouldLogMessage(
+              session: session,
+              endpoint: endpointName,
+              slow: slow,
+              failed: messageError != null,
+            );
+
+            if (shouldLog) {
+              var logEntry = MessageLogEntry(
+                sessionLogId: session.sessionLogs.temporarySessionId,
+                serverId: server.serverId,
+                messageId: session.currentMessageId,
+                endpoint: endpointName,
+                messageName: serialization['className'],
+                duration: duration,
+                order: session.sessionLogs.currentLogOrderId,
+                error: messageError?.toString(),
+                stackTrace: messageStackTrace?.toString(),
+                slow: slow,
+              );
+              unawaited(logManager.logMessage(session, logEntry));
+
+              session.sessionLogs.currentLogOrderId += 1;
+            }
+
+            session.currentMessageId += 1;
+          }
+        }
+      } catch (e, s) {
+        error = e;
+        stackTrace = s;
+      }
+
+      // TODO: Possibly keep a list of open streams instead
+      for (var endpointConnector in server.endpoints.connectors.values) {
+        await _callStreamClosed(session, endpointConnector.endpoint);
+      }
+      for (var module in server.endpoints.modules.values) {
+        for (var endpointConnector in module.connectors.values) {
+          await _callStreamClosed(session, endpointConnector.endpoint);
+        }
+      }
+      await session.close(error: error, stackTrace: stackTrace);
+    } catch (e, stackTrace) {
+      stderr.writeln('$e');
+      stderr.writeln('$stackTrace');
+      return;
+    }
+  }
+
+  static Future<void> _callStreamOpened(
+    StreamingSession session,
+    Endpoint endpoint,
+  ) async {
+    try {
+      session.sessionLogs.currentEndpoint = endpoint.name;
+      var authFailed = await EndpointDispatch.canUserAccessEndpoint(
+        () => session.authenticated,
+        endpoint.requireLogin,
+        endpoint.requiredScopes,
+      );
+      if (authFailed == null) await endpoint.streamOpened(session);
+    } catch (e) {
+      return;
+    }
+  }
+
+  static Future<void> _callStreamClosed(
+    StreamingSession session,
+    Endpoint endpoint,
+  ) async {
+    try {
+      session.sessionLogs.currentEndpoint = endpoint.name;
+      var authFailed = await EndpointDispatch.canUserAccessEndpoint(
+        () => session.authenticated,
+        endpoint.requireLogin,
+        endpoint.requiredScopes,
+      );
+      if (authFailed == null) await endpoint.streamClosed(session);
+    } catch (e) {
+      return;
+    }
+  }
+}

--- a/packages/serverpod/lib/src/server/websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handler.dart
@@ -13,6 +13,7 @@ abstract class WebsocketRequestHandler {
     Server server,
     WebSocket webSocket,
     HttpRequest request,
+    void Function() onClosed,
   ) async {
     try {
       var session = StreamingSession(
@@ -157,6 +158,8 @@ abstract class WebsocketRequestHandler {
       stderr.writeln('$e');
       stderr.writeln('$stackTrace');
       return;
+    } finally {
+      onClosed();
     }
   }
 

--- a/tests/docker/tests_integration/docker-compose.yml
+++ b/tests/docker/tests_integration/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 services:
-  tests:
+  serverpod_test_server:
     build:
       context: ../../..
       dockerfile: tests/docker/tests_integration/Dockerfile

--- a/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
+++ b/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
@@ -2,13 +2,23 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/endpoints.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 
+const _integrationTestFlags = ['-m', 'production'];
+
 class IntegrationTestServer extends TestServerpod {
   IntegrationTestServer()
       : super(
-          ['-m', 'production'],
+          _integrationTestFlags,
           Protocol(),
           Endpoints(),
         );
+
+  static Serverpod create() {
+    return Serverpod(
+      _integrationTestFlags,
+      Protocol(),
+      Endpoints(),
+    );
+  }
 }
 
 class TestServerpod {

--- a/tests/serverpod_test_server/test_integration/websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websocket_connection_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     test('when server is stopped then socket is closed.', () async {
       webSocket.stream.listen((event) {
-        // Listen to the to keep it open.
+        // Listen to the stream to keep it open.
       });
       // Await connection to be established and all handshakes to be done.
       await Future.delayed(Duration(seconds: 1));
@@ -58,10 +58,10 @@ void main() {
 
     test('when server is stopped then sockets are closed.', () async {
       webSocket1.stream.listen((event) {
-        // Listen to the to keep it open.
+        // Listen to the stream to keep it open.
       });
       webSocket2.stream.listen((event) {
-        // Listen to the to keep it open.
+        // Listen to the stream to keep it open.
       });
       // Await connection to be established and all handshakes to be done.
       await Future.delayed(Duration(seconds: 1));

--- a/tests/serverpod_test_server/test_integration/websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websocket_connection_test.dart
@@ -1,0 +1,74 @@
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given websocket connection with connected client', () {
+    var server = IntegrationTestServer.create();
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test('when server is stopped then socket is closed.', () async {
+      webSocket.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+      // Await connection to be established and all handshakes to be done.
+      await Future.delayed(Duration(seconds: 1));
+
+      await server.shutdown(exitProcess: false);
+      expect(webSocket.closeCode, isNotNull);
+    });
+  });
+
+  group('Given multiple websocket connections with connected clients', () {
+    var server = IntegrationTestServer.create();
+    late WebSocketChannel webSocket1;
+    late WebSocketChannel webSocket2;
+
+    setUp(() async {
+      await server.start();
+      webSocket1 = WebSocketChannel.connect(
+        Uri.parse(serverWebsocketUrl),
+      );
+      await webSocket1.ready;
+      webSocket2 = WebSocketChannel.connect(
+        Uri.parse(serverWebsocketUrl),
+      );
+      await webSocket2.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket1.sink.close();
+      await webSocket2.sink.close();
+    });
+
+    test('when server is stopped then sockets are closed.', () async {
+      webSocket1.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+      webSocket2.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+      // Await connection to be established and all handshakes to be done.
+      await Future.delayed(Duration(seconds: 1));
+
+      await server.shutdown(exitProcess: false);
+      expect(webSocket1.closeCode, isNotNull);
+      expect(webSocket2.closeCode, isNotNull);
+    });
+  });
+}

--- a/util/run_tests_integration
+++ b/util/run_tests_integration
@@ -11,4 +11,4 @@ set -e
 
 cd tests/docker/tests_integration
 
-docker compose up --abort-on-container-exit --exit-code-from tests --build --remove-orphans
+docker compose up --abort-on-container-exit --exit-code-from serverpod_test_server --build --remove-orphans


### PR DESCRIPTION
Collection of improvements related to WebSockets and their lifetime management.

### Changes:
- Correctly set session logs to current endpoint when connection is being closed.
- Only log failed websocket upgrade requests if logging verbose is enabled.
- Break out websocket request handling to separate file.
- Make server shutdown async and await all HTTP close calls.
- Close database pool on server shutdown.
- Close all websocket connections on server shutdown.


After these changes, the server can now be gracefully shut down. This was a required change in order to test the websocket lifetime management on the server. This also means we should no longer have to have the `exit(0)` call inside of the shutdown method.

### Guidance for review.
Best reviewed commit by commit to be able to follow the refactoring and break out of the WebSocket request handler.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None: 