### PR TITLE
fix: Create a standalone Session class for the webserver.

### DIFF
--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -126,26 +126,15 @@ class WebServer {
       }
     }
 
-    WebCallSession session;
-    try {
-      // TODO: Fix body
-      session = WebCallSession(
-        server: serverpod.server,
-        uri: uri,
-        path: uri.path,
-        queryParameters: request.uri.queryParameters,
-        authenticationKey: authenticationKey,
-        httpRequest: request,
-      );
-    } catch (e) {
-      // Triggered if the URI query parameters are malformed
-      if (serverpod.runtimeSettings.logMalformedCalls) {
-        logError('Malformed call: $e');
-      }
-      request.response.statusCode = HttpStatus.badRequest;
-      await request.response.close();
-      return;
-    }
+    // TODO: Fix body
+    WebCallSession session = WebCallSession(
+      server: serverpod.server,
+      uri: uri,
+      path: uri.path,
+      queryParameters: request.uri.queryParameters,
+      authenticationKey: authenticationKey,
+      httpRequest: request,
+    );
 
     // Check routes
     for (var route in routes) {

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -126,10 +126,10 @@ class WebServer {
       }
     }
 
-    MethodCallSession session;
+    WebCallSession session;
     try {
       // TODO: Fix body
-      session = MethodCallSession(
+      session = WebCallSession(
         server: serverpod.server,
         uri: uri,
         path: 'webserver',

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -129,14 +129,10 @@ class WebServer {
     var queryParameters = request.uri.queryParameters;
     authenticationKey ??= queryParameters['auth'];
 
-    // TODO: Fix body
     WebCallSession session = WebCallSession(
       server: serverpod.server,
-      uri: uri,
       path: uri.path,
-      queryParameters: queryParameters,
       authenticationKey: authenticationKey,
-      httpRequest: request,
     );
 
     // Check routes

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -132,8 +132,8 @@ class WebServer {
       session = WebCallSession(
         server: serverpod.server,
         uri: uri,
-        path: 'webserver',
-        body: '',
+        path: uri.path,
+        queryParameters: request.uri.queryParameters,
         authenticationKey: authenticationKey,
         httpRequest: request,
       );

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -126,12 +126,15 @@ class WebServer {
       }
     }
 
+    var queryParameters = request.uri.queryParameters;
+    authenticationKey ??= queryParameters['auth'];
+
     // TODO: Fix body
     WebCallSession session = WebCallSession(
       server: serverpod.server,
       uri: uri,
       path: uri.path,
-      queryParameters: request.uri.queryParameters,
+      queryParameters: queryParameters,
       authenticationKey: authenticationKey,
       httpRequest: request,
     );

--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -131,7 +131,7 @@ class WebServer {
 
     WebCallSession session = WebCallSession(
       server: serverpod.server,
-      path: uri.path,
+      endpointName: uri.path,
       authenticationKey: authenticationKey,
     );
 

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -111,24 +111,18 @@ abstract class EndpointDispatch {
     // Get the the authentication key, if any
     String? authenticationKey = queryParameters['auth'];
 
-    MethodCallSession session;
-
-    try {
-      session = MethodCallSession(
-        server: server,
-        uri: uri,
-        body: body,
-        path: path,
-        httpRequest: request,
-        methodName: methodName,
-        endpointName: endpointName,
-        queryParameters: queryParameters,
-        authenticationKey: authenticationKey,
-        enableLogging: connector.endpoint.logSessions,
-      );
-    } catch (e) {
-      return ResultInvalidParams('Malformed call: $uri');
-    }
+    MethodCallSession session = MethodCallSession(
+      server: server,
+      uri: uri,
+      body: body,
+      path: path,
+      httpRequest: request,
+      methodName: methodName,
+      endpointName: endpointName,
+      queryParameters: queryParameters,
+      authenticationKey: authenticationKey,
+      enableLogging: connector.endpoint.logSessions,
+    );
 
     try {
       var endpoint = connector.endpoint;

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -81,7 +81,11 @@ abstract class EndpointDispatch {
     // Read query parameters
     var queryParameters = <String, dynamic>{};
     if (body != '' && body != 'null') {
-      queryParameters = jsonDecode(body).cast<String, dynamic>();
+      try {
+        queryParameters = jsonDecode(body).cast<String, dynamic>();
+      } catch (_) {
+        return ResultInvalidParams('Invalid JSON in body: $body');
+      }
     }
 
     // Add query parameters from uri

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -102,7 +102,7 @@ abstract class EndpointDispatch {
       if (method is String) {
         methodName = method;
       } else {
-        throw FormatException(
+        return ResultInvalidParams(
           'No method name specified in call to $endpointName',
         );
       }

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -78,6 +78,39 @@ abstract class EndpointDispatch {
       return ResultInvalidParams('Endpoint $path does not exist');
     }
 
+    // Read query parameters
+    var queryParameters = <String, dynamic>{};
+    if (body != '' && body != 'null') {
+      queryParameters = jsonDecode(body).cast<String, dynamic>();
+    }
+
+    // Add query parameters from uri
+    queryParameters.addAll(uri.queryParameters);
+
+    String endpointName;
+    String methodName;
+
+    if (path.contains('/')) {
+      // Using the new path format (for OpenAPI)
+      var pathComponents = path.split('/');
+      endpointName = pathComponents[0];
+      methodName = pathComponents[1];
+    } else {
+      // Using the standard format with query parameters
+      endpointName = path;
+      var method = queryParameters['method'];
+      if (method is String) {
+        methodName = method;
+      } else {
+        throw FormatException(
+          'No method name specified in call to $endpointName',
+        );
+      }
+    }
+
+    // Get the the authentication key, if any
+    String? authenticationKey = queryParameters['auth'];
+
     MethodCallSession session;
 
     try {
@@ -87,14 +120,15 @@ abstract class EndpointDispatch {
         body: body,
         path: path,
         httpRequest: request,
+        methodName: methodName,
+        endpointName: endpointName,
+        queryParameters: queryParameters,
+        authenticationKey: authenticationKey,
         enableLogging: connector.endpoint.logSessions,
       );
     } catch (e) {
       return ResultInvalidParams('Malformed call: $uri');
     }
-
-    var methodName = session.methodName;
-    var inputParams = session.queryParameters;
 
     try {
       var endpoint = connector.endpoint;
@@ -117,11 +151,11 @@ abstract class EndpointDispatch {
       // TODO: Check parameters and check null safety
 
       var paramMap = <String, dynamic>{};
-      for (var paramName in inputParams.keys) {
+      for (var paramName in queryParameters.keys) {
         var type = method.params[paramName]?.type;
         if (type == null) continue;
         var formatted = _formatArg(
-            inputParams[paramName], type, server.serializationManager);
+            queryParameters[paramName], type, server.serializationManager);
         paramMap[paramName] = formatted;
       }
 

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -254,17 +253,11 @@ class MethodCallSession extends Session {
   final String body;
 
   /// Query parameters of the server call.
-  late final Map<String, dynamic> queryParameters;
+  final Map<String, dynamic> queryParameters;
 
-  /// The name of the called [Endpoint].
-  late final String _endpointName;
-
-  @override
-  String get endpointName => _endpointName;
+  final String _methodName;
 
   /// The name of the method that is being called.
-  late final String _methodName;
-
   @override
   String get methodName => _methodName;
 
@@ -278,59 +271,24 @@ class MethodCallSession extends Session {
     required this.body,
     required String path,
     required this.httpRequest,
+    required super.endpointName,
+    required String methodName,
+    required this.queryParameters,
     String? authenticationKey,
     super.enableLogging = true,
-  }) : super(endpointName: 'MethodCall') {
-    // Read query parameters
-    var queryParameters = <String, dynamic>{};
-    if (body != '' && body != 'null') {
-      queryParameters = jsonDecode(body).cast<String, dynamic>();
-    }
-
-    // Add query parameters from uri
-    queryParameters.addAll(uri.queryParameters);
-    this.queryParameters = queryParameters;
-
-    if (path.contains('/')) {
-      // Using the new path format (for OpenAPI)
-      var pathComponents = path.split('/');
-      _endpointName = pathComponents[0];
-      _methodName = pathComponents[1];
-    } else {
-      // Using the standard format with query parameters
-      _endpointName = path;
-      var methodName = queryParameters['method'];
-      if (methodName == null && path == 'webserver') {
-        _methodName = '';
-      } else if (methodName != null) {
-        _methodName = methodName;
-      } else {
-        throw FormatException(
-          'No method name specified in call to $endpointName',
-        );
-      }
-    }
-
-    // Get the the authentication key, if any
-    _authenticationKey = authenticationKey ?? queryParameters['auth'];
-  }
+  })  : _methodName = methodName,
+        super(methodName: methodName);
 }
 
+/// When a request is made to the web server a [WebCallSession] object is
+/// created. It contains all data associated with the current connection and
+/// provides easy access to the database.
 class WebCallSession extends Session {
   /// The uri that was used to call the server.
   final Uri uri;
 
-  /// The body of the server call.
-  final String body;
-
   /// Query parameters of the server call.
-  late final Map<String, dynamic> queryParameters;
-
-  /// The name of the called [Endpoint].
-  late final String _endpointName;
-
-  @override
-  String get endpointName => _endpointName;
+  final Map<String, dynamic> queryParameters;
 
   /// The [HttpRequest] associated with the call.
   final HttpRequest httpRequest;
@@ -339,9 +297,9 @@ class WebCallSession extends Session {
   WebCallSession({
     required super.server,
     required this.uri,
-    required this.body,
     required String path,
     required this.httpRequest,
+    required this.queryParameters,
     required String? authenticationKey,
     super.enableLogging = true,
   }) : super(endpointName: path);

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -316,6 +316,37 @@ class MethodCallSession extends Session {
   }
 }
 
+class WebCallSession extends Session {
+  /// The uri that was used to call the server.
+  final Uri uri;
+
+  /// The body of the server call.
+  final String body;
+
+  /// Query parameters of the server call.
+  late final Map<String, dynamic> queryParameters;
+
+  /// The name of the called [Endpoint].
+  late final String _endpointName;
+
+  @override
+  String get endpointName => _endpointName;
+
+  /// The [HttpRequest] associated with the call.
+  final HttpRequest httpRequest;
+
+  /// Creates a new [Session] for a method call to an endpoint.
+  WebCallSession({
+    required super.server,
+    required this.uri,
+    required this.body,
+    required String path,
+    required this.httpRequest,
+    required String? authenticationKey,
+    super.enableLogging = true,
+  }) : super(endpointName: path);
+}
+
 /// When a connection is made to the [Server] to an endpoint method that uses a
 /// stream [MethodStreamSession] object is created. It contains all data
 /// associated with the current connection and provides easy access to the

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -284,22 +284,10 @@ class MethodCallSession extends Session {
 /// created. It contains all data associated with the current connection and
 /// provides easy access to the database.
 class WebCallSession extends Session {
-  /// The uri that was used to call the server.
-  final Uri uri;
-
-  /// Query parameters of the server call.
-  final Map<String, dynamic> queryParameters;
-
-  /// The [HttpRequest] associated with the call.
-  final HttpRequest httpRequest;
-
   /// Creates a new [Session] for a method call to an endpoint.
   WebCallSession({
     required super.server,
-    required this.uri,
     required String path,
-    required this.httpRequest,
-    required this.queryParameters,
     required super.authenticationKey,
     super.enableLogging = true,
   }) : super(endpointName: path);

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -287,10 +287,10 @@ class WebCallSession extends Session {
   /// Creates a new [Session] for a method call to an endpoint.
   WebCallSession({
     required super.server,
-    required String path,
+    required super.endpointName,
     required super.authenticationKey,
     super.enableLogging = true,
-  }) : super(endpointName: path);
+  });
 }
 
 /// When a connection is made to the [Server] to an endpoint method that uses a

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -274,7 +274,7 @@ class MethodCallSession extends Session {
     required super.endpointName,
     required String methodName,
     required this.queryParameters,
-    String? authenticationKey,
+    required super.authenticationKey,
     super.enableLogging = true,
   })  : _methodName = methodName,
         super(methodName: methodName);
@@ -300,7 +300,7 @@ class WebCallSession extends Session {
     required String path,
     required this.httpRequest,
     required this.queryParameters,
-    required String? authenticationKey,
+    required super.authenticationKey,
     super.enableLogging = true,
   }) : super(endpointName: path);
 }


### PR DESCRIPTION
# Changes

Depends on: https://github.com/serverpod/serverpod/pull/2483

- Adds a Web server specific Session class
- Refactors the MethodCallSession to parse the HTTP request outside of the session constructor.

Motivation:
The idea is to move all the parsing away from the session creation. The web server and the endpoint dispatcher were using the same session object but in reality, used very different data and logic internally by a lot of branching. Hence splitting them into to distinct classes makes this more obvious.

Discussion point:

What to call this new session? The current name is `WebCallSession` but it doesn't feel like a great name.


Review notes:
The WebCallSession only supports auth tokens via cookie or query params. This is behavior is preserved from the previous implementation. Meaning tokens in body is not supported as it is in endpoint method calls. However the correct implementation is to parse the headers in the future.


Related issue: https://github.com/serverpod/serverpod/issues/2450

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

There is a small potential break in that you will no longer be able to cast the session in relic to a method call session. But we are advertising this feature as experimental hence I think it is okay.