### PR TITLE
build: fix auth_server pub error

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -37,3 +37,6 @@ dependency_overrides:
     path: ../../../packages/serverpod_lints
   serverpod_shared:
     path: ../../../packages/serverpod_shared
+
+false_secrets:
+  - test/firebase/firebase_auth_mock.dart

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -36,3 +36,6 @@ dependency_overrides:
     path: ../../../packages/serverpod_lints
   serverpod_shared:
     path: ../../../packages/serverpod_shared
+
+false_secrets:
+  - test/firebase/firebase_auth_mock.dart


### PR DESCRIPTION
## Description
Applies the [suggested changes](https://dart.dev/tools/pub/pubspec#false_secrets) referenced in the issue: https://github.com/serverpod/serverpod/issues/2478

## Changes
- Adds `false_secrets` property to `pubspec.yaml` in the `serverpod_auth_server` module
- Verified that it works by running `dart pub publish --dry-run` ✅ 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._