### PR TITLE
feat: Server support endpoints with Stream return.

### DIFF
--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -108,7 +108,7 @@ abstract class EndpointDispatch {
       }
 
       var method = connector.methodConnectors[methodName];
-      if (method == null || method is! MethodConnector) {
+      if (method is! MethodConnector) {
         await session.close();
         return ResultInvalidParams(
             'Method $methodName not found in call: $uri');

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -108,7 +108,7 @@ abstract class EndpointDispatch {
       }
 
       var method = connector.methodConnectors[methodName];
-      if (method == null) {
+      if (method == null || method is! MethodConnector) {
         await session.close();
         return ResultInvalidParams(
             'Method $methodName not found in call: $uri');
@@ -222,7 +222,7 @@ abstract class EndpointDispatch {
 }
 
 /// The [EndpointConnector] associates a name with and endpoint and its
-/// [MethodConnector]s.
+/// [EndpointMethodConnector]s.
 class EndpointConnector {
   /// Name of the [Endpoint].
   final String name;
@@ -230,29 +230,37 @@ class EndpointConnector {
   /// Reference to the [Endpoint].
   final Endpoint endpoint;
 
-  /// All [MethodConnector]s associated with the [Endpoint].
-  final Map<String, MethodConnector> methodConnectors;
+  /// All [EndpointMethodConnector]s associated with the [Endpoint].
+  final Map<String, EndpointMethodConnector> methodConnectors;
 
   /// Creates a new [EndpointConnector].
-  EndpointConnector(
-      {required this.name,
-      required this.endpoint,
-      required this.methodConnectors});
+  EndpointConnector({
+    required this.name,
+    required this.endpoint,
+    required this.methodConnectors,
+  });
 }
 
 /// Calls a named method referenced in a [MethodConnector].
 typedef MethodCall = Future Function(
     Session session, Map<String, dynamic> params);
 
-/// The [MethodConnector] hooks up a method with its name and the actual call
-/// to the method.
-class MethodConnector {
+/// The [EndpointMethodConnector] is a base class for connectors that connect
+/// methods their implementation.
+abstract class EndpointMethodConnector {
   /// The name of the method.
   final String name;
 
   /// List of parameters used by the method.
   final Map<String, ParameterDescription> params;
 
+  /// Creates a new [EndpointMethodConnector].
+  EndpointMethodConnector({required this.name, required this.params});
+}
+
+/// The [MethodConnector] hooks up a method with its name and the actual call
+/// to the method.
+class MethodConnector extends EndpointMethodConnector {
   /// A function that performs a call to the named method.
   final MethodCall call;
 
@@ -262,10 +270,45 @@ class MethodConnector {
 
   /// Creates a new [MethodConnector].
   MethodConnector({
-    required this.name,
-    required this.params,
+    required super.name,
+    required super.params,
     required this.call,
     this.returnsVoid,
+  });
+}
+
+/// Calls a named method referenced in a [MethodStreamConnector].
+typedef MethodStream = Stream Function(
+    Session session, Map<String, dynamic> params);
+
+/// The type of return value from a [MethodStreamConnector].
+enum MethodStreamReturnType {
+  /// The method returns a single value.
+  singleType,
+
+  /// The method returns a stream of values.
+  streamType,
+
+  /// The method returns void.
+  voidType,
+}
+
+/// The [MethodStreamConnector] hooks up a method with its name and
+/// implementation. The method communicates with the client using a websocket
+/// connection. Enabling support for streaming return values or parameters.
+class MethodStreamConnector extends EndpointMethodConnector {
+  /// The type of return value from the method.
+  final MethodStreamReturnType returnType;
+
+  /// A function that performs a call to the named method.
+  final MethodStream call;
+
+  /// Creates a new [MethodStreamConnector].
+  MethodStreamConnector({
+    required super.name,
+    required super.params,
+    required this.returnType,
+    required this.call,
   });
 }
 

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1273,12 +1273,6 @@ class EndpointAuthenticatedMethodStreaming extends _i1.EndpointRef {
 
   @override
   String get name => 'authenticatedMethodStreaming';
-
-  _i2.Future<void> simpleEndpoint() => caller.callServerEndpoint<void>(
-        'authenticatedMethodStreaming',
-        'simpleEndpoint',
-        {},
-      );
 }
 
 /// {@category Endpoint}

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -118,8 +118,6 @@ class AuthenticatedMethodStreaming extends Endpoint {
   @override
   Set<Scope> get requiredScopes => {Scope.admin};
 
-  Future<void> simpleEndpoint(Session session) async {}
-
   Stream<int> simpleStream(Session session) async* {
     for (var i = 0; i < 10; i++) {
       yield i;

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -54,6 +54,20 @@ class MethodStreaming extends Endpoint {
     return completer.future;
   }
 
+  Stream<int> delayedStreamResponse(Session session, int delay) async* {
+    var uuid = Uuid().v4();
+    var completer = Completer<void>();
+    _delayedResponses[uuid] = completer;
+
+    Future.delayed(Duration(seconds: delay), () {
+      _delayedResponses.remove(uuid)?.complete();
+    });
+
+    await completer.future;
+
+    yield 42;
+  }
+
   /// Completes all delayed responses.
   /// This makes the delayedResponse return directly.
   Future<void> completeAllDelayedResponses(Session session) async {

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -6,6 +6,27 @@ import 'package:serverpod_test_server/src/generated/protocol.dart';
 class MethodStreaming extends Endpoint {
   Map<String, Completer> _delayedResponses = {};
 
+  /// Check Null and Object in validation.
+  Stream<int> simpleStream(Session session) async* {
+    for (var i = 0; i < 10; i++) {
+      yield i;
+    }
+  }
+
+  Stream<int> simpleStreamWithParameter(Session session, int value) async* {
+    for (var i in List.generate(value, (index) => index)) {
+      yield i;
+    }
+  }
+
+  Stream<SimpleData> simpleDataStream(Session session, int value) async* {
+    for (var i in List.generate(value, (index) => index)) {
+      yield SimpleData(
+        num: i,
+      );
+    }
+  }
+
   Future<void> simpleEndpoint(Session session) async {}
 
   Future<void> intParameter(Session session, int value) async {}
@@ -58,6 +79,22 @@ class MethodStreaming extends Endpoint {
       someNullableField: 1,
     );
   }
+
+  Stream<int> throwsExceptionStream(Session session) async* {
+    throw Exception('This is an exception');
+  }
+
+  Stream<int> throwsSerializableExceptionStream(Session session) async* {
+    throw ExceptionWithData(
+      message: 'Throwing an exception',
+      creationDate: DateTime.now(),
+      errorFields: [
+        'first line error',
+        'second line error',
+      ],
+      someNullableField: 1,
+    );
+  }
 }
 
 class AuthenticatedMethodStreaming extends Endpoint {
@@ -68,4 +105,10 @@ class AuthenticatedMethodStreaming extends Endpoint {
   Set<Scope> get requiredScopes => {Scope.admin};
 
   Future<void> simpleEndpoint(Session session) async {}
+
+  Stream<int> simpleStream(Session session) async* {
+    for (var i = 0; i < 10; i++) {
+      yield i;
+    }
+  }
 }

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -3114,18 +3114,6 @@ class Endpoints extends _i1.EndpointDispatch {
       name: 'authenticatedMethodStreaming',
       endpoint: endpoints['authenticatedMethodStreaming']!,
       methodConnectors: {
-        'simpleEndpoint': _i1.MethodConnector(
-          name: 'simpleEndpoint',
-          params: {},
-          returnsVoid: true,
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['authenticatedMethodStreaming']
-                      as _i20.AuthenticatedMethodStreaming)
-                  .simpleEndpoint(session),
-        ),
         'simpleStream': _i1.MethodStreamConnector(
           name: 'simpleStream',
           params: {},
@@ -3137,7 +3125,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['authenticatedMethodStreaming']
                       as _i20.AuthenticatedMethodStreaming)
                   .simpleStream(session),
-        ),
+        )
       },
     );
     connectors['moduleSerialization'] = _i1.EndpointConnector(

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -3015,6 +3015,99 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['methodStreaming'] as _i20.MethodStreaming)
                   .throwsSerializableException(session),
         ),
+        'simpleStream': _i1.MethodStreamConnector(
+          name: 'simpleStream',
+          params: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .simpleStream(session),
+        ),
+        'simpleStreamWithParameter': _i1.MethodStreamConnector(
+          name: 'simpleStreamWithParameter',
+          params: {
+            'value': _i1.ParameterDescription(
+              name: 'value',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .simpleStreamWithParameter(
+            session,
+            params['value'],
+          ),
+        ),
+        'simpleDataStream': _i1.MethodStreamConnector(
+          name: 'simpleDataStream',
+          params: {
+            'value': _i1.ParameterDescription(
+              name: 'value',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .simpleDataStream(
+            session,
+            params['value'],
+          ),
+        ),
+        'delayedStreamResponse': _i1.MethodStreamConnector(
+          name: 'delayedStreamResponse',
+          params: {
+            'delay': _i1.ParameterDescription(
+              name: 'delay',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .delayedStreamResponse(
+            session,
+            params['delay'],
+          ),
+        ),
+        'throwsExceptionStream': _i1.MethodStreamConnector(
+          name: 'throwsExceptionStream',
+          params: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .throwsExceptionStream(session),
+        ),
+        'throwsSerializableExceptionStream': _i1.MethodStreamConnector(
+          name: 'throwsSerializableExceptionStream',
+          params: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .throwsSerializableExceptionStream(session),
+        ),
       },
     );
     connectors['authenticatedMethodStreaming'] = _i1.EndpointConnector(
@@ -3032,7 +3125,19 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['authenticatedMethodStreaming']
                       as _i20.AuthenticatedMethodStreaming)
                   .simpleEndpoint(session),
-        )
+        ),
+        'simpleStream': _i1.MethodStreamConnector(
+          name: 'simpleStream',
+          params: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) =>
+              (endpoints['authenticatedMethodStreaming']
+                      as _i20.AuthenticatedMethodStreaming)
+                  .simpleStream(session),
+        ),
       },
     );
     connectors['moduleSerialization'] = _i1.EndpointConnector(

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -149,16 +149,23 @@ mapParameters:
   - returnDurationMap:
   - returnDurationMapNullableDurations:
 methodStreaming:
+  - simpleStream:
+  - simpleStreamWithParameter:
+  - simpleDataStream:
   - simpleEndpoint:
   - intParameter:
   - nullableResponse:
   - doubleInputValue:
   - delayedResponse:
+  - delayedStreamResponse:
   - completeAllDelayedResponses:
   - throwsException:
   - throwsSerializableException:
+  - throwsExceptionStream:
+  - throwsSerializableExceptionStream:
 authenticatedMethodStreaming:
   - simpleEndpoint:
+  - simpleStream:
 moduleSerialization:
   - serializeModuleObject:
   - modifyModuleObject:

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -164,7 +164,6 @@ methodStreaming:
   - throwsExceptionStream:
   - throwsSerializableExceptionStream:
 authenticatedMethodStreaming:
-  - simpleEndpoint:
   - simpleStream:
 moduleSerialization:
   - serializeModuleObject:

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -69,9 +69,10 @@ void main() {
         var tempSession = await server.createSession();
 
         /// Close any open delayed response streams.
-        await server.endpoints
-            .getConnectorByName(endpoint)
-            ?.methodConnectors['completeAllDelayedResponses']
+        await (server.endpoints
+                    .getConnectorByName(endpoint)
+                    ?.methodConnectors['completeAllDelayedResponses']
+                as MethodConnector?)
             ?.call(tempSession, {});
 
         await tempSession.close();

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -58,10 +58,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        await expectLater(
-          delayedResponseOpen.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open all method streams with server.',
+        await delayedResponseOpen.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -130,10 +131,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        await expectLater(
-          delayedResponseOpen.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open all method streams with server.',
+        await delayedResponseOpen.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -25,12 +25,84 @@ void main() {
       await webSocket.sink.close();
     });
 
-    group('with a connected method stream ', () {
+    group('with a connected method stream that has a future response', () {
       late Completer<void> webSocketCompleter;
       late Completer<void> delayedResponseClosed;
 
       var endpoint = 'methodStreaming';
       var method = 'delayedResponse';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        var delayedResponseOpen = Completer<void>();
+        delayedResponseClosed = Completer<void>();
+        webSocketCompleter = Completer<void>();
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            if (message.connectionId == connectionId)
+              delayedResponseOpen.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            if (message.connectionId == connectionId)
+              delayedResponseClosed.complete();
+          }
+        }, onDone: () {
+          webSocketCompleter.complete();
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {'delay': 10},
+          connectionId: connectionId,
+        ));
+
+        await expectLater(
+          delayedResponseOpen.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open all method streams with server.',
+        );
+      });
+
+      tearDown(() async {
+        var tempSession = await server.createSession();
+
+        /// Close any open delayed response streams.
+        await (server.endpoints
+                    .getConnectorByName(endpoint)
+                    ?.methodConnectors['completeAllDelayedResponses']
+                as MethodConnector?)
+            ?.call(tempSession, {});
+
+        await tempSession.close();
+      });
+
+      test(
+          'when stream is closed by a CloseMethodStreamCommand then websocket connection is closed.',
+          () async {
+        webSocket.sink.add(CloseMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          connectionId: connectionId,
+          reason: CloseReason.done,
+        ));
+
+        await expectLater(
+          webSocketCompleter.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason:
+              'Websocket connection was not closed when only stream was closed.',
+        );
+      });
+    });
+
+    group('with a connected method stream that has a stream response', () {
+      late Completer<void> webSocketCompleter;
+      late Completer<void> delayedResponseClosed;
+
+      var endpoint = 'methodStreaming';
+      var method = 'delayedStreamResponse';
       var connectionId = const Uuid().v4obj();
 
       setUp(() async {

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -72,7 +72,7 @@ void main() {
       var method = 'doubleInputValue';
       var connectionId = const Uuid().v4obj();
 
-      setUp(() {
+      setUp(() async {
         endpointResponse = Completer<int>();
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
         webSocketCompleter = Completer<void>();
@@ -99,10 +99,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        expect(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -178,10 +179,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        await expectLater(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -265,10 +267,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        await expectLater(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -340,10 +343,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        await expectLater(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -367,7 +371,7 @@ void main() {
       late Completer<void> delayedResponseClosed;
       var endpoint = 'methodStreaming';
 
-      setUp(() {
+      setUp(() async {
         var returningStreamOpen = Completer<void>();
         var delayedResponseOpen = Completer<void>();
         returningStreamClosed = Completer<void>();
@@ -407,13 +411,14 @@ void main() {
           connectionId: returningStreamConnectionId,
         ));
 
-        expect(
-          Future.wait([
-            returningStreamOpen.future,
-            delayedResponseOpen.future,
-          ]).timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open all method streams with server.',
+        await Future.wait([
+          returningStreamOpen.future,
+          delayedResponseOpen.future,
+        ]).timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open all method stream with server.',
+          ),
         );
       });
 
@@ -449,7 +454,7 @@ void main() {
       late Completer<void> delayedResponseClosed;
       var endpoint = 'methodStreaming';
 
-      setUp(() {
+      setUp(() async {
         var returningStreamOpen = Completer<void>();
         var delayedResponseOpen = Completer<void>();
         returningStreamClosed = Completer<void>();
@@ -489,13 +494,14 @@ void main() {
           connectionId: returningStreamConnectionId,
         ));
 
-        expect(
-          Future.wait([
-            returningStreamOpen.future,
-            delayedResponseOpen.future,
-          ]).timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open all method streams with server.',
+        await Future.wait([
+          returningStreamOpen.future,
+          delayedResponseOpen.future,
+        ]).timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:serverpod_test_server/test_util/config.dart';
 import 'package:serverpod_test_server/test_util/test_serverpod.dart';
 import 'package:test/test.dart';
@@ -41,7 +42,7 @@ void main() {
 
       webSocket.sink.add(MethodStreamMessage.buildMessage(
         endpoint: 'methodStreaming',
-        method: 'doubleInputValue',
+        method: 'simpleStream',
         connectionId: const Uuid().v4obj(),
         object: server.serializationManager.encodeWithType(1),
       ));
@@ -60,7 +61,7 @@ void main() {
     });
 
     group(
-        'when a stream is opened to an endpoint that returns a value based on the input ',
+        'when a stream is opened to an endpoint that returns a Future with a value based on the input ',
         () {
       late Completer<int> endpointResponse;
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
@@ -139,6 +140,180 @@ void main() {
     });
 
     group(
+        'when a stream is opened to an endpoint that returns a stream of numbers counting to the input value starting from 0',
+        () {
+      late List<int> endpointResponses;
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      late Completer<void> webSocketCompleter;
+      var inputValue = 4;
+
+      var endpoint = 'methodStreaming';
+      var method = 'simpleStreamWithParameter';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        endpointResponses = [];
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        webSocketCompleter = Completer<void>();
+        var streamOpened = Completer<void>();
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          } else if (message is MethodStreamMessage) {
+            endpointResponses.add(server.serializationManager
+                .decodeWithType(message.object) as int);
+          }
+        }, onDone: () {
+          webSocketCompleter.complete();
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {'value': inputValue},
+          connectionId: connectionId,
+        ));
+
+        await expectLater(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test(
+          'then once method stream is closed the received MethodStreamMessages matches input specification.',
+          () async {
+        await expectLater(
+          closeMethodStreamCommand.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        expect(
+          endpointResponses,
+          List.generate(inputValue, (index) => index),
+          reason: 'Failed to receive all responses from endpoint.',
+        );
+      });
+
+      test('then CloseMethodStreamCommand matching the endpoint is received.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.done);
+      });
+
+      test('then the stream is closed.', () async {
+        expect(
+          webSocketCompleter.future.timeout(Duration(seconds: 5)),
+          completes,
+        );
+      });
+    });
+
+    group(
+        'when a stream is opened to an endpoint that returns a stream of SimpleData objects with numbers counting to the input value starting from 0',
+        () {
+      late List<SimpleData> endpointResponses;
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      late Completer<void> webSocketCompleter;
+      var inputValue = 4;
+
+      var endpoint = 'methodStreaming';
+      var method = 'simpleDataStream';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        endpointResponses = [];
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        webSocketCompleter = Completer<void>();
+        var streamOpened = Completer<void>();
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          } else if (message is MethodStreamMessage) {
+            endpointResponses.add(server.serializationManager
+                .decodeWithType(message.object) as SimpleData);
+          }
+        }, onDone: () {
+          webSocketCompleter.complete();
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {'value': inputValue},
+          connectionId: connectionId,
+        ));
+
+        await expectLater(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test(
+          'then once method stream is closed the received MethodStreamMessages matches input specification.',
+          () async {
+        await expectLater(
+          closeMethodStreamCommand.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        expect(
+          endpointResponses.map((simpleData) => simpleData.num).toList(),
+          List.generate(inputValue, (index) => index),
+          reason: 'Failed to receive all responses from endpoint.',
+        );
+      });
+
+      test('then CloseMethodStreamCommand matching the endpoint is received.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.done);
+      });
+
+      test('then the stream is closed.', () async {
+        expect(
+          webSocketCompleter.future.timeout(Duration(seconds: 5)),
+          completes,
+        );
+      });
+    });
+
+    group(
         'when a method stream is opened to an endpoint that has null return value then null MethodStreamMessage is received with null value',
         () {
       late Completer<int?> endpointResponse;
@@ -184,7 +359,8 @@ void main() {
         skip:
             'Enable this test once serialize and deserialize by class name supports null types.');
 
-    group('when multiple methods streams are open and one of them is closed',
+    group(
+        'when multiple methods streams are open and one of them with Future response is closed',
         () {
       late Completer<void> returningStreamClosed;
       late Completer<void> webSocketCompleter;
@@ -219,7 +395,7 @@ void main() {
 
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
           endpoint: endpoint,
-          method: 'delayedResponse',
+          method: 'delayedStreamResponse',
           args: {'delay': 10},
           connectionId: delayedResponseConnectionId,
         ));
@@ -227,6 +403,88 @@ void main() {
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
           endpoint: endpoint,
           method: 'simpleEndpoint',
+          args: {},
+          connectionId: returningStreamConnectionId,
+        ));
+
+        expect(
+          Future.wait([
+            returningStreamOpen.future,
+            delayedResponseOpen.future,
+          ]).timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open all method streams with server.',
+        );
+      });
+
+      tearDown(() async {
+        var tempSession = await server.createSession();
+
+        /// Close any open delayed response streams.
+        await (server.endpoints
+                    .getConnectorByName(endpoint)
+                    ?.methodConnectors['completeAllDelayedResponses']
+                as MethodConnector?)
+            ?.call(tempSession, {});
+
+        await tempSession.close();
+      });
+
+      test('then websocket connection stays open.', () async {
+        await returningStreamClosed.future.timeout(Duration(seconds: 5));
+
+        // Monitor websocket connection for 1 second to make sure it stays open.
+        expectLater(
+          webSocketCompleter.future.timeout(Duration(seconds: 1)),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+
+    group(
+        'when multiple methods streams are open and one of them with Stream response is closed',
+        () {
+      late Completer<void> returningStreamClosed;
+      late Completer<void> webSocketCompleter;
+      late Completer<void> delayedResponseClosed;
+      var endpoint = 'methodStreaming';
+
+      setUp(() {
+        var returningStreamOpen = Completer<void>();
+        var delayedResponseOpen = Completer<void>();
+        returningStreamClosed = Completer<void>();
+        delayedResponseClosed = Completer<void>();
+        webSocketCompleter = Completer<void>();
+        var returningStreamConnectionId = const Uuid().v4obj();
+        var delayedResponseConnectionId = const Uuid().v4obj();
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            if (message.connectionId == returningStreamConnectionId)
+              returningStreamOpen.complete();
+            else if (message.connectionId == delayedResponseConnectionId)
+              delayedResponseOpen.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            if (message.connectionId == returningStreamConnectionId)
+              returningStreamClosed.complete();
+            if (message.connectionId == delayedResponseConnectionId)
+              delayedResponseClosed.complete();
+          }
+        }, onDone: () {
+          webSocketCompleter.complete();
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: 'delayedStreamResponse',
+          args: {'delay': 10},
+          connectionId: delayedResponseConnectionId,
+        ));
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: 'simpleStream',
           args: {},
           connectionId: returningStreamConnectionId,
         ));

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -245,9 +245,10 @@ void main() {
         var tempSession = await server.createSession();
 
         /// Close any open delayed response streams.
-        await server.endpoints
-            .getConnectorByName(endpoint)
-            ?.methodConnectors['completeAllDelayedResponses']
+        await (server.endpoints
+                    .getConnectorByName(endpoint)
+                    ?.methodConnectors['completeAllDelayedResponses']
+                as MethodConnector?)
             ?.call(tempSession, {});
 
         await tempSession.close();

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -73,7 +73,7 @@ void main() {
         () async {
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
         endpoint: 'methodStreaming',
-        method: 'simpleEndpoint',
+        method: 'simpleStream',
         args: {},
         connectionId: const Uuid().v4obj(),
       ));
@@ -95,7 +95,7 @@ void main() {
         () async {
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
         endpoint: 'methodStreaming',
-        method: 'intParameter',
+        method: 'simpleStreamWithParameter',
         args: {},
         connectionId: const Uuid().v4obj(),
       ));
@@ -117,7 +117,7 @@ void main() {
         () async {
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
         endpoint: 'methodStreaming',
-        method: 'intParameter',
+        method: 'simpleStreamWithParameter',
         args: {'value': 42},
         connectionId: const Uuid().v4obj(),
       ));
@@ -139,7 +139,7 @@ void main() {
         () async {
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
         endpoint: 'authenticatedMethodStreaming',
-        method: 'simpleEndpoint',
+        method: 'simpleStream',
         args: {},
         connectionId: const Uuid().v4obj(),
         // No authentication token is provided
@@ -162,7 +162,7 @@ void main() {
         () async {
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
         endpoint: 'authenticatedMethodStreaming',
-        method: 'simpleEndpoint',
+        method: 'simpleStream',
         args: {},
         connectionId: const Uuid().v4obj(),
         authentication: 'invalid token',
@@ -203,7 +203,7 @@ void main() {
           () async {
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
           endpoint: 'authenticatedMethodStreaming',
-          method: 'simpleEndpoint',
+          method: 'simpleStream',
           args: {},
           connectionId: const Uuid().v4obj(),
           authentication: token,
@@ -249,7 +249,7 @@ void main() {
           () async {
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
           endpoint: 'authenticatedMethodStreaming',
-          method: 'simpleEndpoint',
+          method: 'simpleStream',
           args: {},
           connectionId: const Uuid().v4obj(),
           authentication: token,

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
@@ -26,7 +26,7 @@ void main() {
     });
 
     group(
-        'when a stream is opened to an endpoint that throws an exception then',
+        'when a stream is opened to an endpoint with a Future return that throws an exception then',
         () {
       var streamOpened = Completer<void>();
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
@@ -79,7 +79,60 @@ void main() {
     });
 
     group(
-        'when a stream is opened to an endpoint that throws a serializable exception',
+        'when a stream is opened to an endpoint with a Stream return that throws an exception then',
+        () {
+      var streamOpened = Completer<void>();
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+
+      var endpoint = 'methodStreaming';
+      var method = 'throwsExceptionStream';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          connectionId: connectionId,
+        ));
+
+        await expectLater(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test('then CloseMethodStreamCommand matching endpoint is received.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
+      });
+    });
+
+    group(
+        'when a stream is opened to an endpoint with a Future return that throws a serializable exception',
         () {
       late Completer<MethodStreamSerializableException>
           methodStreamSerializableException;
@@ -114,6 +167,85 @@ void main() {
         ));
 
         expect(
+          streamOpened.future.timeout(Duration(seconds: 5)),
+          completes,
+          reason: 'Failed to open method stream with server.',
+        );
+      });
+
+      test(
+          'then MethodStreamSerializableException matching the endpoint is received.',
+          () async {
+        var message = methodStreamSerializableException.future
+            .timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason:
+              'Failed to receive MethodStreamSerializableException from server.',
+        );
+
+        var methodStreamSerializableExceptionMessage = await message;
+        expect(methodStreamSerializableExceptionMessage.endpoint, endpoint);
+        expect(methodStreamSerializableExceptionMessage.method, method);
+        expect(methodStreamSerializableExceptionMessage.connectionId,
+            connectionId);
+      });
+
+      test('then CloseMethodStreamCommand matching the endpoint is received.',
+          () async {
+        var message =
+            closeMethodStreamCommand.future.timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
+      });
+    });
+
+    group(
+        'when a stream is opened to an endpoint with a Stream return that throws a serializable exception',
+        () {
+      late Completer<MethodStreamSerializableException>
+          methodStreamSerializableException;
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+
+      var endpoint = 'methodStreaming';
+      var method = 'throwsSerializableExceptionStream';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        var streamOpened = Completer<void>();
+        methodStreamSerializableException =
+            Completer<MethodStreamSerializableException>();
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(event);
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is MethodStreamSerializableException) {
+            methodStreamSerializableException.complete(message);
+          } else if (message is CloseMethodStreamCommand) {
+            closeMethodStreamCommand.complete(message);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          connectionId: connectionId,
+        ));
+
+        await expectLater(
           streamOpened.future.timeout(Duration(seconds: 5)),
           completes,
           reason: 'Failed to open method stream with server.',

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
@@ -53,10 +53,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        expect(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -106,10 +107,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        await expectLater(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -166,10 +168,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        expect(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 
@@ -245,10 +248,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        await expectLater(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/void_response_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/void_response_endpoint_test.dart
@@ -34,7 +34,7 @@ void main() {
       var method = 'simpleEndpoint';
       var connectionId = const Uuid().v4obj();
 
-      setUp(() {
+      setUp(() async {
         endpointResponse = Completer<MethodStreamMessage>();
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
         var streamOpened = Completer<void>();
@@ -56,10 +56,11 @@ void main() {
           connectionId: connectionId,
         ));
 
-        expect(
-          streamOpened.future.timeout(Duration(seconds: 5)),
-          completes,
-          reason: 'Failed to open method stream with server.',
+        await streamOpened.future.timeout(
+          Duration(seconds: 5),
+          onTimeout: () => throw AssertionError(
+            'Failed to open method stream with server.',
+          ),
         );
       });
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -55,6 +55,9 @@ class MethodDefinition {
   /// The named parameters of this method.
   final List<ParameterDefinition> parametersNamed;
 
+  /// Whether this method contains a stream input our output.
+  final bool isStream;
+
   /// Creates a new [MethodDefinition].
   const MethodDefinition({
     required this.name,
@@ -63,6 +66,7 @@ class MethodDefinition {
     required this.parametersPositional,
     required this.parametersNamed,
     required this.returnType,
+    required this.isStream,
   });
 }
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -35,7 +35,7 @@ class EndpointDefinition {
 }
 
 /// Describes a single method in a [EndpointDefinition].
-class MethodDefinition {
+abstract base class MethodDefinition {
   /// The name of the method.
   final String name;
 
@@ -55,22 +55,42 @@ class MethodDefinition {
   /// The named parameters of this method.
   final List<ParameterDefinition> parametersNamed;
 
-  /// Whether this method contains a stream input our output.
-  final bool isStream;
-
-  /// Creates a new [MethodDefinition].
   const MethodDefinition({
     required this.name,
     required this.documentationComment,
+    required this.returnType,
     required this.parameters,
     required this.parametersPositional,
     required this.parametersNamed,
-    required this.returnType,
-    required this.isStream,
   });
 }
 
-/// Describes a single parameter of a [MethodDefinition].
+/// Describes a single callable method in a [EndpointDefinition].
+final class MethodCallDefinition extends MethodDefinition {
+  /// Creates a new [MethodCallDefinition].
+  const MethodCallDefinition({
+    required super.name,
+    required super.documentationComment,
+    required super.parameters,
+    required super.parametersPositional,
+    required super.parametersNamed,
+    required super.returnType,
+  });
+}
+
+/// Describes a single streaming method in a [EndpointDefinition].
+final class MethodStreamDefinition extends MethodDefinition {
+  MethodStreamDefinition({
+    required super.name,
+    required super.documentationComment,
+    required super.returnType,
+    required super.parameters,
+    required super.parametersPositional,
+    required super.parametersNamed,
+  });
+}
+
+/// Describes a single parameter of a [MethodCallDefinition].
 class ParameterDefinition {
   /// The variable name of the parameter.
   final String name;

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -24,7 +24,22 @@ abstract class EndpointMethodAnalyzer {
     MethodElement method,
     Parameters parameters,
   ) {
-    var definition = MethodDefinition(
+    var isStream =
+        method.returnType.isDartAsyncStream || parameters._hasStream();
+
+    if (isStream) {
+      return MethodStreamDefinition(
+        name: method.name,
+        documentationComment: method.documentationComment,
+        // TODO: Move removal of session parameter to Parameter analyzer
+        parameters: parameters.required.sublist(1), // Skip session parameter,
+        parametersNamed: parameters.named,
+        parametersPositional: parameters.positional,
+        returnType: TypeDefinition.fromDartType(method.returnType),
+      );
+    }
+
+    return MethodCallDefinition(
       name: method.name,
       documentationComment: method.documentationComment,
       // TODO: Move removal of session parameter to Parameter analyzer
@@ -32,10 +47,7 @@ abstract class EndpointMethodAnalyzer {
       parametersNamed: parameters.named,
       parametersPositional: parameters.positional,
       returnType: TypeDefinition.fromDartType(method.returnType),
-      isStream: method.returnType.isDartAsyncStream || parameters._hasStream(),
     );
-
-    return definition;
   }
 
   /// Creates a namespace for the [MethodElement] based on the [ClassElement]

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_class_analyzer.dart';
@@ -31,6 +32,7 @@ abstract class EndpointMethodAnalyzer {
       parametersNamed: parameters.named,
       parametersPositional: parameters.positional,
       returnType: TypeDefinition.fromDartType(method.returnType),
+      isStream: method.returnType.isDartAsyncStream || parameters._hasStream(),
     );
 
     return definition;
@@ -68,6 +70,7 @@ abstract class EndpointMethodAnalyzer {
       _validateReturnType(
         dartType: method.returnType,
         dartElement: method,
+        hasStreamParameter: method.parameters._hasStream(),
       )
     ];
 
@@ -82,10 +85,11 @@ abstract class EndpointMethodAnalyzer {
   static SourceSpanSeverityException? _validateReturnType({
     required DartType dartType,
     required Element dartElement,
+    required bool hasStreamParameter,
   }) {
-    if (!dartType.isDartAsyncFuture) {
+    if (!(dartType.isDartAsyncFuture || dartType.isDartAsyncStream)) {
       return SourceSpanSeverityException(
-        'Return type must be a Future.',
+        'Return type must be a Future or a Stream.',
         dartElement.span,
       );
     }
@@ -99,8 +103,10 @@ abstract class EndpointMethodAnalyzer {
 
     var typeArguments = dartType.typeArguments;
     if (typeArguments.length != 1) {
+      // Interface type must always have a type argument so this is just for
+      // safety.
       return SourceSpanSeverityException(
-        'Future must have a type defined. E.g. Future<String>.',
+        'Return generic must be type defined. E.g. ${dartType.element.name}<String>.',
         dartElement.span,
       );
     }
@@ -113,7 +119,15 @@ abstract class EndpointMethodAnalyzer {
 
     if (innerType is DynamicType) {
       return SourceSpanSeverityException(
-        'Future must have a type defined. E.g. Future<String>.',
+        'Return generic must have a type defined. E.g. ${dartType.element.name}<String>.',
+        dartElement.span,
+      );
+    }
+
+    if ((dartType.isDartAsyncStream || hasStreamParameter) &&
+        innerType.nullabilitySuffix != NullabilitySuffix.none) {
+      return SourceSpanSeverityException(
+        'Nullable return type for streaming methods are not supported.',
         dartElement.span,
       );
     }
@@ -129,4 +143,15 @@ abstract class EndpointMethodAnalyzer {
 
     return null;
   }
+}
+
+extension on List<ParameterElement> {
+  bool _hasStream() {
+    return any((element) => element.type.isDartAsyncStream);
+  }
+}
+
+extension on Parameters {
+  bool _hasStream() => [...required, ...positional, ...named]
+      .any((element) => element.type.dartType?.isDartAsyncStream ?? false);
 }

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
@@ -43,55 +43,55 @@ abstract class EndpointParameterAnalyzer {
   static List<SourceSpanSeverityException> validate(
     List<ParameterElement> parameters,
   ) {
-    List<SourceSpanSeverityException> errors = [];
-    for (var parameter in parameters) {
-      var type = parameter.type;
-      if (type.isDartAsyncFuture) {
-        errors.add(SourceSpanSeverityException(
-          'The type "Future" is not a supported endpoint parameter type.',
-          parameter.span,
-        ));
-        continue;
-      }
+    return parameters
+        .map((parameter) {
+          var type = parameter.type;
+          if (type.isDartAsyncFuture) {
+            return SourceSpanSeverityException(
+              'The type "Future" is not a supported endpoint parameter type.',
+              parameter.span,
+            );
+          }
 
-      if (type.isDartAsyncStream && type is ParameterizedType) {
-        var typeArguments = type.typeArguments;
-        if (typeArguments.length != 1) {
-          // Streams only allow a single generic so this case is only here for safety.
-          errors.add(SourceSpanSeverityException(
-            'The type "Stream" must have exactly one type argument. E.g. Stream<String>.',
-            parameter.span,
-          ));
-          continue;
-        }
+          if (type.isDartAsyncStream && type is ParameterizedType) {
+            var typeArguments = type.typeArguments;
+            if (typeArguments.length != 1) {
+              // Streams only allow a single generic so this case is only here for safety.
+              return SourceSpanSeverityException(
+                'The type "Stream" must have exactly one type argument. E.g. Stream<String>.',
+                parameter.span,
+              );
+            }
 
-        var innerType = typeArguments[0];
-        if (innerType is VoidType || innerType is DynamicType) {
-          errors.add(SourceSpanSeverityException(
-            'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
-            parameter.span,
-          ));
-          continue;
-        }
+            var innerType = typeArguments[0];
+            if (innerType is VoidType || innerType is DynamicType) {
+              return SourceSpanSeverityException(
+                'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
+                parameter.span,
+              );
+            }
 
-        if (innerType.nullabilitySuffix != NullabilitySuffix.none) {
-          errors.add(SourceSpanSeverityException(
-            'Nullable types are not supported for "Stream" parameters.',
-            parameter.span,
-          ));
-          continue;
-        }
-      }
-      try {
-        TypeDefinition.fromDartType(parameter.type);
-      } on FromDartTypeClassNameException catch (e) {
-        errors.add(SourceSpanSeverityException(
-          'The type "${e.type}" is not a supported endpoint parameter type.',
-          parameter.span,
-        ));
-      }
-    }
-    return errors;
+            if (innerType.nullabilitySuffix != NullabilitySuffix.none) {
+              return SourceSpanSeverityException(
+                'Nullable types are not supported for "Stream" parameters.',
+                parameter.span,
+              );
+            }
+          }
+
+          try {
+            TypeDefinition.fromDartType(parameter.type);
+          } on FromDartTypeClassNameException catch (e) {
+            return SourceSpanSeverityException(
+              'The type "${e.type}" is not a supported endpoint parameter type.',
+              parameter.span,
+            );
+          }
+
+          return null;
+        })
+        .whereType<SourceSpanSeverityException>()
+        .toList();
   }
 
   static bool _isRequired(ParameterElement parameter) {

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
@@ -68,7 +68,7 @@ abstract class EndpointParameterAnalyzer {
         var innerType = typeArguments[0];
         if (innerType is VoidType || innerType is DynamicType) {
           errors.add(SourceSpanSeverityException(
-            'The type "Stream" must have a type defined. E.g. Stream<String>.',
+            'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
             parameter.span,
           ));
           continue;

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -131,7 +131,7 @@ class LibraryGenerator {
                   for (var endPoint in protocolDefinition.endpoints)
                     for (var method in endPoint.methods) ...[
                       ...method.returnType
-                          .stripFuture()
+                          .stripFutureOrStream()
                           .generateDeserialization(serverCode, config: config),
                       for (var parameter in method.parameters)
                         ...parameter.type.generateDeserialization(serverCode,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -131,7 +131,7 @@ class LibraryGenerator {
                   for (var endPoint in protocolDefinition.endpoints)
                     for (var method in endPoint.methods) ...[
                       ...method.returnType
-                          .stripFutureOrStream()
+                          .retrieveGenericType()
                           .generateDeserialization(serverCode, config: config),
                       for (var parameter in method.parameters)
                         ...parameter.type.generateDeserialization(serverCode,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -372,7 +372,7 @@ class LibraryGenerator {
             ..initializers.add(refer('super').call([refer('caller')]).code)));
 
           for (var methodDef
-              in endpointDef.methods.where((method) => !method.isStream)) {
+              in endpointDef.methods.whereType<MethodCallDefinition>()) {
             var requiredParams = methodDef.parameters;
             var optionalParams = methodDef.parametersPositional;
             var namedParameters = methodDef.parametersNamed;
@@ -664,11 +664,11 @@ class LibraryGenerator {
                 {
                   ..._buildMethodConnectors(
                     endpoint,
-                    endpoint.methods.where((method) => !method.isStream),
+                    endpoint.methods.whereType<MethodCallDefinition>(),
                   ),
                   ..._buildMethodStreamConnectors(
                     endpoint,
-                    endpoint.methods.where((method) => method.isStream),
+                    endpoint.methods.whereType<MethodStreamDefinition>(),
                   )
                 },
               )
@@ -679,7 +679,7 @@ class LibraryGenerator {
 
   Map<Object, Object> _buildMethodConnectors(
     EndpointDefinition endpoint,
-    Iterable<MethodDefinition> methods,
+    Iterable<MethodCallDefinition> methods,
   ) {
     var methodConnectors = <Object, Object>{};
     for (var method in methods) {
@@ -742,7 +742,7 @@ class LibraryGenerator {
 
   Map<Object, Object> _buildMethodStreamConnectors(
     EndpointDefinition endpoint,
-    Iterable<MethodDefinition> methods,
+    Iterable<MethodStreamDefinition> methods,
   ) {
     var methodStreamConnectors = <Object, Object>{};
     for (var method in methods) {

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -266,15 +266,18 @@ class TypeDefinition {
     return 'ColumnSerializable';
   }
 
-  /// Strip the outer most future of this type.
-  /// Throws, if this type is not a future.
-  TypeDefinition stripFuture() {
+  /// Strip the outer most Future or Stream of this type.
+  /// Throws, if this type is not a Future or Stream.
+  TypeDefinition stripFutureOrStream() {
     if (dartType?.isDartAsyncFuture ?? className == 'Future') {
       return generics.first;
-    } else {
-      throw FormatException(
-          '$this is not a Future, so Future cant be stripped.');
     }
+    if (dartType?.isDartAsyncStream ?? className == 'Stream') {
+      return generics.first;
+    }
+
+    throw FormatException(
+        '$this is not a Future or Stream, so Future or Stream cant be stripped.');
   }
 
   /// Generates the constructors for List and Map types

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -57,6 +57,10 @@ class TypeDefinition {
 
   bool get isVoidType => className == 'void';
 
+  bool get isStreamType => className == 'Stream';
+
+  bool get isFutureType => className == 'Future';
+
   bool get isModuleType =>
       url == 'serverpod' || (url?.startsWith(_moduleRef) ?? false);
 

--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -270,18 +270,15 @@ class TypeDefinition {
     return 'ColumnSerializable';
   }
 
-  /// Strip the outer most Future or Stream of this type.
-  /// Throws, if this type is not a Future or Stream.
-  TypeDefinition stripFutureOrStream() {
-    if (dartType?.isDartAsyncFuture ?? className == 'Future') {
-      return generics.first;
-    }
-    if (dartType?.isDartAsyncStream ?? className == 'Stream') {
-      return generics.first;
+  /// Retrieves the generic from this type.
+  /// Throws a [FormatException] if no generic is found.
+  TypeDefinition retrieveGenericType() {
+    var genericType = generics.firstOrNull;
+    if (genericType == null) {
+      throw FormatException('$this does not have a generic type to retrieve.');
     }
 
-    throw FormatException(
-        '$this is not a Future or Stream, so Future or Stream cant be stripped.');
+    return genericType;
   }
 
   /// Generates the constructors for List and Map types

--- a/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
@@ -10,6 +10,7 @@ class MethodDefinitionBuilder {
   List<ParameterDefinition> _parameters = [];
   List<ParameterDefinition> _parametersPositional = [];
   List<ParameterDefinition> _parametersNamed = [];
+  bool _isStream = false;
 
   MethodDefinitionBuilder withName(String name) {
     _name = name;
@@ -44,6 +45,11 @@ class MethodDefinitionBuilder {
     return this;
   }
 
+  MethodDefinitionBuilder withIsStream(bool isStream) {
+    _isStream = isStream;
+    return this;
+  }
+
   MethodDefinition build() {
     return MethodDefinition(
       name: _name,
@@ -52,6 +58,7 @@ class MethodDefinitionBuilder {
       parameters: _parameters,
       parametersPositional: _parametersPositional,
       parametersNamed: _parametersNamed,
+      isStream: _isStream,
     );
   }
 }

--- a/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
@@ -10,7 +10,6 @@ class MethodDefinitionBuilder {
   List<ParameterDefinition> _parameters = [];
   List<ParameterDefinition> _parametersPositional = [];
   List<ParameterDefinition> _parametersNamed = [];
-  bool _isStream = false;
 
   MethodDefinitionBuilder withName(String name) {
     _name = name;
@@ -45,20 +44,25 @@ class MethodDefinitionBuilder {
     return this;
   }
 
-  MethodDefinitionBuilder withIsStream(bool isStream) {
-    _isStream = isStream;
-    return this;
-  }
-
-  MethodDefinition build() {
-    return MethodDefinition(
+  MethodCallDefinition buildMethodCallDefinition() {
+    return MethodCallDefinition(
       name: _name,
       documentationComment: _documentationComment,
       returnType: _returnType,
       parameters: _parameters,
       parametersPositional: _parametersPositional,
       parametersNamed: _parametersNamed,
-      isStream: _isStream,
+    );
+  }
+
+  MethodStreamDefinition buildMethodStreamDefinition() {
+    return MethodStreamDefinition(
+      name: _name,
+      documentationComment: _documentationComment,
+      returnType: _returnType,
+      parameters: _parameters,
+      parametersPositional: _parametersPositional,
+      parametersNamed: _parametersNamed,
     );
   }
 }

--- a/tools/serverpod_cli/lib/src/test_util/builders/type_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/type_definition_builder.dart
@@ -41,6 +41,14 @@ class TypeDefinitionBuilder {
     return this;
   }
 
+  TypeDefinitionBuilder withStreamOf(
+    String className,
+  ) {
+    _className = 'Stream';
+    _generics.add(TypeDefinitionBuilder().withClassName(className).build());
+    return this;
+  }
+
   TypeDefinitionBuilder withListOf(String className, [bool nullable = false]) {
     _className = 'List';
     _generics.add(TypeDefinitionBuilder()

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol_test.dart
@@ -3,7 +3,10 @@ import 'package:recase/recase.dart';
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
 import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/method_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dart';
 import 'package:test/test.dart';
 
 const projectName = 'example_project';
@@ -110,6 +113,55 @@ void main() {
         expect(
           codeMap[expectedFileName],
           isNot(contains(serverOnlyModel.pascalCase)),
+        );
+      },
+    );
+  });
+
+  group(
+      'Given an endpoint with Stream with model generic return type when generating protocol files',
+      () {
+    var modelName = 'example_model';
+    var models = [
+      ClassDefinitionBuilder()
+          .withClassName(modelName.pascalCase)
+          .withFileName(modelName)
+          .build()
+    ];
+    var endpoints = [
+      EndpointDefinitionBuilder().withMethods([
+        MethodDefinitionBuilder()
+            .withName('streamingMethod')
+            .withReturnType(
+              TypeDefinitionBuilder()
+                  .withStreamOf(modelName.pascalCase)
+                  .build(),
+            )
+            .build()
+      ]).build()
+    ];
+
+    var protocolDefinition =
+        ProtocolDefinition(endpoints: endpoints, models: models);
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test(
+      'then the protocol.dart file is created.',
+      () {
+        expect(codeMap[expectedFileName], isNotNull);
+      },
+    );
+
+    test(
+      'then the protocol.dart contains deserialization for the model type.',
+      () {
+        expect(
+          codeMap[expectedFileName],
+          contains(modelName.pascalCase),
         );
       },
     );

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol_test.dart
@@ -137,7 +137,7 @@ void main() {
                   .withStreamOf(modelName.pascalCase)
                   .build(),
             )
-            .build()
+            .buildMethodCallDefinition()
       ]).build()
     ];
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
@@ -150,10 +150,9 @@ void main() {
             .withMethods([
           MethodDefinitionBuilder()
               .withName(methodName)
-              .withIsStream(true)
               .withReturnType(
                   TypeDefinitionBuilder().withStreamOf('String').build())
-              .build(),
+              .buildMethodStreamDefinition(),
         ]).build(),
       ],
       models: [],

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
@@ -3,6 +3,8 @@ import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
 import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/method_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dart';
 import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
 
@@ -133,5 +135,43 @@ void main() {
       },
       skip: endpointsFile == null,
     );
+  });
+
+  group(
+      'Given a protocol definition with a method with Stream return value when generating endpoints file',
+      () {
+    var endpointName = 'testing';
+    var methodName = 'streamMethod';
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('${endpointName.pascalCase}Endpoint')
+            .withName(endpointName)
+            .withMethods([
+          MethodDefinitionBuilder()
+              .withName(methodName)
+              .withIsStream(true)
+              .withReturnType(
+                  TypeDefinitionBuilder().withStreamOf('String').build())
+              .build(),
+        ]).build(),
+      ],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test('then endpoints file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+    var endpointsFile = codeMap[expectedFileName];
+
+    test('then endpoints file contains MethodStreamConnector for method.', () {
+      expect(
+          endpointsFile, contains("'$methodName': _i1.MethodStreamConnector("));
+    });
   });
 }

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol_test.dart
@@ -1,0 +1,72 @@
+import 'package:path/path.dart' as path;
+import 'package:recase/recase.dart';
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/method_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dart';
+import 'package:test/test.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    'lib',
+    'src',
+    'generated',
+    'protocol.dart',
+  );
+
+  group(
+      'Given an endpoint with Stream with model generic return type when generating protocol files',
+      () {
+    var modelName = 'example_model';
+    var models = [
+      ClassDefinitionBuilder()
+          .withClassName(modelName.pascalCase)
+          .withFileName(modelName)
+          .build()
+    ];
+    var endpoints = [
+      EndpointDefinitionBuilder().withMethods([
+        MethodDefinitionBuilder()
+            .withName('streamingMethod')
+            .withReturnType(
+              TypeDefinitionBuilder()
+                  .withStreamOf(modelName.pascalCase)
+                  .build(),
+            )
+            .build()
+      ]).build()
+    ];
+
+    var protocolDefinition =
+        ProtocolDefinition(endpoints: endpoints, models: models);
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test(
+      'then the protocol.dart file is created.',
+      () {
+        expect(codeMap[expectedFileName], isNotNull);
+      },
+    );
+
+    test(
+      'then the protocol.dart contains deserialization for the model type.',
+      () {
+        expect(
+          codeMap[expectedFileName],
+          contains(modelName.pascalCase),
+        );
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol_test.dart
@@ -40,7 +40,7 @@ void main() {
                   .withStreamOf(modelName.pascalCase)
                   .build(),
             )
-            .build()
+            .buildMethodCallDefinition()
       ]).build()
     ];
 

--- a/tools/serverpod_cli/test/generator/yaml/endpoint_description_test.dart
+++ b/tools/serverpod_cli/test/generator/yaml/endpoint_description_test.dart
@@ -95,7 +95,9 @@ example2:
             .withClassName('ExampleEndpoint')
             .withName('example')
             .withMethods([
-          MethodDefinitionBuilder().withName('method').build(),
+          MethodDefinitionBuilder()
+              .withName('method')
+              .buildMethodCallDefinition(),
         ]).build(),
       ],
       models: [],
@@ -124,8 +126,12 @@ example:
             .withClassName('ExampleEndpoint')
             .withName('example')
             .withMethods([
-          MethodDefinitionBuilder().withName('method').build(),
-          MethodDefinitionBuilder().withName('method2').build(),
+          MethodDefinitionBuilder()
+              .withName('method')
+              .buildMethodCallDefinition(),
+          MethodDefinitionBuilder()
+              .withName('method2')
+              .buildMethodCallDefinition(),
         ]).build(),
       ],
       models: [],
@@ -155,8 +161,12 @@ example:
             .withClassName('ExampleEndpoint')
             .withName('example')
             .withMethods([
-          MethodDefinitionBuilder().withName('method').build(),
-          MethodDefinitionBuilder().withName('method2').build(),
+          MethodDefinitionBuilder()
+              .withName('method')
+              .buildMethodCallDefinition(),
+          MethodDefinitionBuilder()
+              .withName('method2')
+              .buildMethodCallDefinition(),
         ]).build(),
         EndpointDefinitionBuilder()
             .withClassName('ExampleEndpoint2')
@@ -166,7 +176,9 @@ example:
             .withClassName('ExampleEndpoint3')
             .withName('example3')
             .withMethods([
-          MethodDefinitionBuilder().withName('method').build(),
+          MethodDefinitionBuilder()
+              .withName('method')
+              .buildMethodCallDefinition(),
         ]).build(),
       ],
       models: [],

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
@@ -422,6 +422,69 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
+  group('Given an endpoint method with a Stream parameter when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Stream<String> stream) async {
+    return stream.first;
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint method definition is created.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, hasLength(1));
+    });
+
+    group('then endpoint method parameter', () {
+      test('is defined.', () {
+        var parameters =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.parameters;
+        expect(parameters, hasLength(1));
+      });
+
+      test('has expected name.', () {
+        var name = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.name;
+        expect(name, 'stream');
+      });
+
+      test('has expected type.', () {
+        var type = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.type;
+        expect(type?.className, 'Stream');
+      });
+
+      test('has expected generic,', () {
+        var generic = endpointDefinitions.firstOrNull?.methods.firstOrNull
+            ?.parameters.firstOrNull?.type.generics.firstOrNull;
+        expect(generic?.className, 'String');
+      });
+    });
+  });
+
   group('Given an endpoint method with a function parameter when analyzed', () {
     var collector = CodeGenerationCollector();
     var testDirectory =
@@ -453,6 +516,224 @@ class ExampleEndpoint extends Endpoint {
       expect(
         collector.errors.firstOrNull?.message,
         'The type "String Function()" is not a supported endpoint parameter type.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group('Given an endpoint method with a Future parameter when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Future<String> name) async {
+    return name;
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test(
+        'then a validation error is reported that informs the type is not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'The type "Future" is not a supported endpoint parameter type.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method with a Stream parameter without generic type when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Stream stream) async {
+    return stream.first as String;
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test(
+        'then a validation error is reported that informs the type is not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'The type "Stream" must have a type defined. E.g. Stream<String>.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method with a Stream parameter with void type when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Stream<void> stream) async {
+    return 'hello';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test(
+        'then a validation error is reported that informs the type is not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'The type "Stream" must have a type defined. E.g. Stream<String>.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method with a Stream parameter with dynamic type when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Stream<dynamic> stream) async {
+    return 'hello';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test(
+        'then a validation error is reported that informs the type is not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'The type "Stream" must have a type defined. E.g. Stream<String>.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method with a Stream parameter with nullable type when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Stream<String?> stream) async {
+    return await stream.first ?? 'Hello';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test(
+        'then a validation error is reported that informs the type is not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'Nullable types are not supported for "Stream" parameters.',
       );
     });
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
@@ -601,7 +601,7 @@ class ExampleEndpoint extends Endpoint {
       expect(collector.errors, hasLength(1));
       expect(
         collector.errors.firstOrNull?.message,
-        'The type "Stream" must have a type defined. E.g. Stream<String>.',
+        'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
       );
     });
 
@@ -645,7 +645,7 @@ class ExampleEndpoint extends Endpoint {
       expect(collector.errors, hasLength(1));
       expect(
         collector.errors.firstOrNull?.message,
-        'The type "Stream" must have a type defined. E.g. Stream<String>.',
+        'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
       );
     });
 
@@ -689,7 +689,7 @@ class ExampleEndpoint extends Endpoint {
       expect(collector.errors, hasLength(1));
       expect(
         collector.errors.firstOrNull?.message,
-        'The type "Stream" must have a type defined. E.g. Stream<String>.',
+        'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
       );
     });
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -191,10 +191,10 @@ class ExampleEndpoint extends Endpoint {
     });
 
     group('then endpoint method definition', () {
-      test('is a streaming method.', () {
-        var isStream =
-            endpointDefinitions.firstOrNull?.methods.firstOrNull?.isStream;
-        expect(isStream, isTrue);
+      test('is a method stream definition.', () {
+        var methodDefinition =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull;
+        expect(methodDefinition, isA<MethodStreamDefinition>());
       });
 
       test('has stream return type.', () {
@@ -240,9 +240,9 @@ class ExampleEndpoint extends Endpoint {
     });
 
     test('then endpoint method definition is a streaming method.', () {
-      var isStream =
-          endpointDefinitions.firstOrNull?.methods.firstOrNull?.isStream;
-      expect(isStream, isTrue);
+      var methodDefinition =
+          endpointDefinitions.firstOrNull?.methods.firstOrNull;
+      expect(methodDefinition, isA<MethodStreamDefinition>());
     });
   });
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -157,6 +157,95 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
+  group('Given an endpoint method with a stream return type when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'dart:async';
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Stream<String> hello(Session session) async* {
+    yield 'Hello';
+    yield 'World';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    group('then endpoint method definition', () {
+      test('is a streaming method.', () {
+        var isStream =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.isStream;
+        expect(isStream, isTrue);
+      });
+
+      test('has stream return type.', () {
+        var returnType =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.returnType;
+        expect(returnType?.className, 'Stream');
+        expect(returnType?.generics, hasLength(1));
+        expect(returnType?.generics.firstOrNull?.className, 'String');
+      });
+    });
+  });
+
+  group('Given an endpoint method with a stream parameter when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'dart:async';
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Stream<String> stream) async {
+    return 'Hello \${await stream.first}';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint method definition is a streaming method.', () {
+      var isStream =
+          endpointDefinitions.firstOrNull?.methods.firstOrNull?.isStream;
+      expect(isStream, isTrue);
+    });
+  });
+
   group('Given an endpoint method that does not return Future when analyzed',
       () {
     var collector = CodeGenerationCollector();
@@ -188,7 +277,7 @@ class ExampleEndpoint extends Endpoint {
     test('then validation error informs that return type must be future', () {
       expect(
         collector.errors.firstOrNull?.message,
-        'Return type must be a Future.',
+        'Return type must be a Future or a Stream.',
       );
     });
 
@@ -234,7 +323,151 @@ class ExampleEndpoint extends Endpoint {
     test('then validation error informs that return type must be future', () {
       expect(
         collector.errors.firstOrNull?.message,
-        'Future must have a type defined. E.g. Future<String>.',
+        'Return generic must have a type defined. E.g. Future<String>.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then no endpoint method definition is created.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method that returns a Stream missing defined type when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Stream hello(Session session, String name) async* {
+    yield 'Hello';
+    yield 'World';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then a validation errors is reported.', () {
+      expect(collector.errors, hasLength(1));
+    });
+
+    test('then validation error informs that return type must be future', () {
+      expect(
+        collector.errors.firstOrNull?.message,
+        'Return generic must have a type defined. E.g. Stream<String>.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then no endpoint method definition is created.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method that returns a Stream with nullable type when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Stream<String?> hello(Session session, String name) async* {
+    yield 'Hello';
+    yield 'World';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then a validation errors is reported.', () {
+      expect(collector.errors, hasLength(1));
+    });
+
+    test(
+        'then validation error informs that nullable return types are not supported.',
+        () {
+      expect(
+        collector.errors.firstOrNull?.message,
+        'Nullable return type for streaming methods are not supported.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then no endpoint method definition is created.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method with Stream parameter that returns a Future with nullable type when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String?> hello2(Session session, Stream<String> stream) async {
+    return 'Hello \${await stream.first}';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then a validation errors is reported.', () {
+      expect(collector.errors, hasLength(1));
+    });
+
+    test(
+        'then validation error informs that nullable return types are not supported.',
+        () {
+      expect(
+        collector.errors.firstOrNull?.message,
+        'Nullable return type for streaming methods are not supported.',
       );
     });
 
@@ -319,7 +552,7 @@ class ExampleEndpoint extends Endpoint {
     test('then validation error informs that return type must be future', () {
       expect(
         collector.errors.firstOrNull?.message,
-        'Future must have a type defined. E.g. Future<String>.',
+        'Return generic must have a type defined. E.g. Future<String>.',
       );
     });
 


### PR DESCRIPTION
Another stepping stone towards #2338.

This PR introduces Server support for endpoints that have a Stream return value.

It also prepares for supporting single and void response type from Streaming method endpoints once Streaming parameters are supported.

This PR includes the Parsing, Code generation and validation required to configure an endpoint with a Streaming return value.

### Important notes.
- An assumption is made that once an exception has been thrown from a Streaming endpoint we will close the connection to the client. The connection will either receive a an optional SerializableException message before a CloseStream message with reason type Error.
- A new base class for MethodConnectors have been introduced. The reason the base class is not called the more fitting name `MethodConnector` is that this would be a breaking change in third-party modules we do not control.

### Guidance for review
Best reviewed commit by commit.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - This is a new unreleased feature.