### PR TITLE
chore: Update analyze command to allow only giving warnings on new major versions.

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/commands/analyze_pubspecs.dart
@@ -17,12 +17,34 @@ class AnalyzePubspecsCommand extends ServerpodCommand {
       'check-latest-version',
       defaultsTo: false,
     );
+
+    argParser.addFlag(
+      'only-major',
+      defaultsTo: false,
+      help: 'Only check for major updates when checking for latest version.',
+    );
+
+    argParser.addFlag(
+      'ignore-serverpod',
+      defaultsTo: false,
+      help: 'Ignore serverpod packages when checking for latest version.',
+    );
   }
 
   @override
   Future<void> run() async {
     bool checkLatestVersion = argResults!['check-latest-version'];
-    if (!await pubspecDependenciesMatch(checkLatestVersion)) {
+    var checkLatestVersionObj = switch (checkLatestVersion) {
+      true => CheckLatestVersion(
+          onlyMajorUpdate: argResults!['only-major'],
+          ignoreServerpodPackages: argResults!['ignore-serverpod'],
+        ),
+      false => null,
+    };
+
+    if (!await pubspecDependenciesMatch(
+      checkLatestVersion: checkLatestVersionObj,
+    )) {
       throw ExitException();
     }
   }

--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -8,9 +8,21 @@ import 'package:serverpod_cli/src/util/directory.dart';
 import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
+class CheckLatestVersion {
+  final bool onlyMajorUpdate;
+  final bool ignoreServerpodPackages;
+
+  CheckLatestVersion({
+    required this.onlyMajorUpdate,
+    required this.ignoreServerpodPackages,
+  });
+}
+
 /// The internal tool for analyzing the pubspec.yaml files in the Serverpod
 /// repo.
-Future<bool> pubspecDependenciesMatch(bool checkLatestVersion) async {
+Future<bool> pubspecDependenciesMatch({
+  required CheckLatestVersion? checkLatestVersion,
+}) async {
   var directory = Directory.current;
   if (!isServerpodRootDirectory(directory)) {
     log.error('Must be run from the serverpod repository root');
@@ -38,21 +50,28 @@ Future<bool> pubspecDependenciesMatch(bool checkLatestVersion) async {
 
   log.info('Dependencies match.');
 
-  if (checkLatestVersion) {
-    await _checkLatestVersion(dependencies);
+  if (checkLatestVersion != null) {
+    return await _checkLatestVersion(
+      dependencies,
+      onlyMajorUpdate: checkLatestVersion.onlyMajorUpdate,
+      ignoreServerpodPackages: checkLatestVersion.ignoreServerpodPackages,
+    );
   }
 
   return true;
 }
 
-Future<void> _checkLatestVersion(
-    Map<String, List<_ServerpodDependency>> dependencies) async {
+Future<bool> _checkLatestVersion(
+  Map<String, List<_ServerpodDependency>> dependencies, {
+  required bool onlyMajorUpdate,
+  required bool ignoreServerpodPackages,
+}) async {
+  bool latestVersionMatch = true;
   log.info('Checking latest pub versions.');
   try {
     var pub = PubApiClient();
     for (var depName in dependencies.keys) {
       var deps = dependencies[depName]!;
-      var depVersion = deps.first.version;
       Version? latestPubVersion;
       try {
         latestPubVersion = await pub.tryFetchLatestStableVersion(depName);
@@ -62,8 +81,23 @@ Future<void> _checkLatestVersion(
         log.error(e.message);
       }
 
-      if (latestPubVersion != null &&
-          depVersion != '^${latestPubVersion.toString()}') {
+      if (ignoreServerpodPackages && depName.startsWith('serverpod')) {
+        continue;
+      }
+
+      var depVersion = VersionConstraint.parse(deps.first.version);
+
+      if (latestPubVersion == null) {
+        continue;
+      }
+
+      var differentVersion = switch (onlyMajorUpdate) {
+        true => !depVersion.allows(latestPubVersion),
+        false => depVersion != latestPubVersion,
+      };
+
+      if (differentVersion) {
+        latestVersionMatch = false;
         log.info(depName);
         log.info('local: $depVersion');
         log.info('pub:   ^$latestPubVersion');
@@ -81,6 +115,8 @@ Future<void> _checkLatestVersion(
     log.error('Version check failed.');
     log.error(e.toString());
   }
+
+  return latestVersionMatch;
 }
 
 void _printMismatchedDependencies(Set<String> mismatchedDeps,

--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -85,12 +85,11 @@ Future<bool> _checkLatestVersion(
         continue;
       }
 
-      var depVersion = VersionConstraint.parse(deps.first.version);
-
       if (latestPubVersion == null) {
         continue;
       }
 
+      var depVersion = VersionConstraint.parse(deps.first.version);
       var differentVersion = switch (onlyMajorUpdate) {
         true => !depVersion.allows(latestPubVersion),
         false => depVersion != latestPubVersion,

--- a/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/internal_tools/analyze_pubspecs.dart
@@ -81,6 +81,9 @@ Future<bool> _checkLatestVersion(
         log.error(e.message);
       }
 
+      // Crude way to ignore serverpod packages when checking for latest version.
+      // This might cause unintentionally exclusion of external packages.
+      // TODO: Improve this, tracking issue: https://github.com/serverpod/serverpod/issues/2603
       if (ignoreServerpodPackages && depName.startsWith('serverpod')) {
         continue;
       }


### PR DESCRIPTION
Updates the hidden helper command to allow us to check if there are any new major versions out for any of the dependencies in the Serverpod mono repo.

Sample output when running the command on the state of the repo now:


```
$ serverpod analyze-pubspecs --check-latest-version --only-major --ignore-serverpod
Dependencies match.
Checking latest pub versions.
web_socket_channel
local: ^2.4.0
pub:   ^3.0.1
found in:
 • serverpod_client
firebase_auth
local: ^4.4.2
pub:   ^5.1.4
found in:
 • serverpod_auth_firebase_flutter
firebase_core
local: ^2.10.0
pub:   ^3.3.0
found in:
 • serverpod_auth_firebase_flutter
material_design_icons_flutter
local: >=6.0.0 <7.0.0
pub:   ^7.0.7296
found in:
 • serverpod_auth_firebase_flutter
 • serverpod_auth_apple_flutter
email_validator
local: ^2.1.17
pub:   ^3.0.0
found in:
 • serverpod_auth_server
 • serverpod_auth_email_flutter
googleapis
local: ^11.0.0
pub:   ^13.2.0
found in:
 • serverpod_auth_server
image_cropper
local: ^5.0.0
pub:   ^8.0.1
found in:
 • serverpod_auth_shared_flutter
```

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Changes to a hidden developer command that targets the development of Serverpod.