### PR TITLE
feat: Make it possible to call endpoints through new streaming protocol.

### DIFF
--- a/examples/auth_example/auth_example_server/lib/src/generated/endpoints.dart
+++ b/examples/auth_example/auth_example_server/lib/src/generated/endpoints.dart
@@ -36,6 +36,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/examples/chat/chat_server/lib/src/generated/endpoints.dart
+++ b/examples/chat/chat_server/lib/src/generated/endpoints.dart
@@ -31,6 +31,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getChannels': _i1.MethodConnector(
           name: 'getChannels',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/endpoints.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/endpoints.dart
@@ -80,6 +80,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -98,6 +99,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -116,6 +118,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -140,6 +143,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -169,6 +173,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -193,6 +198,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -212,6 +218,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -235,6 +242,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -264,6 +272,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -289,6 +298,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -314,6 +324,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -343,6 +354,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -363,6 +375,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -382,6 +395,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'isSignedIn': _i1.MethodConnector(
           name: 'isSignedIn',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -391,6 +405,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'signOut': _i1.MethodConnector(
           name: 'signOut',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -400,6 +415,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getUserInfo': _i1.MethodConnector(
           name: 'getUserInfo',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -409,6 +425,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getUserSettingsConfig': _i1.MethodConnector(
           name: 'getUserSettingsConfig',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -425,6 +442,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'removeUserImage': _i1.MethodConnector(
           name: 'removeUserImage',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -440,6 +458,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -458,6 +477,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/endpoints.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/endpoints.dart
@@ -36,6 +36,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -60,6 +61,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/packages/serverpod/lib/src/generated/endpoints.dart
+++ b/packages/serverpod/lib/src/generated/endpoints.dart
@@ -32,6 +32,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getRuntimeSettings': _i1.MethodConnector(
           name: 'getRuntimeSettings',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -48,6 +49,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -61,6 +63,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'clearAllLogs': _i1.MethodConnector(
           name: 'clearAllLogs',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -82,6 +85,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -106,6 +110,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -125,6 +130,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -137,6 +143,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'shutdown': _i1.MethodConnector(
           name: 'shutdown',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -146,6 +153,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'checkHealth': _i1.MethodConnector(
           name: 'checkHealth',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -167,6 +175,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -180,6 +189,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'hotReload': _i1.MethodConnector(
           name: 'hotReload',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -190,6 +200,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getTargetTableDefinition': _i1.MethodConnector(
           name: 'getTargetTableDefinition',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -200,6 +211,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getLiveDatabaseDefinition': _i1.MethodConnector(
           name: 'getLiveDatabaseDefinition',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -210,6 +222,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getDatabaseDefinitions': _i1.MethodConnector(
           name: 'getDatabaseDefinitions',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -241,6 +254,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -263,6 +277,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -281,6 +296,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -300,6 +316,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -318,6 +335,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -259,9 +259,17 @@ class MethodConnector {
   /// A function that performs a call to the named method.
   final MethodCall call;
 
+  /// True if the method returns void.
+  /// If null, no assumption can be made about the return value.
+  final bool? returnsVoid;
+
   /// Creates a new [MethodConnector].
-  MethodConnector(
-      {required this.name, required this.params, required this.call});
+  MethodConnector({
+    required this.name,
+    required this.params,
+    required this.call,
+    this.returnsVoid,
+  });
 }
 
 /// Defines a parameter in a [MethodConnector].

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -212,10 +212,7 @@ abstract class EndpointDispatch {
           serializedParam,
           description.type,
         );
-
-        continue;
-      }
-      if (!description.nullable) {
+      } else if (!description.nullable) {
         throw Exception('Missing required query parameter: $name');
       }
     }

--- a/packages/serverpod/lib/src/server/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager.dart
@@ -289,7 +289,7 @@ class LogManager {
       return _getLogSettingsForInternalSession();
     } else if (session is FutureCallSession) {
       return _getLogSettingsForFutureCallSession(session.futureCallName);
-    } else if (session is StreamingMethodCallSession) {
+    } else if (session is MethodStreamSession) {
       return _getLogSettingsForMethodCallSession(
           session.endpointName, session.methodName);
     }
@@ -707,7 +707,7 @@ String _endpointForSession(Session session) {
   } else if (session is InternalSession) {
     // Internal session
     return 'InternalSession';
-  } else if (session is StreamingMethodCallSession) {
+  } else if (session is MethodStreamSession) {
     // Streaming method call
     return session.endpointName;
   }

--- a/packages/serverpod/lib/src/server/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager.dart
@@ -289,6 +289,9 @@ class LogManager {
       return _getLogSettingsForInternalSession();
     } else if (session is FutureCallSession) {
       return _getLogSettingsForFutureCallSession(session.futureCallName);
+    } else if (session is StreamingMethodCallSession) {
+      return _getLogSettingsForMethodCallSession(
+          session.endpointName, session.methodName);
     }
     throw UnimplementedError('Unknown session type');
   }
@@ -704,6 +707,9 @@ String _endpointForSession(Session session) {
   } else if (session is InternalSession) {
     // Internal session
     return 'InternalSession';
+  } else if (session is StreamingMethodCallSession) {
+    // Streaming method call
+    return session.endpointName;
   }
 
   throw (UnimplementedError('Unknown Session type'));

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -98,7 +98,7 @@ abstract class Session {
     HttpRequest? httpRequest,
     WebSocket? webSocket,
     required this.enableLogging,
-  }) {
+  }) : _authenticationKey = authenticationKey {
     _startTime = DateTime.now();
 
     storage = StorageAccess._(this);
@@ -288,6 +288,31 @@ class MethodCallSession extends Session {
     // Get the the authentication key, if any
     _authenticationKey = authenticationKey ?? queryParameters['auth'];
   }
+}
+
+/// When a call is made to an endpoint method that uses a stream [Server] a
+/// [StreamingMethodCallSession] object is created. It contains all data
+/// associated with the current connection and provides easy access to the
+/// database.
+class StreamingMethodCallSession extends Session {
+  /// The name of the method that is being called.
+  final String methodName;
+
+  /// The name of the endpoint that is being called.
+  final String endpointName;
+
+  /// The uuid of the stream.
+  final String uuid;
+
+  /// Creates a new [Session] for a method call to a streaming endpoint.
+  StreamingMethodCallSession({
+    required super.server,
+    required super.enableLogging,
+    required super.authenticationKey,
+    required this.endpointName,
+    required this.methodName,
+    required this.uuid,
+  });
 }
 
 /// When a web socket connection is opened to the [Server] a [StreamingSession]

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -301,8 +301,8 @@ class StreamingMethodCallSession extends Session {
   /// The name of the endpoint that is being called.
   final String endpointName;
 
-  /// The uuid of the stream.
-  final String uuid;
+  /// The connection id that uniquely identifies the stream.
+  final UuidValue connectionId;
 
   /// Creates a new [Session] for a method call to a streaming endpoint.
   StreamingMethodCallSession({
@@ -311,7 +311,7 @@ class StreamingMethodCallSession extends Session {
     required super.authenticationKey,
     required this.endpointName,
     required this.methodName,
-    required this.uuid,
+    required this.connectionId,
   });
 }
 

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -290,11 +290,11 @@ class MethodCallSession extends Session {
   }
 }
 
-/// When a call is made to an endpoint method that uses a stream [Server] a
-/// [StreamingMethodCallSession] object is created. It contains all data
+/// When a connection is made to the [Server] to an endpoint method that uses a
+/// stream [MethodStreamSession] object is created. It contains all data
 /// associated with the current connection and provides easy access to the
 /// database.
-class StreamingMethodCallSession extends Session {
+class MethodStreamSession extends Session {
   /// The name of the method that is being called.
   final String methodName;
 
@@ -304,8 +304,8 @@ class StreamingMethodCallSession extends Session {
   /// The connection id that uniquely identifies the stream.
   final UuidValue connectionId;
 
-  /// Creates a new [Session] for a method call to a streaming endpoint.
-  StreamingMethodCallSession({
+  /// Creates a new [MethodStreamSession].
+  MethodStreamSession({
     required super.server,
     required super.enableLogging,
     required super.authenticationKey,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -123,7 +123,7 @@ class MethodWebsocketRequestHandler {
     var session = StreamingMethodCallSession(
       server: server,
       enableLogging: endpointConnector.endpoint.logSessions,
-      authenticationKey: message.auth,
+      authenticationKey: message.authentication,
       endpointName: endpointConnector.name,
       methodName: methodConnector.name,
       uuid: message.uuid,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -120,7 +120,7 @@ class MethodWebsocketRequestHandler {
     }
 
     // Create session
-    var session = StreamingMethodCallSession(
+    var session = MethodStreamSession(
       server: server,
       enableLogging: endpointConnector.endpoint.logSessions,
       authenticationKey: message.authentication,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -145,7 +145,7 @@ class MethodWebsocketRequestHandler {
         AuthenticationFailureReason.insufficientAccess =>
           OpenMethodStreamResponse.buildMessage(
             connectionId: message.connectionId,
-            responseType: OpenMethodStreamResponseType.insufficientScopes,
+            responseType: OpenMethodStreamResponseType.authorizationDeclined,
           ),
         AuthenticationFailureReason.unauthenticated =>
           OpenMethodStreamResponse.buildMessage(

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -280,7 +280,10 @@ class _MethodStreamManager {
       return;
     }
 
-    if (result != null) {
+    // TODO: Support nullable return types.
+    // Becuase encodeWithType doens't support nullable we can't encode null
+    // values.
+    if (methodConnector.returnsVoid == false && result != null) {
       _postMessage(
         endpoint: message.endpoint,
         method: message.method,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -97,7 +97,7 @@ class MethodWebsocketRequestHandler {
       );
       return OpenMethodStreamResponse.buildMessage(
         connectionId: message.connectionId,
-        responseType: OpenMethodStreamResponseType.methodNotFound,
+        responseType: OpenMethodStreamResponseType.endpointNotFound,
       );
     }
 

--- a/packages/serverpod/test/endpoint/parse_parameters_test.dart
+++ b/packages/serverpod/test/endpoint/parse_parameters_test.dart
@@ -46,7 +46,7 @@ void main() {
       );
     });
 
-    test('when parsing null parameter string then exception is thrown.', () {
+    test('when parsing null parameter string then an exception is thrown.', () {
       expect(
         () => EndpointDispatch.parseParameters(
           null,
@@ -58,7 +58,7 @@ void main() {
     });
 
     test(
-        'when parsing a non json decodable param string then exception is thrown.',
+        'when parsing a non json decodable param string then an exception is thrown.',
         () {
       expect(
         () => EndpointDispatch.parseParameters(
@@ -71,7 +71,7 @@ void main() {
     });
 
     test(
-        'when parsing param with different argument name then exception is thrown.',
+        'when parsing param with different argument name then an exception is thrown.',
         () {
       expect(
         () => EndpointDispatch.parseParameters(
@@ -170,7 +170,7 @@ void main() {
     });
 
     test(
-        'when parsing parameter string only containing one of the required parameters then exception is thrown.',
+        'when parsing parameter string only containing one of the required parameters then an exception is thrown.',
         () {
       expect(
         () => EndpointDispatch.parseParameters(
@@ -183,7 +183,7 @@ void main() {
     });
 
     test(
-        'when parsing parameter where only one of the required parameters is passed as additional parameters then exception is thrown.',
+        'when parsing parameter where only one of the required parameters is passed as additional parameters then an exception is thrown.',
         () {
       expect(
         () => EndpointDispatch.parseParameters(

--- a/packages/serverpod/test/endpoint/parse_parameters_test.dart
+++ b/packages/serverpod/test/endpoint/parse_parameters_test.dart
@@ -1,0 +1,199 @@
+import 'package:serverpod/protocol.dart';
+import 'package:serverpod/server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given no parameter descriptions when parsing null parameter string then empty map is returned.',
+      () {
+    expect(
+      EndpointDispatch.parseParameters(null, {}, Protocol()),
+      {},
+    );
+  });
+
+  group('Given single non nullable parameter description', () {
+    var parameterDescriptions = {
+      'arg1': ParameterDescription(
+        name: 'arg1',
+        type: int,
+        nullable: false,
+      ),
+    };
+
+    test('when parsing valid parameter string then parameter is parsed.', () {
+      expect(
+        EndpointDispatch.parseParameters(
+          '{"arg1": 42}',
+          parameterDescriptions,
+          Protocol(),
+        ),
+        {'arg1': 42},
+      );
+    });
+
+    test(
+        'when parsing parameter where required parameter is supplied as additional parameters then parameter is parsed.',
+        () {
+      expect(
+        EndpointDispatch.parseParameters(
+          null,
+          parameterDescriptions,
+          Protocol(),
+          additionalParameters: {'arg1': 42},
+        ),
+        {'arg1': 42},
+      );
+    });
+
+    test('when parsing null parameter string then exception is thrown.', () {
+      expect(
+        () => EndpointDispatch.parseParameters(
+          null,
+          parameterDescriptions,
+          Protocol(),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test(
+        'when parsing a non json decodable param string then exception is thrown.',
+        () {
+      expect(
+        () => EndpointDispatch.parseParameters(
+          'not a json string',
+          parameterDescriptions,
+          Protocol(),
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test(
+        'when parsing param with different argument name then exception is thrown.',
+        () {
+      expect(
+        () => EndpointDispatch.parseParameters(
+          '{"arg2": 42}',
+          parameterDescriptions,
+          Protocol(),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('Given single nullable parameter description', () {
+    var parameterDescriptions = {
+      'arg1': ParameterDescription(
+        name: 'arg1',
+        type: int,
+        nullable: true,
+      ),
+    };
+
+    test('when parsing valid parameter string then parameter is parsed.', () {
+      expect(
+        EndpointDispatch.parseParameters(
+          '{"arg1": 42}',
+          parameterDescriptions,
+          Protocol(),
+        ),
+        {'arg1': 42},
+      );
+    });
+
+    test('when parsing null parameter string then empty map is returned.', () {
+      expect(
+        EndpointDispatch.parseParameters(
+          null,
+          parameterDescriptions,
+          Protocol(),
+        ),
+        {},
+      );
+    });
+  });
+
+  group('Given multiple non nullable parameter descriptions', () {
+    var parameterDescriptions = {
+      'arg1': ParameterDescription(
+        name: 'arg1',
+        type: int,
+        nullable: false,
+      ),
+      'arg2': ParameterDescription(
+        name: 'arg2',
+        type: String,
+        nullable: false,
+      ),
+    };
+
+    test('when parsing valid parameter string then parameters are parsed.', () {
+      expect(
+        EndpointDispatch.parseParameters(
+          '{"arg1": 42, "arg2": "value"}',
+          parameterDescriptions,
+          Protocol(),
+        ),
+        {'arg1': 42, 'arg2': 'value'},
+      );
+    });
+
+    test(
+        'when parsing parameter where required parameters are supplied as additional parameters then parameters are parsed.',
+        () {
+      expect(
+        EndpointDispatch.parseParameters(
+          null,
+          parameterDescriptions,
+          Protocol(),
+          additionalParameters: {'arg1': 42, 'arg2': 'value'},
+        ),
+        {'arg1': 42, 'arg2': 'value'},
+      );
+    });
+
+    test(
+        'when parsing parameter where parameter string contains one parameter and additional parameters contains the other then parameters are parsed.',
+        () {
+      expect(
+        EndpointDispatch.parseParameters(
+          '{"arg1": 42}',
+          parameterDescriptions,
+          Protocol(),
+          additionalParameters: {'arg2': 'value'},
+        ),
+        {'arg1': 42, 'arg2': 'value'},
+      );
+    });
+
+    test(
+        'when parsing parameter string only containing one of the required parameters then exception is thrown.',
+        () {
+      expect(
+        () => EndpointDispatch.parseParameters(
+          "{'arg1': 42}",
+          parameterDescriptions,
+          Protocol(),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test(
+        'when parsing parameter where only one of the required parameters is passed as additional parameters then exception is thrown.',
+        () {
+      expect(
+        () => EndpointDispatch.parseParameters(
+          null,
+          parameterDescriptions,
+          Protocol(),
+          additionalParameters: {'arg1': 42},
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}

--- a/packages/serverpod_serialization/lib/src/extensions/serialization_extensions.dart
+++ b/packages/serverpod_serialization/lib/src/extensions/serialization_extensions.dart
@@ -34,7 +34,7 @@ extension UuidValueJsonExtension on UuidValue {
   /// Returns a deserialized version of the [UuidValue].
   static UuidValue fromJson(dynamic value) {
     if (value is UuidValue) return value;
-    return UuidValue.fromString(value as String);
+    return UuidValue.withValidation(value as String);
   }
 
   /// Returns a serialized version of the [UuidValue] as a [String].

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -28,6 +28,8 @@ sealed class WebSocketMessage {
           return CloseMethodStreamCommand(data);
         case MethodStreamMessage._messageType:
           return MethodStreamMessage(data);
+        case MethodStreamSerializableException._messageType:
+          return MethodStreamSerializableException(data);
       }
 
       throw UnknownMessageException(jsonString);
@@ -262,6 +264,62 @@ class PongCommand extends WebSocketMessage {
 
   @override
   String toString() => buildMessage();
+}
+
+/// A serializable exception sent over a method stream.
+class MethodStreamSerializableException extends WebSocketMessage {
+  static const String _messageType = 'method_stream_serializable_exception';
+
+  /// The endpoint the message is sent to.
+  final String endpoint;
+
+  /// The method the message is sent to.
+  final String method;
+
+  /// The UUID of the stream.
+  final String uuid;
+
+  /// The parameter the message is sent to.
+  /// If this is null the message is sent to the return stream of the method.
+  final String? parameter;
+
+  /// The object to send.
+  final String object;
+
+  /// Creates a new [MethodStreamSerializableException].
+  MethodStreamSerializableException(Map data)
+      : endpoint = data['endpoint'],
+        method = data['method'],
+        uuid = data['uuid'],
+        parameter = data['parameter'],
+        object = data['object'];
+
+  /// Builds a [MethodStreamSerializableException] message.
+  static String buildMessage({
+    required String endpoint,
+    required String method,
+    required String uuid,
+    String? parameter,
+    required String object,
+  }) {
+    return jsonEncode({
+      'messageType': _messageType,
+      'endpoint': endpoint,
+      'method': method,
+      'uuid': uuid,
+      if (parameter != null) 'parameter': parameter,
+      'object': object,
+    });
+  }
+
+  @override
+  String toString() => buildMessage(
+        endpoint: endpoint,
+        method: method,
+        uuid: uuid,
+        parameter: parameter,
+        object: object,
+      );
 }
 
 /// A message sent to a method stream.

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -26,6 +26,8 @@ sealed class WebSocketMessage {
           return OpenMethodStreamResponse(data);
         case CloseMethodStreamCommand._messageType:
           return CloseMethodStreamCommand(data);
+        case MethodStreamMessage._messageType:
+          return MethodStreamMessage(data);
       }
 
       throw UnknownMessageException(jsonString);
@@ -260,6 +262,62 @@ class PongCommand extends WebSocketMessage {
 
   @override
   String toString() => buildMessage();
+}
+
+/// A message sent to a method stream.
+class MethodStreamMessage extends WebSocketMessage {
+  static const String _messageType = 'method_message';
+
+  /// The endpoint the message is sent to.
+  final String endpoint;
+
+  /// The method the message is sent to.
+  final String method;
+
+  /// The UUID of the stream.
+  final String uuid;
+
+  /// The parameter the message is sent to.
+  /// If this is null the message is sent to the return stream of the method.
+  final String? parameter;
+
+  /// The object to send.
+  final String object;
+
+  /// Creates a new [MethodStreamMessage].
+  MethodStreamMessage(Map data)
+      : endpoint = data['endpoint'],
+        method = data['method'],
+        uuid = data['uuid'],
+        parameter = data['parameter'],
+        object = data['object'];
+
+  /// Builds a [MethodStreamMessage] message.
+  static String buildMessage({
+    required String endpoint,
+    required String method,
+    required String uuid,
+    String? parameter,
+    required String object,
+  }) {
+    return jsonEncode({
+      'messageType': _messageType,
+      'endpoint': endpoint,
+      'method': method,
+      'uuid': uuid,
+      if (parameter != null) 'parameter': parameter,
+      'object': object,
+    });
+  }
+
+  @override
+  String toString() => buildMessage(
+        endpoint: endpoint,
+        method: method,
+        uuid: uuid,
+        parameter: parameter,
+        object: object,
+      );
 }
 
 /// A message sent when a bad request is received.

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -77,33 +77,34 @@ enum OpenMethodStreamResponseType {
 class OpenMethodStreamResponse extends WebSocketMessage {
   static const String _messageType = 'open_method_stream_response';
 
-  /// The UUID of the stream.
-  final String uuid;
+  /// The connection id that uniquely identifies the stream.
+  final UuidValue connectionId;
 
   /// The response type.
   final OpenMethodStreamResponseType responseType;
 
   /// Creates a new [OpenMethodStreamResponse].
   OpenMethodStreamResponse(Map data)
-      : uuid = data['uuid'],
+      : connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
         responseType = OpenMethodStreamResponseType.tryParse(
           data['responseType'],
         );
 
   /// Builds a new [OpenMethodStreamResponse] message.
   static String buildMessage({
-    required String uuid,
+    required UuidValue connectionId,
     required OpenMethodStreamResponseType responseType,
   }) {
-    return jsonEncode({
+    return SerializationManager.encode({
       'messageType': _messageType,
-      'uuid': uuid,
+      'connectionId': connectionId,
       'responseType': responseType.name,
     });
   }
 
   @override
-  String toString() => buildMessage(uuid: uuid, responseType: responseType);
+  String toString() =>
+      buildMessage(connectionId: connectionId, responseType: responseType);
 }
 
 /// A message sent over a websocket connection to open a websocket stream of
@@ -122,8 +123,8 @@ class OpenMethodStreamCommand extends WebSocketMessage {
   /// The arguments to pass to the method.
   final String args;
 
-  /// The UUID of the stream.
-  final String uuid;
+  /// The connection id that uniquely identifies the stream.
+  final UuidValue connectionId;
 
   /// The authentication token.
   final String? authentication;
@@ -133,7 +134,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
       : endpoint = data['endpoint'],
         method = data['method'],
         args = data['args'],
-        uuid = data['uuid'],
+        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
         authentication = data['authentication'];
 
   /// Creates a new [OpenMethodStreamCommand].
@@ -141,14 +142,14 @@ class OpenMethodStreamCommand extends WebSocketMessage {
     required String endpoint,
     required String method,
     required Map<String, dynamic> args,
-    required String uuid,
+    required UuidValue connectionId,
     String? authentication,
   }) {
-    return jsonEncode({
+    return SerializationManager.encode({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
-      'uuid': uuid,
+      'connectionId': connectionId,
       'args': SerializationManager.encodeForProtocol(args),
       if (authentication != null) 'authentication': authentication,
     });
@@ -159,7 +160,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
         'messageType': _messageType,
         'endpoint': endpoint,
         'method': method,
-        'uuid': uuid,
+        'connectionId': SerializationManager.encode(connectionId),
         'args': args,
         if (authentication != null) 'authentication': authentication,
       }.toString();
@@ -193,8 +194,8 @@ class CloseMethodStreamCommand extends WebSocketMessage {
   /// The method associated with the stream.
   final String method;
 
-  /// The UUID of the stream.
-  final String uuid;
+  /// The connection id that uniquely identifies the stream.
+  final UuidValue connectionId;
 
   /// The parameter associated with the stream.
   /// If this is null the close command targets the return stream of the method.
@@ -207,23 +208,23 @@ class CloseMethodStreamCommand extends WebSocketMessage {
   CloseMethodStreamCommand(Map data)
       : endpoint = data['endpoint'],
         method = data['method'],
-        uuid = data['uuid'],
+        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
         parameter = data['parameter'],
         reason = CloseReason.tryParse(data['reason']);
 
   /// Creates a new [CloseMethodStreamCommand] message.
   static String buildMessage({
     required String endpoint,
-    required String uuid,
+    required UuidValue connectionId,
     String? parameter,
     required String method,
     required CloseReason reason,
   }) {
-    return jsonEncode({
+    return SerializationManager.encode({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
-      'uuid': uuid,
+      'connectionId': connectionId,
       if (parameter != null) 'parameter': parameter,
       'reason': reason.name,
     });
@@ -232,7 +233,7 @@ class CloseMethodStreamCommand extends WebSocketMessage {
   @override
   String toString() => buildMessage(
         endpoint: endpoint,
-        uuid: uuid,
+        connectionId: connectionId,
         parameter: parameter,
         method: method,
         reason: reason,
@@ -246,7 +247,7 @@ class PingCommand extends WebSocketMessage {
 
   /// Builds a [PingCommand] message.
   static String buildMessage() {
-    return jsonEncode({'messageType': _messageType});
+    return SerializationManager.encode({'messageType': _messageType});
   }
 
   @override
@@ -259,7 +260,7 @@ class PongCommand extends WebSocketMessage {
 
   /// Builds a [PongCommand] message.
   static String buildMessage() {
-    return jsonEncode({'messageType': _messageType});
+    return SerializationManager.encode({'messageType': _messageType});
   }
 
   @override
@@ -276,8 +277,8 @@ class MethodStreamSerializableException extends WebSocketMessage {
   /// The method the message is sent to.
   final String method;
 
-  /// The UUID of the stream.
-  final String uuid;
+  /// The connection id that uniquely identifies the stream.
+  final UuidValue connectionId;
 
   /// The parameter the message is sent to.
   /// If this is null the message is sent to the return stream of the method.
@@ -290,7 +291,7 @@ class MethodStreamSerializableException extends WebSocketMessage {
   MethodStreamSerializableException(Map data)
       : endpoint = data['endpoint'],
         method = data['method'],
-        uuid = data['uuid'],
+        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
         parameter = data['parameter'],
         object = data['object'];
 
@@ -298,15 +299,15 @@ class MethodStreamSerializableException extends WebSocketMessage {
   static String buildMessage({
     required String endpoint,
     required String method,
-    required String uuid,
+    required UuidValue connectionId,
     String? parameter,
     required String object,
   }) {
-    return jsonEncode({
+    return SerializationManager.encode({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
-      'uuid': uuid,
+      'connectionId': connectionId,
       if (parameter != null) 'parameter': parameter,
       'object': object,
     });
@@ -316,7 +317,7 @@ class MethodStreamSerializableException extends WebSocketMessage {
   String toString() => buildMessage(
         endpoint: endpoint,
         method: method,
-        uuid: uuid,
+        connectionId: connectionId,
         parameter: parameter,
         object: object,
       );
@@ -332,8 +333,8 @@ class MethodStreamMessage extends WebSocketMessage {
   /// The method the message is sent to.
   final String method;
 
-  /// The UUID of the stream.
-  final String uuid;
+  /// The connection id that uniquely identifies the stream.
+  final UuidValue connectionId;
 
   /// The parameter the message is sent to.
   /// If this is null the message is sent to the return stream of the method.
@@ -346,7 +347,7 @@ class MethodStreamMessage extends WebSocketMessage {
   MethodStreamMessage(Map data)
       : endpoint = data['endpoint'],
         method = data['method'],
-        uuid = data['uuid'],
+        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
         parameter = data['parameter'],
         object = data['object'];
 
@@ -354,15 +355,15 @@ class MethodStreamMessage extends WebSocketMessage {
   static String buildMessage({
     required String endpoint,
     required String method,
-    required String uuid,
+    required UuidValue connectionId,
     String? parameter,
     required String object,
   }) {
-    return jsonEncode({
+    return SerializationManager.encode({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
-      'uuid': uuid,
+      'connectionId': connectionId,
       if (parameter != null) 'parameter': parameter,
       'object': object,
     });
@@ -372,7 +373,7 @@ class MethodStreamMessage extends WebSocketMessage {
   String toString() => buildMessage(
         endpoint: endpoint,
         method: method,
-        uuid: uuid,
+        connectionId: connectionId,
         parameter: parameter,
         object: object,
       );
@@ -390,7 +391,7 @@ class BadRequestMessage extends WebSocketMessage {
 
   /// Builds a [BadRequestMessage] message.
   static String buildMessage(String request) {
-    return jsonEncode({
+    return SerializationManager.encode({
       'messageType': _messageType,
       'request': request,
     });

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -126,7 +126,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
   final String uuid;
 
   /// The authentication token.
-  final String? auth;
+  final String? authentication;
 
   /// Creates a new [OpenMethodStreamCommand] message.
   OpenMethodStreamCommand(Map data)
@@ -134,7 +134,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
         method = data['method'],
         args = data['args'],
         uuid = data['uuid'],
-        auth = data['auth'];
+        authentication = data['authentication'];
 
   /// Creates a new [OpenMethodStreamCommand].
   static String buildMessage({
@@ -142,7 +142,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
     required String method,
     required Map<String, dynamic> args,
     required String uuid,
-    String? auth,
+    String? authentication,
   }) {
     return jsonEncode({
       'messageType': _messageType,
@@ -150,7 +150,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
       'method': method,
       'uuid': uuid,
       'args': SerializationManager.encodeForProtocol(args),
-      if (auth != null) 'auth': auth,
+      if (authentication != null) 'authentication': authentication,
     });
   }
 
@@ -161,7 +161,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
         'method': method,
         'uuid': uuid,
         'args': args,
-        if (auth != null) 'auth': auth,
+        if (authentication != null) 'authentication': authentication,
       }.toString();
 }
 

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -12,11 +12,11 @@ sealed class WebSocketMessage {
       var messageType = data['messageType'];
 
       switch (messageType) {
-        case PingCommand.messageType:
+        case PingCommand._messageType:
           return PingCommand();
-        case PongCommand.messageType:
+        case PongCommand._messageType:
           return PongCommand();
-        case BadRequestMessage.messageType:
+        case BadRequestMessage._messageType:
           return BadRequestMessage(data);
       }
 
@@ -34,30 +34,27 @@ sealed class WebSocketMessage {
 /// A message sent over a websocket connection to check if the connection is
 /// still alive. The other end should respond with a [PongCommand].
 class PingCommand extends WebSocketMessage {
-  /// The type of message.
-  static const String messageType = 'ping_command';
+  static const String _messageType = 'ping_command';
 
   /// Builds a [PingCommand] message.
   static String buildMessage() {
-    return jsonEncode({'messageType': messageType});
+    return jsonEncode({'messageType': _messageType});
   }
 }
 
 /// A response to a [PingCommand].
 class PongCommand extends WebSocketMessage {
-  /// The type of message.
-  static const String messageType = 'pong_command';
+  static const String _messageType = 'pong_command';
 
   /// Builds a [PongCommand] message.
   static String buildMessage() {
-    return jsonEncode({'messageType': messageType});
+    return jsonEncode({'messageType': _messageType});
   }
 }
 
 /// A message sent when a bad request is received.
 class BadRequestMessage extends WebSocketMessage {
-  /// The type of message.
-  static const String messageType = 'bad_request_message';
+  static const String _messageType = 'bad_request_message';
 
   /// The request that was bad.
   final String request;
@@ -68,7 +65,7 @@ class BadRequestMessage extends WebSocketMessage {
   /// Builds a [BadRequestMessage] message.
   static String buildMessage(String request) {
     return jsonEncode({
-      'messageType': messageType,
+      'messageType': _messageType,
       'request': request,
     });
   }

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -57,8 +57,8 @@ enum OpenMethodStreamResponseType {
   /// The user is not authenticated.
   authenticationFailed,
 
-  /// The user does not have the required scopes.
-  insufficientScopes,
+  /// The user is not authorized.
+  authorizationDeclined,
 
   /// The arguments were invalid.
   invalidArguments;

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -51,9 +51,6 @@ enum OpenMethodStreamResponseType {
   /// The endpoint was not found.
   endpointNotFound,
 
-  /// The method was not found.
-  methodNotFound,
-
   /// The user is not authenticated.
   authenticationFailed,
 

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -40,6 +40,9 @@ class PingCommand extends WebSocketMessage {
   static String buildMessage() {
     return jsonEncode({'messageType': _messageType});
   }
+
+  @override
+  String toString() => buildMessage();
 }
 
 /// A response to a [PingCommand].
@@ -50,6 +53,9 @@ class PongCommand extends WebSocketMessage {
   static String buildMessage() {
     return jsonEncode({'messageType': _messageType});
   }
+
+  @override
+  String toString() => buildMessage();
 }
 
 /// A message sent when a bad request is received.
@@ -69,6 +75,9 @@ class BadRequestMessage extends WebSocketMessage {
       'request': request,
     });
   }
+
+  @override
+  String toString() => buildMessage(request);
 }
 
 /// Exception thrown when an unknown message is received.

--- a/packages/serverpod_serialization/test/extensions_test.dart
+++ b/packages/serverpod_serialization/test/extensions_test.dart
@@ -99,6 +99,13 @@ void main() {
   );
 
   test(
+      'Given invalid UUID string, when deserialized to a UuidValue, then it throws an exception',
+      () {
+    String value = 'hello world';
+    expect(() => UuidValueJsonExtension.fromJson(value),
+        throwsA(isA<FormatException>()));
+  });
+  test(
     'Given a base64-encoded string, when deserialized to ByteData and then serialized back to a string, then it matches the original string',
     () {
       String value = 'decode(\'AAECAwQFBgc=\', \'base64\')';

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -91,7 +91,7 @@ void main() {
       method: 'method',
       args: {'arg1': 'value1', 'arg2': 2},
       uuid: 'uuid',
-      auth: 'auth',
+      authentication: 'auth',
     );
     var result = WebSocketMessage.fromJsonString(message);
     expect(result, isA<OpenMethodStreamCommand>());
@@ -106,7 +106,7 @@ void main() {
       "method": "method',
       "args": {"arg1": "value1", "arg2": 2},
       "uuid": "uuid",
-      "auth": "auth",
+      "authentication": "auth",
     }''';
 
     expect(

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -82,4 +82,39 @@ void main() {
       throwsA(isA<UnknownMessageException>()),
     );
   });
+
+  test(
+      'Given an open method stream command when building websocket message from string then OpenMethodStreamCommand is returned.',
+      () {
+    var message = OpenMethodStreamCommand.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      args: {'arg1': 'value1', 'arg2': 2},
+      uuid: 'uuid',
+      auth: 'auth',
+    );
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<OpenMethodStreamCommand>());
+  });
+
+  test(
+      'Given an invalid open method stream command json String that is missing mandatory endpoint field when building websocket message from string then UnknownMessageException is thrown having FormatException error type.',
+      () {
+    // This message is missing the mandatory endpoint field.
+    var message = '''{
+      "messageType": "open_method_stream_command',
+      "method": "method',
+      "args": {"arg1": "value1", "arg2": 2},
+      "uuid": "uuid",
+      "auth": "auth",
+    }''';
+
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(
+        isA<UnknownMessageException>()
+            .having((e) => e.error, 'error', isA<FormatException>()),
+      ),
+    );
+  });
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -143,4 +143,54 @@ void main() {
       throwsA(isA<UnknownMessageException>()),
     );
   });
+
+  test(
+      'Given a close method stream command when building websocket message from string then CloseMethodStreamCommand is returned.',
+      () {
+    var message = CloseMethodStreamCommand.buildMessage(
+      uuid: 'uuid',
+      endpoint: 'endpoint',
+      parameter: 'parameter',
+      method: 'method',
+      reason: CloseReason.done,
+    );
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<CloseMethodStreamCommand>());
+  });
+
+  test(
+      'Given an invalid close method stream command json String that is missing mandatory uuid field when building websocket message from string then UnknownMessageException is thrown having FormatException error type.',
+      () {
+    // This message is missing the mandatory uuid field.
+    var message = '''{
+      "messageType": "close_method_stream_command",
+      "endpoint": "endpoint",
+      "parameter": "parameter",
+      "method": "method",
+      "reason": "done",
+    }''';
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(
+        isA<UnknownMessageException>()
+            .having((e) => e.error, 'error', isA<FormatException>()),
+      ),
+    );
+  });
+  test(
+      'Given an close method stream command with an invalid reason when building websocket message from string then UnknownMessageException is thrown.',
+      () {
+    var message = '''{
+      "messageType": "close_method_stream_command",
+      "uuid": "uuid",
+      "endpoint": "endpoint",
+      "parameter": "parameter",
+      "method": "method",
+      "reason": "this reason does not exist"
+    }''';
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(isA<UnknownMessageException>()),
+    );
+  });
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -117,4 +117,30 @@ void main() {
       ),
     );
   });
+
+  test(
+      'Given an open method stream response when building websocket message from string then OpenMethodStreamResponse is returned.',
+      () {
+    var message = OpenMethodStreamResponse.buildMessage(
+      uuid: 'uuid',
+      responseType: OpenMethodStreamResponseType.success,
+    );
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<OpenMethodStreamResponse>());
+  });
+
+  test(
+      'Given an open method stream response with an invalid response type when building websocket message from string then UnknownMessageException is thrown.',
+      () {
+    var message = '''{
+      "messageType": "open_method_stream_response",
+      "uuid": "uuid",
+      "responseType": "this response type does not exist"
+    }''';
+
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(isA<UnknownMessageException>()),
+    );
+  });
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -177,6 +177,7 @@ void main() {
       ),
     );
   });
+
   test(
       'Given an close method stream command with an invalid reason when building websocket message from string then UnknownMessageException is thrown.',
       () {
@@ -191,6 +192,39 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(message),
       throwsA(isA<UnknownMessageException>()),
+    );
+  });
+
+  test(
+      'Given a method stream message when building websocket message from string then MethodStreamMessage is returned.',
+      () {
+    var message = MethodStreamMessage.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      uuid: 'uuid',
+      object: '{"className": "bamboo", "data": {"number": 2}}',
+    );
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<MethodStreamMessage>());
+  });
+
+  test(
+      'Given an invalid method stream message json String that is missing mandatory endpoint field when building websocket message from string then UnknownMessageException is thrown.',
+      () {
+    // This message is missing the mandatory endpoint field.
+    var message = '''{
+      "messageType": "method_stream_message",
+      "method": "method",
+      "uuid": "uuid",
+      "object": '{"className": "bamboo", "data": {"number": 2}}',
+    }''';
+
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(
+        isA<UnknownMessageException>()
+            .having((e) => e.error, 'error', isA<FormatException>()),
+      ),
     );
   });
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod_serialization/src/websocket_messages.dart';
 import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
 
 void main() {
   test(
@@ -90,7 +91,7 @@ void main() {
       endpoint: 'endpoint',
       method: 'method',
       args: {'arg1': 'value1', 'arg2': 2},
-      uuid: 'uuid',
+      connectionId: const Uuid().v4obj(),
       authentication: 'auth',
     );
     var result = WebSocketMessage.fromJsonString(message);
@@ -122,7 +123,7 @@ void main() {
       'Given an open method stream response when building websocket message from string then OpenMethodStreamResponse is returned.',
       () {
     var message = OpenMethodStreamResponse.buildMessage(
-      uuid: 'uuid',
+      connectionId: const Uuid().v4obj(),
       responseType: OpenMethodStreamResponseType.success,
     );
     var result = WebSocketMessage.fromJsonString(message);
@@ -148,7 +149,7 @@ void main() {
       'Given a close method stream command when building websocket message from string then CloseMethodStreamCommand is returned.',
       () {
     var message = CloseMethodStreamCommand.buildMessage(
-      uuid: 'uuid',
+      connectionId: const Uuid().v4obj(),
       endpoint: 'endpoint',
       parameter: 'parameter',
       method: 'method',
@@ -201,7 +202,7 @@ void main() {
     var message = MethodStreamMessage.buildMessage(
       endpoint: 'endpoint',
       method: 'method',
-      uuid: 'uuid',
+      connectionId: const Uuid().v4obj(),
       object: '{"className": "bamboo", "data": {"number": 2}}',
     );
     var result = WebSocketMessage.fromJsonString(message);
@@ -234,7 +235,7 @@ void main() {
     var message = MethodStreamSerializableException.buildMessage(
       endpoint: 'endpoint',
       method: 'method',
-      uuid: 'uuid',
+      connectionId: const Uuid().v4obj(),
       object:
           '{"className": "serializableException", "data": {"message": "error message"}}',
     );

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -227,4 +227,38 @@ void main() {
       ),
     );
   });
+
+  test(
+      'Given method stream serializable exception when building websocket message from string then MethodStreamSerializableException is returned.',
+      () {
+    var message = MethodStreamSerializableException.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      uuid: 'uuid',
+      object:
+          '{"className": "serializableException", "data": {"message": "error message"}}',
+    );
+    var result = WebSocketMessage.fromJsonString(message);
+    expect(result, isA<MethodStreamSerializableException>());
+  });
+
+  test(
+      'Given invalid method stream serializable exception json String when building websocket message from string then UnknownMessageException is thrown.',
+      () {
+    // This message is missing the mandatory endpoint field.
+    var message = '''{
+      "messageType": "method_stream_serializable_exception",
+      "method": "method",
+      "uuid": "uuid",
+      "object": '{"className": "serializableException", "data": {"message": "error message"}}',
+    }''';
+
+    expect(
+      () => WebSocketMessage.fromJsonString(message),
+      throwsA(
+        isA<UnknownMessageException>()
+            .having((e) => e.error, 'error', isA<FormatException>()),
+      ),
+    );
+  });
 }

--- a/templates/serverpod_templates/modulename_server/lib/src/generated/endpoints.dart
+++ b/templates/serverpod_templates/modulename_server/lib/src/generated/endpoints.dart
@@ -35,6 +35,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/templates/serverpod_templates/projectname_server/lib/src/generated/endpoints.dart
+++ b/templates/serverpod_templates/projectname_server/lib/src/generated/endpoints.dart
@@ -35,6 +35,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1202,6 +1202,86 @@ class EndpointMapParameters extends _i1.EndpointRef {
 }
 
 /// {@category Endpoint}
+class EndpointMethodStreaming extends _i1.EndpointRef {
+  EndpointMethodStreaming(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'methodStreaming';
+
+  _i2.Future<void> simpleEndpoint() => caller.callServerEndpoint<void>(
+        'methodStreaming',
+        'simpleEndpoint',
+        {},
+      );
+
+  _i2.Future<void> intParameter(int value) => caller.callServerEndpoint<void>(
+        'methodStreaming',
+        'intParameter',
+        {'value': value},
+      );
+
+  _i2.Future<int?> nullableResponse(int? value) =>
+      caller.callServerEndpoint<int?>(
+        'methodStreaming',
+        'nullableResponse',
+        {'value': value},
+      );
+
+  _i2.Future<int> doubleInputValue(int value) => caller.callServerEndpoint<int>(
+        'methodStreaming',
+        'doubleInputValue',
+        {'value': value},
+      );
+
+  /// Delays the response for [delay] seconds.
+  ///
+  /// Responses can be closed by calling [completeAllDelayedResponses].
+  _i2.Future<void> delayedResponse(int delay) =>
+      caller.callServerEndpoint<void>(
+        'methodStreaming',
+        'delayedResponse',
+        {'delay': delay},
+      );
+
+  /// Completes all delayed responses.
+  /// This makes the delayedResponse return directly.
+  _i2.Future<void> completeAllDelayedResponses() =>
+      caller.callServerEndpoint<void>(
+        'methodStreaming',
+        'completeAllDelayedResponses',
+        {},
+      );
+
+  _i2.Future<void> throwsException() => caller.callServerEndpoint<void>(
+        'methodStreaming',
+        'throwsException',
+        {},
+      );
+
+  _i2.Future<void> throwsSerializableException() =>
+      caller.callServerEndpoint<void>(
+        'methodStreaming',
+        'throwsSerializableException',
+        {},
+      );
+}
+
+/// {@category Endpoint}
+class EndpointAuthenticatedMethodStreaming extends _i1.EndpointRef {
+  EndpointAuthenticatedMethodStreaming(_i1.EndpointCaller caller)
+      : super(caller);
+
+  @override
+  String get name => 'authenticatedMethodStreaming';
+
+  _i2.Future<void> simpleEndpoint() => caller.callServerEndpoint<void>(
+        'authenticatedMethodStreaming',
+        'simpleEndpoint',
+        {},
+      );
+}
+
+/// {@category Endpoint}
 class EndpointModuleSerialization extends _i1.EndpointRef {
   EndpointModuleSerialization(_i1.EndpointCaller caller) : super(caller);
 
@@ -1545,6 +1625,8 @@ class Client extends _i1.ServerpodClient {
     logging = EndpointLogging(this);
     loggingDisabled = EndpointLoggingDisabled(this);
     mapParameters = EndpointMapParameters(this);
+    methodStreaming = EndpointMethodStreaming(this);
+    authenticatedMethodStreaming = EndpointAuthenticatedMethodStreaming(this);
     moduleSerialization = EndpointModuleSerialization(this);
     namedParameters = EndpointNamedParameters(this);
     optionalParameters = EndpointOptionalParameters(this);
@@ -1596,6 +1678,10 @@ class Client extends _i1.ServerpodClient {
 
   late final EndpointMapParameters mapParameters;
 
+  late final EndpointMethodStreaming methodStreaming;
+
+  late final EndpointAuthenticatedMethodStreaming authenticatedMethodStreaming;
+
   late final EndpointModuleSerialization moduleSerialization;
 
   late final EndpointNamedParameters namedParameters;
@@ -1642,6 +1728,8 @@ class Client extends _i1.ServerpodClient {
         'logging': logging,
         'loggingDisabled': loggingDisabled,
         'mapParameters': mapParameters,
+        'methodStreaming': methodStreaming,
+        'authenticatedMethodStreaming': authenticatedMethodStreaming,
         'moduleSerialization': moduleSerialization,
         'namedParameters': namedParameters,
         'optionalParameters': optionalParameters,

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
@@ -44,6 +44,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -62,6 +63,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+
+class MethodStreaming extends Endpoint {
+  Map<String, Completer> _delayedResponses = {};
+
+  Future<void> simpleEndpoint(Session session) async {}
+
+  Future<void> intParameter(Session session, int value) async {}
+
+  Future<int?> nullableResponse(Session session, int? value) async {
+    return value;
+  }
+
+  Future<int> doubleInputValue(Session session, int value) async {
+    return value * 2;
+  }
+
+  /// Delays the response for [delay] seconds.
+  ///
+  /// Responses can be closed by calling [completeAllDelayedResponses].
+  Future<void> delayedResponse(Session session, int delay) async {
+    var uuid = Uuid().v4();
+    var completer = Completer<void>();
+    _delayedResponses[uuid] = completer;
+
+    Future.delayed(Duration(seconds: delay), () {
+      _delayedResponses.remove(uuid)?.complete();
+    });
+
+    return completer.future;
+  }
+
+  /// Completes all delayed responses.
+  /// This makes the delayedResponse return directly.
+  Future<void> completeAllDelayedResponses(Session session) async {
+    var delayedResponses = _delayedResponses.values.toList();
+    _delayedResponses.clear();
+    for (var response in delayedResponses) {
+      response.complete();
+    }
+  }
+
+  Future<void> throwsException(Session session) async {
+    throw Exception('This is an exception');
+  }
+
+  Future<void> throwsSerializableException(Session session) async {
+    throw ExceptionWithData(
+      message: 'Throwing an exception',
+      creationDate: DateTime.now(),
+      errorFields: [
+        'first line error',
+        'second line error',
+      ],
+      someNullableField: 1,
+    );
+  }
+}
+
+class AuthenticatedMethodStreaming extends Endpoint {
+  @override
+  bool get requireLogin => true;
+
+  @override
+  Set<Scope> get requiredScopes => {Scope.admin};
+
+  Future<void> simpleEndpoint(Session session) async {}
+}

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -272,6 +272,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -292,6 +293,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -311,6 +313,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'removeAllUsers': _i1.MethodConnector(
           name: 'removeAllUsers',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -321,6 +324,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'countUsers': _i1.MethodConnector(
           name: 'countUsers',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -342,6 +346,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -372,6 +377,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -387,6 +393,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'signOut': _i1.MethodConnector(
           name: 'signOut',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -409,6 +416,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -427,6 +435,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -445,6 +454,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -463,6 +473,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -481,6 +492,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -499,6 +511,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -517,6 +530,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -535,6 +549,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -553,6 +568,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'reset': _i1.MethodConnector(
           name: 'reset',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -574,6 +590,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -594,6 +611,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -613,6 +631,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -632,6 +651,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -651,6 +671,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -670,6 +691,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -689,6 +711,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -719,6 +742,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -739,6 +763,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -758,6 +783,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -777,6 +803,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -796,6 +823,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -815,6 +843,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -834,6 +863,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -853,6 +883,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getProtocolField': _i1.MethodConnector(
           name: 'getProtocolField',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -876,6 +907,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -895,6 +927,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -914,6 +947,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -933,6 +967,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -952,6 +987,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -971,6 +1007,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -990,6 +1027,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1009,6 +1047,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1028,6 +1067,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'deleteAllSimpleTestData': _i1.MethodConnector(
           name: 'deleteAllSimpleTestData',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1044,6 +1084,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1063,6 +1104,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1082,6 +1124,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1106,6 +1149,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1125,6 +1169,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1144,6 +1189,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1178,6 +1224,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1200,6 +1247,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1219,6 +1267,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1238,6 +1287,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1251,6 +1301,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'deleteWhereSimpleData': _i1.MethodConnector(
           name: 'deleteWhereSimpleData',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1261,6 +1312,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'countSimpleData': _i1.MethodConnector(
           name: 'countSimpleData',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1277,6 +1329,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1295,6 +1348,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1307,6 +1361,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'countTypesRows': _i1.MethodConnector(
           name: 'countTypesRows',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1317,6 +1372,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'deleteAllInTypes': _i1.MethodConnector(
           name: 'deleteAllInTypes',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1333,6 +1389,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1351,6 +1408,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1370,6 +1428,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1389,6 +1448,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1408,6 +1468,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1427,6 +1488,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1440,6 +1502,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'deleteAll': _i1.MethodConnector(
           name: 'deleteAll',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1450,6 +1513,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'testByteDataStore': _i1.MethodConnector(
           name: 'testByteDataStore',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1472,6 +1536,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1502,6 +1567,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1535,6 +1601,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1555,6 +1622,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1568,6 +1636,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'tearDown': _i1.MethodConnector(
           name: 'tearDown',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1594,6 +1663,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1615,6 +1685,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'throwNormalException': _i1.MethodConnector(
           name: 'throwNormalException',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1625,6 +1696,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'throwExceptionWithData': _i1.MethodConnector(
           name: 'throwExceptionWithData',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1635,6 +1707,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'workingWithoutException': _i1.MethodConnector(
           name: 'workingWithoutException',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1651,6 +1724,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'failedCall': _i1.MethodConnector(
           name: 'failedCall',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1661,6 +1735,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'failedDatabaseQuery': _i1.MethodConnector(
           name: 'failedDatabaseQuery',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1671,6 +1746,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'failedDatabaseQueryCaughtException': _i1.MethodConnector(
           name: 'failedDatabaseQueryCaughtException',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1681,6 +1757,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'slowCall': _i1.MethodConnector(
           name: 'slowCall',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1691,6 +1768,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'caughtException': _i1.MethodConnector(
           name: 'caughtException',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1713,6 +1791,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1726,6 +1805,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'retrieveObject': _i1.MethodConnector(
           name: 'retrieveObject',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1748,6 +1828,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1773,6 +1854,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1792,6 +1874,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1811,6 +1894,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1830,6 +1914,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1849,6 +1934,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1868,6 +1954,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1887,6 +1974,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1906,6 +1994,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1925,6 +2014,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1944,6 +2034,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1963,6 +2054,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -1982,6 +2074,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2001,6 +2094,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2020,6 +2114,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2039,6 +2134,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2058,6 +2154,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2077,6 +2174,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2096,6 +2194,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2115,6 +2214,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2134,6 +2234,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2153,6 +2254,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2172,6 +2274,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2191,6 +2294,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2216,6 +2320,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2244,6 +2349,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2259,6 +2365,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'twoQueries': _i1.MethodConnector(
           name: 'twoQueries',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2281,6 +2388,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2306,6 +2414,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2325,6 +2434,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2344,6 +2454,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2363,6 +2474,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2382,6 +2494,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2401,6 +2514,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2420,6 +2534,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2439,6 +2554,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2458,6 +2574,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2477,6 +2594,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2496,6 +2614,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2515,6 +2634,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2534,6 +2654,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2553,6 +2674,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2572,6 +2694,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2591,6 +2714,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2610,6 +2734,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2629,6 +2754,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2648,6 +2774,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2667,6 +2794,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2686,6 +2814,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2705,6 +2834,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2724,6 +2854,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2743,6 +2874,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2762,6 +2894,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'simpleEndpoint': _i1.MethodConnector(
           name: 'simpleEndpoint',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2778,6 +2911,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2797,6 +2931,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2816,6 +2951,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2835,6 +2971,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2848,6 +2985,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'completeAllDelayedResponses': _i1.MethodConnector(
           name: 'completeAllDelayedResponses',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2858,6 +2996,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'throwsException': _i1.MethodConnector(
           name: 'throwsException',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2868,6 +3007,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'throwsSerializableException': _i1.MethodConnector(
           name: 'throwsSerializableException',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2884,6 +3024,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'simpleEndpoint': _i1.MethodConnector(
           name: 'simpleEndpoint',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2901,6 +3042,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'serializeModuleObject': _i1.MethodConnector(
           name: 'serializeModuleObject',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2918,6 +3060,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2932,6 +3075,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'serializeNestedModuleObject': _i1.MethodConnector(
           name: 'serializeNestedModuleObject',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2970,6 +3114,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -2997,6 +3142,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3023,6 +3169,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3054,6 +3201,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3078,6 +3226,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3098,6 +3247,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3116,6 +3266,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3128,6 +3279,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'resetMessageCentralTest': _i1.MethodConnector(
           name: 'resetMessageCentralTest',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3144,6 +3296,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3167,6 +3320,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3180,6 +3334,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'countSubscribedChannels': _i1.MethodConnector(
           name: 'countSubscribedChannels',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3196,6 +3351,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getScopeServerOnlyField': _i1.MethodConnector(
           name: 'getScopeServerOnlyField',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3213,6 +3369,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'testMethod': _i1.MethodConnector(
           name: 'testMethod',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3229,6 +3386,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'testMethod': _i1.MethodConnector(
           name: 'testMethod',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3257,6 +3415,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: true,
             ),
           },
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3270,6 +3429,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'addToGlobalInt': _i1.MethodConnector(
           name: 'addToGlobalInt',
           params: {},
+          returnsVoid: true,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3280,6 +3440,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'getGlobalInt': _i1.MethodConnector(
           name: 'getGlobalInt',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3296,6 +3457,7 @@ class Endpoints extends _i1.EndpointDispatch {
               nullable: false,
             )
           },
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3324,6 +3486,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'testMethod': _i1.MethodConnector(
           name: 'testMethod',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,
@@ -3340,6 +3503,7 @@ class Endpoints extends _i1.EndpointDispatch {
         'testMethod': _i1.MethodConnector(
           name: 'testMethod',
           params: {},
+          returnsVoid: false,
           call: (
             _i1.Session session,
             Map<String, dynamic> params,

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -27,34 +27,35 @@ import '../endpoints/list_parameters.dart' as _i16;
 import '../endpoints/logging.dart' as _i17;
 import '../endpoints/logging_disabled.dart' as _i18;
 import '../endpoints/map_parameters.dart' as _i19;
-import '../endpoints/module_serialization.dart' as _i20;
-import '../endpoints/named_parameters.dart' as _i21;
-import '../endpoints/optional_parameters.dart' as _i22;
-import '../endpoints/redis.dart' as _i23;
-import '../endpoints/server_only_scoped_field_model.dart' as _i24;
-import '../endpoints/signin_required.dart' as _i25;
-import '../endpoints/simple.dart' as _i26;
-import '../endpoints/streaming.dart' as _i27;
-import '../endpoints/streaming_logging.dart' as _i28;
-import '../endpoints/subDir/subSubDir/subsubdir_test_endpoint.dart' as _i29;
-import '../endpoints/subDir/subdir_test_endpoint.dart' as _i30;
-import 'dart:typed_data' as _i31;
-import 'package:uuid/uuid_value.dart' as _i32;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i33;
-import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i34;
-import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i35;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i36;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i37;
+import '../endpoints/method_streaming.dart' as _i20;
+import '../endpoints/module_serialization.dart' as _i21;
+import '../endpoints/named_parameters.dart' as _i22;
+import '../endpoints/optional_parameters.dart' as _i23;
+import '../endpoints/redis.dart' as _i24;
+import '../endpoints/server_only_scoped_field_model.dart' as _i25;
+import '../endpoints/signin_required.dart' as _i26;
+import '../endpoints/simple.dart' as _i27;
+import '../endpoints/streaming.dart' as _i28;
+import '../endpoints/streaming_logging.dart' as _i29;
+import '../endpoints/subDir/subSubDir/subsubdir_test_endpoint.dart' as _i30;
+import '../endpoints/subDir/subdir_test_endpoint.dart' as _i31;
+import 'dart:typed_data' as _i32;
+import 'package:uuid/uuid_value.dart' as _i33;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i34;
+import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i35;
+import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i36;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i37;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i38;
 import 'package:serverpod_test_server/src/generated/object_with_enum.dart'
-    as _i38;
-import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i39;
-import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i40;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i41;
+import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+    as _i41;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i42;
 import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
-    as _i42;
-import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i43;
+    as _i43;
+import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i44;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -168,73 +169,85 @@ class Endpoints extends _i1.EndpointDispatch {
           'mapParameters',
           null,
         ),
-      'moduleSerialization': _i20.ModuleSerializationEndpoint()
+      'methodStreaming': _i20.MethodStreaming()
+        ..initialize(
+          server,
+          'methodStreaming',
+          null,
+        ),
+      'authenticatedMethodStreaming': _i20.AuthenticatedMethodStreaming()
+        ..initialize(
+          server,
+          'authenticatedMethodStreaming',
+          null,
+        ),
+      'moduleSerialization': _i21.ModuleSerializationEndpoint()
         ..initialize(
           server,
           'moduleSerialization',
           null,
         ),
-      'namedParameters': _i21.NamedParametersEndpoint()
+      'namedParameters': _i22.NamedParametersEndpoint()
         ..initialize(
           server,
           'namedParameters',
           null,
         ),
-      'optionalParameters': _i22.OptionalParametersEndpoint()
+      'optionalParameters': _i23.OptionalParametersEndpoint()
         ..initialize(
           server,
           'optionalParameters',
           null,
         ),
-      'redis': _i23.RedisEndpoint()
+      'redis': _i24.RedisEndpoint()
         ..initialize(
           server,
           'redis',
           null,
         ),
-      'serverOnlyScopedFieldModel': _i24.ServerOnlyScopedFieldModelEndpoint()
+      'serverOnlyScopedFieldModel': _i25.ServerOnlyScopedFieldModelEndpoint()
         ..initialize(
           server,
           'serverOnlyScopedFieldModel',
           null,
         ),
-      'signInRequired': _i25.SignInRequiredEndpoint()
+      'signInRequired': _i26.SignInRequiredEndpoint()
         ..initialize(
           server,
           'signInRequired',
           null,
         ),
-      'adminScopeRequired': _i25.AdminScopeRequiredEndpoint()
+      'adminScopeRequired': _i26.AdminScopeRequiredEndpoint()
         ..initialize(
           server,
           'adminScopeRequired',
           null,
         ),
-      'simple': _i26.SimpleEndpoint()
+      'simple': _i27.SimpleEndpoint()
         ..initialize(
           server,
           'simple',
           null,
         ),
-      'streaming': _i27.StreamingEndpoint()
+      'streaming': _i28.StreamingEndpoint()
         ..initialize(
           server,
           'streaming',
           null,
         ),
-      'streamingLogging': _i28.StreamingLoggingEndpoint()
+      'streamingLogging': _i29.StreamingLoggingEndpoint()
         ..initialize(
           server,
           'streamingLogging',
           null,
         ),
-      'subSubDirTest': _i29.SubSubDirTestEndpoint()
+      'subSubDirTest': _i30.SubSubDirTestEndpoint()
         ..initialize(
           server,
           'subSubDirTest',
           null,
         ),
-      'subDirTest': _i30.SubDirTestEndpoint()
+      'subDirTest': _i31.SubDirTestEndpoint()
         ..initialize(
           server,
           'subDirTest',
@@ -482,7 +495,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i31.ByteData?>(),
+              type: _i1.getType<_i32.ByteData?>(),
               nullable: true,
             )
           },
@@ -518,7 +531,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i32.UuidValue?>(),
+              type: _i1.getType<_i33.UuidValue?>(),
               nullable: true,
             )
           },
@@ -557,7 +570,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'byteData': _i1.ParameterDescription(
               name: 'byteData',
-              type: _i1.getType<_i31.ByteData>(),
+              type: _i1.getType<_i32.ByteData>(),
               nullable: false,
             ),
           },
@@ -702,7 +715,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'byteData': _i1.ParameterDescription(
               name: 'byteData',
-              type: _i1.getType<_i31.ByteData>(),
+              type: _i1.getType<_i32.ByteData>(),
               nullable: false,
             ),
           },
@@ -859,7 +872,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.CustomClass>(),
+              type: _i1.getType<_i34.CustomClass>(),
               nullable: false,
             )
           },
@@ -878,7 +891,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.CustomClass?>(),
+              type: _i1.getType<_i34.CustomClass?>(),
               nullable: true,
             )
           },
@@ -897,7 +910,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.CustomClass2>(),
+              type: _i1.getType<_i34.CustomClass2>(),
               nullable: false,
             )
           },
@@ -916,7 +929,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i33.CustomClass2?>(),
+              type: _i1.getType<_i34.CustomClass2?>(),
               nullable: true,
             )
           },
@@ -935,7 +948,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i34.ExternalCustomClass>(),
+              type: _i1.getType<_i35.ExternalCustomClass>(),
               nullable: false,
             )
           },
@@ -954,7 +967,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i34.ExternalCustomClass?>(),
+              type: _i1.getType<_i35.ExternalCustomClass?>(),
               nullable: true,
             )
           },
@@ -973,7 +986,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i35.FreezedCustomClass>(),
+              type: _i1.getType<_i36.FreezedCustomClass>(),
               nullable: false,
             )
           },
@@ -992,7 +1005,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i35.FreezedCustomClass?>(),
+              type: _i1.getType<_i36.FreezedCustomClass?>(),
               nullable: true,
             )
           },
@@ -1183,7 +1196,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i36.SimpleData>(),
+              type: _i1.getType<_i37.SimpleData>(),
               nullable: false,
             )
           },
@@ -1202,7 +1215,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i36.SimpleData>(),
+              type: _i1.getType<_i37.SimpleData>(),
               nullable: false,
             )
           },
@@ -1221,7 +1234,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i36.SimpleData>(),
+              type: _i1.getType<_i37.SimpleData>(),
               nullable: false,
             )
           },
@@ -1260,7 +1273,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i37.Types>(),
+              type: _i1.getType<_i38.Types>(),
               nullable: false,
             )
           },
@@ -1278,7 +1291,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i37.Types>(),
+              type: _i1.getType<_i38.Types>(),
               nullable: false,
             )
           },
@@ -1353,7 +1366,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i38.ObjectWithEnum>(),
+              type: _i1.getType<_i39.ObjectWithEnum>(),
               nullable: false,
             )
           },
@@ -1391,7 +1404,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i39.ObjectWithObject>(),
+              type: _i1.getType<_i40.ObjectWithObject>(),
               nullable: false,
             )
           },
@@ -1696,7 +1709,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i40.ObjectFieldScopes>(),
+              type: _i1.getType<_i41.ObjectFieldScopes>(),
               nullable: false,
             )
           },
@@ -1731,7 +1744,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i36.SimpleData?>(),
+              type: _i1.getType<_i37.SimpleData?>(),
               nullable: true,
             )
           },
@@ -2041,7 +2054,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i31.ByteData>>(),
+              type: _i1.getType<List<_i32.ByteData>>(),
               nullable: false,
             )
           },
@@ -2060,7 +2073,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i31.ByteData?>>(),
+              type: _i1.getType<List<_i32.ByteData?>>(),
               nullable: false,
             )
           },
@@ -2079,7 +2092,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i36.SimpleData>>(),
+              type: _i1.getType<List<_i37.SimpleData>>(),
               nullable: false,
             )
           },
@@ -2098,7 +2111,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i36.SimpleData?>>(),
+              type: _i1.getType<List<_i37.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -2117,7 +2130,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i36.SimpleData>?>(),
+              type: _i1.getType<List<_i37.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -2136,7 +2149,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i36.SimpleData?>?>(),
+              type: _i1.getType<List<_i37.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -2403,7 +2416,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<_i41.TestEnum, int>>(),
+              type: _i1.getType<Map<_i42.TestEnum, int>>(),
               nullable: false,
             )
           },
@@ -2422,7 +2435,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i41.TestEnum>>(),
+              type: _i1.getType<Map<String, _i42.TestEnum>>(),
               nullable: false,
             )
           },
@@ -2593,7 +2606,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i31.ByteData>>(),
+              type: _i1.getType<Map<String, _i32.ByteData>>(),
               nullable: false,
             )
           },
@@ -2612,7 +2625,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i31.ByteData?>>(),
+              type: _i1.getType<Map<String, _i32.ByteData?>>(),
               nullable: false,
             )
           },
@@ -2631,7 +2644,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i36.SimpleData>>(),
+              type: _i1.getType<Map<String, _i37.SimpleData>>(),
               nullable: false,
             )
           },
@@ -2650,7 +2663,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i36.SimpleData?>>(),
+              type: _i1.getType<Map<String, _i37.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -2669,7 +2682,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i36.SimpleData>?>(),
+              type: _i1.getType<Map<String, _i37.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -2688,7 +2701,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i36.SimpleData?>?>(),
+              type: _i1.getType<Map<String, _i37.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -2742,6 +2755,145 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
+    connectors['methodStreaming'] = _i1.EndpointConnector(
+      name: 'methodStreaming',
+      endpoint: endpoints['methodStreaming']!,
+      methodConnectors: {
+        'simpleEndpoint': _i1.MethodConnector(
+          name: 'simpleEndpoint',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .simpleEndpoint(session),
+        ),
+        'intParameter': _i1.MethodConnector(
+          name: 'intParameter',
+          params: {
+            'value': _i1.ParameterDescription(
+              name: 'value',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .intParameter(
+            session,
+            params['value'],
+          ),
+        ),
+        'nullableResponse': _i1.MethodConnector(
+          name: 'nullableResponse',
+          params: {
+            'value': _i1.ParameterDescription(
+              name: 'value',
+              type: _i1.getType<int?>(),
+              nullable: true,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .nullableResponse(
+            session,
+            params['value'],
+          ),
+        ),
+        'doubleInputValue': _i1.MethodConnector(
+          name: 'doubleInputValue',
+          params: {
+            'value': _i1.ParameterDescription(
+              name: 'value',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .doubleInputValue(
+            session,
+            params['value'],
+          ),
+        ),
+        'delayedResponse': _i1.MethodConnector(
+          name: 'delayedResponse',
+          params: {
+            'delay': _i1.ParameterDescription(
+              name: 'delay',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .delayedResponse(
+            session,
+            params['delay'],
+          ),
+        ),
+        'completeAllDelayedResponses': _i1.MethodConnector(
+          name: 'completeAllDelayedResponses',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .completeAllDelayedResponses(session),
+        ),
+        'throwsException': _i1.MethodConnector(
+          name: 'throwsException',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .throwsException(session),
+        ),
+        'throwsSerializableException': _i1.MethodConnector(
+          name: 'throwsSerializableException',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .throwsSerializableException(session),
+        ),
+      },
+    );
+    connectors['authenticatedMethodStreaming'] = _i1.EndpointConnector(
+      name: 'authenticatedMethodStreaming',
+      endpoint: endpoints['authenticatedMethodStreaming']!,
+      methodConnectors: {
+        'simpleEndpoint': _i1.MethodConnector(
+          name: 'simpleEndpoint',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['authenticatedMethodStreaming']
+                      as _i20.AuthenticatedMethodStreaming)
+                  .simpleEndpoint(session),
+        )
+      },
+    );
     connectors['moduleSerialization'] = _i1.EndpointConnector(
       name: 'moduleSerialization',
       endpoint: endpoints['moduleSerialization']!,
@@ -2754,7 +2906,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['moduleSerialization']
-                      as _i20.ModuleSerializationEndpoint)
+                      as _i21.ModuleSerializationEndpoint)
                   .serializeModuleObject(session),
         ),
         'modifyModuleObject': _i1.MethodConnector(
@@ -2762,7 +2914,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i42.ModuleClass>(),
+              type: _i1.getType<_i43.ModuleClass>(),
               nullable: false,
             )
           },
@@ -2771,7 +2923,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['moduleSerialization']
-                      as _i20.ModuleSerializationEndpoint)
+                      as _i21.ModuleSerializationEndpoint)
                   .modifyModuleObject(
             session,
             params['object'],
@@ -2785,7 +2937,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['moduleSerialization']
-                      as _i20.ModuleSerializationEndpoint)
+                      as _i21.ModuleSerializationEndpoint)
                   .serializeNestedModuleObject(session),
         ),
       },
@@ -2822,7 +2974,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['namedParameters'] as _i21.NamedParametersEndpoint)
+              (endpoints['namedParameters'] as _i22.NamedParametersEndpoint)
                   .namedParametersMethod(
             session,
             namedInt: params['namedInt'],
@@ -2849,7 +3001,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['namedParameters'] as _i21.NamedParametersEndpoint)
+              (endpoints['namedParameters'] as _i22.NamedParametersEndpoint)
                   .namedParametersMethodEqualInts(
             session,
             namedInt: params['namedInt'],
@@ -2876,7 +3028,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['optionalParameters']
-                      as _i22.OptionalParametersEndpoint)
+                      as _i23.OptionalParametersEndpoint)
                   .returnOptionalInt(
             session,
             params['optionalInt'],
@@ -2898,7 +3050,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i36.SimpleData>(),
+              type: _i1.getType<_i37.SimpleData>(),
               nullable: false,
             ),
           },
@@ -2906,7 +3058,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint).setSimpleData(
+              (endpoints['redis'] as _i24.RedisEndpoint).setSimpleData(
             session,
             params['key'],
             params['data'],
@@ -2922,7 +3074,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i36.SimpleData>(),
+              type: _i1.getType<_i37.SimpleData>(),
               nullable: false,
             ),
           },
@@ -2930,7 +3082,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint)
+              (endpoints['redis'] as _i24.RedisEndpoint)
                   .setSimpleDataWithLifetime(
             session,
             params['key'],
@@ -2950,7 +3102,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint).getSimpleData(
+              (endpoints['redis'] as _i24.RedisEndpoint).getSimpleData(
             session,
             params['key'],
           ),
@@ -2968,7 +3120,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint).deleteSimpleData(
+              (endpoints['redis'] as _i24.RedisEndpoint).deleteSimpleData(
             session,
             params['key'],
           ),
@@ -2980,7 +3132,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint)
+              (endpoints['redis'] as _i24.RedisEndpoint)
                   .resetMessageCentralTest(session),
         ),
         'listenToChannel': _i1.MethodConnector(
@@ -2996,7 +3148,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint).listenToChannel(
+              (endpoints['redis'] as _i24.RedisEndpoint).listenToChannel(
             session,
             params['channel'],
           ),
@@ -3011,7 +3163,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i36.SimpleData>(),
+              type: _i1.getType<_i37.SimpleData>(),
               nullable: false,
             ),
           },
@@ -3019,7 +3171,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint).postToChannel(
+              (endpoints['redis'] as _i24.RedisEndpoint).postToChannel(
             session,
             params['channel'],
             params['data'],
@@ -3032,7 +3184,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['redis'] as _i23.RedisEndpoint)
+              (endpoints['redis'] as _i24.RedisEndpoint)
                   .countSubscribedChannels(session),
         ),
       },
@@ -3049,7 +3201,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['serverOnlyScopedFieldModel']
-                      as _i24.ServerOnlyScopedFieldModelEndpoint)
+                      as _i25.ServerOnlyScopedFieldModelEndpoint)
                   .getScopeServerOnlyField(session),
         )
       },
@@ -3065,7 +3217,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['signInRequired'] as _i25.SignInRequiredEndpoint)
+              (endpoints['signInRequired'] as _i26.SignInRequiredEndpoint)
                   .testMethod(session),
         )
       },
@@ -3082,7 +3234,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['adminScopeRequired']
-                      as _i25.AdminScopeRequiredEndpoint)
+                      as _i26.AdminScopeRequiredEndpoint)
                   .testMethod(session),
         )
       },
@@ -3109,7 +3261,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i26.SimpleEndpoint).setGlobalInt(
+              (endpoints['simple'] as _i27.SimpleEndpoint).setGlobalInt(
             session,
             params['value'],
             params['secondValue'],
@@ -3122,7 +3274,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i26.SimpleEndpoint)
+              (endpoints['simple'] as _i27.SimpleEndpoint)
                   .addToGlobalInt(session),
         ),
         'getGlobalInt': _i1.MethodConnector(
@@ -3132,7 +3284,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i26.SimpleEndpoint)
+              (endpoints['simple'] as _i27.SimpleEndpoint)
                   .getGlobalInt(session),
         ),
         'hello': _i1.MethodConnector(
@@ -3148,7 +3300,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i26.SimpleEndpoint).hello(
+              (endpoints['simple'] as _i27.SimpleEndpoint).hello(
             session,
             params['name'],
           ),
@@ -3176,7 +3328,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['subSubDirTest'] as _i29.SubSubDirTestEndpoint)
+              (endpoints['subSubDirTest'] as _i30.SubSubDirTestEndpoint)
                   .testMethod(session),
         )
       },
@@ -3192,13 +3344,13 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['subDirTest'] as _i30.SubDirTestEndpoint)
+              (endpoints['subDirTest'] as _i31.SubDirTestEndpoint)
                   .testMethod(session),
         )
       },
     );
-    modules['serverpod_auth'] = _i43.Endpoints()..initializeEndpoints(server);
-    modules['serverpod_test_module'] = _i42.Endpoints()
+    modules['serverpod_auth'] = _i44.Endpoints()..initializeEndpoints(server);
+    modules['serverpod_test_module'] = _i43.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -148,6 +148,17 @@ mapParameters:
   - returnNullableSimpleDataMapNullableSimpleData:
   - returnDurationMap:
   - returnDurationMapNullableDurations:
+methodStreaming:
+  - simpleEndpoint:
+  - intParameter:
+  - nullableResponse:
+  - doubleInputValue:
+  - delayedResponse:
+  - completeAllDelayedResponses:
+  - throwsException:
+  - throwsSerializableException:
+authenticatedMethodStreaming:
+  - simpleEndpoint:
 moduleSerialization:
   - serializeModuleObject:
   - modifyModuleObject:

--- a/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
+++ b/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_server/serverpod_auth_server.dart' as auth;
 import 'package:serverpod_test_server/src/generated/endpoints.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 
@@ -17,6 +18,7 @@ class IntegrationTestServer extends TestServerpod {
       _integrationTestFlags,
       Protocol(),
       Endpoints(),
+      authenticationHandler: auth.authenticationHandler,
     );
   }
 }
@@ -37,7 +39,12 @@ class TestServerpod {
     SerializationManagerServer serializationManager,
     EndpointDispatch endpoints,
   ) {
-    _serverpod = Serverpod(args, serializationManager, endpoints);
+    _serverpod = Serverpod(
+      args,
+      serializationManager,
+      endpoints,
+      authenticationHandler: auth.authenticationHandler,
+    );
 
     _serverpodFinalizer.attach(this, _serverpod, detach: this);
   }

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test(
+        'when an CloseMethodStreamCommand message and a ping message is sent to the server then CloseMethodStreamCommand is ignored and the server only responds with a pong message.',
+        () {
+      var pongReceived = Completer<void>();
+      var otherMessageReceived = Completer<void>();
+      webSocket.stream.listen((event) {
+        var message = WebSocketMessage.fromJsonString(event);
+        if (message is PongCommand) {
+          pongReceived.complete();
+        } else {
+          otherMessageReceived.complete();
+        }
+      });
+
+      webSocket.sink.add(CloseMethodStreamCommand.buildMessage(
+        uuid: 'uuid',
+        endpoint: 'endpoint',
+        method: 'method',
+        reason: CloseReason.done,
+      ));
+      webSocket.sink.add(PingCommand.buildMessage());
+
+      expect(
+        otherMessageReceived.future,
+        doesNotComplete,
+        reason: 'OpenMethodStreamResponse not generate any messages.',
+      );
+      expect(
+        pongReceived.future.timeout(Duration(seconds: 5)),
+        completes,
+        reason: 'Failed to receive pong message from server.',
+      );
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -31,7 +31,7 @@ void main() {
 
       var endpoint = 'methodStreaming';
       var method = 'delayedResponse';
-      var uuid = Uuid().v4();
+      var connectionId = const Uuid().v4obj();
 
       setUp(() async {
         var delayedResponseOpen = Completer<void>();
@@ -41,9 +41,11 @@ void main() {
         webSocket.stream.listen((event) {
           var message = WebSocketMessage.fromJsonString(event);
           if (message is OpenMethodStreamResponse) {
-            if (message.uuid == uuid) delayedResponseOpen.complete();
+            if (message.connectionId == connectionId)
+              delayedResponseOpen.complete();
           } else if (message is CloseMethodStreamCommand) {
-            if (message.uuid == uuid) delayedResponseClosed.complete();
+            if (message.connectionId == connectionId)
+              delayedResponseClosed.complete();
           }
         }, onDone: () {
           webSocketCompleter.complete();
@@ -53,7 +55,7 @@ void main() {
           endpoint: endpoint,
           method: method,
           args: {'delay': 10},
-          uuid: uuid,
+          connectionId: connectionId,
         ));
 
         await expectLater(
@@ -81,7 +83,7 @@ void main() {
         webSocket.sink.add(CloseMethodStreamCommand.buildMessage(
           endpoint: endpoint,
           method: method,
-          uuid: uuid,
+          connectionId: connectionId,
           reason: CloseReason.done,
         ));
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test(
+        'when a MethodStreamMessage and a ping message is sent to the server then MethodStreamMessage is ignored and the server only responds with a pong message.',
+        () {
+      var pongReceived = Completer<void>();
+      var otherMessageReceived = Completer<void>();
+      webSocket.stream.listen((event) {
+        var message = WebSocketMessage.fromJsonString(event);
+        if (message is PongCommand) {
+          pongReceived.complete();
+        } else {
+          otherMessageReceived.complete();
+        }
+      });
+
+      webSocket.sink.add(MethodStreamMessage.buildMessage(
+        endpoint: 'methodStreaming',
+        method: 'doubleInputValue',
+        uuid: 'uuid',
+        object: server.serializationManager.encodeWithType(1),
+      ));
+      webSocket.sink.add(PingCommand.buildMessage());
+
+      expect(
+        otherMessageReceived.future,
+        doesNotComplete,
+        reason: 'OpenMethodStreamResponse not generate any messages.',
+      );
+      expect(
+        pongReceived.future.timeout(Duration(seconds: 5)),
+        completes,
+        reason: 'Failed to receive pong message from server.',
+      );
+    });
+
+    group(
+        'when a stream is opened to an endpoint that returns a value based on the input ',
+        () {
+      late Completer<int> endpointResponse;
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      var inputValue = 2;
+
+      var endpoint = 'methodStreaming';
+      var method = 'doubleInputValue';
+      var uuid = Uuid().v4();
+
+      setUp(() {
+        endpointResponse = Completer<int>();
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        var streamOpened = Completer<void>();
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          } else if (message is MethodStreamMessage) {
+            endpointResponse.complete(server.serializationManager
+                .decodeWithType(message.object) as int);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {'value': inputValue},
+          uuid: uuid,
+        ));
+
+        expect(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test('then MethodStreamMessage with modified input is received.', () {
+        expect(
+          endpointResponse.future.timeout(Duration(seconds: 5)),
+          completion(inputValue * 2),
+          reason: 'Return value from endpoint.',
+        );
+      });
+
+      test('then CloseMethodStreamCommand matching the endpoint is received.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.done);
+      });
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -42,7 +42,7 @@ void main() {
       webSocket.sink.add(MethodStreamMessage.buildMessage(
         endpoint: 'methodStreaming',
         method: 'doubleInputValue',
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
         object: server.serializationManager.encodeWithType(1),
       ));
       webSocket.sink.add(PingCommand.buildMessage());
@@ -69,7 +69,7 @@ void main() {
 
       var endpoint = 'methodStreaming';
       var method = 'doubleInputValue';
-      var uuid = Uuid().v4();
+      var connectionId = const Uuid().v4obj();
 
       setUp(() {
         endpointResponse = Completer<int>();
@@ -95,7 +95,7 @@ void main() {
           endpoint: endpoint,
           method: method,
           args: {'value': inputValue},
-          uuid: uuid,
+          connectionId: connectionId,
         ));
 
         expect(
@@ -126,7 +126,7 @@ void main() {
         var closeMethodStreamCommandMessage = await message;
         expect(closeMethodStreamCommandMessage.endpoint, endpoint);
         expect(closeMethodStreamCommandMessage.method, method);
-        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
         expect(closeMethodStreamCommandMessage.reason, CloseReason.done);
       });
 
@@ -144,7 +144,7 @@ void main() {
       late Completer<int?> endpointResponse;
 
       setUp(() async {
-        var uuid = Uuid().v4();
+        var connectionId = const Uuid().v4obj();
         endpointResponse = Completer<int?>();
         var streamOpened = Completer<void>();
 
@@ -162,7 +162,7 @@ void main() {
           endpoint: 'methodStreaming',
           method: 'nullableResponse',
           args: {'value': null},
-          uuid: uuid,
+          connectionId: connectionId,
         ));
 
         await expectLater(
@@ -197,20 +197,20 @@ void main() {
         returningStreamClosed = Completer<void>();
         delayedResponseClosed = Completer<void>();
         webSocketCompleter = Completer<void>();
-        var returningStreamUuid = Uuid().v4();
-        var delayedResponseUuid = Uuid().v4();
+        var returningStreamConnectionId = const Uuid().v4obj();
+        var delayedResponseConnectionId = const Uuid().v4obj();
 
         webSocket.stream.listen((event) {
           var message = WebSocketMessage.fromJsonString(event);
           if (message is OpenMethodStreamResponse) {
-            if (message.uuid == returningStreamUuid)
+            if (message.connectionId == returningStreamConnectionId)
               returningStreamOpen.complete();
-            else if (message.uuid == delayedResponseUuid)
+            else if (message.connectionId == delayedResponseConnectionId)
               delayedResponseOpen.complete();
           } else if (message is CloseMethodStreamCommand) {
-            if (message.uuid == returningStreamUuid)
+            if (message.connectionId == returningStreamConnectionId)
               returningStreamClosed.complete();
-            if (message.uuid == delayedResponseUuid)
+            if (message.connectionId == delayedResponseConnectionId)
               delayedResponseClosed.complete();
           }
         }, onDone: () {
@@ -221,14 +221,14 @@ void main() {
           endpoint: endpoint,
           method: 'delayedResponse',
           args: {'delay': 10},
-          uuid: delayedResponseUuid,
+          connectionId: delayedResponseConnectionId,
         ));
 
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
           endpoint: endpoint,
           method: 'simpleEndpoint',
           args: {},
-          uuid: returningStreamUuid,
+          connectionId: returningStreamConnectionId,
         ));
 
         expect(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test(
+        'when an MethodStreamSerializableException message and a ping message is sent to the server then MethodStreamSerializableException is ignored and the server only responds with a pong message.',
+        () {
+      var pongReceived = Completer<void>();
+      var otherMessageReceived = Completer<void>();
+      webSocket.stream.listen((event) {
+        var message = WebSocketMessage.fromJsonString(event);
+        if (message is PongCommand) {
+          pongReceived.complete();
+        } else {
+          otherMessageReceived.complete();
+        }
+      });
+
+      webSocket.sink.add(MethodStreamSerializableException.buildMessage(
+        uuid: 'uuid',
+        endpoint: 'endpoint',
+        method: 'method',
+        object: server.serializationManager.encodeWithType(ExceptionWithData(
+          message: 'message',
+          creationDate: DateTime.now(),
+          errorFields: ['field'],
+        )),
+      ));
+      webSocket.sink.add(PingCommand.buildMessage());
+
+      expect(
+        otherMessageReceived.future,
+        doesNotComplete,
+        reason: 'OpenMethodStreamResponse not generate any messages.',
+      );
+      expect(
+        pongReceived.future.timeout(Duration(seconds: 5)),
+        completes,
+        reason: 'Failed to receive pong message from server.',
+      );
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
@@ -41,7 +41,7 @@ void main() {
       });
 
       webSocket.sink.add(MethodStreamSerializableException.buildMessage(
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
         endpoint: 'endpoint',
         method: 'method',
         object: server.serializationManager.encodeWithType(ExceptionWithData(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -31,7 +31,7 @@ void main() {
         endpoint: 'this is not an existing endpoint',
         method: 'method',
         args: {},
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
       ));
 
       var response = await webSocket.stream.first as String;
@@ -53,7 +53,7 @@ void main() {
         endpoint: 'methodStreaming',
         method: 'this is not an existing method',
         args: {},
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
       ));
 
       var response = await webSocket.stream.first as String;
@@ -75,7 +75,7 @@ void main() {
         endpoint: 'methodStreaming',
         method: 'simpleEndpoint',
         args: {},
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
       ));
 
       var response = await webSocket.stream.first as String;
@@ -97,7 +97,7 @@ void main() {
         endpoint: 'methodStreaming',
         method: 'intParameter',
         args: {},
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
       ));
 
       var response = await webSocket.stream.first as String;
@@ -119,7 +119,7 @@ void main() {
         endpoint: 'methodStreaming',
         method: 'intParameter',
         args: {'value': 42},
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
       ));
 
       var response = await webSocket.stream.first as String;
@@ -141,7 +141,7 @@ void main() {
         endpoint: 'authenticatedMethodStreaming',
         method: 'simpleEndpoint',
         args: {},
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
         // No authentication token is provided
       ));
 
@@ -164,7 +164,7 @@ void main() {
         endpoint: 'authenticatedMethodStreaming',
         method: 'simpleEndpoint',
         args: {},
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
         authentication: 'invalid token',
       ));
 
@@ -205,7 +205,7 @@ void main() {
           endpoint: 'authenticatedMethodStreaming',
           method: 'simpleEndpoint',
           args: {},
-          uuid: 'uuid',
+          connectionId: const Uuid().v4obj(),
           authentication: token,
         ));
 
@@ -251,7 +251,7 @@ void main() {
           endpoint: 'authenticatedMethodStreaming',
           method: 'simpleEndpoint',
           args: {},
-          uuid: 'uuid',
+          connectionId: const Uuid().v4obj(),
           authentication: token,
         ));
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -1,0 +1,272 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_server/serverpod_auth_server.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test(
+        'when a open method stream command with an invalid endpoint is sent then OpenMethodStreamResponse type "endpointNotFound" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'this is not an existing endpoint',
+        method: 'method',
+        args: {},
+        uuid: 'uuid',
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.endpointNotFound,
+          ));
+    });
+
+    test(
+        'when a open method stream command with an invalid endpoint method is sent then OpenMethodStreamResponse type "methodNotFound" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'methodStreaming',
+        method: 'this is not an existing method',
+        args: {},
+        uuid: 'uuid',
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.methodNotFound,
+          ));
+    });
+
+    test(
+        'when a valid open method stream command is sent then OpenMethodStreamResponse type "success" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'methodStreaming',
+        method: 'simpleEndpoint',
+        args: {},
+        uuid: 'uuid',
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.success,
+          ));
+    });
+
+    test(
+        'when a open method stream command is sent without required argument then OpenMethodStreamResponse type "invalidArguments" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'methodStreaming',
+        method: 'intParameter',
+        args: {},
+        uuid: 'uuid',
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.invalidArguments,
+          ));
+    });
+
+    test(
+        'when a open method stream command is sent with required argument then OpenMethodStreamResponse type "success" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'methodStreaming',
+        method: 'intParameter',
+        args: {'value': 42},
+        uuid: 'uuid',
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.success,
+          ));
+    });
+
+    test(
+        'when a open method stream command is sent to an authenticated endpoint without an authentication token then OpenMethodStreamResponse type "authenticationFailed" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'authenticatedMethodStreaming',
+        method: 'simpleEndpoint',
+        args: {},
+        uuid: 'uuid',
+        // No authentication token is provided
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.authenticationFailed,
+          ));
+    });
+
+    test(
+        'when a open method stream command is sent to an authenticated endpoint with an invalid authentication token then OpenMethodStreamResponse type "authenticationFailed" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'authenticatedMethodStreaming',
+        method: 'simpleEndpoint',
+        args: {},
+        uuid: 'uuid',
+        auth: 'invalid token',
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(response);
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.authenticationFailed,
+          ));
+    });
+
+    group(
+        'when an authenticated open method stream command is sent to an authenticated endpoint with insufficient scopes',
+        () {
+      late String token;
+      setUp(() async {
+        var session = await server.createSession();
+        // Missing required "Admin" scope
+        var authKey = await UserAuthentication.signInUser(session, 1, 'test');
+        session.close();
+        token = '${authKey.id}:${authKey.key}';
+      });
+
+      tearDown(() async {
+        var session = await server.createSession();
+        AuthKey.db.deleteWhere(session, where: (_) => Constant.bool(true));
+        session.close();
+      });
+
+      test(
+          'then OpenMethodStreamResponse type "insufficientScopes" is received.',
+          () async {
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: 'authenticatedMethodStreaming',
+          method: 'simpleEndpoint',
+          args: {},
+          uuid: 'uuid',
+          auth: token,
+        ));
+
+        var response = await webSocket.stream.first as String;
+        var message = WebSocketMessage.fromJsonString(response);
+
+        expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.insufficientScopes,
+          ),
+        );
+      });
+    });
+
+    group(
+        'when an authenticated open method stream command with sufficient privilege is sent to an authenticated endpoint',
+        () {
+      late String token;
+      setUp(() async {
+        var session = await server.createSession();
+        var authKey = await UserAuthentication.signInUser(
+          session,
+          1,
+          'test',
+          scopes: {Scope.admin}, // Scope required by the endpoint
+        );
+        session.close();
+        token = '${authKey.id}:${authKey.key}';
+      });
+
+      tearDown(() async {
+        var session = await server.createSession();
+        AuthKey.db.deleteWhere(session, where: (_) => Constant.bool(true));
+        session.close();
+      });
+
+      test('then OpenMethodStreamResponse type "success" is received.',
+          () async {
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: 'authenticatedMethodStreaming',
+          method: 'simpleEndpoint',
+          args: {},
+          uuid: 'uuid',
+          auth: token,
+        ));
+
+        var response = await webSocket.stream.first as String;
+        var message = WebSocketMessage.fromJsonString(response);
+
+        expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.success,
+          ),
+        );
+      });
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -165,7 +165,7 @@ void main() {
         method: 'simpleEndpoint',
         args: {},
         uuid: 'uuid',
-        auth: 'invalid token',
+        authentication: 'invalid token',
       ));
 
       var response = await webSocket.stream.first as String;
@@ -206,7 +206,7 @@ void main() {
           method: 'simpleEndpoint',
           args: {},
           uuid: 'uuid',
-          auth: token,
+          authentication: token,
         ));
 
         var response = await webSocket.stream.first as String;
@@ -252,7 +252,7 @@ void main() {
           method: 'simpleEndpoint',
           args: {},
           uuid: 'uuid',
-          auth: token,
+          authentication: token,
         ));
 
         var response = await webSocket.stream.first as String;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -199,7 +199,7 @@ void main() {
       });
 
       test(
-          'then OpenMethodStreamResponse type "insufficientScopes" is received.',
+          'then OpenMethodStreamResponse type "authorizationDeclined" is received.',
           () async {
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
           endpoint: 'authenticatedMethodStreaming',
@@ -217,7 +217,7 @@ void main() {
           isA<OpenMethodStreamResponse>().having(
             (m) => m.responseType,
             'responseType',
-            OpenMethodStreamResponseType.insufficientScopes,
+            OpenMethodStreamResponseType.authorizationDeclined,
           ),
         );
       });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -47,7 +47,7 @@ void main() {
     });
 
     test(
-        'when a open method stream command with an invalid endpoint method is sent then OpenMethodStreamResponse type "methodNotFound" is received.',
+        'when a open method stream command with an invalid endpoint method is sent then OpenMethodStreamResponse type "endpointNotFound" is received.',
         () async {
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
         endpoint: 'methodStreaming',
@@ -64,7 +64,7 @@ void main() {
           isA<OpenMethodStreamResponse>().having(
             (m) => m.responseType,
             'responseType',
-            OpenMethodStreamResponseType.methodNotFound,
+            OpenMethodStreamResponseType.endpointNotFound,
           ));
     });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_response_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_response_test.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test(
+        'when an OpenMethodStreamResponse message and a ping message is sent to the server then OpenMethodStreamResponse is ignored and the server only responds with a pong message.',
+        () {
+      var pongReceived = Completer<void>();
+      var otherMessageReceived = Completer<void>();
+      webSocket.stream.listen((event) {
+        var message = WebSocketMessage.fromJsonString(event);
+        if (message is PongCommand) {
+          pongReceived.complete();
+        } else {
+          otherMessageReceived.complete();
+        }
+      });
+
+      webSocket.sink.add(OpenMethodStreamResponse.buildMessage(
+        responseType: OpenMethodStreamResponseType.success,
+        uuid: 'uuid',
+      ));
+      webSocket.sink.add(PingCommand.buildMessage());
+
+      expect(
+        otherMessageReceived.future,
+        doesNotComplete,
+        reason: 'OpenMethodStreamResponse not generate any messages.',
+      );
+      expect(
+        pongReceived.future.timeout(Duration(seconds: 5)),
+        completes,
+        reason: 'Failed to receive pong message from server.',
+      );
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_response_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_response_test.dart
@@ -41,7 +41,7 @@ void main() {
 
       webSocket.sink.add(OpenMethodStreamResponse.buildMessage(
         responseType: OpenMethodStreamResponseType.success,
-        uuid: 'uuid',
+        connectionId: const Uuid().v4obj(),
       ));
       webSocket.sink.add(PingCommand.buildMessage());
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
@@ -33,7 +33,7 @@ void main() {
 
       var endpoint = 'methodStreaming';
       var method = 'throwsException';
-      var uuid = Uuid().v4();
+      var connectionId = const Uuid().v4obj();
 
       setUp(() async {
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
@@ -50,7 +50,7 @@ void main() {
           endpoint: endpoint,
           method: method,
           args: {},
-          uuid: uuid,
+          connectionId: connectionId,
         ));
 
         expect(
@@ -73,7 +73,7 @@ void main() {
         var closeMethodStreamCommandMessage = await message;
         expect(closeMethodStreamCommandMessage.endpoint, endpoint);
         expect(closeMethodStreamCommandMessage.method, method);
-        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
         expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
       });
     });
@@ -87,7 +87,7 @@ void main() {
 
       var endpoint = 'methodStreaming';
       var method = 'throwsSerializableException';
-      var uuid = Uuid().v4();
+      var connectionId = const Uuid().v4obj();
 
       setUp(() async {
         var streamOpened = Completer<void>();
@@ -110,7 +110,7 @@ void main() {
           endpoint: endpoint,
           method: method,
           args: {},
-          uuid: uuid,
+          connectionId: connectionId,
         ));
 
         expect(
@@ -135,7 +135,8 @@ void main() {
         var methodStreamSerializableExceptionMessage = await message;
         expect(methodStreamSerializableExceptionMessage.endpoint, endpoint);
         expect(methodStreamSerializableExceptionMessage.method, method);
-        expect(methodStreamSerializableExceptionMessage.uuid, uuid);
+        expect(methodStreamSerializableExceptionMessage.connectionId,
+            connectionId);
       });
 
       test('then CloseMethodStreamCommand matching the endpoint is received.',
@@ -151,7 +152,7 @@ void main() {
         var closeMethodStreamCommandMessage = await message;
         expect(closeMethodStreamCommandMessage.endpoint, endpoint);
         expect(closeMethodStreamCommandMessage.method, method);
-        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
         expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
       });
     });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    group(
+        'when a stream is opened to an endpoint that throws an exception then',
+        () {
+      var streamOpened = Completer<void>();
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+
+      var endpoint = 'methodStreaming';
+      var method = 'throwsException';
+      var uuid = Uuid().v4();
+
+      setUp(() async {
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          uuid: uuid,
+        ));
+
+        expect(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test('then CloseMethodStreamCommand matching endpoint is received.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
+      });
+    });
+
+    group(
+        'when a stream is opened to an endpoint that throws a serializable exception',
+        () {
+      late Completer<MethodStreamSerializableException>
+          methodStreamSerializableException;
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+
+      var endpoint = 'methodStreaming';
+      var method = 'throwsSerializableException';
+      var uuid = Uuid().v4();
+
+      setUp(() async {
+        var streamOpened = Completer<void>();
+        methodStreamSerializableException =
+            Completer<MethodStreamSerializableException>();
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is MethodStreamSerializableException) {
+            methodStreamSerializableException.complete(message);
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          uuid: uuid,
+        ));
+
+        expect(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test(
+          'then MethodStreamSerializableException matching the endpoint is received.',
+          () async {
+        var message = methodStreamSerializableException.future
+            .timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason:
+              'Failed to receive MethodStreamSerializableException from server.',
+        );
+
+        var methodStreamSerializableExceptionMessage = await message;
+        expect(methodStreamSerializableExceptionMessage.endpoint, endpoint);
+        expect(methodStreamSerializableExceptionMessage.method, method);
+        expect(methodStreamSerializableExceptionMessage.uuid, uuid);
+      });
+
+      test('then CloseMethodStreamCommand matching the endpoint is received.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
+      });
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/void_response_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/void_response_endpoint_test.dart
@@ -32,7 +32,7 @@ void main() {
 
       var endpoint = 'methodStreaming';
       var method = 'simpleEndpoint';
-      var uuid = Uuid().v4();
+      var connectionId = const Uuid().v4obj();
 
       setUp(() {
         endpointResponse = Completer<MethodStreamMessage>();
@@ -53,7 +53,7 @@ void main() {
           endpoint: endpoint,
           method: method,
           args: {},
-          uuid: uuid,
+          connectionId: connectionId,
         ));
 
         expect(
@@ -77,7 +77,7 @@ void main() {
         var closeMethodStreamCommandMessage = await message;
         expect(closeMethodStreamCommandMessage.endpoint, endpoint);
         expect(closeMethodStreamCommandMessage.method, method);
-        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
         expect(closeMethodStreamCommandMessage.reason, CloseReason.done);
         expect(endpointResponse.future, doesNotComplete);
       });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/void_response_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/void_response_endpoint_test.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group('Given method websocket connection', () {
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    group('when a stream is opened to an endpoint that has void return value',
+        () {
+      late Completer<MethodStreamMessage> endpointResponse;
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+
+      var endpoint = 'methodStreaming';
+      var method = 'simpleEndpoint';
+      var uuid = Uuid().v4();
+
+      setUp(() {
+        endpointResponse = Completer<MethodStreamMessage>();
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        var streamOpened = Completer<void>();
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          } else if (message is MethodStreamMessage) {
+            endpointResponse.complete(message);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          uuid: uuid,
+        ));
+
+        expect(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test(
+          'then no message is received other than a CloseMethodStreamCommand with done reason.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.uuid, uuid);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.done);
+        expect(endpointResponse.future, doesNotComplete);
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -679,6 +679,9 @@ class LibraryGenerator {
                           'nullable': literalBool(param.type.nullable),
                         })
                     }),
+                    'returnsVoid': literalBool(
+                      method.returnType.generics.first.isVoidType,
+                    ),
                     'call': Method(
                       (m) => m
                         ..requiredParameters.addAll([

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -55,6 +55,8 @@ class TypeDefinition {
 
   bool get isIdType => className == 'int';
 
+  bool get isVoidType => className == 'void';
+
   bool get isModuleType =>
       url == 'serverpod' || (url?.startsWith(_moduleRef) ?? false);
 


### PR DESCRIPTION
Another stepping stone towards #2338.

This PR expands the protocol for the new WebSocket connection so that it is possible to call existing server endpoints.
The protocol supports:
- Authentication and endpoint validation checks.
- Establishing a connection to an endpoint.
- Getting a value returned from an endpoint.
- Closing a connection to an endpoint.

The next PR will introduce the new streaming endpoints to the server and then make it possible to only establish connections towards these endpoints.

### Note:
 The change (here: 5ebc1f8613b08c765b125987ba280cf739d0ac14) that allows method connectors to report if they return a void value will probably be reverted once the new streaming methods are introduced.

### Guidance for review:
Review commit by commit, as this should greatly reduce the scope of each part.
Tests retaining the functionality are introduced together with each feature.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - only new functionality connected to the new WebSocket streaming interface.