### PR TITLE
Allow static content to not be cached, by path regexp

### DIFF
--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -20,11 +20,17 @@ final _contentTypeMapping = <String, ContentType>{
   '.pdf': ContentType('application', 'pdf'),
 };
 
+/// A path pattern to match, and the max age that paths that match the pattern
+/// should be cached for, in seconds.
 class PathCacheMaxAge {
   final Pattern pathPattern;
   final int maxAge;
 
+  /// A value for [maxAge] that indicates that the path should not be cached.
   static const noCache = 0;
+
+  /// A value for [maxAge] that indicates that the path should be cached for
+  /// one year.
   static const oneYear = 31536000;
 
   PathCacheMaxAge({

--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -38,11 +38,17 @@ class PathCacheMaxAge {
     required this.maxAge,
   });
 
-  bool _shouldCache(String path) => pathPattern is String
-      ? path == pathPattern
-      : pathPattern is RegExp
-          ? (pathPattern as RegExp).hasMatch(path)
-          : false;
+bool _shouldCache(String path) {
+  var pattern = pathPattern;
+
+  if (pattern is String) {
+    return path == pattern;
+  } else if (pattern is RegExp) {
+    return pattern.hasMatch(path);
+  }
+
+  return false;
+}
 }
 
 /// Route for serving a directory of static files.

--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -83,12 +83,13 @@ class RouteStaticDirectory extends Route {
         request.response.headers.contentType = contentType;
       }
 
-      // Enforce strong cache control.
       var regexp = noCachePathRegexp;
       request.response.headers.set(
         'Cache-Control',
         regexp != null && regexp.hasMatch(path)
+            // Don't cache this path
             ? 'max-age=0, s-maxage=0, no-cache, no-store'
+            // Enforce strong cache control
             : 'max-age=31536000',
       );
 

--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -41,7 +41,7 @@ class RouteStaticDirectory extends Route {
     String? noCachePathPattern,
   }) {
     // Pre-compile the regexp pattern, if provided
-    final regexpPath = noCachePathPattern;
+    var regexpPath = noCachePathPattern;
     noCachePathRegexp = regexpPath == null ? null : RegExp(regexpPath);
   }
 

--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -84,12 +84,13 @@ class RouteStaticDirectory extends Route {
       }
 
       // Enforce strong cache control.
-      if (noCachePathRegexp != null && noCachePathRegexp!.hasMatch(path)) {
-        request.response.headers
-            .set('Cache-Control', 'max-age=0, s-maxage=0, no-cache, no-store');
-      } else {
-        request.response.headers.set('Cache-Control', 'max-age=31536000');
-      }
+      var regexp = noCachePathRegexp;
+      request.response.headers.set(
+        'Cache-Control',
+        regexp != null && regexp.hasMatch(path)
+            ? 'max-age=0, s-maxage=0, no-cache, no-store'
+            : 'max-age=31536000',
+      );
 
       var filePath = path.startsWith('/') ? path.substring(1) : path;
       filePath = 'web/$filePath';


### PR DESCRIPTION
Allow static paths to be excluded from CDN caching, by regexp match.

Partially addresses #2534, although for that to be fixed, dynamic responses should also include these same cache denial headers. (I didn't make that change in this PR, but it needs to be done...)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
