### PR TITLE
feat: Add support for willClose listeners on Session.

### DIFF
--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -14,13 +14,12 @@ import '../cache/caches.dart';
 import '../database/database.dart';
 
 /// A listener that will be called when the session is about to close.
-typedef WillCloseListener = FutureOr<void> Function(Session);
+typedef WillCloseListener = FutureOr<void> Function(Session session);
 
 /// When a call is made to the [Server] a [Session] object is created. It
 /// contains all data associated with the current connection and provides
 /// easy access to the database.
 abstract class Session {
-  /// List of listeners that will be called when the session is about to close.
   final LinkedHashSet<WillCloseListener> _willCloseListeners = LinkedHashSet();
 
   /// Adds a listener that will be called when the session is about to close.

--- a/tests/serverpod_test_server/test_integration/session/will_close_listener_test.dart
+++ b/tests/serverpod_test_server/test_integration/session/will_close_listener_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  late Session session;
+  late Serverpod server;
+
+  setUp(() async {
+    server = IntegrationTestServer.create();
+    await server.start();
+    session = await server.createSession();
+  });
+
+  tearDown(() async {
+    await session.close();
+    await server.shutdown(exitProcess: false);
+  });
+
+  test(
+      'Given a session with a will close listener when the session is closed then listener is called.',
+      () async {
+    var listenerCalledCompleter = Completer();
+    session.addWillCloseListener((Session session) {
+      listenerCalledCompleter.complete();
+    });
+
+    await session.close();
+    await expectLater(listenerCalledCompleter.future, completes);
+  });
+
+  test(
+      'Given a session with a will close listener when the session is closed multiple times then listener is only called once.',
+      () async {
+    var callCount = 0;
+    session.addWillCloseListener((Session session) {
+      callCount++;
+    });
+
+    await session.close();
+    await session.close();
+    await session.close();
+    expect(callCount, 1);
+  });
+
+  test(
+      'Given a session with a will close when listener is removed and the session is closed then the listener is not called.',
+      () async {
+    var listenerCalledCompleter = Completer();
+    var listener = (Session session) {
+      listenerCalledCompleter.complete();
+    };
+    session.addWillCloseListener(listener);
+    session.removeWillCloseListener(listener);
+
+    expect(listenerCalledCompleter.future, doesNotComplete);
+    await expectLater(session.close(), completes);
+  });
+
+  test(
+      'Given a session with multiple will close listeners when the session is closed then listener are called in order.',
+      () async {
+    var completeOrder = <int>[];
+    var listener1CalledCompleter = Completer();
+    var listener2CalledCompleter = Completer();
+    var listener3CalledCompleter = Completer();
+    session.addWillCloseListener((Session session) {
+      completeOrder.add(1);
+      listener1CalledCompleter.complete();
+    });
+    session.addWillCloseListener((Session session) {
+      completeOrder.add(2);
+      listener2CalledCompleter.complete();
+    });
+    session.addWillCloseListener((Session session) {
+      completeOrder.add(3);
+      listener3CalledCompleter.complete();
+    });
+
+    await session.close();
+    await expectLater(listener1CalledCompleter.future, completes);
+    await expectLater(listener2CalledCompleter.future, completes);
+    await expectLater(listener3CalledCompleter.future, completes);
+    expect(completeOrder, [1, 2, 3]);
+  });
+
+  test(
+      'Given a session with multiple will close listeners when one is removed and the session is closed then remaining listener are called in order.',
+      () async {
+    var completeOrder = <int>[];
+    var listener1CalledCompleter = Completer();
+    var listener2CalledCompleter = Completer();
+    var listener3CalledCompleter = Completer();
+    session.addWillCloseListener((Session session) {
+      completeOrder.add(1);
+      listener1CalledCompleter.complete();
+    });
+
+    var listener2Callback = (Session session) {
+      completeOrder.add(2);
+      listener2CalledCompleter.complete();
+    };
+    session.addWillCloseListener(listener2Callback);
+
+    session.addWillCloseListener((Session session) {
+      completeOrder.add(3);
+      listener3CalledCompleter.complete();
+    });
+
+    session.removeWillCloseListener(listener2Callback);
+    expect(listener2CalledCompleter.future, doesNotComplete);
+    await session.close();
+
+    await expectLater(listener1CalledCompleter.future, completes);
+    await expectLater(listener3CalledCompleter.future, completes);
+    expect(completeOrder, [1, 3]);
+  });
+}


### PR DESCRIPTION
Closes: #2581 

Adds support for registering listeners that are called when the session is about to close.

This could become handy with the new streaming interface as such:

```dart
  Stream<int> intEchoStream(Session session, Stream<int> stream) async* {
    var closeLog = (Session session) {
      session.log('Stream closed before completion');
    };
    session.addWillCloseListener(closeLog);

    await for (var value in stream) {
      yield value;
    }

    session.removeWillCloseListener(closeLog);
  }
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - new feature on the streaming interface.