### PR TITLE
fix: Support nullable and dynamic types in streams.

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1271,13 +1271,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'value': value},
       );
 
-  _i2.Future<int?> nullableResponse(int? value) =>
-      caller.callServerEndpoint<int?>(
-        'methodStreaming',
-        'nullableResponse',
-        {'value': value},
-      );
-
   _i2.Future<int> doubleInputValue(int value) => caller.callServerEndpoint<int>(
         'methodStreaming',
         'doubleInputValue',

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -35,6 +35,21 @@ class MethodStreaming extends Endpoint {
     }
   }
 
+  Stream dynamicEchoStream(Session session, Stream stream) async* {
+    await for (var value in stream) {
+      yield value;
+    }
+  }
+
+  Stream<int?> nullableIntEchoStream(
+    Session session,
+    Stream<int?> stream,
+  ) async* {
+    await for (var value in stream) {
+      yield value;
+    }
+  }
+
   Future<void> voidReturnAfterStream(
     Session session,
     Stream<int> stream,
@@ -112,10 +127,6 @@ class MethodStreaming extends Endpoint {
   Future<void> simpleEndpoint(Session session) async {}
 
   Future<void> intParameter(Session session, int value) async {}
-
-  Future<int?> nullableResponse(Session session, int? value) async {
-    return value;
-  }
 
   Future<int> doubleInputValue(Session session, int value) async {
     return value * 2;

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -2888,25 +2888,6 @@ class Endpoints extends _i1.EndpointDispatch {
             params['value'],
           ),
         ),
-        'nullableResponse': _i1.MethodConnector(
-          name: 'nullableResponse',
-          params: {
-            'value': _i1.ParameterDescription(
-              name: 'value',
-              type: _i1.getType<int?>(),
-              nullable: true,
-            )
-          },
-          call: (
-            _i1.Session session,
-            Map<String, dynamic> params,
-          ) async =>
-              (endpoints['methodStreaming'] as _i20.MethodStreaming)
-                  .nullableResponse(
-            session,
-            params['value'],
-          ),
-        ),
         'doubleInputValue': _i1.MethodConnector(
           name: 'doubleInputValue',
           params: {
@@ -3050,6 +3031,48 @@ class Endpoints extends _i1.EndpointDispatch {
                   .intEchoStream(
             session,
             streamParams['stream']!.cast<int>(),
+          ),
+        ),
+        'dynamicEchoStream': _i1.MethodStreamConnector(
+          name: 'dynamicEchoStream',
+          params: {},
+          streamParams: {
+            'stream': _i1.StreamParameterDescription<dynamic>(
+              name: 'stream',
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .dynamicEchoStream(
+            session,
+            streamParams['stream']!.cast<dynamic>(),
+          ),
+        ),
+        'nullableIntEchoStream': _i1.MethodStreamConnector(
+          name: 'nullableIntEchoStream',
+          params: {},
+          streamParams: {
+            'stream': _i1.StreamParameterDescription<int?>(
+              name: 'stream',
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .nullableIntEchoStream(
+            session,
+            streamParams['stream']!.cast<int?>(),
           ),
         ),
         'voidReturnAfterStream': _i1.MethodStreamConnector(

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -160,6 +160,8 @@ methodStreaming:
   - intReturnFromStream:
   - intStreamFromValue:
   - intEchoStream:
+  - dynamicEchoStream:
+  - nullableIntEchoStream:
   - voidReturnAfterStream:
   - multipleIntEchoStreams:
   - directVoidReturnWithStreamInput:
@@ -170,7 +172,6 @@ methodStreaming:
   - simpleInOutDataStream:
   - simpleEndpoint:
   - intParameter:
-  - nullableResponse:
   - doubleInputValue:
   - delayedResponse:
   - delayedStreamResponse:

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -311,56 +311,6 @@ void main() {
     });
 
     group(
-        'when a method stream is opened to an endpoint that has null return value then null MethodStreamMessage is received with null value',
-        () {
-      late Completer<int?> endpointResponse;
-
-      setUp(() async {
-        var connectionId = const Uuid().v4obj();
-        endpointResponse = Completer<int?>();
-        var streamOpened = Completer<void>();
-
-        webSocket.stream.listen((event) {
-          var message = WebSocketMessage.fromJsonString(
-            event,
-            server.serializationManager,
-          );
-          ;
-          if (message is OpenMethodStreamResponse) {
-            streamOpened.complete();
-          } else if (message is MethodStreamMessage) {
-            endpointResponse.complete(message.object as int?);
-          }
-        });
-
-        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
-          endpoint: 'methodStreaming',
-          method: 'nullableResponse',
-          args: {'value': null},
-          connectionId: connectionId,
-        ));
-
-        await streamOpened.future.timeout(
-          Duration(seconds: 5),
-          onTimeout: () => throw AssertionError(
-            'Failed to open method stream with server.',
-          ),
-        );
-      });
-
-      test('then MethodStreamMessage with modified input is received.',
-          () async {
-        await expectLater(
-          endpointResponse.future.timeout(Duration(seconds: 5)),
-          completion(null),
-          reason: 'Return value from endpoint.',
-        );
-      });
-    },
-        skip:
-            'Enable this test once serialize and deserialize by class name supports null types.');
-
-    group(
         'when multiple methods streams are open and one of them with Future response is closed',
         () {
       late Completer<void> returningStreamClosed;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/dynamic_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/dynamic_stream_test.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_completer_timeout.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group(
+      'Given a method stream connection to an endpoint that echoes a dynamic input stream',
+      () {
+    var endpoint = 'methodStreaming';
+    var method = 'dynamicEchoStream';
+
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    group('when a stream of values are passed in', () {
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      late Completer<CloseMethodStreamCommand>
+          closeMethodStreamParameterCommand;
+      TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
+      var inputValues = [1, 'hello'];
+      late List<dynamic> endpointResponses;
+
+      var inputParameter = 'stream';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        endpointResponses = [];
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        closeMethodStreamParameterCommand =
+            Completer<CloseMethodStreamCommand>();
+        var streamOpened = Completer<void>();
+
+        testCompleterTimeout.start({
+          'closeMethodStreamCommand': closeMethodStreamCommand,
+          'closeMethodStreamParameterCommand':
+              closeMethodStreamParameterCommand,
+          'streamOpened': streamOpened,
+        });
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            if (message.parameter == inputParameter) {
+              closeMethodStreamParameterCommand.complete(message);
+            } else {
+              closeMethodStreamCommand.complete(message);
+            }
+          } else if (message is MethodStreamMessage) {
+            if (endpointResponses.isEmpty) {
+              endpointResponses.add(message.object as int);
+            } else {
+              endpointResponses.add(message.object as String);
+            }
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          connectionId: connectionId,
+        ));
+
+        await streamOpened.future;
+        assert(streamOpened.isCompleted == true,
+            'Failed to open method stream with server');
+
+        for (var inputValue in inputValues)
+          webSocket.sink.add(MethodStreamMessage.buildMessage(
+            endpoint: endpoint,
+            method: method,
+            parameter: inputParameter,
+            connectionId: connectionId,
+            object: inputValue,
+            serializationManager: server.serializationManager,
+          ));
+
+        webSocket.sink.add(CloseMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          parameter: inputParameter,
+          connectionId: connectionId,
+          reason: CloseReason.done,
+        ));
+      });
+
+      tearDown(() => testCompleterTimeout.cancel());
+
+      test('then received values matches stream of input.', () async {
+        closeMethodStreamCommand.future.catchError((error) {
+          fail('Server failed to close the output stream.');
+        });
+
+        await expectLater(closeMethodStreamCommand.future, completes);
+
+        expect(
+          endpointResponses,
+          inputValues,
+        );
+      });
+
+      test('then CloseMethodStreamCommand matching the endpoint is received.',
+          () async {
+        closeMethodStreamCommand.future.catchError((error) {
+          fail('Failed to receive CloseMethodStreamCommand from server.');
+        }).then((message) {
+          expect(message.endpoint, endpoint);
+          expect(message.method, method);
+          expect(message.connectionId, connectionId);
+          expect(message.reason, CloseReason.done);
+        });
+
+        await expectLater(closeMethodStreamCommand.future, completes);
+      });
+
+      test(
+          'then CloseMethodStreamCommand matching the stream parameter is received.',
+          () async {
+        closeMethodStreamParameterCommand.future.catchError((error) {
+          fail(
+              'Failed to receive CloseMethodStreamCommand from server for input parameter.');
+        }).then((message) {
+          expect(message.endpoint, endpoint);
+          expect(message.method, method);
+          expect(message.parameter, inputParameter);
+          expect(message.connectionId, connectionId);
+          expect(message.reason, CloseReason.done);
+        });
+
+        await expectLater(
+          closeMethodStreamParameterCommand.future,
+          completes,
+        );
+      });
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_completer_timeout.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group(
+      'Given a method stream connection to an endpoint that echoes a input stream with nullable generic',
+      () {
+    var endpoint = 'methodStreaming';
+    var method = 'nullableIntEchoStream';
+
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    group('when a stream of values are passed in', () {
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      late Completer<CloseMethodStreamCommand>
+          closeMethodStreamParameterCommand;
+      TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
+      var inputValues = [1, null, 3];
+      late List<int?> endpointResponses;
+
+      var inputParameter = 'stream';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        endpointResponses = [];
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        closeMethodStreamParameterCommand =
+            Completer<CloseMethodStreamCommand>();
+        var streamOpened = Completer<void>();
+
+        testCompleterTimeout.start({
+          'closeMethodStreamCommand': closeMethodStreamCommand,
+          'closeMethodStreamParameterCommand':
+              closeMethodStreamParameterCommand,
+          'streamOpened': streamOpened,
+        });
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            if (message.parameter == inputParameter) {
+              closeMethodStreamParameterCommand.complete(message);
+            } else {
+              closeMethodStreamCommand.complete(message);
+            }
+          } else if (message is MethodStreamMessage) {
+            endpointResponses.add(message.object as int?);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          connectionId: connectionId,
+        ));
+
+        await streamOpened.future;
+        assert(streamOpened.isCompleted == true,
+            'Failed to open method stream with server');
+
+        for (var inputValue in inputValues)
+          webSocket.sink.add(MethodStreamMessage.buildMessage(
+            endpoint: endpoint,
+            method: method,
+            parameter: inputParameter,
+            connectionId: connectionId,
+            object: inputValue,
+            serializationManager: server.serializationManager,
+          ));
+
+        webSocket.sink.add(CloseMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          parameter: inputParameter,
+          connectionId: connectionId,
+          reason: CloseReason.done,
+        ));
+      });
+
+      tearDown(() => testCompleterTimeout.cancel());
+
+      test('then received values matches stream of input.', () async {
+        closeMethodStreamCommand.future.catchError((error) {
+          fail('Server failed to close the output stream.');
+        });
+
+        await expectLater(closeMethodStreamCommand.future, completes);
+
+        expect(
+          endpointResponses,
+          inputValues,
+        );
+      });
+
+      test('then CloseMethodStreamCommand matching the endpoint is received.',
+          () async {
+        closeMethodStreamCommand.future.catchError((error) {
+          fail('Failed to receive CloseMethodStreamCommand from server.');
+        }).then((message) {
+          expect(message.endpoint, endpoint);
+          expect(message.method, method);
+          expect(message.connectionId, connectionId);
+          expect(message.reason, CloseReason.done);
+        });
+
+        await expectLater(closeMethodStreamCommand.future, completes);
+      });
+
+      test(
+          'then CloseMethodStreamCommand matching the stream parameter is received.',
+          () async {
+        closeMethodStreamParameterCommand.future.catchError((error) {
+          fail(
+              'Failed to receive CloseMethodStreamCommand from server for input parameter.');
+        }).then((message) {
+          expect(message.endpoint, endpoint);
+          expect(message.method, method);
+          expect(message.parameter, inputParameter);
+          expect(message.connectionId, connectionId);
+          expect(message.reason, CloseReason.done);
+        });
+
+        await expectLater(
+          closeMethodStreamParameterCommand.future,
+          completes,
+        );
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -136,14 +136,6 @@ abstract class EndpointMethodAnalyzer {
       );
     }
 
-    if ((dartType.isDartAsyncStream || hasStreamParameter) &&
-        innerType.nullabilitySuffix != NullabilitySuffix.none) {
-      return SourceSpanSeverityException(
-        'Nullable return type for streaming methods are not supported.',
-        dartElement.span,
-      );
-    }
-
     try {
       TypeDefinition.fromDartType(innerType);
     } on FromDartTypeClassNameException catch (e) {

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -129,7 +129,7 @@ abstract class EndpointMethodAnalyzer {
       return null;
     }
 
-    if (innerType is DynamicType) {
+    if (innerType is DynamicType && !dartType.isDartAsyncStream) {
       return SourceSpanSeverityException(
         'Return generic must have a type defined. E.g. ${dartType.element.name}<String>.',
         dartElement.span,

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_class_analyzer.dart';

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
@@ -62,18 +62,10 @@ abstract class EndpointParameterAnalyzer {
                 parameter.span,
               );
             }
-
             var innerType = typeArguments[0];
-            if (innerType is VoidType || innerType is DynamicType) {
+            if (innerType is VoidType) {
               return SourceSpanSeverityException(
-                'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
-                parameter.span,
-              );
-            }
-
-            if (innerType.nullabilitySuffix != NullabilitySuffix.none) {
-              return SourceSpanSeverityException(
-                'Nullable types are not supported for "Stream" parameters.',
+                'The type "Stream" does not support void generic type.',
                 parameter.span,
               );
             }

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
@@ -595,23 +595,43 @@ class ExampleEndpoint extends Endpoint {
       analyzer = EndpointsAnalyzer(testDirectory);
       endpointDefinitions = await analyzer.analyze(collector: collector);
     });
-    test(
-        'then a validation error is reported that informs the type is not supported.',
-        () {
-      expect(collector.errors, hasLength(1));
-      expect(
-        collector.errors.firstOrNull?.message,
-        'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
-      );
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
     });
 
     test('then endpoint definition is created.', () {
       expect(endpointDefinitions, hasLength(1));
     });
 
-    test('then endpoint definition method is not defined.', () {
+    test('then endpoint method definition is created.', () {
       var methods = endpointDefinitions.firstOrNull?.methods;
-      expect(methods, isEmpty);
+      expect(methods, hasLength(1));
+    });
+
+    group('then endpoint method parameter', () {
+      test('is defined.', () {
+        var parameters =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.parameters;
+        expect(parameters, hasLength(1));
+      });
+
+      test('has expected name.', () {
+        var name = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.name;
+        expect(name, 'stream');
+      });
+
+      test('has stream type.', () {
+        var type = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.type;
+        expect(type?.className, 'Stream');
+      });
+
+      test('has dynamic generic,', () {
+        var generic = endpointDefinitions.firstOrNull?.methods.firstOrNull
+            ?.parameters.firstOrNull?.type.generics.firstOrNull;
+        expect(generic?.className, 'dynamic');
+      });
     });
   });
 
@@ -645,7 +665,7 @@ class ExampleEndpoint extends Endpoint {
       expect(collector.errors, hasLength(1));
       expect(
         collector.errors.firstOrNull?.message,
-        'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
+        'The type "Stream" does not support void generic type.',
       );
     });
 
@@ -683,23 +703,43 @@ class ExampleEndpoint extends Endpoint {
       analyzer = EndpointsAnalyzer(testDirectory);
       endpointDefinitions = await analyzer.analyze(collector: collector);
     });
-    test(
-        'then a validation error is reported that informs the type is not supported.',
-        () {
-      expect(collector.errors, hasLength(1));
-      expect(
-        collector.errors.firstOrNull?.message,
-        'The type "Stream" must have a concrete type defined. E.g. Stream<String>.',
-      );
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
     });
 
     test('then endpoint definition is created.', () {
       expect(endpointDefinitions, hasLength(1));
     });
 
-    test('then endpoint definition method is not defined.', () {
+    test('then endpoint method definition is created.', () {
       var methods = endpointDefinitions.firstOrNull?.methods;
-      expect(methods, isEmpty);
+      expect(methods, hasLength(1));
+    });
+
+    group('then endpoint method parameter', () {
+      test('is defined.', () {
+        var parameters =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.parameters;
+        expect(parameters, hasLength(1));
+      });
+
+      test('has expected name.', () {
+        var name = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.name;
+        expect(name, 'stream');
+      });
+
+      test('has stream type.', () {
+        var type = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.type;
+        expect(type?.className, 'Stream');
+      });
+
+      test('has dynamic generic,', () {
+        var generic = endpointDefinitions.firstOrNull?.methods.firstOrNull
+            ?.parameters.firstOrNull?.type.generics.firstOrNull;
+        expect(generic?.className, 'dynamic');
+      });
     });
   });
 
@@ -727,23 +767,45 @@ class ExampleEndpoint extends Endpoint {
       analyzer = EndpointsAnalyzer(testDirectory);
       endpointDefinitions = await analyzer.analyze(collector: collector);
     });
-    test(
-        'then a validation error is reported that informs the type is not supported.',
-        () {
-      expect(collector.errors, hasLength(1));
-      expect(
-        collector.errors.firstOrNull?.message,
-        'Nullable types are not supported for "Stream" parameters.',
-      );
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
     });
 
     test('then endpoint definition is created.', () {
       expect(endpointDefinitions, hasLength(1));
     });
 
-    test('then endpoint definition method is not defined.', () {
+    test('then endpoint method definition is created.', () {
       var methods = endpointDefinitions.firstOrNull?.methods;
-      expect(methods, isEmpty);
+      expect(methods, hasLength(1));
+    });
+
+    group('then endpoint method parameter', () {
+      test('is defined.', () {
+        var parameters =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.parameters;
+        expect(parameters, hasLength(1));
+      });
+
+      test('has expected name.', () {
+        var name = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.name;
+        expect(name, 'stream');
+      });
+
+      test('has stream type.', () {
+        var type = endpointDefinitions
+            .firstOrNull?.methods.firstOrNull?.parameters.firstOrNull?.type;
+        expect(type?.className, 'Stream');
+      });
+
+      test('has nullable string generic,', () {
+        var generic = endpointDefinitions.firstOrNull?.methods.firstOrNull
+            ?.parameters.firstOrNull?.type.generics.firstOrNull;
+        expect(generic?.className, 'String');
+        expect(generic?.nullable, isTrue);
+      });
     });
   });
 }

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -410,26 +410,29 @@ class ExampleEndpoint extends Endpoint {
       endpointDefinitions = await analyzer.analyze(collector: collector);
     });
 
-    test('then a validation errors is reported.', () {
-      expect(collector.errors, hasLength(1));
-    });
-
-    test(
-        'then validation error informs that nullable return types are not supported.',
-        () {
-      expect(
-        collector.errors.firstOrNull?.message,
-        'Nullable return type for streaming methods are not supported.',
-      );
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
     });
 
     test('then endpoint definition is created.', () {
       expect(endpointDefinitions, hasLength(1));
     });
 
-    test('then no endpoint method definition is created.', () {
-      var methods = endpointDefinitions.firstOrNull?.methods;
-      expect(methods, isEmpty);
+    group('then endpoint method definition', () {
+      test('is a method stream definition.', () {
+        var methodDefinition =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull;
+        expect(methodDefinition, isA<MethodStreamDefinition>());
+      });
+
+      test('has stream return type.', () {
+        var returnType =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.returnType;
+        expect(returnType?.className, 'Stream');
+        expect(returnType?.generics, hasLength(1));
+        expect(returnType?.generics.firstOrNull?.className, 'String');
+        expect(returnType?.generics.firstOrNull?.nullable, isTrue);
+      });
     });
   });
 
@@ -458,26 +461,29 @@ class ExampleEndpoint extends Endpoint {
       endpointDefinitions = await analyzer.analyze(collector: collector);
     });
 
-    test('then a validation errors is reported.', () {
-      expect(collector.errors, hasLength(1));
-    });
-
-    test(
-        'then validation error informs that nullable return types are not supported.',
-        () {
-      expect(
-        collector.errors.firstOrNull?.message,
-        'Nullable return type for streaming methods are not supported.',
-      );
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
     });
 
     test('then endpoint definition is created.', () {
       expect(endpointDefinitions, hasLength(1));
     });
 
-    test('then no endpoint method definition is created.', () {
-      var methods = endpointDefinitions.firstOrNull?.methods;
-      expect(methods, isEmpty);
+    group('then endpoint method definition', () {
+      test('is a method stream definition.', () {
+        var methodDefinition =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull;
+        expect(methodDefinition, isA<MethodStreamDefinition>());
+      });
+
+      test('has future return type.', () {
+        var returnType =
+            endpointDefinitions.firstOrNull?.methods.firstOrNull?.returnType;
+        expect(returnType?.className, 'Future');
+        expect(returnType?.generics, hasLength(1));
+        expect(returnType?.generics.firstOrNull?.className, 'String');
+        expect(returnType?.generics.firstOrNull?.nullable, isTrue);
+      });
     });
   });
 


### PR DESCRIPTION
Connected to #2338 

### Change:
- Add support for nullable types in streams now that we support deserializing and serializing streams.
- Add support for dynamic types in streams.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this touches unreleased features.