### PR TITLE
Handle malformed URI params more gracefully

### DIFF
--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:serverpod/serverpod.dart';
 import 'package:path/path.dart' as path;
+import 'package:serverpod/serverpod.dart';
 
 /// The Serverpod webserver.
 class WebServer {
@@ -126,15 +126,24 @@ class WebServer {
       }
     }
 
-    // TODO: Fix body
-    var session = MethodCallSession(
-      server: serverpod.server,
-      uri: uri,
-      path: 'webserver',
-      body: '',
-      authenticationKey: authenticationKey,
-      httpRequest: request,
-    );
+    MethodCallSession session;
+    try {
+      // TODO: Fix body
+      session = MethodCallSession(
+        server: serverpod.server,
+        uri: uri,
+        path: 'webserver',
+        body: '',
+        authenticationKey: authenticationKey,
+        httpRequest: request,
+      );
+    } catch (e) {
+      // Triggered if the URI query parameters are malformed
+      logDebug('Failed to create method call session: $e');
+      request.response.statusCode = HttpStatus.badRequest;
+      await request.response.close();
+      return;
+    }
 
 //    print('Getting path: ${uri.path}');
 


### PR DESCRIPTION
I get tons of these errors in my server logs, from web crawlers hitting my server:

```
INFO 2024-06-19T05:26:54.014840366Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: 2024-06-19 05:26:54.014234 Relic zoned error: FormatException: Unexpected extension byte (at offset 0)
INFO 2024-06-19T05:26:54.014932207Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #0 _Utf8Decoder.convertSingle (dart:convert-patch/convert_patch.dart:1760)
INFO 2024-06-19T05:26:54.014950960Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #1 Utf8Decoder.convert (dart:convert/utf.dart:349)
INFO 2024-06-19T05:26:54.014979399Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #2 Utf8Codec.decode (dart:convert/utf.dart:63)
INFO 2024-06-19T05:26:54.015009443Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #3 _Uri._uriDecode (dart:core/uri.dart:3140)
INFO 2024-06-19T05:26:54.015024187Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #4 Uri.decodeQueryComponent (dart:core/uri.dart:1262)
INFO 2024-06-19T05:26:54.015039699Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #5 Uri.splitQueryString.<anonymous closure> (dart:core/uri.dart:1329)
INFO 2024-06-19T05:26:54.015056163Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #6 ListBase.fold (dart:collection/list.dart:202)
INFO 2024-06-19T05:26:54.015087346Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #7 Uri.splitQueryString (dart:core/uri.dart:1325)
INFO 2024-06-19T05:26:54.015106366Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #8 _Uri.queryParameters (dart:core/uri.dart:1560)
INFO 2024-06-19T05:26:54.015120683Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #9 _Uri.queryParameters (dart:core/uri.dart)
INFO 2024-06-19T05:26:54.015150611Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #10 new MethodCallSession (package:serverpod/src/server/session.dart:265)
INFO 2024-06-19T05:26:54.015166984Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #11 WebServer._handleRequest (package:serverpod/src/relic/web_server.dart:130)
INFO 2024-06-19T05:26:54.015180903Z [resource.labels.instanceId: serverpod-production-06jz] startup-script: #12 WebServer._start (package:serverpod/src/relic/web_server.dart:94)
```

This change returns `HttpStatus.badRequest` and logs only one line instead.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
