### PR TITLE
fix: Misc stream cleaninups along with proper subscription handling.

### DIFF
--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -563,11 +563,7 @@ class _MethodStreamManager {
       return;
     }
 
-    // TODO: Support nullable return types.
-    // Because encodeWithType does not support nullable we can't encode null
-    // values.
-    if (methodConnector.returnType != MethodStreamReturnType.voidType &&
-        result != null) {
+    if (methodConnector.returnType != MethodStreamReturnType.voidType) {
       _postMessage(
         endpoint: message.endpoint,
         method: message.method,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -74,6 +74,7 @@ class MethodWebsocketRequestHandler {
               connectionId: message.connectionId,
               reason: message.reason,
             );
+            break;
           case MethodStreamSerializableException():
             _methodStreamManager.dispatchSerializableException(
               message,

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1275,12 +1275,19 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
   @override
   String get name => 'methodStreaming';
 
-  /// Check Null and Object in validation.
   _i2.Stream<int> simpleStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
         'simpleStream',
         {},
+        {},
+      );
+
+  _i2.Stream<int> neverEndingStreamWithDelay(int millisecondsDelay) =>
+      caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
+        'methodStreaming',
+        'neverEndingStreamWithDelay',
+        {'millisecondsDelay': millisecondsDelay},
         {},
       );
 
@@ -1294,6 +1301,14 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
         'intReturnFromStream',
+        {},
+        {'stream': stream},
+      );
+
+  _i2.Future<int?> nullableIntReturnFromStream(_i2.Stream<int?> stream) =>
+      caller.callStreamingServerEndpoint<_i2.Future<int?>, int?>(
+        'methodStreaming',
+        'nullableIntReturnFromStream',
         {},
         {'stream': stream},
       );

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -23,6 +23,13 @@ class MethodStreaming extends Endpoint {
     return stream.first;
   }
 
+  Future<int?> nullableIntReturnFromStream(
+    Session session,
+    Stream<int?> stream,
+  ) async {
+    return stream.first;
+  }
+
   Stream<int> intStreamFromValue(Session session, int value) async* {
     for (var i in List.generate(value, (index) => index)) {
       yield i;

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -7,10 +7,20 @@ import 'package:serverpod_test_server/src/generated/protocol.dart';
 class MethodStreaming extends Endpoint {
   Map<String, Completer> _delayedResponses = {};
 
-  /// Check Null and Object in validation.
   Stream<int> simpleStream(Session session) async* {
     for (var i = 0; i < 10; i++) {
       yield i;
+    }
+  }
+
+  Stream<int> neverEndingStreamWithDelay(
+    Session session,
+    int millisecondsDelay,
+  ) async* {
+    int i = 0;
+    while (true) {
+      await Future.delayed(Duration(milliseconds: millisecondsDelay));
+      yield i++;
     }
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -2989,6 +2989,28 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['methodStreaming'] as _i20.MethodStreaming)
                   .simpleStream(session),
         ),
+        'neverEndingStreamWithDelay': _i1.MethodStreamConnector(
+          name: 'neverEndingStreamWithDelay',
+          params: {
+            'millisecondsDelay': _i1.ParameterDescription(
+              name: 'millisecondsDelay',
+              type: _i1.getType<int>(),
+              nullable: false,
+            )
+          },
+          streamParams: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .neverEndingStreamWithDelay(
+            session,
+            params['millisecondsDelay'],
+          ),
+        ),
         'intReturnFromStream': _i1.MethodStreamConnector(
           name: 'intReturnFromStream',
           params: {},

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -3010,6 +3010,27 @@ class Endpoints extends _i1.EndpointDispatch {
             streamParams['stream']!.cast<int>(),
           ),
         ),
+        'nullableIntReturnFromStream': _i1.MethodStreamConnector(
+          name: 'nullableIntReturnFromStream',
+          params: {},
+          streamParams: {
+            'stream': _i1.StreamParameterDescription<int?>(
+              name: 'stream',
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.futureType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['methodStreaming'] as _i20.MethodStreaming)
+                  .nullableIntReturnFromStream(
+            session,
+            streamParams['stream']!.cast<int?>(),
+          ),
+        ),
         'intStreamFromValue': _i1.MethodStreamConnector(
           name: 'intStreamFromValue',
           params: {

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -161,6 +161,7 @@ methodStreaming:
   - simpleStream:
   - methodCallEndpoint:
   - intReturnFromStream:
+  - nullableIntReturnFromStream:
   - intStreamFromValue:
   - intEchoStream:
   - dynamicEchoStream:

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -159,6 +159,7 @@ mapParameters:
   - returnDurationMapNullableDurations:
 methodStreaming:
   - simpleStream:
+  - neverEndingStreamWithDelay:
   - methodCallEndpoint:
   - intReturnFromStream:
   - nullableIntReturnFromStream:

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/close_method_stream_command_test.dart
@@ -343,7 +343,6 @@ void main() {
         () async {
       var websocketCompleter = Completer<void>();
       webSocket.stream.listen((event) {
-        print(event);
         // Listen to the to keep it open.
       }, onDone: () {
         websocketCompleter.complete();

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/dynamic_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/dynamic_stream_test.dart
@@ -33,8 +33,6 @@ void main() {
 
     group('when a stream of values are passed in', () {
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
-      late Completer<CloseMethodStreamCommand>
-          closeMethodStreamParameterCommand;
       TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
       var inputValues = [1, 'hello'];
       late List<dynamic> endpointResponses;
@@ -45,14 +43,10 @@ void main() {
       setUp(() async {
         endpointResponses = [];
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
-        closeMethodStreamParameterCommand =
-            Completer<CloseMethodStreamCommand>();
         var streamOpened = Completer<void>();
 
         testCompleterTimeout.start({
           'closeMethodStreamCommand': closeMethodStreamCommand,
-          'closeMethodStreamParameterCommand':
-              closeMethodStreamParameterCommand,
           'streamOpened': streamOpened,
         });
 
@@ -65,11 +59,7 @@ void main() {
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
-            if (message.parameter == inputParameter) {
-              closeMethodStreamParameterCommand.complete(message);
-            } else {
-              closeMethodStreamCommand.complete(message);
-            }
+            closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
             if (endpointResponses.isEmpty) {
               endpointResponses.add(message.object as int);
@@ -137,26 +127,6 @@ void main() {
         });
 
         await expectLater(closeMethodStreamCommand.future, completes);
-      });
-
-      test(
-          'then CloseMethodStreamCommand matching the stream parameter is received.',
-          () async {
-        closeMethodStreamParameterCommand.future.catchError((error) {
-          fail(
-              'Failed to receive CloseMethodStreamCommand from server for input parameter.');
-        }).then((message) {
-          expect(message.endpoint, endpoint);
-          expect(message.method, method);
-          expect(message.parameter, inputParameter);
-          expect(message.connectionId, connectionId);
-          expect(message.reason, CloseReason.done);
-        });
-
-        await expectLater(
-          closeMethodStreamParameterCommand.future,
-          completes,
-        );
       });
     });
   });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/in_out_endpoint_test.dart
@@ -272,8 +272,6 @@ void main() {
 
     group('when a stream of values are passed in', () {
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
-      late Completer<CloseMethodStreamCommand>
-          closeMethodStreamParameterCommand;
       TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
       var inputValues = List.generate(4, (index) => index);
       late List<int> endpointResponses;
@@ -284,14 +282,10 @@ void main() {
       setUp(() async {
         endpointResponses = [];
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
-        closeMethodStreamParameterCommand =
-            Completer<CloseMethodStreamCommand>();
         var streamOpened = Completer<void>();
 
         testCompleterTimeout.start({
           'closeMethodStreamCommand': closeMethodStreamCommand,
-          'closeMethodStreamParameterCommand':
-              closeMethodStreamParameterCommand,
           'streamOpened': streamOpened,
         });
 
@@ -304,11 +298,7 @@ void main() {
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
-            if (message.parameter == inputParameter) {
-              closeMethodStreamParameterCommand.complete(message);
-            } else {
-              closeMethodStreamCommand.complete(message);
-            }
+            closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
             endpointResponses.add(message.object as int);
           }
@@ -372,26 +362,6 @@ void main() {
         });
 
         await expectLater(closeMethodStreamCommand.future, completes);
-      });
-
-      test(
-          'then CloseMethodStreamCommand matching the stream parameter is received.',
-          () async {
-        closeMethodStreamParameterCommand.future.catchError((error) {
-          fail(
-              'Failed to receive CloseMethodStreamCommand from server for input parameter.');
-        }).then((message) {
-          expect(message.endpoint, endpoint);
-          expect(message.method, method);
-          expect(message.parameter, inputParameter);
-          expect(message.connectionId, connectionId);
-          expect(message.reason, CloseReason.done);
-        });
-
-        await expectLater(
-          closeMethodStreamParameterCommand.future,
-          completes,
-        );
       });
     });
   });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/multiple_input_streams_endpoint_test.dart
@@ -132,9 +132,6 @@ void main() {
 
     group('when one stream parameter is closed', () {
       late Completer<int> endpointResponse;
-      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
-      late Completer<CloseMethodStreamCommand>
-          closeMethodStreamParameterCommand;
       TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
       var inputValue = 2;
 
@@ -144,16 +141,10 @@ void main() {
 
       setUp(() async {
         endpointResponse = Completer<int>();
-        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
-        closeMethodStreamParameterCommand =
-            Completer<CloseMethodStreamCommand>();
         var streamOpened = Completer<void>();
 
         testCompleterTimeout.start({
           'endpointResponse': endpointResponse,
-          'closeMethodStreamCommand': closeMethodStreamCommand,
-          'closeMethodStreamParameterCommand':
-              closeMethodStreamParameterCommand,
           'streamOpened': streamOpened,
         });
 
@@ -165,9 +156,6 @@ void main() {
           ;
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
-          } else if (message is CloseMethodStreamCommand &&
-              message.parameter == closedStreamParameter) {
-            closeMethodStreamParameterCommand.complete(message);
           } else if (message is MethodStreamMessage) {
             endpointResponse.complete(message.object as int);
           }
@@ -196,26 +184,6 @@ void main() {
 
       tearDown(() => testCompleterTimeout.cancel());
 
-      test(
-          'then CloseMethodStreamCommand matching the closed stream parameter is received.',
-          () async {
-        closeMethodStreamParameterCommand.future.catchError((error) {
-          fail(
-              'Failed to receive CloseMethodStreamCommand from server for input parameter.');
-        }).then((message) {
-          expect(message.endpoint, endpoint);
-          expect(message.method, method);
-          expect(message.parameter, closedStreamParameter);
-          expect(message.connectionId, connectionId);
-          expect(message.reason, CloseReason.done);
-        });
-
-        await expectLater(
-          closeMethodStreamParameterCommand.future,
-          completes,
-        );
-      });
-
       test('then values are still echoed on other parameter.', () async {
         endpointResponse.future.catchError((error) {
           fail('Failed to receive response from server.');
@@ -240,10 +208,6 @@ void main() {
 
     group('when both streams are closed', () {
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
-      late Completer<CloseMethodStreamCommand>
-          closeMethodStreamParameter1Command;
-      late Completer<CloseMethodStreamCommand>
-          closeMethodStreamParameter2Command;
       TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
 
       var inputStreamParameter1 = 'stream1';
@@ -252,18 +216,11 @@ void main() {
 
       setUp(() async {
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
-        closeMethodStreamParameter1Command =
-            Completer<CloseMethodStreamCommand>();
-        closeMethodStreamParameter2Command =
-            Completer<CloseMethodStreamCommand>();
+        Completer<CloseMethodStreamCommand>();
         var streamOpened = Completer<void>();
 
         testCompleterTimeout.start({
           'closeMethodStreamCommand': closeMethodStreamCommand,
-          'closeMethodStreamParameter1Command':
-              closeMethodStreamParameter1Command,
-          'closeMethodStreamParameter2Command':
-              closeMethodStreamParameter2Command,
           'streamOpened': streamOpened,
         });
 
@@ -276,13 +233,7 @@ void main() {
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
-            if (message.parameter == null) {
-              closeMethodStreamCommand.complete(message);
-            } else if (message.parameter == inputStreamParameter1) {
-              closeMethodStreamParameter1Command.complete(message);
-            } else if (message.parameter == inputStreamParameter2) {
-              closeMethodStreamParameter2Command.complete(message);
-            }
+            closeMethodStreamCommand.complete(message);
           }
         });
 
@@ -329,46 +280,6 @@ void main() {
         });
 
         await expectLater(closeMethodStreamCommand.future, completes);
-      });
-
-      test(
-          'then CloseMethodStreamCommand matching the first stream parameter is received.',
-          () async {
-        closeMethodStreamParameter1Command.future.catchError((error) {
-          fail(
-              'Failed to receive CloseMethodStreamCommand from server for first input parameter.');
-        }).then((message) {
-          expect(message.endpoint, endpoint);
-          expect(message.method, method);
-          expect(message.parameter, inputStreamParameter1);
-          expect(message.connectionId, connectionId);
-          expect(message.reason, CloseReason.done);
-        });
-
-        await expectLater(
-          closeMethodStreamParameter1Command.future,
-          completes,
-        );
-      });
-
-      test(
-          'then CloseMethodStreamCommand matching the second stream parameter is received.',
-          () async {
-        closeMethodStreamParameter2Command.future.catchError((error) {
-          fail(
-              'Failed to receive CloseMethodStreamCommand from server for second input parameter.');
-        }).then((message) {
-          expect(message.endpoint, endpoint);
-          expect(message.method, method);
-          expect(message.parameter, inputStreamParameter2);
-          expect(message.connectionId, connectionId);
-          expect(message.reason, CloseReason.done);
-        });
-
-        await expectLater(
-          closeMethodStreamParameter2Command.future,
-          completes,
-        );
       });
     });
   });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/never_ending_yield_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/never_ending_yield_test.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_completer_timeout.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+void main() {
+  group(
+      'Given a method stream connection to an endpoint that continuously yields values with a small delay',
+      () {
+    var endpoint = 'methodStreaming';
+    var method = 'neverEndingStreamWithDelay';
+
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+    late Completer webSocketClosed;
+    TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
+
+    var connectionId = const Uuid().v4obj();
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+      webSocketClosed = Completer();
+      var streamOpened = Completer<void>();
+
+      testCompleterTimeout.start({
+        'streamOpened': streamOpened,
+        'webSocketClosed': webSocketClosed,
+      });
+
+      webSocket.stream.listen((event) {
+        var message = WebSocketMessage.fromJsonString(
+          event,
+          server.serializationManager,
+        );
+        ;
+        if (message is OpenMethodStreamResponse) {
+          streamOpened.complete();
+        }
+      }, onDone: () {
+        webSocketClosed.complete();
+      });
+
+      webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+        endpoint: endpoint,
+        method: method,
+        args: {'millisecondsDelay': 100},
+        connectionId: connectionId,
+        inputStreams: [],
+      ));
+
+      await streamOpened.future;
+      assert(streamOpened.isCompleted == true,
+          'Failed to open method stream with server');
+    });
+
+    tearDown(() async {
+      testCompleterTimeout.cancel();
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    test('when method stream is closed then websocket connection is closed.',
+        () async {
+      webSocket.sink.add(CloseMethodStreamCommand.buildMessage(
+        endpoint: endpoint,
+        method: method,
+        connectionId: connectionId,
+        reason: CloseReason.done,
+      ));
+
+      webSocketClosed.future.catchError((error) {
+        fail('Failed to close websocket connection.');
+      });
+
+      await expectLater(webSocketClosed.future, completes);
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
@@ -155,7 +155,6 @@ void main() {
       late Completer<CloseMethodStreamCommand>
           closeMethodStreamParameterCommand;
       TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
-      var inputValue = null;
       late List<int?> endpointResponses;
 
       var inputParameter = 'stream';
@@ -211,7 +210,7 @@ void main() {
           method: method,
           parameter: inputParameter,
           connectionId: connectionId,
-          object: inputValue,
+          object: null,
           serializationManager: server.serializationManager,
         ));
 
@@ -233,10 +232,7 @@ void main() {
 
         await expectLater(closeMethodStreamCommand.future, completes);
 
-        expect(
-          endpointResponses,
-          [inputValue],
-        );
+        expect(endpointResponses, [null]);
       });
     });
   });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
@@ -33,8 +33,6 @@ void main() {
 
     group('when a stream of values are passed in', () {
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
-      late Completer<CloseMethodStreamCommand>
-          closeMethodStreamParameterCommand;
       TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
       var inputValues = [1, null, 3];
       late List<int?> endpointResponses;
@@ -45,14 +43,10 @@ void main() {
       setUp(() async {
         endpointResponses = [];
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
-        closeMethodStreamParameterCommand =
-            Completer<CloseMethodStreamCommand>();
         var streamOpened = Completer<void>();
 
         testCompleterTimeout.start({
           'closeMethodStreamCommand': closeMethodStreamCommand,
-          'closeMethodStreamParameterCommand':
-              closeMethodStreamParameterCommand,
           'streamOpened': streamOpened,
         });
 
@@ -65,11 +59,7 @@ void main() {
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
-            if (message.parameter == inputParameter) {
-              closeMethodStreamParameterCommand.complete(message);
-            } else {
-              closeMethodStreamCommand.complete(message);
-            }
+            closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
             endpointResponses.add(message.object as int?);
           }
@@ -133,26 +123,6 @@ void main() {
         });
 
         await expectLater(closeMethodStreamCommand.future, completes);
-      });
-
-      test(
-          'then CloseMethodStreamCommand matching the stream parameter is received.',
-          () async {
-        closeMethodStreamParameterCommand.future.catchError((error) {
-          fail(
-              'Failed to receive CloseMethodStreamCommand from server for input parameter.');
-        }).then((message) {
-          expect(message.endpoint, endpoint);
-          expect(message.method, method);
-          expect(message.parameter, inputParameter);
-          expect(message.connectionId, connectionId);
-          expect(message.reason, CloseReason.done);
-        });
-
-        await expectLater(
-          closeMethodStreamParameterCommand.future,
-          completes,
-        );
       });
     });
   });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/nullable_stream_test.dart
@@ -156,4 +156,118 @@ void main() {
       });
     });
   });
+
+  group(
+      'Given a method stream endpoint that returns first value from nullable int stream in',
+      () {
+    var endpoint = 'methodStreaming';
+    var method = 'nullableIntReturnFromStream';
+
+    late Serverpod server;
+    late WebSocketChannel webSocket;
+
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      webSocket = WebSocketChannel.connect(
+        Uri.parse(serverMethodWebsocketUrl),
+      );
+      await webSocket.ready;
+    });
+
+    tearDown(() async {
+      await server.shutdown(exitProcess: false);
+      await webSocket.sink.close();
+    });
+
+    group('when a null value is passed in', () {
+      late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      late Completer<CloseMethodStreamCommand>
+          closeMethodStreamParameterCommand;
+      TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
+      var inputValue = null;
+      late List<int?> endpointResponses;
+
+      var inputParameter = 'stream';
+      var connectionId = const Uuid().v4obj();
+
+      setUp(() async {
+        endpointResponses = [];
+        closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        closeMethodStreamParameterCommand =
+            Completer<CloseMethodStreamCommand>();
+        var streamOpened = Completer<void>();
+
+        testCompleterTimeout.start({
+          'closeMethodStreamCommand': closeMethodStreamCommand,
+          'closeMethodStreamParameterCommand':
+              closeMethodStreamParameterCommand,
+          'streamOpened': streamOpened,
+        });
+
+        webSocket.stream.listen((event) {
+          var message = WebSocketMessage.fromJsonString(
+            event,
+            server.serializationManager,
+          );
+          ;
+          if (message is OpenMethodStreamResponse) {
+            streamOpened.complete();
+          } else if (message is CloseMethodStreamCommand) {
+            if (message.parameter == inputParameter) {
+              closeMethodStreamParameterCommand.complete(message);
+            } else {
+              closeMethodStreamCommand.complete(message);
+            }
+          } else if (message is MethodStreamMessage) {
+            endpointResponses.add(message.object as int?);
+          }
+        });
+
+        webSocket.sink.add(OpenMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          args: {},
+          connectionId: connectionId,
+          inputStreams: [inputParameter],
+        ));
+
+        await streamOpened.future;
+        assert(streamOpened.isCompleted == true,
+            'Failed to open method stream with server');
+
+        webSocket.sink.add(MethodStreamMessage.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          parameter: inputParameter,
+          connectionId: connectionId,
+          object: inputValue,
+          serializationManager: server.serializationManager,
+        ));
+
+        webSocket.sink.add(CloseMethodStreamCommand.buildMessage(
+          endpoint: endpoint,
+          method: method,
+          parameter: inputParameter,
+          connectionId: connectionId,
+          reason: CloseReason.done,
+        ));
+      });
+
+      tearDown(() => testCompleterTimeout.cancel());
+
+      test('then received values matches stream of input.', () async {
+        closeMethodStreamCommand.future.catchError((error) {
+          fail('Server failed to close the output stream.');
+        });
+
+        await expectLater(closeMethodStreamCommand.future, completes);
+
+        expect(
+          endpointResponses,
+          [inputValue],
+        );
+      });
+    });
+  });
 }

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/void_return_endpoint_test.dart
@@ -34,8 +34,6 @@ void main() {
     group('when parameter stream is closed', () {
       late Completer<void> endpointResponse;
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
-      late Completer<CloseMethodStreamCommand>
-          closeMethodStreamParameterCommand;
       TestCompleterTimeout testCompleterTimeout = TestCompleterTimeout();
 
       var inputParameter = 'stream';
@@ -44,15 +42,11 @@ void main() {
       setUp(() async {
         endpointResponse = Completer<MethodStreamMessage>();
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
-        closeMethodStreamParameterCommand =
-            Completer<CloseMethodStreamCommand>();
         var streamOpened = Completer<void>();
 
         testCompleterTimeout.start({
           'endpointResponse': endpointResponse,
           'closeMethodStreamCommand': closeMethodStreamCommand,
-          'closeMethodStreamParameterCommand':
-              closeMethodStreamParameterCommand,
           'streamOpened': streamOpened,
         });
 
@@ -65,11 +59,7 @@ void main() {
           if (message is OpenMethodStreamResponse) {
             streamOpened.complete();
           } else if (message is CloseMethodStreamCommand) {
-            if (message.parameter == inputParameter) {
-              closeMethodStreamParameterCommand.complete(message);
-            } else {
-              closeMethodStreamCommand.complete(message);
-            }
+            closeMethodStreamCommand.complete(message);
           } else if (message is MethodStreamMessage) {
             endpointResponse.complete(message.object as int);
           }
@@ -118,26 +108,6 @@ void main() {
         });
 
         await expectLater(closeMethodStreamCommand.future, completes);
-      });
-
-      test(
-          'then CloseMethodStreamCommand matching the stream parameter is received.',
-          () async {
-        closeMethodStreamParameterCommand.future.catchError((error) {
-          fail(
-              'Failed to receive CloseMethodStreamCommand from server for input parameter.');
-        }).then((message) {
-          expect(message.endpoint, endpoint);
-          expect(message.method, method);
-          expect(message.parameter, inputParameter);
-          expect(message.connectionId, connectionId);
-          expect(message.reason, CloseReason.done);
-        });
-
-        await expectLater(
-          closeMethodStreamParameterCommand.future,
-          completes,
-        );
       });
     });
   });

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/throwing_method_endpoint_test.dart
@@ -28,15 +28,21 @@ void main() {
     group(
         'when a stream is opened to an endpoint with a Future return that throws an exception',
         () {
-      var streamOpened = Completer<void>();
+      late Completer<void> streamOpened;
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      late Completer<CloseMethodStreamCommand>
+          closeMethodStreamParameterCommand;
 
       var endpoint = 'methodStreaming';
       var method = 'inStreamThrowsException';
+      var parameter = 'stream';
       var connectionId = const Uuid().v4obj();
 
       setUp(() async {
+        streamOpened = Completer<void>();
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        closeMethodStreamParameterCommand =
+            Completer<CloseMethodStreamCommand>();
         webSocket.stream.listen((event) {
           var message = WebSocketMessage.fromJsonString(
             event,
@@ -47,6 +53,9 @@ void main() {
           } else if (message is CloseMethodStreamCommand &&
               message.parameter == null) {
             closeMethodStreamCommand.complete(message);
+          } else if (message is CloseMethodStreamCommand &&
+              message.parameter == parameter) {
+            closeMethodStreamParameterCommand.complete(message);
           }
         });
 
@@ -55,7 +64,7 @@ void main() {
           method: method,
           args: {},
           connectionId: connectionId,
-          inputStreams: ['stream'],
+          inputStreams: [parameter],
         ));
 
         await streamOpened.future.timeout(
@@ -80,6 +89,25 @@ void main() {
         var closeMethodStreamCommandMessage = await message;
         expect(closeMethodStreamCommandMessage.endpoint, endpoint);
         expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
+      });
+
+      test(
+          'then CloseMethodStreamCommand matching endpoint parameter is received with error reason.',
+          () async {
+        var message = closeMethodStreamParameterCommand.future
+            .timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.parameter, parameter);
         expect(closeMethodStreamCommandMessage.connectionId, connectionId);
         expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
       });
@@ -149,17 +177,23 @@ void main() {
         () {
       late Completer<MethodStreamSerializableException>
           methodStreamSerializableException;
+      late Completer<void> streamOpened;
       late Completer<CloseMethodStreamCommand> closeMethodStreamCommand;
+      late Completer<CloseMethodStreamCommand>
+          closeMethodStreamParameterCommand;
 
       var endpoint = 'methodStreaming';
       var method = 'inStreamThrowsSerializableException';
+      var parameter = 'stream';
       var connectionId = const Uuid().v4obj();
 
       setUp(() async {
-        var streamOpened = Completer<void>();
+        streamOpened = Completer<void>();
         methodStreamSerializableException =
             Completer<MethodStreamSerializableException>();
         closeMethodStreamCommand = Completer<CloseMethodStreamCommand>();
+        closeMethodStreamParameterCommand =
+            Completer<CloseMethodStreamCommand>();
 
         webSocket.stream.listen((event) {
           var message = WebSocketMessage.fromJsonString(
@@ -173,6 +207,9 @@ void main() {
           } else if (message is CloseMethodStreamCommand &&
               message.parameter == null) {
             closeMethodStreamCommand.complete(message);
+          } else if (message is CloseMethodStreamCommand &&
+              message.parameter == parameter) {
+            closeMethodStreamParameterCommand.complete(message);
           }
         });
 
@@ -225,6 +262,25 @@ void main() {
         var closeMethodStreamCommandMessage = await message;
         expect(closeMethodStreamCommandMessage.endpoint, endpoint);
         expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.connectionId, connectionId);
+        expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
+      });
+
+      test(
+          'then CloseMethodStreamCommand matching endpoint parameter is received with error reason.',
+          () async {
+        var message = closeMethodStreamParameterCommand.future
+            .timeout(Duration(seconds: 5));
+        expect(
+          message,
+          completes,
+          reason: 'Failed to receive CloseMethodStreamCommand from server.',
+        );
+
+        var closeMethodStreamCommandMessage = await message;
+        expect(closeMethodStreamCommandMessage.endpoint, endpoint);
+        expect(closeMethodStreamCommandMessage.method, method);
+        expect(closeMethodStreamCommandMessage.parameter, parameter);
         expect(closeMethodStreamCommandMessage.connectionId, connectionId);
         expect(closeMethodStreamCommandMessage.reason, CloseReason.error);
       });


### PR DESCRIPTION
Fixes some misc bugs and corrects som tests for the new streaming method interface.

The main subject of this PR is removing the middle controller layer between the websocket and streaming methods return value.

This makes the implementation simpler and allows us to cancel the subscription of a streaming endpoint when requested by either the client or by the server.

Related issue: #2338 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None: changes related to an unreleased feature.