### PR TITLE
Add timeout to sendStreamMessage

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -431,9 +431,16 @@ abstract class EndpointRef {
   /// Stream of messages sent from an endpoint that supports streaming.
   Stream<SerializableModel> get stream => _streamController.stream;
 
-  /// Sends a message to the endpoint's stream.
-  Future<void> sendStreamMessage(SerializableModel message) async {
-    return client._sendSerializableObjectToStream(name, message);
+  /// Sends a message to the endpoint's stream. The default [timeout] is 15
+  /// seconds. If the message is not sent within the timeout period, a
+  /// [TimeoutException] is thrown. If [timeout] is null, the message will be
+  /// sent without a timeout.
+  Future<void> sendStreamMessage(
+    SerializableModel message, {
+    Duration? timeout = const Duration(seconds: 15),
+  }) async {
+    var future = client._sendSerializableObjectToStream(name, message);
+    return timeout == null ? future : future.timeout(timeout);
   }
 
   /// Resets web socket stream, so it's possible to re-listen to endpoint

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -431,17 +431,10 @@ abstract class EndpointRef {
   /// Stream of messages sent from an endpoint that supports streaming.
   Stream<SerializableModel> get stream => _streamController.stream;
 
-  /// Sends a message to the endpoint's stream. The default [timeout] is 15
-  /// seconds. If the message is not sent within the timeout period, a
-  /// [TimeoutException] is thrown. If [timeout] is null, the message will be
-  /// sent without a timeout.
-  Future<void> sendStreamMessage(
-    SerializableModel message, {
-    Duration? timeout = const Duration(seconds: 15),
-  }) async {
-    var future = client._sendSerializableObjectToStream(name, message);
-    return timeout == null ? future : future.timeout(timeout);
-  }
+  /// Sends a message to the endpoint's stream.
+  Future<void> sendStreamMessage(SerializableModel message) => client
+      ._sendSerializableObjectToStream(name, message)
+      .timeout(client.streamingConnectionTimeout);
 
   /// Resets web socket stream, so it's possible to re-listen to endpoint
   /// streams.


### PR DESCRIPTION
Causes an endpoint's `sendStreamMessage` to time out after `client.streamingConnectionTimeout`.

Solves issue (2) in https://github.com/serverpod/serverpod/issues/2289

No time for tests, sorry! But I tested using `Future.timeout` this way on my own server, and it seems to work.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
