### PR TITLE
feat: Improve error handling in SignInWithGoogle by rethrowing exceptions

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
@@ -43,6 +43,7 @@ Future<UserInfo?> signInWithGoogle(
   String? serverClientId,
   List<String> additionalScopes = const [],
   required Uri redirectUri,
+  void Function(Object error, StackTrace stackTrace)? onError,
 }) async {
   var scopes = [
     'email',
@@ -103,6 +104,7 @@ Future<UserInfo?> signInWithGoogle(
   } catch (e, stackTrace) {
     if (kDebugMode) print('serverpod_auth_google: $e');
     if (kDebugMode) print('$stackTrace');
-    rethrow;
+    onError?.call(e, stackTrace);
+    return null;
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/src/auth.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:serverpod_auth_client/serverpod_auth_client.dart';
 import 'package:serverpod_auth_shared_flutter/serverpod_auth_shared_flutter.dart';
+
 import 'google/sign_in_with_google.dart';
 
 /// Attempts to Sign in with Google. If successful, a [UserInfo] is returned.
@@ -102,6 +103,6 @@ Future<UserInfo?> signInWithGoogle(
   } catch (e, stackTrace) {
     if (kDebugMode) print('serverpod_auth_google: $e');
     if (kDebugMode) print('$stackTrace');
-    return null;
+    rethrow;
   }
 }


### PR DESCRIPTION
This PR enhances the exception handling in the SignInWithGoogle process by rethrowing exceptions. This will allow us to differentiate between the types of exceptions that occur, including distinguishing between an actual error and a user cancellation.

closes #2417 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
