### PR TITLE
fix: Add experimental warning to streaming methods on client.

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1275,6 +1275,9 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
   @override
   String get name => 'methodStreaming';
 
+  /// Warning: Streaming methods are still experimental.
+  ///
+  /// Returns a simple stream of integers from 0 to 9.
   _i2.Stream<int> simpleStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1283,6 +1286,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> neverEndingStreamWithDelay(int millisecondsDelay) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1297,6 +1301,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> intReturnFromStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1305,6 +1310,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<int?> nullableIntReturnFromStream(_i2.Stream<int?> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int?>, int?>(
         'methodStreaming',
@@ -1313,6 +1319,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> intStreamFromValue(int value) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1321,6 +1328,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> intEchoStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1329,6 +1337,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<dynamic> dynamicEchoStream(_i2.Stream<dynamic> stream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<dynamic>, dynamic>(
         'methodStreaming',
@@ -1337,6 +1346,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int?> nullableIntEchoStream(_i2.Stream<int?> stream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int?>, int?>(
         'methodStreaming',
@@ -1345,6 +1355,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> voidReturnAfterStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1353,6 +1364,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> multipleIntEchoStreams(
     _i2.Stream<int> stream1,
     _i2.Stream<int> stream2,
@@ -1367,6 +1379,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         },
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> directVoidReturnWithStreamInput(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1375,6 +1388,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> directOneIntReturnWithStreamInput(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1383,6 +1397,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> simpleInputReturnStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1391,6 +1406,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> simpleStreamWithParameter(int value) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1399,6 +1415,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<_i10.SimpleData> simpleDataStream(int value) =>
       caller.callStreamingServerEndpoint<_i2.Stream<_i10.SimpleData>,
           _i10.SimpleData>(
@@ -1408,6 +1425,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<_i10.SimpleData> simpleInOutDataStream(
           _i2.Stream<_i10.SimpleData> simpleDataStream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<_i10.SimpleData>,
@@ -1446,6 +1464,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'delay': delay},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> delayedStreamResponse(int delay) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1454,6 +1473,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> delayedNeverListenedInputStream(
     int delay,
     _i2.Stream<int> stream,
@@ -1465,6 +1485,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> delayedPausedInputStream(
     int delay,
     _i2.Stream<int> stream,
@@ -1485,6 +1506,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> inStreamThrowsException(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1493,6 +1515,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> inStreamThrowsSerializableException(
           _i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
@@ -1502,6 +1525,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> outStreamThrowsException() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1510,6 +1534,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> outStreamThrowsSerializableException() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1518,6 +1543,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> throwsExceptionVoid(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1526,6 +1552,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> throwsSerializableExceptionVoid(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1534,6 +1561,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> throwsException(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1542,6 +1570,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> throwsSerializableException(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1550,6 +1579,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> throwsExceptionStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1558,6 +1588,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> throwsSerializableExceptionStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1566,6 +1597,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<bool> didInputStreamHaveError(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<bool>, bool>(
         'methodStreaming',
@@ -1574,6 +1606,7 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Future<bool> didInputStreamHaveSerializableExceptionError(
           _i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<bool>, bool>(
@@ -1592,6 +1625,7 @@ class EndpointAuthenticatedMethodStreaming extends _i1.EndpointRef {
   @override
   String get name => 'authenticatedMethodStreaming';
 
+  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> simpleStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'authenticatedMethodStreaming',

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -7,6 +7,7 @@ import 'package:serverpod_test_server/src/generated/protocol.dart';
 class MethodStreaming extends Endpoint {
   Map<String, Completer> _delayedResponses = {};
 
+  /// Returns a simple stream of integers from 0 to 9.
   Stream<int> simpleStream(Session session) async* {
     for (var i = 0; i < 10; i++) {
       yield i;

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -640,8 +640,20 @@ class LibraryGenerator {
     return library.build();
   }
 
-  String _buildEndpointCallDocumentation(MethodDefinition methodDef) =>
-      methodDef.documentationComment ?? '';
+  String _buildEndpointCallDocumentation(MethodDefinition methodDef) {
+    if (methodDef is! MethodStreamDefinition) {
+      return methodDef.documentationComment ?? '';
+    }
+
+    const experimentalWarning =
+        '/// Warning: Streaming methods are still experimental.';
+    var documentationComment = methodDef.documentationComment;
+    if (documentationComment == null) {
+      return experimentalWarning;
+    }
+
+    return '$experimentalWarning\n///\n$documentationComment';
+  }
 
   Code _buildCallServerEndpoint(
     String modulePrefix,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -383,7 +383,7 @@ class LibraryGenerator {
             endpoint.methods.add(
               Method(
                 (m) => m
-                  ..docs.add(methodDef.documentationComment ?? '')
+                  ..docs.add(_buildEndpointCallDocumentation(methodDef))
                   ..returns = returnType.reference(false, config: config)
                   ..name = methodDef.name
                   ..requiredParameters.addAll([
@@ -639,6 +639,9 @@ class LibraryGenerator {
 
     return library.build();
   }
+
+  String _buildEndpointCallDocumentation(MethodDefinition methodDef) =>
+      methodDef.documentationComment ?? '';
 
   Code _buildCallServerEndpoint(
     String modulePrefix,

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -58,6 +58,14 @@ void main() {
     });
     var endpointsFile = codeMap[expectedFileName];
 
+    test('then client file contains experimental warning for method.', () {
+      expect(
+        endpointsFile,
+        contains(
+          '/// Warning: Streaming methods are still experimental.',
+        ),
+      );
+    });
     test(
         'then client file contains endpoint method for the streaming endpoint.',
         () {
@@ -104,6 +112,15 @@ void main() {
       expect(codeMap, contains(expectedFileName));
     });
     var endpointsFile = codeMap[expectedFileName];
+
+    test('then client file contains experimental warning for method.', () {
+      expect(
+        endpointsFile,
+        contains(
+          '/// Warning: Streaming methods are still experimental.',
+        ),
+      );
+    });
 
     test('then client file endpoint method for the streaming endpoint.', () {
       expect(


### PR DESCRIPTION
Adds an experimental warning to client streaming methods.

Relates to: #2338 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple docs fix.