### PR TITLE
fix: Start database pool manager on Serverpod instance creation.

### DIFF
--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -52,7 +52,7 @@ class DatabasePoolManager {
   /// Starts the database connection pool.
   void start() {
     // Setup database connection pool
-    _pgPool = pg.Pool.withEndpoints(
+    _pgPool ??= pg.Pool.withEndpoints(
       [
         pg.Endpoint(
           host: config.host,

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -415,9 +415,6 @@ class Serverpod {
   /// Starts the Serverpod and all [Server]s that it manages.
   Future<void> start() async {
     _startedTime = DateTime.now().toUtc();
-    // It is important that we start the database pool manager before
-    // attempting to connect to the database.
-    _databasePoolManager?.start();
 
     await runZonedGuarded(() async {
       // Register cloud store endpoint if we're using the database cloud store
@@ -425,6 +422,10 @@ class Serverpod {
           storage['private'] is DatabaseCloudStorage) {
         CloudStoragePublicEndpoint().register(this);
       }
+
+      // It is important that we start the database pool manager before
+      // attempting to connect to the database.
+      _databasePoolManager?.start();
 
       if (_databasePoolManager == null) {
         _runtimeSettings = _defaultRuntimeSettings;

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -315,6 +315,13 @@ class Serverpod {
         serializationManager,
         databaseConfiguration,
       );
+
+      // TODO: Remove this when we have a better way to handle this.
+      // Tracked by issue: https://github.com/serverpod/serverpod/issues/2421
+      // This is required because other operations in Serverpod assumes that the
+      // database is connected when the Serverpod is created
+      // (such as createSession(...)).
+      _databasePoolManager?.start();
     }
 
     if (Features.enableDatabase) {


### PR DESCRIPTION
A recent change (https://github.com/serverpod/serverpod/pull/2397)  separated establishing a database connection from creating the Serverpod instance.

This behavior breaks the possibility of doing database operations without starting the Server. And feature such as just registering FutureCall methods require a database connection in order to function which is a breaking change.

This PR re-introduced the possibility of establishing a database connection when instantiating the Serverpod instance.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Revevert of a previous change to prevent a breaking change.