### PR TITLE
fix: respect ProtocolSerialization even in List/Map when calling enco…

### DIFF
--- a/packages/serverpod_serialization/test/json_serialization_test.dart
+++ b/packages/serverpod_serialization/test/json_serialization_test.dart
@@ -25,4 +25,47 @@ void main() {
   "b": 2
 }''');
   });
+
+  test('respect ProtocolSerialization even in List/Map', () {
+    var user = _User(name: 'John', password: '123');
+    var userList = [user];
+    var userMap = {'user': user, 'users': userList};
+
+    var stringifiedJson = SerializationManager.encode(user);
+    expect(true, stringifiedJson.contains('password'));
+
+    stringifiedJson = SerializationManager.encodeForProtocol(user);
+    expect(false, stringifiedJson.contains('password'));
+
+    stringifiedJson = SerializationManager.encode(userMap);
+    expect(true, stringifiedJson.contains('password'));
+
+    stringifiedJson = SerializationManager.encodeForProtocol(userMap);
+    expect(false, stringifiedJson.contains('password'));
+  });
+}
+
+class _User implements SerializableModel, ProtocolSerialization {
+  final String name;
+  final String password;
+
+  _User({
+    required this.name,
+    required this.password,
+  });
+
+  @override
+  Map<String, String> toJson() {
+    return {
+      'name': name,
+      'password': password,
+    };
+  }
+
+  @override
+  Map<String, String> toJsonForProtocol() {
+    return {
+      'name': name,
+    };
+  }
 }


### PR DESCRIPTION
…deForProtocol

now Endpoint will leak serverOnly fields to client when return List<Model> or Map.

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._