### PR TITLE
test: add exclude path to dart analyzer

### DIFF
--- a/tools/serverpod_cli/analysis_options.yaml
+++ b/tools/serverpod_cli/analysis_options.yaml
@@ -1,1 +1,4 @@
 include: package:serverpod_lints/cli.yaml
+analyzer:
+  exclude:
+    - test/integration/util/test_assets/pubspec_helpers/conditionally_ignored/pubspec.yaml


### PR DESCRIPTION
## Description
When using dart `3.5.0`, the `util/run_tests_analyze --allow-infos` command fails due the following warning by the analyzer:
```
warning • test/integration/util/test_assets/pubspec_helpers/conditionally_ignored/pubspec.yaml:1:1 •
          The 'name' field is required but missing. Try adding a field named 'name'. •
          missing_name
```

Simply excluding the file in `tools/serverpod_cli/analysis_options.yaml` fixes it.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

