### PR TITLE
feat: Introduce new websocket connection endpoint.

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -7,7 +7,7 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/database/database.dart';
 import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/server/health_check.dart';
-import 'package:serverpod/src/server/websocket_request_handler.dart';
+import 'package:serverpod/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart';
 
 import '../cache/caches.dart';
 
@@ -245,7 +245,7 @@ class Server {
       webSocket.pingInterval = const Duration(seconds: 30);
       var websocketKey = const Uuid().v4();
       _webSockets[websocketKey] = (
-        WebsocketRequestHandler.handleWebsocket(
+        EndpointWebsocketRequestHandler.handleWebsocket(
           this,
           webSocket,
           request,

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -4,13 +4,12 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:serverpod/serverpod.dart';
-import 'package:serverpod/src/database/database.dart';
+import 'package:serverpod/src/cache/caches.dart';
 import 'package:serverpod/src/database/database_pool_manager.dart';
+import 'package:serverpod/src/database/database.dart';
 import 'package:serverpod/src/server/health_check.dart';
 import 'package:serverpod/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart';
 import 'package:serverpod/src/server/websocket_request_handlers/method_websocket_request_handler.dart';
-
-import '../cache/caches.dart';
 
 /// Handling incoming calls and routing them to the correct [Endpoint]
 /// methods.

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -5,10 +5,14 @@ import 'dart:io';
 import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 
-/// Handles incoming websocket requests for the provided [WebSocket].
-abstract class WebsocketRequestHandler {
-  /// Handles incoming websocket requests.
+/// This class is used by the [Server] to handle incoming websocket requests
+/// to an endpoint. It is not intended to be used directly by the user.
+abstract class EndpointWebsocketRequestHandler {
+  /// Creates a new [StreamingSession] and handles incoming websocket requests.
   /// Returns a [Future] that completes when the websocket is closed.
+  ///
+  /// This method dispatches incoming messages to the correct endpoint and
+  /// handles control messages such as 'ping' and 'auth'.
   static Future<void> handleWebsocket(
     Server server,
     WebSocket webSocket,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -35,6 +35,8 @@ class MethodWebsocketRequestHandler {
       var session = await server.serverpod.createSession();
       await session.close(error: e, stackTrace: stackTrace);
     } finally {
+      // Send a close message to the client.
+      await webSocket.close();
       onClosed();
     }
   }

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
 
 /// This class is used by the [Server] to handle incoming websocket requests
 /// to a method. It is not intended to be used directly by the user.
+@internal
 class MethodWebsocketRequestHandler {
   /// Handles incoming websocket requests.
   /// Returns a [Future] that completes when the websocket is closed.

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -16,8 +16,18 @@ class MethodWebsocketRequestHandler {
     try {
       server.serverpod.logVerbose('Method websocket connection established.');
       await for (String jsonData in webSocket) {
-        // TODO: Implementation will be replaced here in future commits.
-        stdout.writeln('Received data: $jsonData');
+        var message = WebSocketMessage.fromJsonString(jsonData);
+
+        switch (message) {
+          case PingCommand():
+            webSocket.add(PongCommand.buildMessage());
+            break;
+          case PongCommand():
+            break;
+          case UnknownMessage():
+            server.serverpod.logVerbose(
+                'Unknown message received on websocket connection: ${message.jsonString}');
+        }
       }
     } catch (e, stackTrace) {
       var session = await server.serverpod.createSession();

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+
+/// This class is used by the [Server] to handle incoming websocket requests
+/// to a method. It is not intended to be used directly by the user.
+class MethodWebsocketRequestHandler {
+  /// Handles incoming websocket requests.
+  /// Returns a [Future] that completes when the websocket is closed.
+  Future<void> handleWebsocket(
+    Server server,
+    WebSocket webSocket,
+    HttpRequest request,
+    void Function() onClosed,
+  ) async {
+    try {
+      server.serverpod.logVerbose('Method websocket connection established.');
+      await for (String jsonData in webSocket) {
+        // TODO: Implementation will be replaced here in future commits.
+        stdout.writeln('Received data: $jsonData');
+      }
+    } catch (e, stackTrace) {
+      var session = await server.serverpod.createSession();
+      await session.close(error: e, stackTrace: stackTrace);
+    } finally {
+      onClosed();
+    }
+  }
+}

--- a/packages/serverpod_serialization/lib/serverpod_serialization.dart
+++ b/packages/serverpod_serialization/lib/serverpod_serialization.dart
@@ -7,3 +7,4 @@ export 'src/copy_with.dart';
 export 'src/exceptions.dart';
 export 'src/extensions/serialization_extensions.dart';
 export 'src/serialization.dart';
+export 'src/websocket_messages.dart';

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+/// Base class for messages sent over a WebSocket connection.
+sealed class WebSocketMessage {
+  /// Converts a JSON string to a [WebSocketMessage] object.
+  static WebSocketMessage fromJsonString(String jsonString) {
+    Map data;
+    try {
+      data = jsonDecode(jsonString) as Map;
+    } catch (e) {
+      return UnknownMessage(jsonString);
+    }
+
+    var messageType = data['messageType'];
+
+    switch (messageType) {
+      case PingCommand.messageType:
+        return PingCommand();
+      case PongCommand.messageType:
+        return PongCommand();
+      default:
+        return UnknownMessage(jsonString);
+    }
+  }
+}
+
+/// A message sent over a websocket connection to check if the connection is
+/// still alive. The other end should respond with a [PongCommand].
+class PingCommand extends WebSocketMessage {
+  /// The type of message.
+  static const String messageType = 'ping_command';
+
+  /// Creates a new [PingCommand].
+  static String buildMessage() {
+    return jsonEncode({'messageType': messageType});
+  }
+}
+
+/// A response to a [PingCommand].
+class PongCommand extends WebSocketMessage {
+  /// The type of message.
+  static const String messageType = 'pong_command';
+
+  /// Creates a new [PongCommand].
+  static String buildMessage() {
+    return jsonEncode({'messageType': messageType});
+  }
+}
+
+/// A message that is not recognized.
+class UnknownMessage extends WebSocketMessage {
+  /// The JSON string that was not recognized.
+  final String jsonString;
+
+  /// Creates a new [UnknownMessage].
+  UnknownMessage(this.jsonString);
+}

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -30,7 +30,7 @@ class PingCommand extends WebSocketMessage {
   /// The type of message.
   static const String messageType = 'ping_command';
 
-  /// Creates a new [PingCommand].
+  /// Builds a [PingCommand] message.
   static String buildMessage() {
     return jsonEncode({'messageType': messageType});
   }
@@ -41,7 +41,7 @@ class PongCommand extends WebSocketMessage {
   /// The type of message.
   static const String messageType = 'pong_command';
 
-  /// Creates a new [PongCommand].
+  /// Builds a [PongCommand] message.
   static String buildMessage() {
     return jsonEncode({'messageType': messageType});
   }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -19,6 +19,14 @@ void main() {
   });
 
   test(
+      'Given a upper cased command message when building websocket message from string then UnknownMessage is returned.',
+      () {
+    var message = PingCommand.buildMessage().toUpperCase();
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<UnknownMessage>());
+  });
+
+  test(
       'Given an unknown command json String when building websocket message from string then UnknownMessage is returned.',
       () {
     var message = '{"messageType": "this is not a known message type"}';

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -1,0 +1,44 @@
+import 'package:serverpod_serialization/src/websocket_messages.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given a Ping command message when building websocket message from string then PingCommand is returned.',
+      () {
+    var message = PingCommand.buildMessage();
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<PingCommand>());
+  });
+
+  test(
+      'Given a Pong command message when building websocket message from string then PongCommand is returned.',
+      () {
+    var message = PongCommand.buildMessage();
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<PongCommand>());
+  });
+
+  test(
+      'Given an unknown command json String when building websocket message from string then UnknownMessage is returned.',
+      () {
+    var message = '{"messageType": "this is not a known message type"}';
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<UnknownMessage>());
+  });
+
+  test(
+      'Given an invalid json String when building websocket message from string then UnknownMessage is returned.',
+      () {
+    var message = 'This is not a valid json string';
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<UnknownMessage>());
+  });
+
+  test(
+      'Given a null messageType when building websocket message from string then UnknownMessage is returned.',
+      () {
+    var message = '{"messageType": null}';
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<UnknownMessage>());
+  });
+}

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -19,34 +19,67 @@ void main() {
   });
 
   test(
+      'Given a bad request message when building websocket message from string then BadRequestMessage is returned.',
+      () {
+    var message = BadRequestMessage.buildMessage('This is a bad request');
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<BadRequestMessage>());
+  });
+
+  test(
+      'Given a bad request message without mandatory field building websocket message from string then unknown message is returned.',
+      () {
+    /// Missing mandatory field 'request'
+    var message = '{"messageType": "bad_request_message"}';
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(
+        isA<UnknownMessageException>()
+            .having((e) => e.error, 'error', isA<TypeError>()),
+      ),
+    );
+  });
+
+  test(
       'Given a upper cased command message when building websocket message from string then UnknownMessage is returned.',
       () {
     var message = PingCommand.buildMessage().toUpperCase();
-    var result = WebSocketMessage.fromJsonString(message);
-    expect(result, isA<UnknownMessage>());
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(isA<UnknownMessageException>()),
+    );
   });
 
   test(
       'Given an unknown command json String when building websocket message from string then UnknownMessage is returned.',
       () {
     var message = '{"messageType": "this is not a known message type"}';
-    var result = WebSocketMessage.fromJsonString(message);
-    expect(result, isA<UnknownMessage>());
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(isA<UnknownMessageException>()),
+    );
   });
 
   test(
       'Given an invalid json String when building websocket message from string then UnknownMessage is returned.',
       () {
     var message = 'This is not a valid json string';
-    var result = WebSocketMessage.fromJsonString(message);
-    expect(result, isA<UnknownMessage>());
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(
+        isA<UnknownMessageException>()
+            .having((e) => e.error, 'error', isA<FormatException>()),
+      ),
+    );
   });
 
   test(
       'Given a null messageType when building websocket message from string then UnknownMessage is returned.',
       () {
     var message = '{"messageType": null}';
-    var result = WebSocketMessage.fromJsonString(message);
-    expect(result, isA<UnknownMessage>());
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(isA<UnknownMessageException>()),
+    );
   });
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   test(
-      'Given a bad request message without mandatory field building websocket message from string then unknown message is returned.',
+      'Given a bad request message without mandatory field building websocket message from string then UnknownMessageException is thrown having TypeError error type.',
       () {
     /// Missing mandatory field 'request'
     var message = '{"messageType": "bad_request_message"}';
@@ -41,7 +41,7 @@ void main() {
   });
 
   test(
-      'Given a upper cased command message when building websocket message from string then UnknownMessage is returned.',
+      'Given a upper cased command message when building websocket message from string then UnknownMessageException is thrown.',
       () {
     var message = PingCommand.buildMessage().toUpperCase();
     expect(
@@ -51,7 +51,7 @@ void main() {
   });
 
   test(
-      'Given an unknown command json String when building websocket message from string then UnknownMessage is returned.',
+      'Given an unknown command json String when building websocket message from string then UnknownMessageException is thrown.',
       () {
     var message = '{"messageType": "this is not a known message type"}';
     expect(
@@ -61,7 +61,7 @@ void main() {
   });
 
   test(
-      'Given an invalid json String when building websocket message from string then UnknownMessage is returned.',
+      'Given an invalid json String when building websocket message from string then UnknownMessageException is thrown having FormatException error type.',
       () {
     var message = 'This is not a valid json string';
     expect(
@@ -74,7 +74,7 @@ void main() {
   });
 
   test(
-      'Given a null messageType when building websocket message from string then UnknownMessage is returned.',
+      'Given a null messageType when building websocket message from string then UnknownMessageException is thrown.',
       () {
     var message = '{"messageType": null}';
     expect(

--- a/tests/serverpod_test_server/lib/test_util/config.dart
+++ b/tests/serverpod_test_server/lib/test_util/config.dart
@@ -1,12 +1,8 @@
 // The url of the server
 const serverUrl = 'http://serverpod_test_server:8080/';
-//const serverUrl = 'http://localhost:8080/';
 
 const serverEndpointWebsocketUrl = 'ws://serverpod_test_server:8080/websocket';
-//const serverEndpointWebsocketUrl = 'ws://localhost:8080/websocket';
 
 const serverMethodWebsocketUrl = 'ws://serverpod_test_server:8080/v1/websocket';
-//const serverMethodWebsocketUrl = 'ws://localhost:8080/v1/websocket';
 
 const serviceServerUrl = 'http://serverpod_test_server:8081/';
-// const serviceServerUrl = 'http://localhost:8081/';

--- a/tests/serverpod_test_server/lib/test_util/config.dart
+++ b/tests/serverpod_test_server/lib/test_util/config.dart
@@ -2,8 +2,8 @@
 const serverUrl = 'http://serverpod_test_server:8080/';
 //const serverUrl = 'http://localhost:8080/';
 
-const serverWebsocketUrl = 'ws://serverpod_test_server:8080/websocket';
-//const serverWebsocketUrl = 'ws://localhost:8080/websocket';
+const serverEndpointWebsocketUrl = 'ws://serverpod_test_server:8080/websocket';
+//const serverEndpointWebsocketUrl = 'ws://localhost:8080/websocket';
 
 const serviceServerUrl = 'http://serverpod_test_server:8081/';
 // const serviceServerUrl = 'http://localhost:8081/';

--- a/tests/serverpod_test_server/lib/test_util/config.dart
+++ b/tests/serverpod_test_server/lib/test_util/config.dart
@@ -5,5 +5,8 @@ const serverUrl = 'http://serverpod_test_server:8080/';
 const serverEndpointWebsocketUrl = 'ws://serverpod_test_server:8080/websocket';
 //const serverEndpointWebsocketUrl = 'ws://localhost:8080/websocket';
 
+const serverMethodWebsocketUrl = 'ws://serverpod_test_server:8080/v1/websocket';
+//const serverMethodWebsocketUrl = 'ws://localhost:8080/v1/websocket';
+
 const serviceServerUrl = 'http://serverpod_test_server:8081/';
 // const serviceServerUrl = 'http://localhost:8081/';

--- a/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
@@ -59,7 +59,7 @@ void main() {
 
     setUpAll(() async {
       WebSocketChannel websocket = WebSocketChannel.connect(
-        Uri.parse(serverWebsocketUrl),
+        Uri.parse(serverEndpointWebsocketUrl),
       );
       message = await websocket.stream.asBroadcastStream().first;
       await websocket.sink.close();
@@ -114,7 +114,7 @@ void main() {
 
       setUpAll(() async {
         WebSocketChannel websocket = WebSocketChannel.connect(
-          Uri.parse(serverWebsocketUrl),
+          Uri.parse(serverEndpointWebsocketUrl),
         );
         message = await websocket.stream.asBroadcastStream().first;
         await websocket.sink.close();
@@ -163,7 +163,7 @@ void main() {
 
       setUpAll(() async {
         WebSocketChannel websocket = WebSocketChannel.connect(
-          Uri.parse(serverWebsocketUrl),
+          Uri.parse(serverEndpointWebsocketUrl),
         );
         message = await websocket.stream.asBroadcastStream().first;
         await websocket.sink.close();

--- a/tests/serverpod_test_server/test_integration/websockets/endpoint_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/endpoint_websocket_connection_test.dart
@@ -4,14 +4,14 @@ import 'package:test/test.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
-  group('Given websocket connection with connected client', () {
+  group('Given endpoint websocket connection with connected client', () {
     var server = IntegrationTestServer.create();
     late WebSocketChannel webSocket;
 
     setUp(() async {
       await server.start();
       webSocket = WebSocketChannel.connect(
-        Uri.parse(serverWebsocketUrl),
+        Uri.parse(serverEndpointWebsocketUrl),
       );
       await webSocket.ready;
     });
@@ -33,7 +33,8 @@ void main() {
     });
   });
 
-  group('Given multiple websocket connections with connected clients', () {
+  group('Given multiple endpoint websocket connections with connected clients',
+      () {
     var server = IntegrationTestServer.create();
     late WebSocketChannel webSocket1;
     late WebSocketChannel webSocket2;
@@ -41,11 +42,11 @@ void main() {
     setUp(() async {
       await server.start();
       webSocket1 = WebSocketChannel.connect(
-        Uri.parse(serverWebsocketUrl),
+        Uri.parse(serverEndpointWebsocketUrl),
       );
       await webSocket1.ready;
       webSocket2 = WebSocketChannel.connect(
-        Uri.parse(serverWebsocketUrl),
+        Uri.parse(serverEndpointWebsocketUrl),
       );
       await webSocket2.ready;
     });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websocket_connection_test.dart
@@ -1,0 +1,70 @@
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection with connected client', () {
+    var server = IntegrationTestServer.create();
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test('when server is stopped then socket is closed.', () async {
+      webSocket.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+
+      await server.shutdown(exitProcess: false);
+      expect(webSocket.closeCode, isNotNull);
+    });
+  });
+
+  group('Given multiple method websocket connections with connected clients',
+      () {
+    var server = IntegrationTestServer.create();
+    late WebSocketChannel webSocket1;
+    late WebSocketChannel webSocket2;
+
+    setUp(() async {
+      await server.start();
+      webSocket1 = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      webSocket2 = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await Future.wait([webSocket1.ready, webSocket2.ready]);
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket1.sink.close();
+      await webSocket2.sink.close();
+    });
+
+    test('when server is stopped then sockets are closed.', () async {
+      webSocket1.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+      webSocket2.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+
+      await server.shutdown(exitProcess: false);
+      expect(webSocket1.closeCode, isNotNull);
+      expect(webSocket2.closeCode, isNotNull);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/bad_request_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/bad_request_command_test.dart
@@ -10,8 +10,6 @@ void main() {
   group('Given method websocket connection', () {
     late Serverpod server;
     late WebSocketChannel webSocket;
-    var unrecognizedCommandMessage =
-        '{"command":"this is not a valid command"}';
 
     setUp(() async {
       server = IntegrationTestServer.create();
@@ -27,30 +25,17 @@ void main() {
       await webSocket.sink.close();
     });
 
-    test('when an unrecognized message is sent then connection is closed.',
-        () async {
+    test('when bad request is sent then connection is closed.', () async {
       var webSocketCompleter = Completer<void>();
       webSocket.stream.listen((event) {}, onDone: () {
         webSocketCompleter.complete();
       });
 
-      webSocket.sink.add(unrecognizedCommandMessage);
+      webSocket.sink.add(BadRequestMessage.buildMessage('request'));
 
       expectLater(
-        webSocketCompleter.future.timeout(Duration(seconds: 10)),
+        webSocketCompleter.future.timeout(Duration(seconds: 5)),
         completes,
-      );
-    });
-
-    test(
-        'when an unrecognized message is sent then BadRequestMessage is response is received.',
-        () async {
-      var response = webSocket.stream.first.timeout(Duration(seconds: 10));
-      webSocket.sink.add(unrecognizedCommandMessage);
-
-      expect(
-        await response,
-        BadRequestMessage.buildMessage(unrecognizedCommandMessage),
       );
     });
   });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/invalid_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/invalid_command_test.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test('when invalid command is sent no response is received.', () async {
+      webSocket.sink.add('{"command":"this is not a valid command"}');
+
+      expectLater(
+        webSocket.stream.first.timeout(Duration(seconds: 1)),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test('when invalid json string is sent then no response is received.',
+        () async {
+      webSocket.sink.add('this is not valid json');
+
+      expectLater(
+        webSocket.stream.first.timeout(Duration(seconds: 1)),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/ping_pong_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/ping_pong_command_test.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test('when ping command is sent then pong response is received.', () async {
+      webSocket.sink.add(PingCommand.buildMessage());
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(message, isA<PongCommand>());
+    });
+
+    test('when pong command is sent then no response is received.', () async {
+      webSocket.sink.add(PongCommand.buildMessage());
+
+      expectLater(
+        webSocket.stream.first.timeout(Duration(seconds: 1)),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/mixed_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/mixed_websocket_connection_test.dart
@@ -1,0 +1,50 @@
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group(
+      'Given a method websocket connection and an endpoint method connection with connected clients',
+      () {
+    var server = IntegrationTestServer.create();
+    late WebSocketChannel methodWebSocketConnection;
+    late WebSocketChannel endpointWebSocketConnection;
+
+    setUp(() async {
+      await server.start();
+      methodWebSocketConnection = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      endpointWebSocketConnection = WebSocketChannel.connect(
+        Uri.parse(serverEndpointWebsocketUrl),
+      );
+      await Future.wait([
+        methodWebSocketConnection.ready,
+        endpointWebSocketConnection.ready,
+      ]);
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await methodWebSocketConnection.sink.close();
+      await endpointWebSocketConnection.sink.close();
+    });
+
+    test('when server is stopped then sockets are closed.', () async {
+      methodWebSocketConnection.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+      endpointWebSocketConnection.stream.listen((event) {
+        // Listen to the to keep it open.
+      });
+
+      // Await connection to be established and all handshakes to be done.
+      await Future.delayed(Duration(seconds: 1));
+
+      await server.shutdown(exitProcess: false);
+      expect(methodWebSocketConnection.closeCode, isNotNull);
+      expect(endpointWebSocketConnection.closeCode, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
Introduces a new Web Socket connection endpoint '/v1/websocket` that will be used to implement #2338.

### Change:
- Serverpod now accepts websocket connection on `/v1/websocket`.
- Introduce WebSocket messages to the serialization package to give a standardized way of communicating over the websocket.
- Add ping/pong command to new websocket connection point.

This PR depends on: https://github.com/serverpod/serverpod/pull/2397

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this is a new websocket endpoint.