### PR TITLE
fix: add mechanism for awaiting pending future calls on shutdown

### DIFF
--- a/packages/serverpod/lib/src/server/future_call_manager.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager.dart
@@ -19,6 +19,8 @@ class FutureCallManager {
   final SerializationManager _serializationManager;
   final _futureCalls = <String, FutureCall>{};
   Timer? _timer;
+  Completer<void>? _pendingFutureCall;
+  bool _shuttingDown = false;
 
   /// Creates a new [FutureCallManager]. Typically, this is done internally by
   /// the [Serverpod].
@@ -82,9 +84,15 @@ class FutureCallManager {
   }
 
   /// Stops the manager.
-  void stop() {
+  Future<void> stop() async {
     _timer?.cancel();
     _timer = null;
+    _shuttingDown = true;
+
+    var pendingFutureCall = _pendingFutureCall;
+    if (pendingFutureCall != null) {
+      await pendingFutureCall.future;
+    }
   }
 
   void _run() async {
@@ -92,6 +100,9 @@ class FutureCallManager {
   }
 
   Future<void> _checkQueue() async {
+    var pendingFutureCall = Completer<void>();
+    _pendingFutureCall = pendingFutureCall;
+
     if (_server.serverpod.commandLineArgs.role == ServerpodRole.maintenance) {
       stdout.writeln('Processing future calls.');
     }
@@ -147,12 +158,15 @@ class FutureCallManager {
 
     // If we are running as a maintenance task, we shouldn't check the queue
     // again.
-    if (_server.serverpod.commandLineArgs.role == ServerpodRole.monolith) {
+    if (_server.serverpod.commandLineArgs.role == ServerpodRole.monolith &&
+        !_shuttingDown) {
       // Check the queue again in 5 seconds
       _timer = Timer(const Duration(seconds: 5), _checkQueue);
     } else if (_server.serverpod.commandLineArgs.role ==
         ServerpodRole.maintenance) {
       onCompleted();
     }
+
+    pendingFutureCall.complete();
   }
 }

--- a/packages/serverpod/lib/src/server/future_call_manager.dart
+++ b/packages/serverpod/lib/src/server/future_call_manager.dart
@@ -19,7 +19,7 @@ class FutureCallManager {
   final SerializationManager _serializationManager;
   final _futureCalls = <String, FutureCall>{};
   Timer? _timer;
-  Completer<void>? _pendingFutureCall;
+  Completer<void> _pendingFutureCall = Completer<void>()..complete();
   bool _shuttingDown = false;
 
   /// Creates a new [FutureCallManager]. Typically, this is done internally by
@@ -89,10 +89,7 @@ class FutureCallManager {
     _timer = null;
     _shuttingDown = true;
 
-    var pendingFutureCall = _pendingFutureCall;
-    if (pendingFutureCall != null) {
-      await pendingFutureCall.future;
-    }
+    await _pendingFutureCall.future;
   }
 
   void _run() async {

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -758,7 +758,7 @@ class Serverpod {
     await server.shutdown();
     await _webServer?.stop();
     await _serviceServer?.shutdown();
-    _futureCallManager?.stop();
+    await _futureCallManager?.stop();
     _healthCheckManager?.stop();
 
     // This needs to be closed last as it is used by the other services.


### PR DESCRIPTION
When shutting down the server we did not await any pending future calls which could lead to lost data.
I encountered this during integration tests where the server was started and stopped multiple times in quick succession.

This PR introduces a mechanism for awaiting pending future calls and prevents additional ones from being started during shutdown.

No tests added since we don't really have the infrastructure for it around future calls.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.