### PR TITLE
fix: Handle nullable stream parameters for Method Streams.

### DIFF
--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -219,6 +219,27 @@ abstract class EndpointDispatch {
 
     return deserializedParams;
   }
+
+  /// Parses a list of requested input stream parameter descriptions and returns
+  /// a list of stream parameter descriptions.
+  ///
+  /// Throws an exception if a required input stream parameter is missing.
+  static List<StreamParameterDescription> parseRequestedInputStreams({
+    required Map<String, StreamParameterDescription> descriptions,
+    required List<String> requestedInputStreams,
+  }) {
+    var streamDescriptions = <StreamParameterDescription>[];
+    for (var description in descriptions.values) {
+      if (requestedInputStreams.contains(description.name)) {
+        streamDescriptions.add(description);
+      } else if (!description.nullable) {
+        throw Exception(
+            'Missing required stream parameter: ${description.name}');
+      }
+    }
+
+    return streamDescriptions;
+  }
 }
 
 /// The [EndpointConnector] associates a name with and endpoint and its

--- a/packages/serverpod/test/endpoint/parse_parameters_test.dart
+++ b/packages/serverpod/test/endpoint/parse_parameters_test.dart
@@ -82,6 +82,19 @@ void main() {
         throwsA(isA<Exception>()),
       );
     });
+
+    test(
+        'when parsing parameter string with additional parameter then additional parameter is ignored',
+        () {
+      expect(
+        EndpointDispatch.parseParameters(
+          '{"arg1": 42, "arg2": "ignored"}',
+          parameterDescriptions,
+          Protocol(),
+        ),
+        {'arg1': 42},
+      );
+    });
   });
 
   group('Given single nullable parameter description', () {

--- a/packages/serverpod/test/endpoint/parse_requested_input_streams_test.dart
+++ b/packages/serverpod/test/endpoint/parse_requested_input_streams_test.dart
@@ -1,0 +1,151 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'Given no parameter descriptions when empty parameter list is provided then empty list is returned.',
+      () {
+    expect(
+      EndpointDispatch.parseRequestedInputStreams(
+        descriptions: {},
+        requestedInputStreams: [],
+      ),
+      [],
+    );
+  });
+
+  group('Given single non nullable parameter description', () {
+    var streamParameterName = 'stream1';
+    var streamParameterDescription = {
+      streamParameterName: StreamParameterDescription<int>(
+        name: streamParameterName,
+        nullable: false,
+      ),
+    };
+    test(
+        'when valid stream name is provided then stream description is returned.',
+        () {
+      var result = EndpointDispatch.parseRequestedInputStreams(
+        descriptions: streamParameterDescription,
+        requestedInputStreams: [streamParameterName],
+      );
+
+      expect(result, hasLength(1));
+      expect(result, [streamParameterDescription[streamParameterName]]);
+    });
+
+    test(
+        'when invalid stream name is provided then exception is thrown informing that required stream parameter is missing.',
+        () {
+      expect(
+        () => EndpointDispatch.parseRequestedInputStreams(
+          descriptions: streamParameterDescription,
+          requestedInputStreams: ['invalid_stream_name'],
+        ),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'exception',
+            'Exception: Missing required stream parameter: $streamParameterName')),
+      );
+    });
+
+    test(
+        'when additional stream name is provided then only existing stream parameter description is returned.',
+        () {
+      expect(
+        EndpointDispatch.parseRequestedInputStreams(
+          descriptions: streamParameterDescription,
+          requestedInputStreams: [
+            streamParameterName,
+            'additional_stream_name'
+          ],
+        ),
+        [streamParameterDescription[streamParameterName]],
+      );
+    });
+  });
+  group('Given single nullable parameter description', () {
+    var nullableStreamParameterName = 'stream1';
+    var streamParameterDescription = {
+      nullableStreamParameterName: StreamParameterDescription<int>(
+        name: nullableStreamParameterName,
+        nullable: true,
+      ),
+    };
+    test(
+        'when valid stream name is provided then stream description is returned.',
+        () {
+      var result = EndpointDispatch.parseRequestedInputStreams(
+        descriptions: streamParameterDescription,
+        requestedInputStreams: [nullableStreamParameterName],
+      );
+      expect(result, hasLength(1));
+      expect(result, [streamParameterDescription[nullableStreamParameterName]]);
+    });
+
+    test('when no stream name is provided then empty list returned.', () {
+      expect(
+        EndpointDispatch.parseRequestedInputStreams(
+          descriptions: streamParameterDescription,
+          requestedInputStreams: [],
+        ),
+        [],
+      );
+    });
+
+    test(
+        'when additional stream name is provided then only existing stream parameter description is returned.',
+        () {
+      expect(
+        EndpointDispatch.parseRequestedInputStreams(
+          descriptions: streamParameterDescription,
+          requestedInputStreams: [
+            nullableStreamParameterName,
+            'additional_stream_name'
+          ],
+        ),
+        [streamParameterDescription[nullableStreamParameterName]],
+      );
+    });
+  });
+  group('Given multiple non nullable parameter descriptions', () {
+    var streamParameterName1 = 'stream1';
+    var streamParameterName2 = 'stream2';
+    var streamParameterDescription = {
+      streamParameterName1: StreamParameterDescription<int>(
+        name: streamParameterName1,
+        nullable: false,
+      ),
+      streamParameterName2: StreamParameterDescription<int>(
+        name: streamParameterName2,
+        nullable: false,
+      ),
+    };
+    test(
+        'when valid stream names are provided then stream descriptions are returned.',
+        () {
+      var result = EndpointDispatch.parseRequestedInputStreams(
+        descriptions: streamParameterDescription,
+        requestedInputStreams: [streamParameterName1, streamParameterName2],
+      );
+      expect(result, hasLength(2));
+      expect(
+          result,
+          containsAll([
+            streamParameterDescription[streamParameterName1],
+            streamParameterDescription[streamParameterName2]
+          ]));
+    });
+
+    test(
+        'when only one stream name is provided then exception is thrown informing that required stream parameter is missing.',
+        () {
+      expect(
+        () => EndpointDispatch.parseRequestedInputStreams(
+          descriptions: streamParameterDescription,
+          requestedInputStreams: [streamParameterName1],
+        ),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'exception',
+            'Exception: Missing required stream parameter: $streamParameterName2')),
+      );
+    });
+  });
+}

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -150,6 +150,9 @@ class OpenMethodStreamCommand extends WebSocketMessage {
   /// The arguments to pass to the method.
   final String args;
 
+  /// The input streams that should be opened.
+  final List<String> inputStreams;
+
   /// The connection id that uniquely identifies the stream.
   final UuidValue connectionId;
 
@@ -162,7 +165,8 @@ class OpenMethodStreamCommand extends WebSocketMessage {
         method = data['method'],
         args = data['args'],
         connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
-        authentication = data['authentication'];
+        authentication = data['authentication'],
+        inputStreams = List<String>.from(data['inputStreams']);
 
   /// Creates a new [OpenMethodStreamCommand].
   static String buildMessage({
@@ -170,6 +174,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
     required String method,
     required Map<String, dynamic> args,
     required UuidValue connectionId,
+    required List<String> inputStreams,
     String? authentication,
   }) {
     return WebSocketMessage._buildMessage(_messageType, {
@@ -177,6 +182,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
       'method': method,
       'connectionId': connectionId,
       'args': SerializationManager.encodeForProtocol(args),
+      'inputStreams': inputStreams,
       if (authentication != null) 'authentication': authentication,
     });
   }
@@ -187,6 +193,7 @@ class OpenMethodStreamCommand extends WebSocketMessage {
         'method': method,
         'connectionId': SerializationManager.encodeForProtocol(connectionId),
         'args': args,
+        'inputStreams': inputStreams,
         if (authentication != null) 'authentication': authentication,
       }).toString();
 }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -206,12 +206,40 @@ void main() {
       args: {'arg1': 'value1', 'arg2': 2},
       connectionId: const Uuid().v4obj(),
       authentication: 'auth',
+      inputStreams: ['input1'],
     );
     var result = WebSocketMessage.fromJsonString(
       message,
       _TestSerializationManager(),
     );
     expect(result, isA<OpenMethodStreamCommand>());
+  });
+
+  test(
+      'Given an invalid open method stream command json String that has int for input stream when building websocket message from string then UnknownMessageException is thrown having TypeError error type.',
+      () {
+    var message = OpenMethodStreamCommand.buildMessage(
+      endpoint: 'endpoint',
+      method: 'method',
+      args: {'arg1': 'value1', 'arg2': 2},
+      connectionId: const Uuid().v4obj(),
+      authentication: 'auth',
+      inputStreams: ['input1'],
+    );
+
+    // This message is missing the mandatory endpoint field.
+    message = message.replaceAll('"input1"', '1');
+
+    expect(
+      () => WebSocketMessage.fromJsonString(
+        message,
+        _TestSerializationManager(),
+      ),
+      throwsA(
+        isA<UnknownMessageException>()
+            .having((e) => e.error, 'error', isA<TypeError>()),
+      ),
+    );
   });
 
   test(
@@ -223,6 +251,7 @@ void main() {
       args: {'arg1': 'value1', 'arg2': 2},
       connectionId: const Uuid().v4obj(),
       authentication: 'auth',
+      inputStreams: ['input1'],
     );
 
     // This message is missing the mandatory endpoint field.

--- a/tests/serverpod_test_server/test_integration/websockets/method_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websocket_connection_test.dart
@@ -48,6 +48,7 @@ void main() {
         endpoint: endpoint,
         method: 'intEchoStream',
         args: {},
+        inputStreams: ['stream'],
         connectionId: const Uuid().v4obj(),
       ));
     });
@@ -90,6 +91,7 @@ void main() {
         endpoint: endpoint,
         method: 'delayedStreamResponse',
         args: {'delay': 20},
+        inputStreams: [],
         connectionId: const Uuid().v4obj(),
       ));
     });
@@ -132,6 +134,7 @@ void main() {
         endpoint: endpoint,
         method: 'delayedPausedInputStream',
         args: {'delay': 20},
+        inputStreams: ['stream'],
         connectionId: const Uuid().v4obj(),
       ));
     });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -61,6 +61,7 @@ void main() {
           method: method,
           args: {'delay': 10},
           connectionId: connectionId,
+          inputStreams: [],
         ));
 
         await delayedResponseOpen.future.timeout(
@@ -151,6 +152,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputStreamParameter],
         ));
 
         await streamOpened.future;
@@ -217,6 +219,7 @@ void main() {
         method: method,
         args: {'delay': 20},
         connectionId: connectionId,
+        inputStreams: [],
       ));
     });
 
@@ -271,6 +274,7 @@ void main() {
         method: method,
         args: {'delay': 20},
         connectionId: connectionId,
+        inputStreams: ['stream'],
       ));
     });
 
@@ -325,6 +329,7 @@ void main() {
         method: method,
         args: {'delay': 20},
         connectionId: connectionId,
+        inputStreams: ['stream'],
       ));
     });
 
@@ -422,6 +427,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputParameter],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_return_websocket_connection_test.dart
@@ -58,6 +58,7 @@ void main() {
         method: method,
         args: {'value': 4},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       await streamOpened.future;
@@ -145,6 +146,7 @@ void main() {
         method: keepAliveMethod,
         args: {},
         connectionId: keepAliveConnectionId,
+        inputStreams: ['stream'],
       ));
 
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
@@ -152,6 +154,7 @@ void main() {
         method: closeMethod,
         args: {'value': 4},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       await streamOpened.future;
@@ -238,6 +241,7 @@ void main() {
         method: method,
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       await streamOpened.future;
@@ -312,6 +316,7 @@ void main() {
         method: method,
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       await streamOpened.future;
@@ -398,6 +403,7 @@ void main() {
         method: keepAliveMethod,
         args: {},
         connectionId: keepAliveConnectionId,
+        inputStreams: ['stream'],
       ));
 
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
@@ -405,6 +411,7 @@ void main() {
         method: throwMethod,
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       await streamOpened.future;
@@ -505,6 +512,7 @@ void main() {
         method: keepAliveMethod,
         args: {},
         connectionId: keepAliveConnectionId,
+        inputStreams: ['stream'],
       ));
 
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
@@ -512,6 +520,7 @@ void main() {
         method: throwMethod,
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_message_test.dart
@@ -97,6 +97,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: ['stream'],
         ));
 
         await streamOpened.future;
@@ -168,6 +169,7 @@ void main() {
           method: method,
           args: {'value': inputValue},
           connectionId: connectionId,
+          inputStreams: [],
         ));
 
         await streamOpened.future.timeout(
@@ -259,6 +261,7 @@ void main() {
           method: method,
           args: {'value': inputValue},
           connectionId: connectionId,
+          inputStreams: [],
         ));
 
         await streamOpened.future.timeout(
@@ -353,6 +356,7 @@ void main() {
           method: 'delayedStreamResponse',
           args: {'delay': 10},
           connectionId: delayedResponseConnectionId,
+          inputStreams: [],
         ));
 
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
@@ -360,6 +364,7 @@ void main() {
           method: 'directVoidReturnWithStreamInput',
           args: {},
           connectionId: returningStreamConnectionId,
+          inputStreams: ['stream'],
         ));
 
         await Future.wait([
@@ -440,6 +445,7 @@ void main() {
           method: 'delayedStreamResponse',
           args: {'delay': 10},
           connectionId: delayedResponseConnectionId,
+          inputStreams: [],
         ));
 
         webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
@@ -447,6 +453,7 @@ void main() {
           method: 'simpleStream',
           args: {},
           connectionId: returningStreamConnectionId,
+          inputStreams: [],
         ));
 
         await Future.wait([
@@ -546,6 +553,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: ['stream'],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_stream_serializable_exception_test.dart
@@ -72,6 +72,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputParameter],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/dynamic_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/dynamic_stream_test.dart
@@ -84,6 +84,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputParameter],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
@@ -81,6 +81,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputParameter],
         ));
 
         await streamOpened.future;
@@ -208,6 +209,7 @@ void main() {
           method: method,
           args: {'value': inputValue},
           connectionId: connectionId,
+          inputStreams: [],
         ));
 
         await streamOpened.future;
@@ -317,6 +319,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputParameter],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
@@ -76,6 +76,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputStreamParameter1, inputStreamParameter2],
         ));
 
         await streamOpened.future;
@@ -177,6 +178,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [closedStreamParameter, openStreamParameter],
         ));
 
         await streamOpened.future;
@@ -289,6 +291,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputStreamParameter1, inputStreamParameter2],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
@@ -80,6 +80,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputParameter],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
@@ -80,6 +80,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [inputParameter],
         ));
 
         await streamOpened.future;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -32,6 +32,7 @@ void main() {
         method: 'method',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       var response = await webSocket.stream.first as String;
@@ -58,6 +59,7 @@ void main() {
         method: 'this is not an existing method',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       var response = await webSocket.stream.first as String;
@@ -84,6 +86,7 @@ void main() {
         method: 'methodCallEndpoint',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       var response = await webSocket.stream.first as String;
@@ -110,6 +113,7 @@ void main() {
         method: 'simpleStream',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       var response = await webSocket.stream.first as String;
@@ -136,6 +140,7 @@ void main() {
         method: 'simpleStreamWithParameter',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       var response = await webSocket.stream.first as String;
@@ -162,6 +167,7 @@ void main() {
         method: 'simpleStreamWithParameter',
         args: {'value': 42},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
       ));
 
       var response = await webSocket.stream.first as String;
@@ -188,6 +194,7 @@ void main() {
         method: 'simpleInputReturnStream',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: ['stream'],
       ));
 
       var response = webSocket.stream.first;
@@ -218,6 +225,7 @@ void main() {
         method: 'simpleStream',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
         // No authentication token is provided
       ));
 
@@ -245,6 +253,7 @@ void main() {
         method: 'simpleStream',
         args: {},
         connectionId: const Uuid().v4obj(),
+        inputStreams: [],
         authentication: 'invalid token',
       ));
 
@@ -291,6 +300,7 @@ void main() {
           args: {},
           connectionId: const Uuid().v4obj(),
           authentication: token,
+          inputStreams: [],
         ));
 
         var response = await webSocket.stream.first as String;
@@ -341,6 +351,7 @@ void main() {
           args: {},
           connectionId: const Uuid().v4obj(),
           authentication: token,
+          inputStreams: [],
         ));
 
         var response = await webSocket.stream.first as String;

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/open_method_stream_command_test.dart
@@ -160,6 +160,33 @@ void main() {
     });
 
     test(
+        'when an open method stream command is sent without required input stream then OpenMethodStreamResponse type "invalidArguments" is received.',
+        () async {
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: 'methodStreaming',
+        method: 'intEchoStream',
+        args: {},
+        connectionId: const Uuid().v4obj(),
+        inputStreams: [],
+      ));
+
+      var response = await webSocket.stream.first as String;
+      var message = WebSocketMessage.fromJsonString(
+        response,
+        server.serializationManager,
+      );
+      ;
+
+      expect(
+          message,
+          isA<OpenMethodStreamResponse>().having(
+            (m) => m.responseType,
+            'responseType',
+            OpenMethodStreamResponseType.invalidArguments,
+          ));
+    });
+
+    test(
         'when a open method stream command is sent with required argument then OpenMethodStreamResponse type "success" is received.',
         () async {
       webSocket.sink.add(OpenMethodStreamCommand.buildMessage(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
@@ -55,6 +55,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: ['stream'],
         ));
 
         await streamOpened.future.timeout(
@@ -113,6 +114,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [],
         ));
 
         await streamOpened.future.timeout(
@@ -179,6 +181,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: ['stream'],
         ));
 
         await streamOpened.future.timeout(
@@ -263,6 +266,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
+          inputStreams: [],
         ));
 
         await streamOpened.future.timeout(

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
@@ -54,6 +54,13 @@ abstract class EndpointParameterAnalyzer {
           }
 
           if (type.isDartAsyncStream && type is ParameterizedType) {
+            if (type.nullabilitySuffix != NullabilitySuffix.none) {
+              return SourceSpanSeverityException(
+                'Nullable parameters of the type "Stream" are not supported.',
+                parameter.span,
+              );
+            }
+
             var typeArguments = type.typeArguments;
             if (typeArguments.length != 1) {
               // Streams only allow a single generic so this case is only here for safety.

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_parameter_test.dart
@@ -808,4 +808,139 @@ class ExampleEndpoint extends Endpoint {
       });
     });
   });
+
+  group(
+      'Given an endpoint method with a nullable Stream parameter when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, Stream<String>? stream) async {
+    return await stream?.first ?? 'Hello';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test(
+        'then a validation error is reported that informs the nullable stream parameters are not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'Nullable parameters of the type "Stream" are not supported.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method with a nullable optional Stream parameter when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, [Stream<String>? stream]) async {
+    return await stream?.first ?? 'Hello';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test(
+        'then a validation error is reported that informs the optional stream parameters are not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'Nullable parameters of the type "Stream" are not supported.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method with a nullable named Stream parameter when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, {Stream<String>? stream}) async {
+    return await stream?.first ?? 'Hello';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test(
+        'then a validation error is reported that informs the nullable named stream parameters are not supported.',
+        () {
+      expect(collector.errors, hasLength(1));
+      expect(
+        collector.errors.firstOrNull?.message,
+        'Nullable parameters of the type "Stream" are not supported.',
+      );
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method is not defined.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
Another stepping stone towards #2338:

To preserve backwards compatibility for an endpoint, new parameters are added as optional. However, adding a new parameter as a stream parameter would break compatibility with existing clients by transforming the endpoint from a method call to a method stream.

To prevent this unexpected API-breaking change, we will not allow stream parameters to be nullable.

Since this issue is solvable (e.g., by allowing method calls to invoke streams without the optional stream parameter), we will add information to the OpenMethodStreamCommand listing the stream parameters the stream should open. This approach enables future support for nullable streams without breaking the current protocol.

### Change
- Adds the input streams that should be opened to the OpenMethodStreamCommand.
- Rejects open method stream requests that don't include all required input stream parameters.
- Prevents nullable streams from being used in endpoint methods.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - touches a feature that has not yet been released.