### PR TITLE
fix: change stderr writeline to print and remove dart:io dependency.

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -276,6 +276,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
         }
       });
     } catch (e) {
+      // ignore: avoid_print
       print('Failed to open streaming connection: $e');
       _webSocket = null;
       _cancelConnectionTimer();
@@ -315,6 +316,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
       _webSocket = null;
       _cancelConnectionTimer();
     } catch (e) {
+      // ignore: avoid_print
       print('Error while listening to websocket stream: $e');
       _webSocket = null;
       _cancelConnectionTimer();

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:serverpod_client/serverpod_client.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -277,7 +276,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
         }
       });
     } catch (e) {
-      stderr.writeln('Failed to open streaming connection: $e');
+      print('Failed to open streaming connection: $e');
       _webSocket = null;
       _cancelConnectionTimer();
       rethrow;
@@ -316,7 +315,7 @@ abstract class ServerpodClientShared extends EndpointCaller {
       _webSocket = null;
       _cancelConnectionTimer();
     } catch (e) {
-      stderr.writeln('Error while listening to websocket stream: $e');
+      print('Error while listening to websocket stream: $e');
       _webSocket = null;
       _cancelConnectionTimer();
     }


### PR DESCRIPTION
While implementing the new method streams, I noticed that we had accidentally added a dependency towards `dart:io` in some shared client code used inside the browser client.

This PR removes that dependency.

I find it very strange that our browser tests don't pick this issue up.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.