### PR TITLE
fix: Verify Google ID Token correctly

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
@@ -149,7 +149,8 @@ class GoogleEndpoint extends Endpoint {
       }
 
       var data = jsonDecode(response.body);
-      if (data['iss'] != 'accounts.google.com') {
+      if (data['iss'] != 'accounts.google.com' &&
+          data['iss'] != 'https://accounts.google.com') {
         session.log('Invalid token received', level: LogLevel.debug);
         return AuthenticationResponse(
           success: false,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/google_endpoint.dart
@@ -149,8 +149,8 @@ class GoogleEndpoint extends Endpoint {
       }
 
       var data = jsonDecode(response.body);
-      if (data['iss'] != 'accounts.google.com' &&
-          data['iss'] != 'https://accounts.google.com') {
+      if (!(data['iss'] == 'accounts.google.com' ||
+          data['iss'] == 'https://accounts.google.com')) {
         session.log('Invalid token received', level: LogLevel.debug);
         return AuthenticationResponse(
           success: false,


### PR DESCRIPTION
While trying to work around sign in with Google on Windows using [google_sign_in_dartio](https://pub.dev/packages/google_sign_in_dartio), I managed to sign in thru the windows frontend but failed on back end. After some digging into the auth module, I found that it was caused by the `authenticateWithIdToken` function in `google_endpoint.dart` failing to verify a valid ID token with `iss` equals `https://accounts.google.com`.

According to [Verify the Google ID token on your server side](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token):

> The value of `iss` in the ID token is equal to `accounts.google.com` or `https://accounts.google.com`.

This PR fixed #2536 auth issues related to ID token flow.

It may also fixed #2354, but I do not have a Mac device to verify it.

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None