### PR TITLE
fix: Remove messageId management from new stream session.

### DIFF
--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -313,7 +313,7 @@ class MethodStreamSession extends Session {
     required String methodName,
     required this.connectionId,
   })  : _methodName = methodName,
-        super(methodName: methodName, messageId: 0);
+        super(methodName: methodName);
 }
 
 /// When a web socket connection is opened to the [Server] a [StreamingSession]


### PR DESCRIPTION
# Changes

Removes the messageId from MethodStreamSession as we are not supporting message logging yet for this session type.
Feature is tracked here: https://github.com/serverpod/serverpod/issues/2563

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none