### PR TITLE
chore: Bump web_socket_channel to allow '3.0.0'.

### DIFF
--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   serverpod_serialization: 2.0.2
   http: '>=1.0.0 <2.0.0'
   meta: ^1.8.0
-  web_socket_channel: ^2.4.0
+  web_socket_channel: '>=2.4.0 <4.0.0'
 
 dev_dependencies:
   serverpod_lints: 2.0.2

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   http: '>=1.0.0 <2.0.0'
   meta: ^1.8.0
-  web_socket_channel: ^2.4.0
+  web_socket_channel: '>=2.4.0 <4.0.0'
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION


### PR DESCRIPTION
Bumps the web_socket_channel dependency from `^2.4.0` to `'>=2.4.0 <4.0.0'`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes for the Serverpod code.