### PR TITLE
fix: Validate model and custom class names collisions

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -36,7 +36,7 @@ class SerializableModelAnalyzer {
     Keyword.enumType,
   };
 
-  /// Best effort attempt to extract an model definition from a yaml file.
+  /// Best effort attempt to extract a model definition from a yaml file.
   static SerializableModelDefinition? extractModelDefinition(
     ModelSource modelSource,
     List<TypeDefinition> extraClasses,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -164,6 +164,21 @@ class Restrictions {
       ];
     }
 
+    var duplicateExtraClass =
+        config.extraClasses.cast<TypeDefinition?>().firstWhere(
+              (extraClass) => extraClass?.className == className,
+              orElse: () => null,
+            );
+
+    if (duplicateExtraClass != null) {
+      return [
+        SourceSpanSeverityException(
+          'The $documentType name "$className" is already used by a custom class (${duplicateExtraClass.url}).',
+          span,
+        )
+      ];
+    }
+
     var classesByName = parsedModels.classNames[className]?.where(
         (model) => model.moduleAlias == documentDefinition?.moduleAlias);
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_conflicts_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_conflicts_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
@@ -41,6 +42,42 @@ void main() {
     expect(
       error.message,
       'The class name "Example" is already used by another model class.',
+    );
+  });
+
+  test(
+      'Given a model and a custom class with the same class name, then an error is collected that there is a collision in the class names.',
+      () {
+    var modelSources = [
+      ModelSourceBuilder().withYaml(
+        '''
+        class: CustomClass
+        fields:
+          name: String
+        ''',
+      ).build(),
+    ];
+    var extraClassDefinition = TypeDefinition(
+        className: 'CustomClass',
+        nullable: false,
+        url: 'package:my_app_shared/my_app_shared.dart');
+    var config = GeneratorConfigBuilder()
+        .withExtraClasses([extraClassDefinition]).build();
+    var collector = CodeGenerationCollector();
+
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
+
+    expect(
+      collector.errors,
+      isNotEmpty,
+      reason: 'Expected an error but none was generated.',
+    );
+
+    var error = collector.errors.first;
+    expect(
+      error.message,
+      'The class name "CustomClass" is already used by a custom class (package:my_app_shared/my_app_shared.dart).',
     );
   });
 


### PR DESCRIPTION
## Description
This PR fixes [#2339](https://github.com/serverpod/serverpod/issues/2339).

Adds an additional check for custom classes to the `Restrictions.validateClassName` method and returns an error in case there are collisions. Tried to keep the error message similar to the one for colliding model class names:
```
Model class collision:  "The class name "HampusCustomClass" is already used by another model class."
Custom class collision: "The class name "HampusCustomClass" is already used by a custom class (package:onboarding_todo_app_shared/onboarding_todo_app_shared.dart)."
```
## Changes
- Fixes a tiny typo
- Adds validation for collisions between model class names and custom class names 
<img width="730" alt="image" src="https://github.com/user-attachments/assets/c0049b48-8865-4467-bcb8-fca4c5d572df">
<img width="920" alt="image" src="https://github.com/user-attachments/assets/0d3c10b3-6f53-4716-9b9f-7a90e4af5e5f">


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).
