### PR TITLE
refactor: Move query counter to the log manager.

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_manager.dart
@@ -147,6 +147,7 @@ class SessionLogManager {
     required StackTrace stackTrace,
   }) async {
     var executionTime = duration.inMicroseconds / _microNormalizer;
+    _numberOfQueries++;
 
     var logSettings = _settingsForSession(session);
 
@@ -179,8 +180,6 @@ class SessionLogManager {
       _logWriter.logStreamQuery,
       (sessionLogId, entry) => entry.sessionLogId = sessionLogId,
     );
-
-    _numberOfQueries++;
   }
 
   /// Logs a message from a stream, depending on the session type it will be

--- a/packages/serverpod/lib/src/server/log_manager/session_log_cache.dart
+++ b/packages/serverpod/lib/src/server/log_manager/session_log_cache.dart
@@ -10,9 +10,6 @@ class SessionLogEntryCache {
   /// Queries made during the session.
   final List<QueryLogEntry> queries = [];
 
-  /// Number of queries made during this session.
-  int get numQueries => queries.length;
-
   /// Log entries made during the session.
   final List<LogEntry> logEntries = [];
 

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -970,6 +970,12 @@ class EndpointLogging extends _i1.EndpointRef {
         {'seconds': seconds},
       );
 
+  _i2.Future<void> queryMethod(int queries) => caller.callServerEndpoint<void>(
+        'logging',
+        'queryMethod',
+        {'queries': queries},
+      );
+
   _i2.Future<void> failedQueryMethod() => caller.callServerEndpoint<void>(
         'logging',
         'failedQueryMethod',

--- a/tests/serverpod_test_server/lib/src/endpoints/logging.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/logging.dart
@@ -5,17 +5,21 @@ class LoggingEndpoint extends Endpoint {
   Future<void> slowQueryMethod(Session session, int seconds) async {
     try {
       await session.db.unsafeQuery('SELECT pg_sleep($seconds);');
-    } catch (e) {
-      print(e);
-    }
+    } catch (e) {}
+  }
+
+  Future<void> queryMethod(Session session, int queries) async {
+    try {
+      for (var i = 0; i < queries; i++) {
+        await Types.db.findFirstRow(session);
+      }
+    } catch (e) {}
   }
 
   Future<void> failedQueryMethod(Session session) async {
     try {
       await session.db.unsafeQuery('SELECT * FROM table_does_not_exist;');
-    } catch (e) {
-      print(e);
-    }
+    } catch (e) {}
   }
 
   Future<void> slowMethod(Session session, int delayMillis) async {

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -2225,6 +2225,24 @@ class Endpoints extends _i1.EndpointDispatch {
             params['seconds'],
           ),
         ),
+        'queryMethod': _i1.MethodConnector(
+          name: 'queryMethod',
+          params: {
+            'queries': _i1.ParameterDescription(
+              name: 'queries',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['logging'] as _i17.LoggingEndpoint).queryMethod(
+            session,
+            params['queries'],
+          ),
+        ),
         'failedQueryMethod': _i1.MethodConnector(
           name: 'failedQueryMethod',
           params: {},

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -119,6 +119,7 @@ listParameters:
   - returnDurationListNullableDurations:
 logging:
   - slowQueryMethod:
+  - queryMethod:
   - failedQueryMethod:
   - slowMethod:
   - failingMethod:

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
@@ -147,6 +147,48 @@ void main() async {
     });
 
     test(
+        'Given a log setting that enables all logs when calling a method executing a query then a query log is created',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(
+            LogSettingsBuilder().build(),
+          )
+          .build();
+
+      await server.updateRuntimeSettings(settings);
+
+      await client.logging.queryMethod(1);
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, hasLength(1));
+
+      expect(logs.first.queries, hasLength(1));
+      expect(logs.first.sessionLogEntry.numQueries, 1);
+    });
+
+    test(
+        'Given a log setting that enables all logs when calling a method executing several queries then a log for each query is created',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(
+            LogSettingsBuilder().build(),
+          )
+          .build();
+
+      await server.updateRuntimeSettings(settings);
+
+      await client.logging.queryMethod(4);
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, hasLength(1));
+
+      expect(logs.first.queries, hasLength(4));
+      expect(logs.first.sessionLogEntry.numQueries, 4);
+    });
+
+    test(
         'Given a log setting that enables failed query logging when calling a method executing an invalid query then a single log entry is created.',
         () async {
       var settings = RuntimeSettingsBuilder()

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
@@ -189,6 +189,30 @@ void main() async {
     });
 
     test(
+        'Given a log setting that turns off all database query logging when calling a method executing several queries then the number of queries are still counted.',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(
+            LogSettingsBuilder()
+                .withLoggingTurnedDown()
+                .withLogAllSessions(true)
+                .build(),
+          )
+          .build();
+
+      await server.updateRuntimeSettings(settings);
+
+      await client.logging.queryMethod(4);
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, hasLength(1));
+
+      expect(logs.first.queries, isEmpty);
+      expect(logs.first.sessionLogEntry.numQueries, 4);
+    });
+
+    test(
         'Given a log setting that enables failed query logging when calling a method executing an invalid query then a single log entry is created.',
         () async {
       var settings = RuntimeSettingsBuilder()


### PR DESCRIPTION
# Changes

Moves the query counter into the log manager.

Motivation is that the cache class will be deleted and replaced with a different system.

Related issue: https://github.com/serverpod/serverpod/issues/2450

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none