### PR TITLE
SignInWithEmailDialog: Update KeyboardType for validationCode 

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -266,7 +266,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         TextField(
           enabled: _enabled,
           controller: _validationCodeController,
-          keyboardType: TextInputType.number,
+          keyboardType: TextInputType.text,
           decoration: InputDecoration(
             hintText: 'Validation code',
             helperText: ' ',
@@ -307,7 +307,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
         TextField(
           enabled: _enabled,
           controller: _validationCodeController,
-          keyboardType: TextInputType.number,
+          keyboardType: TextInputType.text,
           decoration: InputDecoration(
             hintText: 'Validation code',
             helperText: ' ',


### PR DESCRIPTION
Since the validation code is alpha numeric the KeyboardType in the `SignInWithEmailDialog`  needs to be updated otherwise the code can't be entered directly.  

_not linked to an issue_

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

no breaking changes