### PR TITLE
fix: Await all logging has completed before finalizing the session.

### DIFF
--- a/packages/serverpod/lib/src/server/log_manager/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_manager.dart
@@ -312,6 +312,7 @@ class SessionLogManager {
     String? exception,
     StackTrace? stackTrace,
   }) async {
+    await _openStreamLogLock.synchronized(() {});
     await _logTasks.awaitAllTasks();
 
     var duration = session.duration;

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_call_logging_test.dart
@@ -166,13 +166,15 @@ void main() async {
         await client.logging.failedQueryMethod();
       } catch (_) {}
 
+      await Future.delayed(Duration(milliseconds: 100));
+
       var logs = await LoggingUtil.findAllLogs(session);
 
       expect(logs, hasLength(1));
 
       expect(logs.first.sessionLogEntry.endpoint, 'logging');
       expect(logs.first.sessionLogEntry.method, 'failedQueryMethod');
-    }, skip: 'Fail because of the synchronized lock method, not sure why.');
+    });
 
     test(
         'Given a log setting with everything turned on when calling a method logging a message then the log including the message log is written.',

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
@@ -52,6 +52,59 @@ void main() async {
     });
 
     test(
+        'Given that continuous logging is turned on when sending a stream message and closing the connection then the log is created.',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(LogSettingsBuilder()
+              .withLogStreamingSessionsContinuously(true)
+              .build())
+          .build();
+      await server.updateRuntimeSettings(settings);
+      await client.openStreamingConnection(
+        disconnectOnLostInternetConnection: false,
+      );
+
+      await client.logging.sendStreamMessage(Types());
+
+      await client.closeStreamingConnection();
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, hasLength(1));
+      expect(logs.first.messages, hasLength(1));
+    });
+
+    test(
+        'Given that continuous logging is turned on when sending a stream message and closing the connection then the log is created.',
+        () async {
+      var settings = RuntimeSettingsBuilder()
+          .withLogSettings(LogSettingsBuilder()
+              .withLogStreamingSessionsContinuously(true)
+              .build())
+          .build();
+      await server.updateRuntimeSettings(settings);
+      await client.openStreamingConnection(
+        disconnectOnLostInternetConnection: false,
+      );
+
+      await client.logging.sendStreamMessage(Types());
+      await client.logging.sendStreamMessage(Types());
+
+      await client.closeStreamingConnection();
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, hasLength(1));
+      expect(logs.first.messages, hasLength(2));
+    });
+
+    test(
         'Given that continuous logging is turned on when sending several stream messages without closing the connection then the logs are created with different message ids.',
         () async {
       var settings = RuntimeSettingsBuilder()


### PR DESCRIPTION
# Changes

Fixes two bugs, one where two log entries were created if the session was very short-lived, e.g. the open log was called at the same time as the finalized logs. This meant that the logs where not collected to the same session and it looked like two different sessions was executed.

The second bug was related to database queries where they may be in transit when the finalize logger was called. This resulted in no logs being recorded. This is fixed by collecting all logging tasks and awaiting any pending jobs before starting the finalize sequence. 

Related issue: https://github.com/serverpod/serverpod/issues/2450

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none