### PR TITLE
feat: Add a random generated id to sessions.

### DIFF
--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -14,6 +14,9 @@ import '../generated/protocol.dart';
 /// contains all data associated with the current connection and provides
 /// easy access to the database.
 abstract class Session {
+  /// The id of the session.
+  final UuidValue sessionId;
+
   /// The [Server] that created the session.
   final Server server;
 
@@ -93,12 +96,14 @@ abstract class Session {
 
   /// Creates a new session. This is typically done internally by the [Server].
   Session({
+    UuidValue? sessionId,
     required this.server,
     String? authenticationKey,
     HttpRequest? httpRequest,
     WebSocket? webSocket,
     required this.enableLogging,
-  }) : _authenticationKey = authenticationKey {
+  })  : _authenticationKey = authenticationKey,
+        sessionId = sessionId ?? const Uuid().v4obj() {
     _startTime = DateTime.now();
 
     storage = StorageAccess._(this);


### PR DESCRIPTION
# Changes

Adds a random uuid to sessions.

Motivation is to get traceability of sessions internally which gives us the ability to link a session directly with logs and client requests.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none