### PR TITLE
fix: Improve Method Stream Websocket Message data structure.

### DIFF
--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -28,9 +28,6 @@ class MethodWebsocketRequestHandler {
             jsonData,
             server.serializationManager,
           );
-        } on IncompatibleVersionException catch (_) {
-          webSocket.tryAdd(BadRequestMessage.buildMessage(jsonData));
-          rethrow;
         } on UnknownMessageException catch (_) {
           webSocket.tryAdd(BadRequestMessage.buildMessage(jsonData));
           rethrow;

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -28,11 +28,12 @@ class MethodWebsocketRequestHandler {
             jsonData,
             server.serializationManager,
           );
+        } on IncompatibleVersionException catch (_) {
+          webSocket.tryAdd(BadRequestMessage.buildMessage(jsonData));
+          rethrow;
         } on UnknownMessageException catch (_) {
           webSocket.tryAdd(BadRequestMessage.buildMessage(jsonData));
-          throw Exception(
-            'Unknown message received on websocket connection: $jsonData',
-          );
+          rethrow;
         }
 
         switch (message) {

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -4,12 +4,6 @@ import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Base class for messages sent over a WebSocket connection.
 sealed class WebSocketMessage {
-  /// The version of the protocol.
-  static const int version = 1;
-
-  /// The keyword used for the version in the websocket message.
-  static const String messageVersionKeyword = 'version';
-
   /// The keyword used for the message type in the websocket message.
   static const String messageTypeKeyword = 'type';
 
@@ -21,7 +15,6 @@ sealed class WebSocketMessage {
     Map<String, dynamic>? data,
   ]) {
     return SerializationManager.encodeForProtocol({
-      messageVersionKeyword: version,
       messageTypeKeyword: messageType,
       messageDataKeyword: data,
     });
@@ -36,12 +29,6 @@ sealed class WebSocketMessage {
   ) {
     try {
       Map data = jsonDecode(jsonString) as Map;
-
-      var messageVersion = data[messageVersionKeyword] as int;
-
-      if (messageVersion != version) {
-        throw IncompatibleVersionException(messageVersion, version, version);
-      }
 
       var messageType = data[messageTypeKeyword];
       var messageData = data[messageDataKeyword];
@@ -72,8 +59,6 @@ sealed class WebSocketMessage {
       }
 
       throw UnknownMessageException(jsonString, error: 'Unknown message type');
-    } on IncompatibleVersionException {
-      rethrow;
     } on UnknownMessageException {
       rethrow;
     } catch (e, stackTrace) {
@@ -481,29 +466,5 @@ class UnknownMessageException implements Exception {
   @override
   String toString() {
     return 'UnknownMessageException: $jsonString\n$error\n$stackTrace';
-  }
-}
-
-/// Exception thrown when a message with an incompatible version is received.
-class IncompatibleVersionException implements Exception {
-  /// The version that was received.
-  final int version;
-
-  /// The minimum allowed version.
-  final int minAllowedVersion;
-
-  /// The maximum allowed version.
-  final int maxAllowedVersion;
-
-  /// Creates a new [IncompatibleVersionException].
-  IncompatibleVersionException(
-    this.version,
-    this.minAllowedVersion,
-    this.maxAllowedVersion,
-  );
-
-  @override
-  String toString() {
-    return 'IncompatibleVersionException: message version "$version", not in allowed range ($minAllowedVersion-$maxAllowedVersion)';
   }
 }

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -4,6 +4,29 @@ import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Base class for messages sent over a WebSocket connection.
 sealed class WebSocketMessage {
+  /// The version of the protocol.
+  static const int version = 1;
+
+  /// The keyword used for the version in the websocket message.
+  static const String messageVersionKeyword = 'version';
+
+  /// The keyword used for the message type in the websocket message.
+  static const String messageTypeKeyword = 'type';
+
+  /// The keyword used for the message data in the websocket message.
+  static const String messageDataKeyword = 'data';
+
+  static String _buildMessage(
+    String messageType, [
+    Map<String, dynamic>? data,
+  ]) {
+    return SerializationManager.encodeForProtocol({
+      messageVersionKeyword: version,
+      messageTypeKeyword: messageType,
+      messageDataKeyword: data,
+    });
+  }
+
   /// Converts a JSON string to a [WebSocketMessage] object.
   ///
   /// Throws an [UnknownMessageException] if the message is not recognized.
@@ -14,7 +37,14 @@ sealed class WebSocketMessage {
     try {
       Map data = jsonDecode(jsonString) as Map;
 
-      var messageType = data['messageType'];
+      var messageVersion = data[messageVersionKeyword] as int;
+
+      if (messageVersion != version) {
+        throw IncompatibleVersionException(messageVersion, version, version);
+      }
+
+      var messageType = data[messageTypeKeyword];
+      var messageData = data[messageDataKeyword];
 
       switch (messageType) {
         case PingCommand._messageType:
@@ -22,20 +52,30 @@ sealed class WebSocketMessage {
         case PongCommand._messageType:
           return PongCommand();
         case BadRequestMessage._messageType:
-          return BadRequestMessage(data);
+          return BadRequestMessage(messageData);
         case OpenMethodStreamCommand._messageType:
-          return OpenMethodStreamCommand(data);
+          return OpenMethodStreamCommand(messageData);
         case OpenMethodStreamResponse._messageType:
-          return OpenMethodStreamResponse(data);
+          return OpenMethodStreamResponse(messageData);
         case CloseMethodStreamCommand._messageType:
-          return CloseMethodStreamCommand(data);
+          return CloseMethodStreamCommand(messageData);
         case MethodStreamMessage._messageType:
-          return MethodStreamMessage(data, serializationManager);
+          return MethodStreamMessage(
+            messageData,
+            serializationManager,
+          );
         case MethodStreamSerializableException._messageType:
-          return MethodStreamSerializableException(data, serializationManager);
+          return MethodStreamSerializableException(
+            messageData,
+            serializationManager,
+          );
       }
 
-      throw UnknownMessageException(jsonString);
+      throw UnknownMessageException(jsonString, error: 'Unknown message type');
+    } on IncompatibleVersionException {
+      rethrow;
+    } on UnknownMessageException {
+      rethrow;
     } catch (e, stackTrace) {
       throw UnknownMessageException(
         jsonString,
@@ -95,11 +135,13 @@ class OpenMethodStreamResponse extends WebSocketMessage {
     required UuidValue connectionId,
     required OpenMethodStreamResponseType responseType,
   }) {
-    return SerializationManager.encodeForProtocol({
-      'messageType': _messageType,
-      'connectionId': connectionId,
-      'responseType': responseType.name,
-    });
+    return WebSocketMessage._buildMessage(
+      _messageType,
+      {
+        'connectionId': connectionId,
+        'responseType': responseType.name,
+      },
+    );
   }
 
   @override
@@ -145,8 +187,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
     required UuidValue connectionId,
     String? authentication,
   }) {
-    return SerializationManager.encodeForProtocol({
-      'messageType': _messageType,
+    return WebSocketMessage._buildMessage(_messageType, {
       'endpoint': endpoint,
       'method': method,
       'connectionId': connectionId,
@@ -156,14 +197,13 @@ class OpenMethodStreamCommand extends WebSocketMessage {
   }
 
   @override
-  String toString() => {
-        'messageType': _messageType,
+  String toString() => WebSocketMessage._buildMessage(_messageType, {
         'endpoint': endpoint,
         'method': method,
         'connectionId': SerializationManager.encodeForProtocol(connectionId),
         'args': args,
         if (authentication != null) 'authentication': authentication,
-      }.toString();
+      }).toString();
 }
 
 /// The reason a stream was closed.
@@ -220,8 +260,7 @@ class CloseMethodStreamCommand extends WebSocketMessage {
     required String method,
     required CloseReason reason,
   }) {
-    return SerializationManager.encodeForProtocol({
-      'messageType': _messageType,
+    return WebSocketMessage._buildMessage(_messageType, {
       'endpoint': endpoint,
       'method': method,
       'connectionId': connectionId,
@@ -247,8 +286,7 @@ class PingCommand extends WebSocketMessage {
 
   /// Builds a [PingCommand] message.
   static String buildMessage() {
-    return SerializationManager.encodeForProtocol(
-        {'messageType': _messageType});
+    return WebSocketMessage._buildMessage(_messageType);
   }
 
   @override
@@ -261,8 +299,7 @@ class PongCommand extends WebSocketMessage {
 
   /// Builds a [PongCommand] message.
   static String buildMessage() {
-    return SerializationManager.encodeForProtocol(
-        {'messageType': _messageType});
+    return WebSocketMessage._buildMessage(_messageType);
   }
 
   @override
@@ -313,25 +350,29 @@ class MethodStreamSerializableException extends WebSocketMessage {
     required dynamic object,
     required SerializationManager serializationManager,
   }) {
-    return SerializationManager.encodeForProtocol({
-      'messageType': _messageType,
-      'endpoint': endpoint,
-      'method': method,
-      'connectionId': connectionId,
-      if (parameter != null) 'parameter': parameter,
-      'exception': serializationManager.wrapWithClassName(object),
-    });
-  }
-
-  @override
-  String toString() => {
-        'messageType': _messageType,
+    return WebSocketMessage._buildMessage(
+      _messageType,
+      {
         'endpoint': endpoint,
         'method': method,
         'connectionId': connectionId,
         if (parameter != null) 'parameter': parameter,
-        'exception': exception,
-      }.toString();
+        'exception': serializationManager.wrapWithClassName(object),
+      },
+    );
+  }
+
+  @override
+  String toString() => WebSocketMessage._buildMessage(
+        _messageType,
+        {
+          'endpoint': endpoint,
+          'method': method,
+          'connectionId': connectionId,
+          if (parameter != null) 'parameter': parameter,
+          'exception': exception,
+        },
+      ).toString();
 }
 
 /// A message sent to a method stream.
@@ -373,8 +414,7 @@ class MethodStreamMessage extends WebSocketMessage {
     required dynamic object,
     required SerializationManager serializationManager,
   }) {
-    return SerializationManager.encodeForProtocol({
-      'messageType': _messageType,
+    return WebSocketMessage._buildMessage(_messageType, {
       'endpoint': endpoint,
       'method': method,
       'connectionId': connectionId,
@@ -384,14 +424,16 @@ class MethodStreamMessage extends WebSocketMessage {
   }
 
   @override
-  String toString() => {
-        'messageType': _messageType,
-        'endpoint': endpoint,
-        'method': method,
-        'connectionId': connectionId,
-        if (parameter != null) 'parameter': parameter,
-        'object': object,
-      }.toString();
+  String toString() => WebSocketMessage._buildMessage(
+        _messageType,
+        {
+          'endpoint': endpoint,
+          'method': method,
+          'connectionId': connectionId,
+          if (parameter != null) 'parameter': parameter,
+          'object': object,
+        },
+      ).toString();
 }
 
 /// A message sent when a bad request is received.
@@ -406,10 +448,12 @@ class BadRequestMessage extends WebSocketMessage {
 
   /// Builds a [BadRequestMessage] message.
   static String buildMessage(String request) {
-    return SerializationManager.encodeForProtocol({
-      'messageType': _messageType,
-      'request': request,
-    });
+    return WebSocketMessage._buildMessage(
+      _messageType,
+      {
+        'request': request,
+      },
+    );
   }
 
   @override
@@ -437,5 +481,29 @@ class UnknownMessageException implements Exception {
   @override
   String toString() {
     return 'UnknownMessageException: $jsonString\n$error\n$stackTrace';
+  }
+}
+
+/// Exception thrown when a message with an incompatible version is received.
+class IncompatibleVersionException implements Exception {
+  /// The version that was received.
+  final int version;
+
+  /// The minimum allowed version.
+  final int minAllowedVersion;
+
+  /// The maximum allowed version.
+  final int maxAllowedVersion;
+
+  /// Creates a new [IncompatibleVersionException].
+  IncompatibleVersionException(
+    this.version,
+    this.minAllowedVersion,
+    this.maxAllowedVersion,
+  );
+
+  @override
+  String toString() {
+    return 'IncompatibleVersionException: message version "$version", not in allowed range ($minAllowedVersion-$maxAllowedVersion)';
   }
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -157,7 +157,7 @@ void main() {
       'Given an unknown command json String when building websocket message from string then UnknownMessageException is thrown.',
       () {
     var message =
-        '{"${WebSocketMessage.messageTypeKeyword}": "this is not a known message type", "${WebSocketMessage.messageVersionKeyword}": ${WebSocketMessage.version}}';
+        '{"${WebSocketMessage.messageTypeKeyword}": "this is not a known message type"}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -187,8 +187,7 @@ void main() {
   test(
       'Given a null messageType when building websocket message from string then UnknownMessageException is thrown.',
       () {
-    var message =
-        '{"${WebSocketMessage.messageTypeKeyword}": null, "${WebSocketMessage.messageVersionKeyword}": ${WebSocketMessage.version}}';
+    var message = '{"${WebSocketMessage.messageTypeKeyword}": null}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -466,133 +465,6 @@ void main() {
         isA<UnknownMessageException>()
             .having((e) => e.error, 'error', isA<TypeError>()),
       ),
-    );
-  });
-
-  test('Given a ping command when building message then version is included.',
-      () {
-    var message = PingCommand.buildMessage();
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given a pong command when building message then version is included in serialization.',
-      () {
-    var message = PongCommand.buildMessage();
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given a bad request message when building message then version is included.',
-      () {
-    var message = BadRequestMessage.buildMessage('This is a bad request');
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given an open method stream command when building message then version is included.',
-      () {
-    var message = OpenMethodStreamCommand.buildMessage(
-      endpoint: 'endpoint',
-      method: 'method',
-      args: {'arg1': 'value1', 'arg2': 2},
-      connectionId: const Uuid().v4obj(),
-      authentication: 'auth',
-    );
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given an open method stream response when building message then version is included.',
-      () {
-    var message = OpenMethodStreamResponse.buildMessage(
-      connectionId: const Uuid().v4obj(),
-      responseType: OpenMethodStreamResponseType.success,
-    );
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given a close method stream command when building message then version is included.',
-      () {
-    var message = CloseMethodStreamCommand.buildMessage(
-      connectionId: const Uuid().v4obj(),
-      endpoint: 'endpoint',
-      parameter: 'parameter',
-      method: 'method',
-      reason: CloseReason.done,
-    );
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given a method stream message when building message then version is included.',
-      () {
-    var serializationManager = _TestSerializationManager();
-    var message = MethodStreamMessage.buildMessage(
-      endpoint: 'endpoint',
-      method: 'method',
-      connectionId: const Uuid().v4obj(),
-      object: _SimpleData('hello world'),
-      serializationManager: serializationManager,
-    );
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given a method stream serializable exception when building message then version is included.',
-      () {
-    var serializationManager = _TestSerializationManager();
-    var message = MethodStreamSerializableException.buildMessage(
-      endpoint: 'endpoint',
-      method: 'method',
-      connectionId: const Uuid().v4obj(),
-      object: _TestSerializableException(),
-      serializationManager: serializationManager,
-    );
-    expect(
-        message,
-        contains(
-            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
-  });
-
-  test(
-      'Given a message with an incompatible version when build web socket message from string then IncompatibleVersionException is thrown.',
-      () {
-    var message = PingCommand.buildMessage();
-
-    message = message.replaceAll(
-      '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}',
-      '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version + 1}',
-    );
-
-    expect(
-      () => WebSocketMessage.fromJsonString(
-        message,
-        _TestSerializationManager(),
-      ),
-      throwsA(isA<IncompatibleVersionException>()),
     );
   });
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -124,8 +124,10 @@ void main() {
   test(
       'Given a bad request message without mandatory field building websocket message from string then UnknownMessageException is thrown having TypeError error type.',
       () {
+    var message = BadRequestMessage.buildMessage('testRequest');
+
     /// Missing mandatory field 'request'
-    var message = '{"messageType": "bad_request_message"}';
+    message = message.replaceAll('"request":"testRequest"', '');
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -154,13 +156,15 @@ void main() {
   test(
       'Given an unknown command json String when building websocket message from string then UnknownMessageException is thrown.',
       () {
-    var message = '{"messageType": "this is not a known message type"}';
+    var message =
+        '{"${WebSocketMessage.messageTypeKeyword}": "this is not a known message type", "${WebSocketMessage.messageVersionKeyword}": ${WebSocketMessage.version}}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
         _TestSerializationManager(),
       ),
-      throwsA(isA<UnknownMessageException>()),
+      throwsA(isA<UnknownMessageException>()
+          .having((e) => e.error, 'error', 'Unknown message type')),
     );
   });
 
@@ -183,7 +187,8 @@ void main() {
   test(
       'Given a null messageType when building websocket message from string then UnknownMessageException is thrown.',
       () {
-    var message = '{"messageType": null}';
+    var message =
+        '{"${WebSocketMessage.messageTypeKeyword}": null, "${WebSocketMessage.messageVersionKeyword}": ${WebSocketMessage.version}}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -211,16 +216,18 @@ void main() {
   });
 
   test(
-      'Given an invalid open method stream command json String that is missing mandatory endpoint field when building websocket message from string then UnknownMessageException is thrown having FormatException error type.',
+      'Given an invalid open method stream command json String that is missing mandatory endpoint field when building websocket message from string then UnknownMessageException is thrown having TypeError error type.',
       () {
+    var message = OpenMethodStreamCommand.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      args: {'arg1': 'value1', 'arg2': 2},
+      connectionId: const Uuid().v4obj(),
+      authentication: 'auth',
+    );
+
     // This message is missing the mandatory endpoint field.
-    var message = '''{
-      "messageType": "open_method_stream_command',
-      "method": "method',
-      "args": {"arg1": "value1", "arg2": 2},
-      "uuid": "uuid",
-      "authentication": "auth",
-    }''';
+    message = message.replaceAll('"endpoint":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -229,7 +236,7 @@ void main() {
       ),
       throwsA(
         isA<UnknownMessageException>()
-            .having((e) => e.error, 'error', isA<FormatException>()),
+            .having((e) => e.error, 'error', isA<TypeError>()),
       ),
     );
   });
@@ -251,11 +258,15 @@ void main() {
   test(
       'Given an open method stream response with an invalid response type when building websocket message from string then UnknownMessageException is thrown.',
       () {
-    var message = '''{
-      "messageType": "open_method_stream_response",
-      "uuid": "uuid",
-      "responseType": "this response type does not exist"
-    }''';
+    var message = OpenMethodStreamResponse.buildMessage(
+      connectionId: const Uuid().v4obj(),
+      responseType: OpenMethodStreamResponseType.success,
+    );
+
+    message = message.replaceAll(
+      OpenMethodStreamResponseType.success.name,
+      'this response type does not exist',
+    );
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -284,16 +295,23 @@ void main() {
   });
 
   test(
-      'Given an invalid close method stream command json String that is missing mandatory uuid field when building websocket message from string then UnknownMessageException is thrown having FormatException error type.',
+      'Given an invalid close method stream command json String that is missing mandatory connectionId field when building websocket message from string then UnknownMessageException is thrown having TypeError error type.',
       () {
-    // This message is missing the mandatory uuid field.
-    var message = '''{
-      "messageType": "close_method_stream_command",
-      "endpoint": "endpoint",
-      "parameter": "parameter",
-      "method": "method",
-      "reason": "done",
-    }''';
+    var connectionId = const Uuid().v4obj();
+    var message = CloseMethodStreamCommand.buildMessage(
+      connectionId: connectionId,
+      endpoint: 'endpoint',
+      parameter: 'parameter',
+      method: 'method',
+      reason: CloseReason.done,
+    );
+
+    // This message is missing the mandatory connectionId field.
+    message = message.replaceAll(
+      '"connectionId":${SerializationManager.encodeForProtocol(connectionId)},',
+      '',
+    );
+
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -301,7 +319,7 @@ void main() {
       ),
       throwsA(
         isA<UnknownMessageException>()
-            .having((e) => e.error, 'error', isA<FormatException>()),
+            .having((e) => e.error, 'error', isA<TypeError>()),
       ),
     );
   });
@@ -309,14 +327,19 @@ void main() {
   test(
       'Given an close method stream command with an invalid reason when building websocket message from string then UnknownMessageException is thrown.',
       () {
-    var message = '''{
-      "messageType": "close_method_stream_command",
-      "uuid": "uuid",
-      "endpoint": "endpoint",
-      "parameter": "parameter",
-      "method": "method",
-      "reason": "this reason does not exist"
-    }''';
+    var message = CloseMethodStreamCommand.buildMessage(
+      connectionId: const Uuid().v4obj(),
+      endpoint: 'endpoint',
+      parameter: 'parameter',
+      method: 'method',
+      reason: CloseReason.done,
+    );
+
+    message = message.replaceAll(
+      CloseReason.done.name,
+      'this reason does not exist',
+    );
+
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -360,15 +383,19 @@ void main() {
   });
 
   test(
-      'Given an invalid method stream message json String that is missing mandatory endpoint field when building websocket message from string then UnknownMessageException is thrown.',
+      'Given an invalid method stream message json String that is missing mandatory endpoint field when building websocket message from string then UnknownMessageException is thrown having TypeError error type.',
       () {
+    var serializationManager = _TestSerializationManager();
+    var message = MethodStreamMessage.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      connectionId: const Uuid().v4obj(),
+      object: _SimpleData('hello world'),
+      serializationManager: serializationManager,
+    );
+
     // This message is missing the mandatory endpoint field.
-    var message = '''{
-      "messageType": "method_stream_message",
-      "method": "method",
-      "uuid": "uuid",
-      "object": '{"className": "bamboo", "data": {"number": 2}}',
-    }''';
+    message = message.replaceAll('"endpoint":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -377,7 +404,7 @@ void main() {
       ),
       throwsA(
         isA<UnknownMessageException>()
-            .having((e) => e.error, 'error', isA<FormatException>()),
+            .having((e) => e.error, 'error', isA<TypeError>()),
       ),
     );
   });
@@ -416,15 +443,19 @@ void main() {
   });
 
   test(
-      'Given invalid method stream serializable exception json String when building websocket message from string then UnknownMessageException is thrown.',
+      'Given invalid method stream serializable exception json String when building websocket message from string then UnknownMessageException is thrown having TypeError error type.',
       () {
+    var serializationManager = _TestSerializationManager();
+    var message = MethodStreamSerializableException.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      connectionId: const Uuid().v4obj(),
+      object: _TestSerializableException(),
+      serializationManager: serializationManager,
+    );
+
     // This message is missing the mandatory endpoint field.
-    var message = '''{
-      "messageType": "method_stream_serializable_exception",
-      "method": "method",
-      "uuid": "uuid",
-      "object": '{"className": "serializableException", "data": {"message": "error message"}}',
-    }''';
+    message = message.replaceAll('"endpoint":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -433,8 +464,135 @@ void main() {
       ),
       throwsA(
         isA<UnknownMessageException>()
-            .having((e) => e.error, 'error', isA<FormatException>()),
+            .having((e) => e.error, 'error', isA<TypeError>()),
       ),
+    );
+  });
+
+  test('Given a ping command when building message then version is included.',
+      () {
+    var message = PingCommand.buildMessage();
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given a pong command when building message then version is included in serialization.',
+      () {
+    var message = PongCommand.buildMessage();
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given a bad request message when building message then version is included.',
+      () {
+    var message = BadRequestMessage.buildMessage('This is a bad request');
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given an open method stream command when building message then version is included.',
+      () {
+    var message = OpenMethodStreamCommand.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      args: {'arg1': 'value1', 'arg2': 2},
+      connectionId: const Uuid().v4obj(),
+      authentication: 'auth',
+    );
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given an open method stream response when building message then version is included.',
+      () {
+    var message = OpenMethodStreamResponse.buildMessage(
+      connectionId: const Uuid().v4obj(),
+      responseType: OpenMethodStreamResponseType.success,
+    );
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given a close method stream command when building message then version is included.',
+      () {
+    var message = CloseMethodStreamCommand.buildMessage(
+      connectionId: const Uuid().v4obj(),
+      endpoint: 'endpoint',
+      parameter: 'parameter',
+      method: 'method',
+      reason: CloseReason.done,
+    );
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given a method stream message when building message then version is included.',
+      () {
+    var serializationManager = _TestSerializationManager();
+    var message = MethodStreamMessage.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      connectionId: const Uuid().v4obj(),
+      object: _SimpleData('hello world'),
+      serializationManager: serializationManager,
+    );
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given a method stream serializable exception when building message then version is included.',
+      () {
+    var serializationManager = _TestSerializationManager();
+    var message = MethodStreamSerializableException.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      connectionId: const Uuid().v4obj(),
+      object: _TestSerializableException(),
+      serializationManager: serializationManager,
+    );
+    expect(
+        message,
+        contains(
+            '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}'));
+  });
+
+  test(
+      'Given a message with an incompatible version when build web socket message from string then IncompatibleVersionException is thrown.',
+      () {
+    var message = PingCommand.buildMessage();
+
+    message = message.replaceAll(
+      '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version}',
+      '"${WebSocketMessage.messageVersionKeyword}":${WebSocketMessage.version + 1}',
+    );
+
+    expect(
+      () => WebSocketMessage.fromJsonString(
+        message,
+        _TestSerializationManager(),
+      ),
+      throwsA(isA<IncompatibleVersionException>()),
     );
   });
 }

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/invalid_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/invalid_command_test.dart
@@ -53,19 +53,5 @@ void main() {
         BadRequestMessage.buildMessage(unrecognizedCommandMessage),
       );
     });
-
-    test(
-        'when a message with an invalid version is sent then BadRequestMessage response is received.',
-        () async {
-      var response = webSocket.stream.first.timeout(Duration(seconds: 10));
-      var invalidVersionMessage =
-          '{"${WebSocketMessage.messageVersionKeyword}": ${WebSocketMessage.version + 1}}';
-      webSocket.sink.add(invalidVersionMessage);
-
-      expect(
-        await response,
-        BadRequestMessage.buildMessage(invalidVersionMessage),
-      );
-    });
   });
 }

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/invalid_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/invalid_command_test.dart
@@ -43,7 +43,7 @@ void main() {
     });
 
     test(
-        'when an unrecognized message is sent then BadRequestMessage is response is received.',
+        'when an unrecognized message is sent then BadRequestMessage response is received.',
         () async {
       var response = webSocket.stream.first.timeout(Duration(seconds: 10));
       webSocket.sink.add(unrecognizedCommandMessage);
@@ -51,6 +51,20 @@ void main() {
       expect(
         await response,
         BadRequestMessage.buildMessage(unrecognizedCommandMessage),
+      );
+    });
+
+    test(
+        'when a message with an invalid version is sent then BadRequestMessage response is received.',
+        () async {
+      var response = webSocket.stream.first.timeout(Duration(seconds: 10));
+      var invalidVersionMessage =
+          '{"${WebSocketMessage.messageVersionKeyword}": ${WebSocketMessage.version + 1}}';
+      webSocket.sink.add(invalidVersionMessage);
+
+      expect(
+        await response,
+        BadRequestMessage.buildMessage(invalidVersionMessage),
       );
     });
   });


### PR DESCRIPTION
Another stepping stone towards #2338.

### Changes:
- ~~Adds a single digit version to websocket messages.~~
- ~~Add tests for this change.~~

~~This will allow us to update WebSocket messages in the future allowing us to possibly support multiple clients along with deprecating old ones.~~

### Update:

After the review it was concluded that we can probably do a version handshake as part of the WebSocket upgrade request and therefore we can skip versioning all together at this stage.

The PR now contains the grouping of the metadata for the messages.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - these are changes related to a non-released feature.