### PR TITLE
fix: Encode method stream messages with encode for protocol.

### DIFF
--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -505,7 +505,8 @@ class _MethodStreamManager {
             endpoint: message.endpoint,
             method: message.method,
             connectionId: message.connectionId,
-            object: server.serializationManager.wrapWithClassName(e),
+            object: e,
+            serializationManager: server.serializationManager,
           ),
         );
       }
@@ -533,7 +534,8 @@ class _MethodStreamManager {
           endpoint: message.endpoint,
           method: message.method,
           connectionId: message.connectionId,
-          object: server.serializationManager.wrapWithClassName(result),
+          object: result,
+          serializationManager: server.serializationManager,
         ),
       );
     }
@@ -565,7 +567,8 @@ class _MethodStreamManager {
             endpoint: message.endpoint,
             method: message.method,
             connectionId: message.connectionId,
-            object: server.serializationManager.wrapWithClassName(value),
+            object: value,
+            serializationManager: server.serializationManager,
           ),
         );
       },
@@ -588,7 +591,8 @@ class _MethodStreamManager {
               endpoint: message.endpoint,
               method: message.method,
               connectionId: message.connectionId,
-              object: server.serializationManager.wrapWithClassName(e),
+              object: e,
+              serializationManager: server.serializationManager,
             ),
           );
         }

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -95,8 +95,10 @@ class MethodWebsocketRequestHandler {
         }
       }
     } catch (e, stackTrace) {
-      var session = await server.serverpod.createSession();
-      await session.close(error: e, stackTrace: stackTrace);
+      stderr
+          .writeln('${DateTime.now().toUtc()} Method stream websocket error.');
+      stderr.writeln('$e');
+      stderr.writeln('$stackTrace');
     } finally {
       await _methodStreamManager.closeAllStreams();
       // Send a close message to the client.

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -332,8 +332,7 @@ class _MethodStreamManager {
       return false;
     }
 
-    streamContext.controller
-        .add(server.serializationManager.decodeWithType(message.object));
+    streamContext.controller.add(message.object);
     return true;
   }
 
@@ -532,7 +531,7 @@ class _MethodStreamManager {
           endpoint: message.endpoint,
           method: message.method,
           connectionId: message.connectionId,
-          object: server.serializationManager.encodeWithType(result),
+          object: server.serializationManager.wrapWithClassName(result),
         ),
       );
     }
@@ -564,7 +563,7 @@ class _MethodStreamManager {
             endpoint: message.endpoint,
             method: message.method,
             connectionId: message.connectionId,
-            object: server.serializationManager.encodeWithType(value),
+            object: server.serializationManager.wrapWithClassName(value),
           ),
         );
       },

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -24,7 +24,10 @@ class MethodWebsocketRequestHandler {
       await for (String jsonData in webSocket) {
         WebSocketMessage message;
         try {
-          message = WebSocketMessage.fromJsonString(jsonData);
+          message = WebSocketMessage.fromJsonString(
+            jsonData,
+            server.serializationManager,
+          );
         } on UnknownMessageException catch (_) {
           webSocket.tryAdd(BadRequestMessage.buildMessage(jsonData));
           throw Exception(
@@ -349,14 +352,7 @@ class _MethodStreamManager {
       return;
     }
 
-    var serializableException =
-        server.serializationManager.decodeWithType(message.object);
-
-    if (serializableException is! SerializableException) {
-      throw Exception(
-        'Expected SerializableException, but got ${serializableException.runtimeType}',
-      );
-    }
+    var serializableException = message.exception;
 
     streamContext.controller.addError(serializableException);
   }
@@ -508,7 +504,7 @@ class _MethodStreamManager {
             endpoint: message.endpoint,
             method: message.method,
             connectionId: message.connectionId,
-            object: server.serializationManager.encodeWithType(e),
+            object: server.serializationManager.wrapWithClassName(e),
           ),
         );
       }
@@ -591,7 +587,7 @@ class _MethodStreamManager {
               endpoint: message.endpoint,
               method: message.method,
               connectionId: message.connectionId,
-              object: server.serializationManager.encodeWithType(e),
+              object: server.serializationManager.wrapWithClassName(e),
             ),
           );
         }

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -95,10 +95,12 @@ class MethodWebsocketRequestHandler {
         }
       }
     } catch (e, stackTrace) {
-      stderr
-          .writeln('${DateTime.now().toUtc()} Method stream websocket error.');
-      stderr.writeln('$e');
-      stderr.writeln('$stackTrace');
+      if (server.serverpod.runtimeSettings.logMalformedCalls) {
+        stderr.writeln(
+            '${DateTime.now().toUtc()} Method stream websocket error.');
+        stderr.writeln('$e');
+        stderr.writeln('$stackTrace');
+      }
     } finally {
       await _methodStreamManager.closeAllStreams();
       // Send a close message to the client.

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -303,7 +303,7 @@ class MethodStreamSerializableException extends WebSocketMessage {
             serializationManager.deserializeByClassName(data['exception']);
 
   /// Builds a [MethodStreamSerializableException] message.
-  /// The [object] must be a serializable exception processed by the
+  /// The [exception] must be a serializable exception processed by the
   /// [SerializationManager.wrapWithClassName] method.
   static String buildMessage({
     required String endpoint,

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -92,7 +92,7 @@ class OpenMethodStreamResponse extends WebSocketMessage {
     required UuidValue connectionId,
     required OpenMethodStreamResponseType responseType,
   }) {
-    return SerializationManager.encode({
+    return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
       'connectionId': connectionId,
       'responseType': responseType.name,
@@ -142,7 +142,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
     required UuidValue connectionId,
     String? authentication,
   }) {
-    return SerializationManager.encode({
+    return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
@@ -157,7 +157,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
         'messageType': _messageType,
         'endpoint': endpoint,
         'method': method,
-        'connectionId': SerializationManager.encode(connectionId),
+        'connectionId': SerializationManager.encodeForProtocol(connectionId),
         'args': args,
         if (authentication != null) 'authentication': authentication,
       }.toString();
@@ -217,7 +217,7 @@ class CloseMethodStreamCommand extends WebSocketMessage {
     required String method,
     required CloseReason reason,
   }) {
-    return SerializationManager.encode({
+    return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
@@ -244,7 +244,8 @@ class PingCommand extends WebSocketMessage {
 
   /// Builds a [PingCommand] message.
   static String buildMessage() {
-    return SerializationManager.encode({'messageType': _messageType});
+    return SerializationManager.encodeForProtocol(
+        {'messageType': _messageType});
   }
 
   @override
@@ -257,7 +258,8 @@ class PongCommand extends WebSocketMessage {
 
   /// Builds a [PongCommand] message.
   static String buildMessage() {
-    return SerializationManager.encode({'messageType': _messageType});
+    return SerializationManager.encodeForProtocol(
+        {'messageType': _messageType});
   }
 
   @override
@@ -300,7 +302,7 @@ class MethodStreamSerializableException extends WebSocketMessage {
     String? parameter,
     required String object,
   }) {
-    return SerializationManager.encode({
+    return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
@@ -356,7 +358,7 @@ class MethodStreamMessage extends WebSocketMessage {
     String? parameter,
     required String object,
   }) {
-    return SerializationManager.encode({
+    return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
       'endpoint': endpoint,
       'method': method,
@@ -388,7 +390,7 @@ class BadRequestMessage extends WebSocketMessage {
 
   /// Builds a [BadRequestMessage] message.
   static String buildMessage(String request) {
-    return SerializationManager.encode({
+    return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
       'request': request,
     });

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -310,7 +310,8 @@ class MethodStreamSerializableException extends WebSocketMessage {
     required String method,
     required UuidValue connectionId,
     String? parameter,
-    required Map<String, dynamic> object,
+    required dynamic object,
+    required SerializationManager serializationManager,
   }) {
     return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
@@ -318,7 +319,7 @@ class MethodStreamSerializableException extends WebSocketMessage {
       'method': method,
       'connectionId': connectionId,
       if (parameter != null) 'parameter': parameter,
-      'exception': object,
+      'exception': serializationManager.wrapWithClassName(object),
     });
   }
 
@@ -364,14 +365,13 @@ class MethodStreamMessage extends WebSocketMessage {
         object = serializationManager.deserializeByClassName(data['object']);
 
   /// Builds a [MethodStreamMessage] message.
-  /// The [object] must be an object processed by the
-  /// [SerializationManager.wrapWithClassName] method.
   static String buildMessage({
     required String endpoint,
     required String method,
     required UuidValue connectionId,
     String? parameter,
-    required Map<String, dynamic> object,
+    required dynamic object,
+    required SerializationManager serializationManager,
   }) {
     return SerializationManager.encodeForProtocol({
       'messageType': _messageType,
@@ -379,7 +379,7 @@ class MethodStreamMessage extends WebSocketMessage {
       'method': method,
       'connectionId': connectionId,
       if (parameter != null) 'parameter': parameter,
-      'object': object,
+      'object': serializationManager.wrapWithClassName(object),
     });
   }
 

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -415,4 +415,9 @@ class UnknownMessageException implements Exception {
     this.error,
     this.stackTrace,
   });
+
+  @override
+  String toString() {
+    return 'UnknownMessageException: $jsonString\n$error\n$stackTrace';
+  }
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -336,6 +336,7 @@ void main() {
       connectionId: const Uuid().v4obj(),
       object:
           serializationManager.wrapWithClassName(_SimpleData('hello world')),
+      serializationManager: serializationManager,
     );
     var result = WebSocketMessage.fromJsonString(
       message,
@@ -354,6 +355,7 @@ void main() {
       connectionId: const Uuid().v4obj(),
       object: serializationManager.wrapWithClassName(
           _SimpleData('hello world', serverOnlyField: 'this is awesome')),
+      serializationManager: serializationManager,
     );
 
     expect(message, isNot(contains('serverOnlyField')));
@@ -393,6 +395,7 @@ void main() {
       object: serializationManager.wrapWithClassName(
         _TestSerializableException(),
       ),
+      serializationManager: serializationManager,
     );
     var result = WebSocketMessage.fromJsonString(
       message,
@@ -412,6 +415,7 @@ void main() {
       object: serializationManager.wrapWithClassName(
         _TestSerializableException(),
       ),
+      serializationManager: serializationManager,
     );
 
     expect(message, isNot(contains('serverOnlyField')));

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -1,12 +1,12 @@
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 import 'package:test/test.dart';
 
-class TestSerializationManager extends SerializationManager {
-  TestSerializationManager();
+class _TestSerializationManager extends SerializationManager {
+  _TestSerializationManager();
   @override
   dynamic deserializeByClassName(Map<String, dynamic> data) {
-    if (data['className'] == 'TestSerializableException') {
-      return deserialize<TestSerializableException>(data['data']);
+    if (data['className'] == '_TestSerializableException') {
+      return deserialize<_TestSerializableException>(data['data']);
     }
 
     return super.deserializeByClassName(data);
@@ -16,8 +16,8 @@ class TestSerializationManager extends SerializationManager {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is TestSerializableException) {
-      return 'TestSerializableException';
+    if (data is _TestSerializableException) {
+      return '_TestSerializableException';
     }
     return null;
   }
@@ -28,15 +28,15 @@ class TestSerializationManager extends SerializationManager {
     Type? t,
   ]) {
     t ??= T;
-    if (t == TestSerializableException) {
-      return TestSerializableException() as T;
+    if (t == _TestSerializableException) {
+      return _TestSerializableException() as T;
     }
 
     return super.deserialize<T>(data, t);
   }
 }
 
-class TestSerializableException implements SerializableException {
+class _TestSerializableException implements SerializableException {
   @override
   toJson() {
     return 'Test serializable exception';
@@ -50,7 +50,7 @@ void main() {
     var message = PingCommand.buildMessage();
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<PingCommand>());
   });
@@ -61,7 +61,7 @@ void main() {
     var message = PongCommand.buildMessage();
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<PongCommand>());
   });
@@ -72,7 +72,7 @@ void main() {
     var message = BadRequestMessage.buildMessage('This is a bad request');
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<BadRequestMessage>());
   });
@@ -85,7 +85,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(
         isA<UnknownMessageException>()
@@ -101,7 +101,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(isA<UnknownMessageException>()),
     );
@@ -114,7 +114,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(isA<UnknownMessageException>()),
     );
@@ -127,7 +127,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(
         isA<UnknownMessageException>()
@@ -143,7 +143,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(isA<UnknownMessageException>()),
     );
@@ -161,7 +161,7 @@ void main() {
     );
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<OpenMethodStreamCommand>());
   });
@@ -181,7 +181,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(
         isA<UnknownMessageException>()
@@ -199,7 +199,7 @@ void main() {
     );
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<OpenMethodStreamResponse>());
   });
@@ -216,7 +216,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(isA<UnknownMessageException>()),
     );
@@ -234,7 +234,7 @@ void main() {
     );
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<CloseMethodStreamCommand>());
   });
@@ -253,7 +253,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(
         isA<UnknownMessageException>()
@@ -276,7 +276,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(isA<UnknownMessageException>()),
     );
@@ -293,7 +293,7 @@ void main() {
     );
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<MethodStreamMessage>());
   });
@@ -312,7 +312,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(
         isA<UnknownMessageException>()
@@ -324,18 +324,18 @@ void main() {
   test(
       'Given method stream serializable exception when building websocket message from string then MethodStreamSerializableException is returned.',
       () {
-    var serializationManager = TestSerializationManager();
+    var serializationManager = _TestSerializationManager();
     var message = MethodStreamSerializableException.buildMessage(
       endpoint: 'endpoint',
       method: 'method',
       connectionId: const Uuid().v4obj(),
       object: serializationManager.wrapWithClassName(
-        TestSerializableException(),
+        _TestSerializableException(),
       ),
     );
     var result = WebSocketMessage.fromJsonString(
       message,
-      TestSerializationManager(),
+      _TestSerializationManager(),
     );
     expect(result, isA<MethodStreamSerializableException>());
   });
@@ -354,7 +354,7 @@ void main() {
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
-        TestSerializationManager(),
+        _TestSerializationManager(),
       ),
       throwsA(
         isA<UnknownMessageException>()

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -334,8 +334,7 @@ void main() {
       endpoint: 'endpoint',
       method: 'method',
       connectionId: const Uuid().v4obj(),
-      object:
-          serializationManager.wrapWithClassName(_SimpleData('hello world')),
+      object: _SimpleData('hello world'),
       serializationManager: serializationManager,
     );
     var result = WebSocketMessage.fromJsonString(
@@ -353,8 +352,7 @@ void main() {
       endpoint: 'endpoint',
       method: 'method',
       connectionId: const Uuid().v4obj(),
-      object: serializationManager.wrapWithClassName(
-          _SimpleData('hello world', serverOnlyField: 'this is awesome')),
+      object: _SimpleData('hello world', serverOnlyField: 'this is awesome'),
       serializationManager: serializationManager,
     );
 
@@ -392,9 +390,7 @@ void main() {
       endpoint: 'endpoint',
       method: 'method',
       connectionId: const Uuid().v4obj(),
-      object: serializationManager.wrapWithClassName(
-        _TestSerializableException(),
-      ),
+      object: _TestSerializableException(),
       serializationManager: serializationManager,
     );
     var result = WebSocketMessage.fromJsonString(
@@ -412,9 +408,7 @@ void main() {
       endpoint: 'endpoint',
       method: 'method',
       connectionId: const Uuid().v4obj(),
-      object: serializationManager.wrapWithClassName(
-        _TestSerializableException(),
-      ),
+      object: _TestSerializableException(),
       serializationManager: serializationManager,
     );
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -413,8 +413,7 @@ void main() {
               message.parameter == null) {
             closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
-            endpointResponse.complete(server.serializationManager
-                .decodeWithType(message.object) as bool);
+            endpointResponse.complete(message.object as bool);
           }
         });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -40,7 +40,11 @@ void main() {
         webSocketCompleter = Completer<void>();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             if (message.connectionId == connectionId)
               delayedResponseOpen.complete();
@@ -127,7 +131,10 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
@@ -395,7 +402,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand &&

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
@@ -39,7 +39,11 @@ void main() {
       });
 
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is OpenMethodStreamResponse) {
           streamOpened.complete();
         } else if (message is CloseMethodStreamCommand) {
@@ -117,7 +121,11 @@ void main() {
       });
 
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is OpenMethodStreamResponse &&
             message.connectionId == keepAliveConnectionId) {
           streamOpened.complete();
@@ -210,7 +218,11 @@ void main() {
       });
 
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is OpenMethodStreamResponse) {
           streamOpened.complete();
         } else if (message is CloseMethodStreamCommand) {
@@ -280,7 +292,11 @@ void main() {
       });
 
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is OpenMethodStreamResponse) {
           streamOpened.complete();
         } else if (message is CloseMethodStreamCommand) {
@@ -357,7 +373,11 @@ void main() {
       });
 
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is OpenMethodStreamResponse &&
             message.connectionId == keepAliveConnectionId) {
           streamOpened.complete();
@@ -459,7 +479,11 @@ void main() {
       });
 
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is OpenMethodStreamResponse &&
             message.connectionId == keepAliveConnectionId) {
           streamOpened.complete();

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
@@ -176,7 +176,7 @@ void main() {
         endpoint: endpoint,
         method: keepAliveMethod,
         parameter: 'stream',
-        object: server.serializationManager.encodeWithType(4),
+        object: server.serializationManager.wrapWithClassName(4),
         connectionId: keepAliveConnectionId,
       ));
 
@@ -428,7 +428,7 @@ void main() {
         endpoint: endpoint,
         method: keepAliveMethod,
         parameter: 'stream',
-        object: server.serializationManager.encodeWithType(4),
+        object: server.serializationManager.wrapWithClassName(4),
         connectionId: keepAliveConnectionId,
       ));
 
@@ -534,7 +534,7 @@ void main() {
         endpoint: endpoint,
         method: keepAliveMethod,
         parameter: 'stream',
-        object: server.serializationManager.encodeWithType(4),
+        object: server.serializationManager.wrapWithClassName(4),
         connectionId: keepAliveConnectionId,
       ));
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
@@ -176,7 +176,8 @@ void main() {
         endpoint: endpoint,
         method: keepAliveMethod,
         parameter: 'stream',
-        object: server.serializationManager.wrapWithClassName(4),
+        object: 4,
+        serializationManager: server.serializationManager,
         connectionId: keepAliveConnectionId,
       ));
 
@@ -428,7 +429,8 @@ void main() {
         endpoint: endpoint,
         method: keepAliveMethod,
         parameter: 'stream',
-        object: server.serializationManager.wrapWithClassName(4),
+        object: 4,
+        serializationManager: server.serializationManager,
         connectionId: keepAliveConnectionId,
       ));
 
@@ -534,7 +536,8 @@ void main() {
         endpoint: endpoint,
         method: keepAliveMethod,
         parameter: 'stream',
-        object: server.serializationManager.wrapWithClassName(4),
+        object: 4,
+        serializationManager: server.serializationManager,
         connectionId: keepAliveConnectionId,
       ));
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -46,7 +46,8 @@ void main() {
         method: 'simpleStream',
         parameter: 'stream',
         connectionId: const Uuid().v4obj(),
-        object: server.serializationManager.wrapWithClassName(1),
+        object: 1,
+        serializationManager: server.serializationManager,
       ));
 
       await expectLater(
@@ -605,7 +606,8 @@ void main() {
           endpoint: endpoint,
           method: method,
           connectionId: connectionId,
-          object: server.serializationManager.wrapWithClassName(1),
+          object: 1,
+          serializationManager: server.serializationManager,
         ));
       });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -36,7 +36,6 @@ void main() {
           event,
           server.serializationManager,
         );
-        ;
         if (message is CloseMethodStreamCommand) {
           closeMethodCommand.complete(message);
         }
@@ -47,7 +46,7 @@ void main() {
         method: 'simpleStream',
         parameter: 'stream',
         connectionId: const Uuid().v4obj(),
-        object: server.serializationManager.encodeWithType(1),
+        object: server.serializationManager.wrapWithClassName(1),
       ));
 
       await expectLater(
@@ -114,7 +113,7 @@ void main() {
           expect(message.connectionId, connectionId);
 
           expect(
-            server.serializationManager.decodeWithType(message.object),
+            message.object,
             1,
             reason: 'Failed to receive expected value from endpoint.',
           );
@@ -157,8 +156,7 @@ void main() {
           } else if (message is CloseMethodStreamCommand) {
             closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
-            endpointResponses.add(server.serializationManager
-                .decodeWithType(message.object) as int);
+            endpointResponses.add(message.object as int);
           }
         }, onDone: () {
           webSocketCompleter.complete();
@@ -249,8 +247,7 @@ void main() {
           } else if (message is CloseMethodStreamCommand) {
             closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
-            endpointResponses.add(server.serializationManager
-                .decodeWithType(message.object) as SimpleData);
+            endpointResponses.add(message.object as SimpleData);
           }
         }, onDone: () {
           webSocketCompleter.complete();
@@ -331,8 +328,7 @@ void main() {
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is MethodStreamMessage) {
-            endpointResponse.complete(server.serializationManager
-                .decodeWithType(message.object) as int?);
+            endpointResponse.complete(message.object as int?);
           }
         });
 
@@ -609,7 +605,7 @@ void main() {
           endpoint: endpoint,
           method: method,
           connectionId: connectionId,
-          object: server.serializationManager.encodeWithType(1),
+          object: server.serializationManager.wrapWithClassName(1),
         ));
       });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -32,7 +32,11 @@ void main() {
         () async {
       var closeMethodCommand = Completer<CloseMethodStreamCommand>();
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is CloseMethodStreamCommand) {
           closeMethodCommand.complete(message);
         }
@@ -76,7 +80,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is MethodStreamMessage) {
@@ -139,7 +147,11 @@ void main() {
         var streamOpened = Completer<void>();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
@@ -227,7 +239,11 @@ void main() {
         var streamOpened = Completer<void>();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
@@ -307,7 +323,11 @@ void main() {
         var streamOpened = Completer<void>();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is MethodStreamMessage) {
@@ -361,7 +381,11 @@ void main() {
         var delayedResponseConnectionId = const Uuid().v4obj();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             if (message.connectionId == returningStreamConnectionId)
               returningStreamOpen.complete();
@@ -444,7 +468,11 @@ void main() {
         var delayedResponseConnectionId = const Uuid().v4obj();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             if (message.connectionId == returningStreamConnectionId)
               returningStreamOpen.complete();
@@ -552,7 +580,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is BadRequestMessage) {

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
@@ -78,23 +78,22 @@ void main() {
         assert(streamOpened.isCompleted == true,
             'Failed to open method stream with server');
 
-        var serializedException = server.serializationManager.wrapWithClassName(
-          ExceptionWithData(
-            message: 'Throwing an exception',
-            creationDate: DateTime.now(),
-            errorFields: [
-              'first line error',
-              'second line error',
-            ],
-            someNullableField: 1,
-          ),
+        var serializableException = ExceptionWithData(
+          message: 'Throwing an exception',
+          creationDate: DateTime.now(),
+          errorFields: [
+            'first line error',
+            'second line error',
+          ],
+          someNullableField: 1,
         );
         webSocket.sink.add(MethodStreamSerializableException.buildMessage(
           endpoint: endpoint,
           method: method,
           parameter: inputParameter,
           connectionId: connectionId,
-          object: serializedException,
+          object: serializableException,
+          serializationManager: server.serializationManager,
         ));
       });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
@@ -63,8 +63,7 @@ void main() {
               message.parameter == null) {
             closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
-            endpointResponse.complete(server.serializationManager
-                .decodeWithType(message.object) as bool);
+            endpointResponse.complete(message.object as bool);
           }
         });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
@@ -52,7 +52,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand &&
@@ -75,7 +79,7 @@ void main() {
         assert(streamOpened.isCompleted == true,
             'Failed to open method stream with server');
 
-        var serializedException = server.serializationManager.encodeWithType(
+        var serializedException = server.serializationManager.wrapWithClassName(
           ExceptionWithData(
             message: 'Throwing an exception',
             creationDate: DateTime.now(),

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
@@ -72,8 +72,7 @@ void main() {
               closeMethodStreamCommand.complete(message);
             }
           } else if (message is MethodStreamMessage) {
-            endpointResponse.complete(server.serializationManager
-                .decodeWithType(message.object) as int);
+            endpointResponse.complete(message.object as int);
           }
         });
 
@@ -93,7 +92,7 @@ void main() {
           method: method,
           parameter: inputParameter,
           connectionId: connectionId,
-          object: server.serializationManager.encodeWithType(inputValue),
+          object: server.serializationManager.wrapWithClassName(inputValue),
         ));
       });
 
@@ -199,8 +198,7 @@ void main() {
           } else if (message is CloseMethodStreamCommand) {
             closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
-            endpointResponses.add(server.serializationManager
-                .decodeWithType(message.object) as int);
+            endpointResponses.add(message.object as int);
           }
         });
 
@@ -309,8 +307,7 @@ void main() {
               closeMethodStreamCommand.complete(message);
             }
           } else if (message is MethodStreamMessage) {
-            endpointResponses.add(server.serializationManager
-                .decodeWithType(message.object) as int);
+            endpointResponses.add(message.object as int);
           }
         });
 
@@ -331,7 +328,7 @@ void main() {
             method: method,
             parameter: inputParameter,
             connectionId: connectionId,
-            object: server.serializationManager.encodeWithType(inputValue),
+            object: server.serializationManager.wrapWithClassName(inputValue),
           ));
 
         webSocket.sink.add(CloseMethodStreamCommand.buildMessage(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
@@ -92,7 +92,8 @@ void main() {
           method: method,
           parameter: inputParameter,
           connectionId: connectionId,
-          object: server.serializationManager.wrapWithClassName(inputValue),
+          object: inputValue,
+          serializationManager: server.serializationManager,
         ));
       });
 
@@ -328,7 +329,8 @@ void main() {
             method: method,
             parameter: inputParameter,
             connectionId: connectionId,
-            object: server.serializationManager.wrapWithClassName(inputValue),
+            object: inputValue,
+            serializationManager: server.serializationManager,
           ));
 
         webSocket.sink.add(CloseMethodStreamCommand.buildMessage(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
@@ -58,7 +58,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
@@ -185,7 +189,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
@@ -287,7 +295,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
@@ -62,8 +62,7 @@ void main() {
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is MethodStreamMessage) {
-            endpointResponses.add(server.serializationManager
-                .decodeWithType(message.object) as int);
+            endpointResponses.add(message.object as int);
 
             if (++responsesReceived ==
                 inputValuesStream1.length + inputValuesStream2.length) {
@@ -89,7 +88,7 @@ void main() {
             method: method,
             parameter: inputStreamParameter1,
             connectionId: connectionId,
-            object: server.serializationManager.encodeWithType(value),
+            object: server.serializationManager.wrapWithClassName(value),
           ));
         }
 
@@ -99,7 +98,7 @@ void main() {
             method: method,
             parameter: inputStreamParameter2,
             connectionId: connectionId,
-            object: server.serializationManager.encodeWithType(value),
+            object: server.serializationManager.wrapWithClassName(value),
           ));
         }
       });
@@ -167,8 +166,7 @@ void main() {
               message.parameter == closedStreamParameter) {
             closeMethodStreamParameterCommand.complete(message);
           } else if (message is MethodStreamMessage) {
-            endpointResponse.complete(server.serializationManager
-                .decodeWithType(message.object) as int);
+            endpointResponse.complete(message.object as int);
           }
         });
 
@@ -224,7 +222,7 @@ void main() {
           method: method,
           parameter: openStreamParameter,
           connectionId: connectionId,
-          object: server.serializationManager.encodeWithType(inputValue),
+          object: server.serializationManager.wrapWithClassName(inputValue),
         ));
 
         await expectLater(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
@@ -54,7 +54,11 @@ void main() {
 
         var responsesReceived = 0;
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is MethodStreamMessage) {
@@ -152,7 +156,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand &&
@@ -257,7 +265,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
@@ -88,7 +88,8 @@ void main() {
             method: method,
             parameter: inputStreamParameter1,
             connectionId: connectionId,
-            object: server.serializationManager.wrapWithClassName(value),
+            object: value,
+            serializationManager: server.serializationManager,
           ));
         }
 
@@ -98,7 +99,8 @@ void main() {
             method: method,
             parameter: inputStreamParameter2,
             connectionId: connectionId,
-            object: server.serializationManager.wrapWithClassName(value),
+            object: value,
+            serializationManager: server.serializationManager,
           ));
         }
       });
@@ -222,7 +224,8 @@ void main() {
           method: method,
           parameter: openStreamParameter,
           connectionId: connectionId,
-          object: server.serializationManager.wrapWithClassName(inputValue),
+          object: inputValue,
+          serializationManager: server.serializationManager,
         ));
 
         await expectLater(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
@@ -57,7 +57,11 @@ void main() {
         });
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
@@ -71,8 +71,7 @@ void main() {
               closeMethodStreamCommand.complete(message);
             }
           } else if (message is MethodStreamMessage) {
-            endpointResponse.complete(server.serializationManager
-                .decodeWithType(message.object) as int);
+            endpointResponse.complete(message.object as int);
           }
         });
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -35,7 +35,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -57,7 +61,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -79,7 +87,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -101,7 +113,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -123,7 +139,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -145,7 +165,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -173,7 +197,10 @@ void main() {
         reason: 'Expected a response from the server.',
       );
 
-      var message = WebSocketMessage.fromJsonString(await response as String);
+      var message = WebSocketMessage.fromJsonString(
+        await response as String,
+        server.serializationManager,
+      );
       expect(
           message,
           isA<OpenMethodStreamResponse>().having(
@@ -195,7 +222,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -218,7 +249,11 @@ void main() {
       ));
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
 
       expect(
           message,
@@ -259,7 +294,11 @@ void main() {
         ));
 
         var response = await webSocket.stream.first as String;
-        var message = WebSocketMessage.fromJsonString(response);
+        var message = WebSocketMessage.fromJsonString(
+          response,
+          server.serializationManager,
+        );
+        ;
 
         expect(
           message,
@@ -305,7 +344,11 @@ void main() {
         ));
 
         var response = await webSocket.stream.first as String;
-        var message = WebSocketMessage.fromJsonString(response);
+        var message = WebSocketMessage.fromJsonString(
+          response,
+          server.serializationManager,
+        );
+        ;
 
         expect(
           message,

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_response_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_response_test.dart
@@ -31,7 +31,11 @@ void main() {
       var pongReceived = Completer<void>();
       var otherMessageReceived = Completer<void>();
       webSocket.stream.listen((event) {
-        var message = WebSocketMessage.fromJsonString(event);
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
         if (message is PongCommand) {
           pongReceived.complete();
         } else {

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/ping_pong_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/ping_pong_command_test.dart
@@ -29,7 +29,10 @@ void main() {
       webSocket.sink.add(PingCommand.buildMessage());
 
       var response = await webSocket.stream.first as String;
-      var message = WebSocketMessage.fromJsonString(response);
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
 
       expect(message, isA<PongCommand>());
     });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
@@ -38,7 +38,10 @@ void main() {
       setUp(() async {
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand &&
@@ -94,7 +97,10 @@ void main() {
       setUp(() async {
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
@@ -154,7 +160,10 @@ void main() {
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is MethodStreamSerializableException) {
@@ -236,7 +245,10 @@ void main() {
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
 
         webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(event);
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is MethodStreamSerializableException) {


### PR DESCRIPTION
Related to #2338 

### Changes:
- Encodes all method stream messages with encoding for the protocol to ensure that server-only fields are not leaked.
- Only encode serializable objects once by utilising wrapWithClassName instead of taking a string for message creation.
- Write any method stream errors to stderr.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None: touches unreleased features.