### PR TITLE
fix: Only consider positional `Session` parameter when validating Endpoint method.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -6,6 +6,7 @@ import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_para
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/dart/element_extensions.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/keywords.dart';
 
 const _excludedMethodNameSet = {
   'streamOpened',
@@ -92,7 +93,7 @@ abstract class EndpointMethodAnalyzer {
     if (parameters.isEmpty) return true;
 
     bool firstParameterIsNotSession =
-        parameters.first.type.element?.displayName != 'Session';
+        parameters.first.type.element?.displayName != Keyword.sessionClassName;
     if (firstParameterIsNotSession) return true;
 
     if (parameters.first.isNamed) return true;

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -90,7 +90,12 @@ abstract class EndpointMethodAnalyzer {
 
   static bool _missingSessionParameter(List<ParameterElement> parameters) {
     if (parameters.isEmpty) return true;
-    return parameters.first.type.element?.displayName != 'Session';
+
+    bool firstParameterIsNotSession =
+        parameters.first.type.element?.displayName != 'Session';
+    if (firstParameterIsNotSession) return true;
+
+    return parameters.first.isNamed;
   }
 
   static SourceSpanSeverityException? _validateReturnType({

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -94,11 +94,10 @@ abstract class EndpointMethodAnalyzer {
 
     bool firstParameterIsNotSession =
         parameters.first.type.element?.displayName != Keyword.sessionClassName;
-    if (firstParameterIsNotSession) return true;
 
-    if (parameters.first.isNamed) return true;
-
-    return parameters.first.isOptional;
+    return firstParameterIsNotSession ||
+        parameters.first.isNamed ||
+        parameters.first.isOptional;
   }
 
   static SourceSpanSeverityException? _validateReturnType({

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -95,7 +95,9 @@ abstract class EndpointMethodAnalyzer {
         parameters.first.type.element?.displayName != 'Session';
     if (firstParameterIsNotSession) return true;
 
-    return parameters.first.isNamed;
+    if (parameters.first.isNamed) return true;
+
+    return parameters.first.isOptional;
   }
 
   static SourceSpanSeverityException? _validateReturnType({

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
@@ -54,7 +54,7 @@ abstract class EndpointParameterAnalyzer {
           parameters.first.type.nullabilitySuffix != NullabilitySuffix.none;
       if (sessionIsNullable) {
         exceptions.add(SourceSpanSeverityException(
-            'The "Session" argument in an endpoint method does not have to be nullable, consider removing the "?".',
+            'The "Session" argument in an endpoint method does not have to be nullable, consider making it non-nullable.',
             parameters.first.span,
             severity: SourceSpanSeverity.hint));
       }

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/dart/element_extensions.dart';
+import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/keywords.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
 
 abstract class EndpointParameterAnalyzer {
@@ -43,54 +44,69 @@ abstract class EndpointParameterAnalyzer {
   static List<SourceSpanSeverityException> validate(
     List<ParameterElement> parameters,
   ) {
-    return parameters
-        .map((parameter) {
-          var type = parameter.type;
-          if (type.isDartAsyncFuture) {
-            return SourceSpanSeverityException(
-              'The type "Future" is not a supported endpoint parameter type.',
-              parameter.span,
-            );
-          }
+    List<SourceSpanSeverityException> exceptions = [];
 
-          if (type.isDartAsyncStream && type is ParameterizedType) {
-            if (type.nullabilitySuffix != NullabilitySuffix.none) {
-              return SourceSpanSeverityException(
-                'Nullable parameters of the type "Stream" are not supported.',
-                parameter.span,
-              );
-            }
+    bool firstParameterIsSession = parameters.isNotEmpty &&
+        parameters.first.type.element?.displayName == Keyword.sessionClassName;
 
-            var typeArguments = type.typeArguments;
-            if (typeArguments.length != 1) {
-              // Streams only allow a single generic so this case is only here for safety.
-              return SourceSpanSeverityException(
-                'The type "Stream" must have exactly one type argument. E.g. Stream<String>.',
-                parameter.span,
-              );
-            }
-            var innerType = typeArguments[0];
-            if (innerType is VoidType) {
-              return SourceSpanSeverityException(
-                'The type "Stream" does not support void generic type.',
-                parameter.span,
-              );
-            }
-          }
+    if (firstParameterIsSession) {
+      bool sessionIsNullable =
+          parameters.first.type.nullabilitySuffix != NullabilitySuffix.none;
+      if (sessionIsNullable) {
+        exceptions.add(SourceSpanSeverityException(
+            'The "Session" argument in an endpoint method does not have to be nullable, consider removing the "?".',
+            parameters.first.span,
+            severity: SourceSpanSeverity.hint));
+      }
+    }
 
-          try {
-            TypeDefinition.fromDartType(parameter.type);
-          } on FromDartTypeClassNameException catch (e) {
-            return SourceSpanSeverityException(
-              'The type "${e.type}" is not a supported endpoint parameter type.',
-              parameter.span,
-            );
-          }
+    exceptions.addAll(parameters.map((parameter) {
+      var type = parameter.type;
+      if (type.isDartAsyncFuture) {
+        return SourceSpanSeverityException(
+          'The type "Future" is not a supported endpoint parameter type.',
+          parameter.span,
+        );
+      }
 
-          return null;
-        })
-        .whereType<SourceSpanSeverityException>()
-        .toList();
+      if (type.isDartAsyncStream && type is ParameterizedType) {
+        if (type.nullabilitySuffix != NullabilitySuffix.none) {
+          return SourceSpanSeverityException(
+            'Nullable parameters of the type "Stream" are not supported.',
+            parameter.span,
+          );
+        }
+
+        var typeArguments = type.typeArguments;
+        if (typeArguments.length != 1) {
+          // Streams only allow a single generic so this case is only here for safety.
+          return SourceSpanSeverityException(
+            'The type "Stream" must have exactly one type argument. E.g. Stream<String>.',
+            parameter.span,
+          );
+        }
+        var innerType = typeArguments[0];
+        if (innerType is VoidType) {
+          return SourceSpanSeverityException(
+            'The type "Stream" does not support void generic type.',
+            parameter.span,
+          );
+        }
+      }
+
+      try {
+        TypeDefinition.fromDartType(parameter.type);
+      } on FromDartTypeClassNameException catch (e) {
+        return SourceSpanSeverityException(
+          'The type "${e.type}" is not a supported endpoint parameter type.',
+          parameter.span,
+        );
+      }
+
+      return null;
+    }).whereType<SourceSpanSeverityException>());
+
+    return exceptions;
   }
 
   static bool _isRequired(ParameterElement parameter) {

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/keywords.dart
@@ -1,0 +1,3 @@
+abstract class Keyword {
+  static const String sessionClassName = "Session";
+}

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/keywords.dart
@@ -1,3 +1,3 @@
 abstract class Keyword {
-  static const String sessionClassName = "Session";
+  static const String sessionClassName = 'Session';
 }

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -233,7 +233,8 @@ class EndpointsAnalyzer {
   }
 
   Map<String, List<SourceSpanSeverityException>> _filterNoFailExceptions(
-      Map<String, List<SourceSpanSeverityException>> validationErrors) {
+    Map<String, List<SourceSpanSeverityException>> validationErrors,
+  ) {
     var noFailSeverities = [SourceSpanSeverity.hint, SourceSpanSeverity.info];
 
     var failingErrors = validationErrors.map((key, exceptions) {

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -137,7 +137,7 @@ class ExampleEndpoint extends Endpoint {
 import 'package:serverpod/serverpod.dart';
 
 class ExampleEndpoint extends Endpoint {
-  Future<String> hello(String name) async {
+  Future<String> hello(String name, int num) async {
     return 'Hello \$name';
   }
 }

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -120,7 +120,8 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
-  group('Given an endpoint method without a first positional `Session` param',
+  group(
+      'Given an endpoint method without a first positional `Session` param and the other parameters are not a `Session` parameter when analyzed',
       () {
     var collector = CodeGenerationCollector();
     var testDirectory =
@@ -129,13 +130,10 @@ class ExampleEndpoint extends Endpoint {
     late List<EndpointDefinition> endpointDefinitions;
     late EndpointsAnalyzer analyzer;
 
-    group(
-        'and the other parameters are not a `Session` parameter when analyzed',
-        () {
-      setUpAll(() async {
-        var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
-        endpointFile.createSync(recursive: true);
-        endpointFile.writeAsStringSync('''
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
 import 'package:serverpod/serverpod.dart';
 
 class ExampleEndpoint extends Endpoint {
@@ -144,30 +142,37 @@ class ExampleEndpoint extends Endpoint {
   }
 }
 ''');
-        analyzer = EndpointsAnalyzer(testDirectory);
-        endpointDefinitions = await analyzer.analyze(collector: collector);
-      });
-      test('then no validation errors are reported.', () {
-        expect(collector.errors, isEmpty);
-      });
-
-      test('then endpoint definition is created.', () {
-        expect(endpointDefinitions, hasLength(1));
-      });
-
-      test('then no endpoint method definition is created.', () {
-        var methods = endpointDefinitions.firstOrNull?.methods;
-        expect(methods, isEmpty);
-      });
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
     });
 
-    group(
-        'and the first parameter instead contains a named `Session` parameter when analyzed',
-        () {
-      setUpAll(() async {
-        var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
-        endpointFile.createSync(recursive: true);
-        endpointFile.writeAsStringSync('''
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then no endpoint method definition is created.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method without a first positional `Session` param and the first parameter instead contains a named `Session` parameter when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
 import 'package:serverpod/serverpod.dart';
 
 class ExampleEndpoint extends Endpoint {
@@ -176,30 +181,37 @@ class ExampleEndpoint extends Endpoint {
   }
 }
 ''');
-        analyzer = EndpointsAnalyzer(testDirectory);
-        endpointDefinitions = await analyzer.analyze(collector: collector);
-      });
-      test('then no validation errors are reported.', () {
-        expect(collector.errors, isEmpty);
-      });
-
-      test('then endpoint definition is created.', () {
-        expect(endpointDefinitions, hasLength(1));
-      });
-
-      test('then no endpoint method definition is created.', () {
-        var methods = endpointDefinitions.firstOrNull?.methods;
-        expect(methods, isEmpty);
-      });
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
     });
 
-    group(
-        'and the first parameter instead contains an optional `Session` parameter when analyzed',
-        () {
-      setUpAll(() async {
-        var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
-        endpointFile.createSync(recursive: true);
-        endpointFile.writeAsStringSync('''
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then no endpoint method definition is created.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
+    });
+  });
+
+  group(
+      'Given an endpoint method without a first positional `Session` param and the first parameter instead contains an optional `Session` parameter when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
 import 'package:serverpod/serverpod.dart';
 
 class ExampleEndpoint extends Endpoint {
@@ -208,21 +220,20 @@ class ExampleEndpoint extends Endpoint {
   }
 }
 ''');
-        analyzer = EndpointsAnalyzer(testDirectory);
-        endpointDefinitions = await analyzer.analyze(collector: collector);
-      });
-      test('then no validation errors are reported.', () {
-        expect(collector.errors, isEmpty);
-      });
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
 
-      test('then endpoint definition is created.', () {
-        expect(endpointDefinitions, hasLength(1));
-      });
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
 
-      test('then no endpoint method definition is created.', () {
-        var methods = endpointDefinitions.firstOrNull?.methods;
-        expect(methods, isEmpty);
-      });
+    test('then no endpoint method definition is created.', () {
+      var methods = endpointDefinitions.firstOrNull?.methods;
+      expect(methods, isEmpty);
     });
   });
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -108,7 +108,7 @@ class ExampleEndpoint extends Endpoint {
     test('then a hint message is reported.', () {
       expect(collector.errors, hasLength(1));
       expect(collector.errors.first.message,
-          'The "Session" argument in an endpoint method does not have to be nullable, consider removing the "?".');
+          'The "Session" argument in an endpoint method does not have to be nullable, consider making it non-nullable.');
     });
 
     test('then endpoint definition is created.', () {

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -191,6 +191,38 @@ class ExampleEndpoint extends Endpoint {
         expect(methods, isEmpty);
       });
     });
+
+    group(
+        'and the first parameter instead contains an optional `Session` parameter when analyzed',
+        () {
+      setUpAll(() async {
+        var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+        endpointFile.createSync(recursive: true);
+        endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello([Session? session, String name = "name"]) async {
+    return 'Hello \$name';
+  }
+}
+''');
+        analyzer = EndpointsAnalyzer(testDirectory);
+        endpointDefinitions = await analyzer.analyze(collector: collector);
+      });
+      test('then no validation errors are reported.', () {
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then endpoint definition is created.', () {
+        expect(endpointDefinitions, hasLength(1));
+      });
+
+      test('then no endpoint method definition is created.', () {
+        var methods = endpointDefinitions.firstOrNull?.methods;
+        expect(methods, isEmpty);
+      });
+    });
   });
 
   test(

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -120,7 +120,8 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
-  group('Given an endpoint method without a first unnamed `Session` param', () {
+  group('Given an endpoint method without a first positional `Session` param',
+      () {
     var collector = CodeGenerationCollector();
     var testDirectory =
         Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
@@ -129,7 +130,7 @@ class ExampleEndpoint extends Endpoint {
     late EndpointsAnalyzer analyzer;
 
     group(
-        'And the other parameters are not a `Session` parameter when analyzed',
+        'and the other parameters are not a `Session` parameter when analyzed',
         () {
       setUpAll(() async {
         var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
@@ -161,7 +162,7 @@ class ExampleEndpoint extends Endpoint {
     });
 
     group(
-        'And the first parameter instead contains a named `Session` parameter when analyzed',
+        'and the first parameter instead contains a named `Session` parameter when analyzed',
         () {
       setUpAll(() async {
         var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));


### PR DESCRIPTION
## Description
Fixes #2557, where a public method was incorrectly interpreted as an Endpoint method. This causes the following two `sublist` calls to throw a `RangeError`:
```dart
// tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart

if (isStream) {
      return MethodStreamDefinition(
       // ...
        parameters: parameters.required.sublist(1), // Skip session parameter,
      // ...
      );
    }
return MethodCallDefinition(
    // ...
      parameters: parameters.required.sublist(1), // Skip session parameter,
    // ...
);

Additionally, for the case of a nullable `Session` (`Future<void> hello(Session? session) async {}`), there is now a hint message, see below. 
```

## Changes
- Adds a test case according to the filed bug (#2557)
- Adds an additional check for named parameter in the `EndpointMethodAnalyzer._missingSessionParameter` method. If the first parameter is a `Session` but is named, it shouldn't be interpreted as an Endpoint method.
- Adds a hint message for nullable `Session` argument in a valid Endpoint method.
<img width="728" alt="image" src="https://github.com/user-attachments/assets/e6bd562b-2287-4eed-bef8-8c76ebbd7687">

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
