### PR TITLE
fix: Invalid session type cast removed.

### DIFF
--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -32,9 +32,7 @@ class RouteStaticDirectory extends Route {
 
   @override
   Future<bool> handleCall(Session session, HttpRequest request) async {
-    session as MethodCallSession;
-
-    var path = Uri.decodeFull(session.uri.path);
+    var path = Uri.decodeFull(request.requestedUri.path);
 
     try {
       // Remove version control string
@@ -48,9 +46,10 @@ class RouteStaticDirectory extends Route {
       }
       base = baseParts.join('@');
 
-      if (basePath != null && path.startsWith(basePath!)) {
+      var localBasePath = basePath;
+      if (localBasePath != null && path.startsWith(localBasePath)) {
         var requestDir = p.dirname(path);
-        var middlePath = requestDir.substring(basePath!.length);
+        var middlePath = requestDir.substring(localBasePath.length);
 
         if (middlePath.isNotEmpty) {
           path = p.join(dir, middlePath, base + extension);


### PR DESCRIPTION
# Fix

Solves a bug where the wrong session type cast was made in the relic web server.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none