### PR TITLE
test: Fix flaky streaming log tests.

### DIFF
--- a/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
@@ -22,6 +22,7 @@ void main() async {
 
     tearDown(() async {
       await client.closeStreamingConnection();
+      client.close();
       await await session.close();
       await server.shutdown(exitProcess: false);
     });
@@ -92,6 +93,9 @@ void main() async {
 
       var logs = await LoggingUtil.findAllLogs(session);
 
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
       expect(logs, hasLength(1));
       expect(logs.first.messages, hasLength(1));
     });
@@ -110,6 +114,9 @@ void main() async {
 
       await client.logging.sendStreamMessage(Types());
       await client.closeStreamingConnection();
+
+      // Wait for the log to potentially be written
+      await Future.delayed(Duration(milliseconds: 100));
 
       var logs = await LoggingUtil.findAllLogs(session);
 
@@ -135,6 +142,9 @@ void main() async {
       await client.logging.sendStreamMessage(Types());
       await client.closeStreamingConnection();
 
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
       var logs = await LoggingUtil.findAllLogs(session);
 
       expect(logs, hasLength(1));
@@ -158,6 +168,9 @@ void main() async {
 
       await client.logging.sendStreamMessage(Types());
       await client.closeStreamingConnection();
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
 
       var logs = await LoggingUtil.findAllLogs(session);
 


### PR DESCRIPTION
Adds a small delay after the test action is completed so that any potential logs have time to be written to the database.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple test fixes.