### PR TITLE
fix: Client streaming method connection fixes.

### DIFF
--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -318,6 +318,10 @@ final class ClientMethodStreamManager {
       return;
     }
 
+    // Remove the onCancel callback to prevent the controller from sending
+    // a close message to the server.
+    inboundStreamContext.controller.onCancel = null;
+
     if (reason == CloseReason.error) {
       inboundStreamContext.controller.addError(
         const ServerpodClientException(

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -169,6 +169,12 @@ final class ClientMethodStreamManager {
         _inboundStreams.values.map((c) => c.controller).toList();
     _inboundStreams.clear();
 
+    // Remove onCancel callbacks to prevent controllers from
+    // sending a close command to the server.
+    for (var c in inputControllers) {
+      c.onCancel = null;
+    }
+
     if (exception != null) {
       for (var c in inputControllers) {
         c.addError(exception);

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -533,7 +533,8 @@ final class ClientMethodStreamManager {
     var webSocket = _webSocket;
     if (webSocket == null) {
       throw StateError(
-          'Message posted when web socket connection is closed: $message');
+        'Message posted when web socket connection is closed: $message',
+      );
     }
 
     webSocket.sink.add(message);

--- a/tests/serverpod_test_server/test_e2e/method_streaming/close_connection_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/close_connection_test.dart
@@ -11,6 +11,10 @@ void main() {
     serverUrl,
     authenticationKeyManager: TestAuthKeyManager(),
   );
+
+  tearDown(() async =>
+      await client.closeStreamingMethodConnections(exception: null));
+
   test(
       'Given open streaming method connection when close method streams is called then connection is closed with exception.',
       () async {
@@ -36,29 +40,50 @@ void main() {
   test(
       'Given a streaming connection that was closed when establishing a new streaming connection then messages can be successfully transmitted.',
       () async {
-    var firstConnectionEstablished = Completer();
-    var firstInputStream = StreamController<int>();
-    var firstStream =
-        client.methodStreaming.intEchoStream(firstInputStream.stream);
+    {
+      var firstConnectionEstablished = Completer();
+      var firstInputStream = StreamController<int>();
+      var firstStream =
+          client.methodStreaming.intEchoStream(firstInputStream.stream);
 
-    firstStream.listen((event) {
-      firstConnectionEstablished.complete();
-    }, onError: (e, s) {
-      // ignore
+      firstStream.listen((event) {
+        firstConnectionEstablished.complete();
+      });
+      firstInputStream.sink.add(42);
+      await expectLater(firstConnectionEstablished.future, completes);
+      await client.closeStreamingMethodConnections(exception: null);
+    }
+
+    {
+      var secondConnectionEstablished = Completer();
+      var secondInputStream = StreamController<int>();
+      var secondStream =
+          client.methodStreaming.intEchoStream(secondInputStream.stream);
+
+      secondStream.listen((event) {
+        secondConnectionEstablished.complete();
+      });
+      secondInputStream.sink.add(42);
+      await expectLater(secondConnectionEstablished.future, completes);
+    }
+  });
+
+  test(
+      'Given an input stream that continuously sends data to the server when closing all method streams then the method stream is successfully closed.',
+      () async {
+    var stream = client.methodStreaming.intEchoStream(
+      Stream.periodic(Duration(microseconds: 1), (i) => i),
+    );
+
+    var streamComplete = Completer();
+    stream.listen((event) {
+      if (event == 10) {
+        client.closeStreamingMethodConnections(exception: null);
+      }
+    }, onDone: () {
+      streamComplete.complete();
     });
-    firstInputStream.sink.add(42);
-    await firstConnectionEstablished.future;
-    await client.closeStreamingMethodConnections();
 
-    var secondConnectionEstablished = Completer();
-    var secondInputStream = StreamController<int>();
-    var secondStream =
-        client.methodStreaming.intEchoStream(secondInputStream.stream);
-
-    secondStream.listen((event) {
-      secondConnectionEstablished.complete();
-    });
-    secondInputStream.sink.add(42);
-    await firstConnectionEstablished.future;
+    await expectLater(streamComplete.future, completes);
   });
 }


### PR DESCRIPTION
Mixed fixes to the clients connection handling.

### Changes:
- Throw exception if the client ever tries to post a message on a closed websocket connection. This will help us detect any disruptions that might occur.
- Prevent echoing a close command to the server when the server closes the streaming method.
- Prevent redundant close command when closing web socket connection.
- Add a future to wait for the web socket listen to close when closing web socket connection.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._