### PR TITLE
Allow for rewrite rule for root path

### DIFF
--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -43,7 +43,7 @@ class RouteStaticDirectory extends Route {
 
     var path = Uri.decodeFull(session.uri.path);
 
-    var rootPath = serverAsRootPath;
+    var rootPath = serveAsRootPath;
     if (rootPath != null && path == '/') {
       path = rootPath;
     }

--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -43,8 +43,9 @@ class RouteStaticDirectory extends Route {
 
     var path = Uri.decodeFull(session.uri.path);
 
-    if (serveAsRootPath != null && path == '/') {
-      path = serveAsRootPath!;
+    var rootPath = serverAsRootPath;
+    if (rootPath != null && path == '/') {
+      path = rootPath;
     }
 
     try {

--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -27,14 +27,25 @@ class RouteStaticDirectory extends Route {
   /// The path to the directory to serve static files from.
   final String? basePath;
 
+  /// The path to serve as the root path ('/'), e.g. '/index.html'.
+  final String? serveAsRootPath;
+
   /// Creates a static directory with the [serverDirectory] as its root.
-  RouteStaticDirectory({required this.serverDirectory, this.basePath});
+  RouteStaticDirectory({
+    required this.serverDirectory,
+    this.basePath,
+    this.serveAsRootPath,
+  });
 
   @override
   Future<bool> handleCall(Session session, HttpRequest request) async {
     session as MethodCallSession;
 
     var path = Uri.decodeFull(session.uri.path);
+
+    if (serveAsRootPath != null && path == '/') {
+      path = serveAsRootPath!;
+    }
 
     try {
       // Remove version control string


### PR DESCRIPTION
Allows `/index.html` (or any other page) to be served statically at path `/`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
