### PR TITLE
refactor: Move currentMessageId into the base session.

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_manager.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import 'package:serverpod/database.dart';
 import 'package:serverpod/src/server/log_manager/log_writer.dart';
 import 'package:serverpod/src/server/log_manager/session_log_cache.dart';
+import 'package:serverpod/src/server/session.dart';
 import 'package:synchronized/synchronized.dart';
 
 import '../../../server.dart';
@@ -93,7 +94,6 @@ class SessionLogManager {
   @internal
   Future<void> logEntry(
     Session session, {
-    int? messageId,
     LogLevel? level,
     required String message,
     String? error,
@@ -102,7 +102,7 @@ class SessionLogManager {
     var entry = LogEntry(
       sessionLogId: _temporarySessionId,
       serverId: _serverId,
-      messageId: messageId,
+      messageId: session.messageId,
       logLevel: level ?? LogLevel.info,
       message: message,
       time: DateTime.now(),
@@ -160,6 +160,7 @@ class SessionLogManager {
       sessionLogId: _temporarySessionId,
       serverId: _serverId,
       query: query,
+      messageId: session.messageId,
       duration: executionTime,
       numRows: numRowsAffected,
       error: error,

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -222,7 +222,6 @@ abstract class Session {
     _logManager?.logEntry(
       this,
       message: message,
-      messageId: _messageId,
       level: level ?? LogLevel.info,
       error: exception?.toString(),
       stackTrace: stackTrace,
@@ -582,7 +581,10 @@ extension SessionInternalMethods on Session {
   SessionLogManager? get logManager => _logManager;
 
   /// Returns the next message id for the session.
-  int currentMessageId() {
+  int? get messageId => _messageId;
+
+  /// Returns the next message id for the session.
+  int nextMessageId() {
     var id = _messageId ?? 0;
     _messageId = id + 1;
 

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -107,15 +107,13 @@ abstract class EndpointWebsocketRequestHandler {
             var duration = DateTime.now().difference(startTime);
             unawaited(session.logManager?.logMessage(
               session,
-              messageId: session.currentMessageId,
+              messageId: session.currentMessageId(),
               endpointName: endpointName,
               messageName: serialization['className'],
               duration: duration,
               error: messageError?.toString(),
               stackTrace: messageStackTrace,
             ));
-
-            session.currentMessageId += 1;
           }
         }
       } catch (e, s) {

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -107,7 +107,7 @@ abstract class EndpointWebsocketRequestHandler {
             var duration = DateTime.now().difference(startTime);
             unawaited(session.logManager?.logMessage(
               session,
-              messageId: session.currentMessageId(),
+              messageId: session.nextMessageId(),
               endpointName: endpointName,
               messageName: serialization['className'],
               duration: duration,

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1045,6 +1045,14 @@ class EndpointStreamLogging extends _i1.EndpointRef {
 }
 
 /// {@category Endpoint}
+class EndpointStreamQueryLogging extends _i1.EndpointRef {
+  EndpointStreamQueryLogging(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'streamQueryLogging';
+}
+
+/// {@category Endpoint}
 class EndpointLoggingDisabled extends _i1.EndpointRef {
   EndpointLoggingDisabled(_i1.EndpointCaller caller) : super(caller);
 
@@ -1670,6 +1678,7 @@ class Client extends _i1.ServerpodClient {
     listParameters = EndpointListParameters(this);
     logging = EndpointLogging(this);
     streamLogging = EndpointStreamLogging(this);
+    streamQueryLogging = EndpointStreamQueryLogging(this);
     loggingDisabled = EndpointLoggingDisabled(this);
     mapParameters = EndpointMapParameters(this);
     methodStreaming = EndpointMethodStreaming(this);
@@ -1722,6 +1731,8 @@ class Client extends _i1.ServerpodClient {
   late final EndpointLogging logging;
 
   late final EndpointStreamLogging streamLogging;
+
+  late final EndpointStreamQueryLogging streamQueryLogging;
 
   late final EndpointLoggingDisabled loggingDisabled;
 
@@ -1776,6 +1787,7 @@ class Client extends _i1.ServerpodClient {
         'listParameters': listParameters,
         'logging': logging,
         'streamLogging': streamLogging,
+        'streamQueryLogging': streamQueryLogging,
         'loggingDisabled': loggingDisabled,
         'mapParameters': mapParameters,
         'methodStreaming': methodStreaming,

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1037,6 +1037,14 @@ class EndpointLogging extends _i1.EndpointRef {
 }
 
 /// {@category Endpoint}
+class EndpointStreamLogging extends _i1.EndpointRef {
+  EndpointStreamLogging(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'streamLogging';
+}
+
+/// {@category Endpoint}
 class EndpointLoggingDisabled extends _i1.EndpointRef {
   EndpointLoggingDisabled(_i1.EndpointCaller caller) : super(caller);
 
@@ -1661,6 +1669,7 @@ class Client extends _i1.ServerpodClient {
     futureCalls = EndpointFutureCalls(this);
     listParameters = EndpointListParameters(this);
     logging = EndpointLogging(this);
+    streamLogging = EndpointStreamLogging(this);
     loggingDisabled = EndpointLoggingDisabled(this);
     mapParameters = EndpointMapParameters(this);
     methodStreaming = EndpointMethodStreaming(this);
@@ -1711,6 +1720,8 @@ class Client extends _i1.ServerpodClient {
   late final EndpointListParameters listParameters;
 
   late final EndpointLogging logging;
+
+  late final EndpointStreamLogging streamLogging;
 
   late final EndpointLoggingDisabled loggingDisabled;
 
@@ -1764,6 +1775,7 @@ class Client extends _i1.ServerpodClient {
         'futureCalls': futureCalls,
         'listParameters': listParameters,
         'logging': logging,
+        'streamLogging': streamLogging,
         'loggingDisabled': loggingDisabled,
         'mapParameters': mapParameters,
         'methodStreaming': methodStreaming,

--- a/tests/serverpod_test_server/lib/src/endpoints/logging.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/logging.dart
@@ -73,3 +73,13 @@ class StreamLogging extends Endpoint {
     session.log('This is a message', level: LogLevel.debug);
   }
 }
+
+class StreamQueryLogging extends Endpoint {
+  @override
+  Future<void> handleStreamMessage(
+    StreamingSession session,
+    SerializableModel message,
+  ) async {
+    await session.db.findFirstRow<SimpleData>();
+  }
+}

--- a/tests/serverpod_test_server/lib/src/endpoints/logging.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/logging.dart
@@ -63,3 +63,13 @@ class LoggingEndpoint extends Endpoint {
     // do nothing
   }
 }
+
+class StreamLogging extends Endpoint {
+  @override
+  Future<void> handleStreamMessage(
+    StreamingSession session,
+    SerializableModel message,
+  ) async {
+    session.log('This is a message', level: LogLevel.debug);
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -163,6 +163,12 @@ class Endpoints extends _i1.EndpointDispatch {
           'streamLogging',
           null,
         ),
+      'streamQueryLogging': _i17.StreamQueryLogging()
+        ..initialize(
+          server,
+          'streamQueryLogging',
+          null,
+        ),
       'loggingDisabled': _i18.LoggingDisabledEndpoint()
         ..initialize(
           server,
@@ -2367,6 +2373,11 @@ class Endpoints extends _i1.EndpointDispatch {
     connectors['streamLogging'] = _i1.EndpointConnector(
       name: 'streamLogging',
       endpoint: endpoints['streamLogging']!,
+      methodConnectors: {},
+    );
+    connectors['streamQueryLogging'] = _i1.EndpointConnector(
+      name: 'streamQueryLogging',
+      endpoint: endpoints['streamQueryLogging']!,
       methodConnectors: {},
     );
     connectors['loggingDisabled'] = _i1.EndpointConnector(

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -157,6 +157,12 @@ class Endpoints extends _i1.EndpointDispatch {
           'logging',
           null,
         ),
+      'streamLogging': _i17.StreamLogging()
+        ..initialize(
+          server,
+          'streamLogging',
+          null,
+        ),
       'loggingDisabled': _i18.LoggingDisabledEndpoint()
         ..initialize(
           server,
@@ -2357,6 +2363,11 @@ class Endpoints extends _i1.EndpointDispatch {
                   .twoQueries(session),
         ),
       },
+    );
+    connectors['streamLogging'] = _i1.EndpointConnector(
+      name: 'streamLogging',
+      endpoint: endpoints['streamLogging']!,
+      methodConnectors: {},
     );
     connectors['loggingDisabled'] = _i1.EndpointConnector(
       name: 'loggingDisabled',

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -127,6 +127,7 @@ logging:
   - logInfo:
   - logDebugAndInfoAndError:
   - twoQueries:
+streamLogging:
 loggingDisabled:
   - logInfo:
 mapParameters:

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -128,6 +128,7 @@ logging:
   - logDebugAndInfoAndError:
   - twoQueries:
 streamLogging:
+streamQueryLogging:
 loggingDisabled:
   - logInfo:
 mapParameters:

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
@@ -194,6 +194,23 @@ void main() async {
     });
 
     test(
+        'Given a log setting with everything turned on when calling a method logging a message then the logs messageId is null.',
+        () async {
+      var settings = RuntimeSettingsBuilder().build();
+
+      await server.updateRuntimeSettings(settings);
+
+      await client.logging.log('message', [LogLevel.debug.toJson()]);
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, isNotEmpty);
+
+      expect(logs.first.logs, isNotEmpty);
+      expect(logs.first.logs.first.messageId, isNull);
+    });
+
+    test(
         'Given a log setting with everything turned on but only accepting info level and below when calling a method logging a message then the log is written but only includes the info level message.',
         () async {
       var settings = RuntimeSettingsBuilder()

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
@@ -109,6 +109,60 @@ void main() async {
     });
 
     test(
+        'Given that continuous logging is turned on when sending a stream message and writing a log without closing the stream then a query log is written.',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(LogSettingsBuilder()
+              .withLogStreamingSessionsContinuously(true)
+              .build())
+          .build();
+      await server.updateRuntimeSettings(settings);
+      await client.openStreamingConnection(
+        disconnectOnLostInternetConnection: false,
+      );
+
+      await client.streamQueryLogging.sendStreamMessage(Types());
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, hasLength(1));
+      expect(logs.first.messages, hasLength(1));
+      expect(logs.first.queries, hasLength(1));
+    });
+
+    test(
+        'Given that continuous logging is turned on when sending a stream message and writing a log without closing the stream then the query logs has the messageId set.',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(LogSettingsBuilder()
+              .withLogStreamingSessionsContinuously(true)
+              .build())
+          .build();
+      await server.updateRuntimeSettings(settings);
+      await client.openStreamingConnection(
+        disconnectOnLostInternetConnection: false,
+      );
+
+      await client.streamQueryLogging.sendStreamMessage(Types());
+      await client.streamQueryLogging.sendStreamMessage(Types());
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, isNotEmpty);
+      expect(logs.first.messages, isNotEmpty);
+      expect(logs.first.queries, isNotEmpty);
+
+      expect(logs.first.queries.first.messageId, 0);
+      expect(logs.first.queries.last.messageId, 1);
+    });
+
+    test(
         'Given that continuous logging is turned off when sending a stream message without closing the connection no log entries are created.',
         () async {
       var settings = RuntimeSettingsBuilder()

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
@@ -52,6 +52,63 @@ void main() async {
     });
 
     test(
+        'Given that continuous logging is turned on when sending several stream messages without closing the connection then the logs are created with different message ids.',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(LogSettingsBuilder()
+              .withLogStreamingSessionsContinuously(true)
+              .build())
+          .build();
+      await server.updateRuntimeSettings(settings);
+      await client.openStreamingConnection(
+        disconnectOnLostInternetConnection: false,
+      );
+
+      await client.logging.sendStreamMessage(Types());
+      await client.logging.sendStreamMessage(Types());
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, isNotEmpty);
+      expect(logs.first.messages, isNotEmpty);
+
+      expect(logs.first.messages.first.messageId, 0);
+      expect(logs.first.messages.last.messageId, 1);
+    });
+
+    test(
+        'Given that continuous logging is turned on when sending a stream message and writing a log without closing then a messageId is attached to each log message.',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(LogSettingsBuilder()
+              .withLogStreamingSessionsContinuously(true)
+              .build())
+          .build();
+      await server.updateRuntimeSettings(settings);
+      await client.openStreamingConnection(
+        disconnectOnLostInternetConnection: false,
+      );
+
+      await client.streamLogging.sendStreamMessage(Types());
+      await client.streamLogging.sendStreamMessage(Types());
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, isNotEmpty);
+      expect(logs.first.messages, isNotEmpty);
+      expect(logs.first.logs, isNotEmpty);
+
+      expect(logs.first.logs.first.messageId, 0);
+      expect(logs.first.logs.last.messageId, 1);
+    });
+
+    test(
         'Given that continuous logging is turned off when sending a stream message without closing the connection no log entries are created.',
         () async {
       var settings = RuntimeSettingsBuilder()
@@ -91,10 +148,10 @@ void main() async {
       await client.logging.sendStreamMessage(Types());
       await client.closeStreamingConnection();
 
-      var logs = await LoggingUtil.findAllLogs(session);
-
       // Wait for the log to be written
       await Future.delayed(Duration(milliseconds: 100));
+
+      var logs = await LoggingUtil.findAllLogs(session);
 
       expect(logs, hasLength(1));
       expect(logs.first.messages, hasLength(1));
@@ -148,6 +205,7 @@ void main() async {
       var logs = await LoggingUtil.findAllLogs(session);
 
       expect(logs, hasLength(1));
+      expect(logs.first.messages, hasLength(1));
     });
 
     test(


### PR DESCRIPTION
# Changes

Moves the currentMessageId from StreamingSession to the base session.
Fixes a bug where the messageId was not recorded for logged database queries.

Motivation for this change is that we want a generic way to deal with the message id rather than having to cast types as this functionality needs to be supported in more than one session.

There is an argument to be made that this id could be handled in the logger instead and have a similar logic to the session logs life cycle. Meaning each message would require an "open" and a "close" method. But this would make this much more complex. Reason for this is that we are writing the logs before we write the message log. Message log being the message received on the stream. The reason for this order is that the message log also records the execution time of the callback. 

Related issue: https://github.com/serverpod/serverpod/issues/2450

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none