### PR TITLE
Create `config/firebase_service_account_key.json` during deployment

### DIFF
--- a/examples/auth_example/.github/workflows/deployment-aws.yml
+++ b/examples/auth_example/.github/workflows/deployment-aws.yml
@@ -45,6 +45,16 @@ jobs:
           echo "$SERVERPOD_PASSWORDS" > config/passwords.yaml
           ls config/
 
+      - name: Create Firebase service account key file
+        working-directory: click_server
+        shell: bash
+        env:
+          FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+        run: |
+          pwd
+          echo "$FIREBASE_SERVICE_ACCOUNT_KEY" > config/firebase_service_account_key.json
+          ls config/
+
       - name: Get Dart packages
         working-directory: auth_example_server
         run: dart pub get

--- a/examples/auth_example/.github/workflows/deployment-aws.yml
+++ b/examples/auth_example/.github/workflows/deployment-aws.yml
@@ -36,7 +36,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Create passwords file
-        working-directory: projectname_server
+        working-directory: auth_example_server
         shell: bash
         env:
           SERVERPOD_PASSWORDS: ${{ secrets.SERVERPOD_PASSWORDS }}

--- a/examples/auth_example/.github/workflows/deployment-aws.yml
+++ b/examples/auth_example/.github/workflows/deployment-aws.yml
@@ -36,13 +36,13 @@ jobs:
           aws-region: us-west-2
 
       - name: Create passwords file
-        working-directory: auth_example_server
+        working-directory: projectname_server
         shell: bash
         env:
           SERVERPOD_PASSWORDS: ${{ secrets.SERVERPOD_PASSWORDS }}
         run: |
           pwd
-          echo "$SERVERPOD_PASSWORDS" > config/passwords.yaml
+          printenv SERVERPOD_PASSWORDS > config/passwords.yaml
           ls config/
 
       - name: Create Firebase service account key file
@@ -52,7 +52,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
         run: |
           pwd
-          echo "$FIREBASE_SERVICE_ACCOUNT_KEY" > config/firebase_service_account_key.json
+          printenv FIREBASE_SERVICE_ACCOUNT_KEY > config/firebase_service_account_key.json
           ls config/
 
       - name: Get Dart packages

--- a/templates/serverpod_templates/github/workflows/deployment-aws.yml
+++ b/templates/serverpod_templates/github/workflows/deployment-aws.yml
@@ -45,6 +45,16 @@ jobs:
           echo "$SERVERPOD_PASSWORDS" > config/passwords.yaml
           ls config/
 
+      - name: Create Firebase service account key file
+        working-directory: click_server
+        shell: bash
+        env:
+          FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+        run: |
+          pwd
+          echo "$FIREBASE_SERVICE_ACCOUNT_KEY" > config/firebase_service_account_key.json
+          ls config/
+
       - name: Get Dart packages
         working-directory: projectname_server
         run: dart pub get

--- a/templates/serverpod_templates/github/workflows/deployment-aws.yml
+++ b/templates/serverpod_templates/github/workflows/deployment-aws.yml
@@ -42,7 +42,7 @@ jobs:
           SERVERPOD_PASSWORDS: ${{ secrets.SERVERPOD_PASSWORDS }}
         run: |
           pwd
-          echo "$SERVERPOD_PASSWORDS" > config/passwords.yaml
+          printenv SERVERPOD_PASSWORDS > config/passwords.yaml
           ls config/
 
       - name: Create Firebase service account key file
@@ -52,7 +52,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
         run: |
           pwd
-          echo "$FIREBASE_SERVICE_ACCOUNT_KEY" > config/firebase_service_account_key.json
+          printenv FIREBASE_SERVICE_ACCOUNT_KEY > config/firebase_service_account_key.json
           ls config/
 
       - name: Get Dart packages

--- a/templates/serverpod_templates/github/workflows/deployment-gcp.yml
+++ b/templates/serverpod_templates/github/workflows/deployment-gcp.yml
@@ -66,7 +66,7 @@ jobs:
           SERVERPOD_PASSWORDS: ${{ secrets.SERVERPOD_PASSWORDS }}
         run: |
           pwd
-          echo "$SERVERPOD_PASSWORDS" > config/passwords.yaml
+          printenv SERVERPOD_PASSWORDS > config/passwords.yaml
           ls config/
 
       - name: Create Firebase service account key file
@@ -76,7 +76,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
         run: |
           pwd
-          echo "$FIREBASE_SERVICE_ACCOUNT_KEY" > config/firebase_service_account_key.json
+          printenv FIREBASE_SERVICE_ACCOUNT_KEY > config/firebase_service_account_key.json
           ls config/
 
       - name: Configure Docker

--- a/templates/serverpod_templates/github/workflows/deployment-gcp.yml
+++ b/templates/serverpod_templates/github/workflows/deployment-gcp.yml
@@ -69,6 +69,16 @@ jobs:
           echo "$SERVERPOD_PASSWORDS" > config/passwords.yaml
           ls config/
 
+      - name: Create Firebase service account key file
+        working-directory: click_server
+        shell: bash
+        env:
+          FIREBASE_SERVICE_ACCOUNT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+        run: |
+          pwd
+          echo "$FIREBASE_SERVICE_ACCOUNT_KEY" > config/firebase_service_account_key.json
+          ls config/
+
       - name: Configure Docker
         working-directory: projectname_server
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev


### PR DESCRIPTION
Firebase login requires `config/firebase_service_account_key.json` to be created, which, like `config/passwords.yaml`, cannot be checked into git, but should be sourced from a GitHub secret. This adds this to the GitHub actions deploy yaml files.

The docs will also need to be updated to inform the user that they need to add this file as a GitHub secret if they are using Firebase login. (I didn't create a PR for the docs.)

If the user doesn't create the secret, this will just create an empty file (which will be ignored anyway), so it's fine to leave it in place even if the user is not using Firebase.

This PR also changes the use of `echo "$VAR" > file` for `printenv VAR > file`, because it is a much safer way to write an environment variable's value to a file (the contents of $VAR can contain double quotes, and sequences like `-n`).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
