### PR TITLE
fix: restric void returns in streams output.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -124,7 +124,14 @@ abstract class EndpointMethodAnalyzer {
 
     var innerType = typeArguments[0];
 
-    if (innerType is VoidType) {
+    if (innerType is VoidType && dartType.isDartAsyncStream) {
+      return SourceSpanSeverityException(
+        'The type void is not supported for streams.',
+        dartElement.span,
+      );
+    }
+
+    if (innerType is VoidType && dartType.isDartAsyncFuture) {
       return null;
     }
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -126,7 +126,7 @@ abstract class EndpointMethodAnalyzer {
 
     if (innerType is VoidType && dartType.isDartAsyncStream) {
       return SourceSpanSeverityException(
-        'The type void is not supported for streams.',
+        'The type "void" is not supported for streams.',
         dartElement.span,
       );
     }

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -185,7 +185,7 @@ class ExampleEndpoint extends Endpoint {
     expect(collector.errors, isNotEmpty);
     expect(
       collector.errors.first.message,
-      'The type void is not supported for streams.',
+      'The type "void" is not supported for streams.',
     );
   });
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -157,6 +157,38 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
+  test(
+      'Given an endpoint method with a Stream<void> return when analyzed then an error is reported',
+      () async {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late EndpointsAnalyzer analyzer;
+
+    var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+    endpointFile.createSync(recursive: true);
+    endpointFile.writeAsStringSync('''
+import 'dart:async';
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Stream<void> hello(Session session) async* {
+    yield 'Hello';
+    yield 'World';
+  }
+}
+''');
+    analyzer = EndpointsAnalyzer(testDirectory);
+    await analyzer.analyze(collector: collector);
+
+    expect(collector.errors, isNotEmpty);
+    expect(
+      collector.errors.first.message,
+      'The type void is not supported for streams.',
+    );
+  });
+
   group('Given an endpoint method with a stream return type when analyzed', () {
     var collector = CodeGenerationCollector();
     var testDirectory =


### PR DESCRIPTION
# Changes

Restrict void in stream output of methods e.g.


```dart
Stream<void> myMethod(Session session) {
  ...
}
```

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none