### PR TITLE
fix: Updated example template files to replace old 'protocol' name with 'models'.

### DIFF
--- a/examples/auth_example/auth_example_server/lib/src/models/example.spy.yaml
+++ b/examples/auth_example/auth_example_server/lib/src/models/example.spy.yaml
@@ -1,4 +1,4 @@
-# Yaml-files in the `protocol` directory specify which serializable objects
+# Yaml-files in the `models` directory specify which serializable objects
 # should be generated. When you add or modify a file, you will need to run
 # `serverpod generate` to make the generated classes available in the server and
 # client.

--- a/templates/serverpod_templates/projectname_server/lib/src/models/example.spy.yaml
+++ b/templates/serverpod_templates/projectname_server/lib/src/models/example.spy.yaml
@@ -1,4 +1,4 @@
-# Yaml-files in the `protocol` directory specify which serializable objects
+# Yaml-files in the `models` directory specify which serializable objects
 # should be generated. When you add or modify a file, you will need to run
 # `serverpod generate` to make the generated classes available in the server and
 # client.


### PR DESCRIPTION
Updated example template files to replace old 'protocol' name with 'models'.

Closes #2598

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a