### PR TITLE
feat: Deprecated annotation reflected in generated client code.

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -123,8 +123,5 @@ class AnnotationDefinition {
   /// Null means no arguments and no parenthesis; empty list means no arguments but with parenthesis.
   final List<String>? arguments;
 
-  const AnnotationDefinition({
-    required this.name,
-    this.arguments,
-  });
+  const AnnotationDefinition({required this.name, this.arguments});
 }

--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -118,8 +118,9 @@ class ParameterDefinition {
 /// Describes an annotation.
 class AnnotationDefinition {
   final String name;
+
   /// The arguments of the annotation.
-  /// Null means no arguments and no parenthesis; empty list means no arguments but with parenthesis. 
+  /// Null means no arguments and no parenthesis; empty list means no arguments but with parenthesis.
   final List<String>? arguments;
 
   const AnnotationDefinition({

--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -42,6 +42,9 @@ abstract base class MethodDefinition {
   /// The documentation of this method.
   final String? documentationComment;
 
+  /// The annotations of this method.
+  final List<String>? annotations;
+
   /// The returned type of this method.
   /// This should always be a future.
   final TypeDefinition returnType;
@@ -58,6 +61,7 @@ abstract base class MethodDefinition {
   const MethodDefinition({
     required this.name,
     required this.documentationComment,
+    required this.annotations,
     required this.returnType,
     required this.parameters,
     required this.parametersPositional,
@@ -71,6 +75,7 @@ final class MethodCallDefinition extends MethodDefinition {
   const MethodCallDefinition({
     required super.name,
     required super.documentationComment,
+    required super.annotations,
     required super.parameters,
     required super.parametersPositional,
     required super.parametersNamed,
@@ -83,6 +88,7 @@ final class MethodStreamDefinition extends MethodDefinition {
   MethodStreamDefinition({
     required super.name,
     required super.documentationComment,
+    required super.annotations,
     required super.returnType,
     required super.parameters,
     required super.parametersPositional,

--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -43,7 +43,7 @@ abstract base class MethodDefinition {
   final String? documentationComment;
 
   /// The annotations of this method.
-  final List<String>? annotations;
+  final List<AnnotationDefinition> annotations;
 
   /// The returned type of this method.
   /// This should always be a future.
@@ -112,5 +112,18 @@ class ParameterDefinition {
     required this.name,
     required this.type,
     required this.required,
+  });
+}
+
+/// Describes an annotation.
+class AnnotationDefinition {
+  final String name;
+  /// The arguments of the annotation.
+  /// Null means no arguments and no parenthesis; empty list means no arguments but with parenthesis. 
+  final List<String>? arguments;
+
+  const AnnotationDefinition({
+    required this.name,
+    this.arguments,
   });
 }

--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -121,6 +121,7 @@ class AnnotationDefinition {
 
   /// The arguments of the annotation.
   /// Null means no arguments and no parenthesis; empty list means no arguments but with parenthesis.
+  /// Arguments must be valid Dart literals.
   final List<String>? arguments;
 
   const AnnotationDefinition({required this.name, this.arguments});

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -156,8 +156,10 @@ abstract class EndpointMethodAnalyzer {
     return null;
   }
 
-  static List<String>? _parseAnnotationArgument(
-      ElementAnnotation annotation, String fieldName) {
+  static List<String>? _parseAnnotationStringArgument(
+    ElementAnnotation annotation,
+    String fieldName,
+  ) {
     var argument =
         annotation.computeConstantValue()?.getField(fieldName)?.toStringValue();
     return argument != null ? ["'$argument'"] : null;
@@ -176,7 +178,7 @@ abstract class EndpointMethodAnalyzer {
         'Deprecated' => [
             AnnotationDefinition(
               name: annotationName,
-              arguments: _parseAnnotationArgument(annotation, 'message'),
+              arguments: _parseAnnotationStringArgument(annotation, 'message'),
             )
           ],
         'deprecated' =>

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -156,6 +156,13 @@ abstract class EndpointMethodAnalyzer {
     return null;
   }
 
+  static List<String>? _parseAnnotationArgument(
+      ElementAnnotation annotation, String fieldName) {
+    var argument =
+        annotation.computeConstantValue()?.getField(fieldName)?.toStringValue();
+    return argument != null ? ["'$argument'"] : null;
+  }
+
   static List<AnnotationDefinition> _parseAnnotations({
     required Element dartElement,
   }) {
@@ -169,12 +176,7 @@ abstract class EndpointMethodAnalyzer {
         'Deprecated' => [
             AnnotationDefinition(
               name: annotationName,
-              arguments: [
-                annotation
-                    .computeConstantValue()
-                    ?.getField('message')
-                    ?.toStringValue(),
-              ].whereType<String>().toList(),
+              arguments: _parseAnnotationArgument(annotation, 'message'),
             )
           ],
         'deprecated' =>

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart
@@ -160,13 +160,15 @@ abstract class EndpointMethodAnalyzer {
     required Element dartElement,
   }) {
     return dartElement.metadata.expand<AnnotationDefinition>((annotation) {
-      var annotationName = annotation.element is ConstructorElement
-          ? (annotation.element as ConstructorElement).enclosingElement.name
-          : annotation.element?.name;
+      var annotationElement = annotation.element;
+      var annotationName = annotationElement is ConstructorElement
+          ? annotationElement.enclosingElement.name
+          : annotationElement?.name;
+      if (annotationName == null) return [];
       return switch (annotationName) {
         'Deprecated' => [
             AnnotationDefinition(
-              name: annotationName!,
+              name: annotationName,
               arguments: [
                 annotation
                     .computeConstantValue()
@@ -178,7 +180,7 @@ abstract class EndpointMethodAnalyzer {
         'deprecated' =>
           // @deprecated is a shorthand for @Deprecated(..)
           // see https://api.flutter.dev/flutter/dart-core/deprecated-constant.html
-          [AnnotationDefinition(name: annotationName!)],
+          [AnnotationDefinition(name: annotationName)],
         _ => [],
       };
     }).toList();

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -658,11 +658,12 @@ class LibraryGenerator {
 
   Iterable<Expression> _buildEndpointCallAnnotations(
       MethodDefinition methodDef) {
-    return methodDef.annotations.map((annotation) => refer(annotation
-                .arguments !=
-            null
-        ? '${annotation.name}(${annotation.arguments!.map((a) => "'$a'").join(',')})'
-        : annotation.name));
+    return [
+      for (var annotation in methodDef.annotations)
+        refer(annotation.arguments != null
+            ? '${annotation.name}(${annotation.arguments!.map((a) => "'$a'").join(',')})'
+            : annotation.name)
+    ];
   }
 
   Code _buildCallServerEndpoint(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -384,6 +384,7 @@ class LibraryGenerator {
               Method(
                 (m) => m
                   ..docs.add(_buildEndpointCallDocumentation(methodDef))
+                  ..annotations.addAll(_buildEndpointCallAnnotations(methodDef))
                   ..returns = returnType.reference(false, config: config)
                   ..name = methodDef.name
                   ..requiredParameters.addAll([
@@ -653,6 +654,13 @@ class LibraryGenerator {
     }
 
     return '$experimentalWarning\n///\n$documentationComment';
+  }
+
+  Iterable<Expression> _buildEndpointCallAnnotations(MethodDefinition methodDef) {
+    // skips the first character of the annotation string which is a '@'
+    return methodDef.annotations
+            ?.map((annotation) => refer(annotation.substring(1))) ??
+        [];
   }
 
   Code _buildCallServerEndpoint(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -661,7 +661,7 @@ class LibraryGenerator {
     return methodDef.annotations.map((annotation) {
       var args = annotation.arguments;
       return refer(args != null
-          ? '${annotation.name}(${args.map((a) => "'$a'").join(',')})'
+          ? '${annotation.name}(${args.join(',')})'
           : annotation.name);
     });
   }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -658,12 +658,12 @@ class LibraryGenerator {
 
   Iterable<Expression> _buildEndpointCallAnnotations(
       MethodDefinition methodDef) {
-    return [
-      for (var annotation in methodDef.annotations)
-        refer(annotation.arguments != null
-            ? '${annotation.name}(${annotation.arguments!.map((a) => "'$a'").join(',')})'
-            : annotation.name)
-    ];
+    return methodDef.annotations.map((annotation) {
+      var args = annotation.arguments;
+      return refer(args != null
+          ? '${annotation.name}(${args.map((a) => "'$a'").join(',')})'
+          : annotation.name);
+    });
   }
 
   Code _buildCallServerEndpoint(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -658,10 +658,11 @@ class LibraryGenerator {
 
   Iterable<Expression> _buildEndpointCallAnnotations(
       MethodDefinition methodDef) {
-    return methodDef.annotations.map((annotation) => refer(
-        annotation.arguments != null
-            ? '${annotation.name}(${annotation.arguments!.map((a) => "'$a'").join(',')})'
-            : annotation.name));
+    return methodDef.annotations.map((annotation) => refer(annotation
+                .arguments !=
+            null
+        ? '${annotation.name}(${annotation.arguments!.map((a) => "'$a'").join(',')})'
+        : annotation.name));
   }
 
   Code _buildCallServerEndpoint(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -656,11 +656,12 @@ class LibraryGenerator {
     return '$experimentalWarning\n///\n$documentationComment';
   }
 
-  Iterable<Expression> _buildEndpointCallAnnotations(MethodDefinition methodDef) {
-    // skips the first character of the annotation string which is a '@'
-    return methodDef.annotations
-            ?.map((annotation) => refer(annotation.substring(1))) ??
-        [];
+  Iterable<Expression> _buildEndpointCallAnnotations(
+      MethodDefinition methodDef) {
+    return methodDef.annotations.map((annotation) => refer(
+        annotation.arguments != null
+            ? '${annotation.name}(${annotation.arguments!.map((a) => "'$a'").join(',')})'
+            : annotation.name));
   }
 
   Code _buildCallServerEndpoint(

--- a/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
@@ -5,7 +5,7 @@ import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dar
 class MethodDefinitionBuilder {
   String _name = 'example';
   String? _documentationComment;
-  List<String>? _annotations;
+  List<AnnotationDefinition> _annotations = [];
   TypeDefinition _returnType =
       TypeDefinitionBuilder().withFutureOf('String').build();
   List<ParameterDefinition> _parameters = [];
@@ -24,7 +24,7 @@ class MethodDefinitionBuilder {
   }
 
   MethodDefinitionBuilder withAnnotations(
-      List<String>? annotations) {
+      List<AnnotationDefinition> annotations) {
     _annotations = annotations;
     return this;
   }

--- a/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
@@ -5,6 +5,7 @@ import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dar
 class MethodDefinitionBuilder {
   String _name = 'example';
   String? _documentationComment;
+  List<String>? _annotations;
   TypeDefinition _returnType =
       TypeDefinitionBuilder().withFutureOf('String').build();
   List<ParameterDefinition> _parameters = [];
@@ -19,6 +20,12 @@ class MethodDefinitionBuilder {
   MethodDefinitionBuilder withDocumentationComment(
       String? documentationComment) {
     _documentationComment = documentationComment;
+    return this;
+  }
+
+  MethodDefinitionBuilder withAnnotations(
+      List<String>? annotations) {
+    _annotations = annotations;
     return this;
   }
 
@@ -48,6 +55,7 @@ class MethodDefinitionBuilder {
     return MethodCallDefinition(
       name: _name,
       documentationComment: _documentationComment,
+      annotations: _annotations,
       returnType: _returnType,
       parameters: _parameters,
       parametersPositional: _parametersPositional,
@@ -59,6 +67,7 @@ class MethodDefinitionBuilder {
     return MethodStreamDefinition(
       name: _name,
       documentationComment: _documentationComment,
+      annotations: _annotations,
       returnType: _returnType,
       parameters: _parameters,
       parametersPositional: _parametersPositional,

--- a/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/method_definition_builder.dart
@@ -18,13 +18,15 @@ class MethodDefinitionBuilder {
   }
 
   MethodDefinitionBuilder withDocumentationComment(
-      String? documentationComment) {
+    String? documentationComment,
+  ) {
     _documentationComment = documentationComment;
     return this;
   }
 
   MethodDefinitionBuilder withAnnotations(
-      List<AnnotationDefinition> annotations) {
+    List<AnnotationDefinition> annotations,
+  ) {
     _annotations = annotations;
     return this;
   }
@@ -40,13 +42,15 @@ class MethodDefinitionBuilder {
   }
 
   MethodDefinitionBuilder withParametersPositional(
-      List<ParameterDefinition> parametersPositional) {
+    List<ParameterDefinition> parametersPositional,
+  ) {
     _parametersPositional = parametersPositional;
     return this;
   }
 
   MethodDefinitionBuilder withParametersNamed(
-      List<ParameterDefinition> parametersNamed) {
+    List<ParameterDefinition> parametersNamed,
+  ) {
     _parametersNamed = parametersNamed;
     return this;
   }

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -147,7 +147,9 @@ void main() {
             .withMethods([
           MethodDefinitionBuilder().withName(methodName).withAnnotations([
             const AnnotationDefinition(
-                name: 'Deprecated', arguments: ['This method is deprecated.'])
+              name: 'Deprecated',
+              arguments: ["'This method is deprecated.'"],
+            )
           ]).buildMethodCallDefinition(),
         ]).build(),
       ],
@@ -164,7 +166,8 @@ void main() {
     });
     var endpointsFile = codeMap[expectedFileName];
 
-    test('then client file contains Deprecated(..) annotation for method.', () {
+    test('then client file contains "@Deprecated(..)" annotation for method.',
+        () {
       expect(
         endpointsFile,
         contains(
@@ -203,11 +206,55 @@ void main() {
     });
     var endpointsFile = codeMap[expectedFileName];
 
-    test('then client file contains deprecated annotation for method.', () {
+    test('then client file contains "@deprecated" annotation for method.', () {
       expect(
         endpointsFile,
         contains(
           '@deprecated\n',
+        ),
+      );
+    });
+  });
+
+  group(
+      'Given a protocol definition with a method with "@TestCustomAnnotation(.., ..)" annotation when generating client file',
+      () {
+    var endpointName = 'testing';
+    var methodName = 'customAnnotatedMethod';
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('${endpointName.pascalCase}Endpoint')
+            .withName(endpointName)
+            .withMethods([
+          MethodDefinitionBuilder().withName(methodName).withAnnotations([
+            const AnnotationDefinition(
+              name: 'TestCustomAnnotation',
+              arguments: ["'a string literal argument'", '42'],
+            )
+          ]).buildMethodCallDefinition(),
+        ]).build(),
+      ],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test('then client file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+    var endpointsFile = codeMap[expectedFileName];
+
+    test(
+        'then client file contains "@TestCustomAnnotation(.., ..)" annotation for method.',
+        () {
+      expect(
+        endpointsFile,
+        contains(
+          "@TestCustomAnnotation('a string literal argument', 42)",
         ),
       );
     });

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -135,7 +135,7 @@ void main() {
   });
 
   group(
-      'Given a protocol definition with a method with Deprecated annotation when generating client file',
+      'Given a protocol definition with a method with Deprecated(..) annotation when generating client file',
       () {
     var endpointName = 'testing';
     var methodName = 'deprecatedMethod';
@@ -147,7 +147,7 @@ void main() {
             .withMethods([
           MethodDefinitionBuilder()
               .withName(methodName)
-              .withAnnotations(["@Deprecated('This method is deprecated.')"])
+              .withAnnotations([const AnnotationDefinition(name: 'Deprecated', arguments: ['This method is deprecated.'])])
               .buildMethodCallDefinition(),
         ]).build(),
       ],
@@ -164,11 +164,51 @@ void main() {
     });
     var endpointsFile = codeMap[expectedFileName];
 
-    test('then client file contains Deprecated annotation for method.', () {
+    test('then client file contains Deprecated(..) annotation for method.', () {
       expect(
         endpointsFile,
         contains(
           "@Deprecated('This method is deprecated.')",
+        ),
+      );
+    });
+  });
+
+  group(
+      'Given a protocol definition with a method with deprecated annotation when generating client file',
+      () {
+    var endpointName = 'testing';
+    var methodName = 'deprecatedMethod';
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('${endpointName.pascalCase}Endpoint')
+            .withName(endpointName)
+            .withMethods([
+          MethodDefinitionBuilder()
+              .withName(methodName)
+              .withAnnotations([const AnnotationDefinition(name: 'deprecated')])
+              .buildMethodCallDefinition(),
+        ]).build(),
+      ],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test('then client file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+    var endpointsFile = codeMap[expectedFileName];
+
+    test('then client file contains deprecated annotation for method.', () {
+      expect(
+        endpointsFile,
+        contains(
+          '@deprecated\n',
         ),
       );
     });

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -133,4 +133,44 @@ void main() {
               'caller.callStreamingServerEndpoint<Future<String>, String'));
     });
   });
+
+  group(
+      'Given a protocol definition with a method with Deprecated annotation when generating client file',
+      () {
+    var endpointName = 'testing';
+    var methodName = 'deprecatedMethod';
+    var protocolDefinition = ProtocolDefinition(
+      endpoints: [
+        EndpointDefinitionBuilder()
+            .withClassName('${endpointName.pascalCase}Endpoint')
+            .withName(endpointName)
+            .withMethods([
+          MethodDefinitionBuilder()
+              .withName(methodName)
+              .withAnnotations(["@Deprecated('This method is deprecated.')"])
+              .buildMethodCallDefinition(),
+        ]).build(),
+      ],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    test('then client file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+    var endpointsFile = codeMap[expectedFileName];
+
+    test('then client file contains Deprecated annotation for method.', () {
+      expect(
+        endpointsFile,
+        contains(
+          "@Deprecated('This method is deprecated.')",
+        ),
+      );
+    });
+  });
 }

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -145,10 +145,10 @@ void main() {
             .withClassName('${endpointName.pascalCase}Endpoint')
             .withName(endpointName)
             .withMethods([
-          MethodDefinitionBuilder()
-              .withName(methodName)
-              .withAnnotations([const AnnotationDefinition(name: 'Deprecated', arguments: ['This method is deprecated.'])])
-              .buildMethodCallDefinition(),
+          MethodDefinitionBuilder().withName(methodName).withAnnotations([
+            const AnnotationDefinition(
+                name: 'Deprecated', arguments: ['This method is deprecated.'])
+          ]).buildMethodCallDefinition(),
         ]).build(),
       ],
       models: [],
@@ -185,10 +185,9 @@ void main() {
             .withClassName('${endpointName.pascalCase}Endpoint')
             .withName(endpointName)
             .withMethods([
-          MethodDefinitionBuilder()
-              .withName(methodName)
-              .withAnnotations([const AnnotationDefinition(name: 'deprecated')])
-              .buildMethodCallDefinition(),
+          MethodDefinitionBuilder().withName(methodName).withAnnotations([
+            const AnnotationDefinition(name: 'deprecated')
+          ]).buildMethodCallDefinition(),
         ]).build(),
       ],
       models: [],

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -135,7 +135,7 @@ void main() {
   });
 
   group(
-      'Given a protocol definition with a method with Deprecated(..) annotation when generating client file',
+      'Given a protocol definition with a method with "@Deprecated(..)" annotation when generating client file',
       () {
     var endpointName = 'testing';
     var methodName = 'deprecatedMethod';
@@ -175,7 +175,7 @@ void main() {
   });
 
   group(
-      'Given a protocol definition with a method with deprecated annotation when generating client file',
+      'Given a protocol definition with a method with "@deprecated" annotation when generating client file',
       () {
     var endpointName = 'testing';
     var methodName = 'deprecatedMethod';

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -783,6 +783,89 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
+  group('Given a valid endpoint method with @Deprecated() annotation', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+const deprecatedMessage = 'is deprecated';
+
+class ExampleEndpoint extends Endpoint {
+  @Deprecated('This method \${deprecatedMessage}.')
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method has expected annotations.', () {
+      final annotations = endpointDefinitions
+          .firstOrNull?.methods.firstOrNull?.annotations;
+      expect(annotations, ["@Deprecated('This method is deprecated.')"]);
+    });
+  });
+
+
+  group('Given a valid endpoint method with @deprecated annotation', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+const deprecatedMessage = 'is deprecated';
+
+class ExampleEndpoint extends Endpoint {
+  @deprecated
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+
+    test('then endpoint definition method has expected annotations.', () {
+      final annotations = endpointDefinitions
+          .firstOrNull?.methods.firstOrNull?.annotations;
+      expect(annotations, ["@deprecated"]);
+    });
+  });
+
   group('Given an endpoint method with a void return type', () {
     var collector = CodeGenerationCollector();
     var testDirectory =

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -784,7 +784,7 @@ class ExampleEndpoint extends Endpoint {
   });
 
   group(
-      'Given a valid endpoint method with @Deprecated(<string literal>) annotation',
+      'Given a valid endpoint method with "@Deprecated(<string literal>)" annotation',
       () {
     var collector = CodeGenerationCollector();
     var testDirectory =
@@ -827,7 +827,7 @@ class ExampleEndpoint extends Endpoint {
   });
 
   group(
-      'Given a valid endpoint method with @Deprecated(<string const expr>) annotation',
+      'Given a valid endpoint method with "@Deprecated(<string const expr>)" annotation',
       () {
     var collector = CodeGenerationCollector();
     var testDirectory =
@@ -871,7 +871,7 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
-  group('Given a valid endpoint method with @deprecated annotation', () {
+  group('Given a valid endpoint method with "@deprecated" annotation', () {
     var collector = CodeGenerationCollector();
     var testDirectory =
         Directory(path.join(testProjectDirectory.path, const Uuid().v4()));

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -818,14 +818,13 @@ class ExampleEndpoint extends Endpoint {
     });
 
     test('then endpoint definition method has expected annotations.', () {
-      var annotations = endpointDefinitions
-          .firstOrNull?.methods.firstOrNull?.annotations;
+      var annotations =
+          endpointDefinitions.firstOrNull?.methods.firstOrNull?.annotations;
       expect(annotations?.length, 1);
       expect(annotations![0].name, 'Deprecated');
       expect(annotations[0].arguments, ['This method is deprecated.']);
     });
   });
-
 
   group('Given a valid endpoint method with @deprecated annotation', () {
     var collector = CodeGenerationCollector();
@@ -862,8 +861,8 @@ class ExampleEndpoint extends Endpoint {
     });
 
     test('then endpoint definition method has expected annotations.', () {
-      var annotations = endpointDefinitions
-          .firstOrNull?.methods.firstOrNull?.annotations;
+      var annotations =
+          endpointDefinitions.firstOrNull?.methods.firstOrNull?.annotations;
       expect(annotations?.length, 1);
       expect(annotations![0].name, 'deprecated');
       expect(annotations[0].arguments, null);

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -818,9 +818,11 @@ class ExampleEndpoint extends Endpoint {
     });
 
     test('then endpoint definition method has expected annotations.', () {
-      final annotations = endpointDefinitions
+      var annotations = endpointDefinitions
           .firstOrNull?.methods.firstOrNull?.annotations;
-      expect(annotations, ["@Deprecated('This method is deprecated.')"]);
+      expect(annotations?.length, 1);
+      expect(annotations![0].name, 'Deprecated');
+      expect(annotations[0].arguments, ['This method is deprecated.']);
     });
   });
 
@@ -860,9 +862,11 @@ class ExampleEndpoint extends Endpoint {
     });
 
     test('then endpoint definition method has expected annotations.', () {
-      final annotations = endpointDefinitions
+      var annotations = endpointDefinitions
           .firstOrNull?.methods.firstOrNull?.annotations;
-      expect(annotations, ["@deprecated"]);
+      expect(annotations?.length, 1);
+      expect(annotations![0].name, 'deprecated');
+      expect(annotations[0].arguments, null);
     });
   });
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_method_test.dart
@@ -822,7 +822,7 @@ class ExampleEndpoint extends Endpoint {
           endpointDefinitions.firstOrNull?.methods.firstOrNull?.annotations;
       expect(annotations?.length, 1);
       expect(annotations![0].name, 'Deprecated');
-      expect(annotations[0].arguments, ['This method is deprecated.']);
+      expect(annotations[0].arguments, ["'This method is deprecated.'"]);
     });
   });
 
@@ -867,7 +867,7 @@ class ExampleEndpoint extends Endpoint {
           endpointDefinitions.firstOrNull?.methods.firstOrNull?.annotations;
       expect(annotations?.length, 1);
       expect(annotations![0].name, 'Deprecated');
-      expect(annotations[0].arguments, ['This method is deprecated.']);
+      expect(annotations[0].arguments, ["'This method is deprecated.'"]);
     });
   });
 


### PR DESCRIPTION
Deprecated annotation reflected in generated client code. Handles `@Deprecated('..')` and `@deprecated`.

Closes #2214

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a