### PR TITLE
chore: Enable dependabot version update pull requests for pub.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Pub dependencies
   - package-ecosystem: "pub"
     directories:
       - packages/**/*
@@ -11,8 +10,9 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: "widen"
-    # Since we are using a monorepo, we want to update the same package
+    # Since this is a library monorepo, it is important that the same package is updated
     # in all directories at the same time.
-    # Currently dependabot does not support this, so we limit the number of
-    # open pull requests to 1 to avoid conflicts.
+    # Currently dependabot does not support this type of grouping, therefore the number
+    # of open pull requests is limited to 1. This prevents multiple pull requests
+    # from being opened for the same dependency.
     open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Pub dependencies
+  - package-ecosystem: "pub"
+    directories:
+      - packages/**/*
+      - modules/**/*
+      - integrations/**/*
+      - templates/serverpod_templates
+      - tools/serverpod_cli
+    schedule:
+      interval: "daily"
+    versioning-strategy: "widen"
+    # Since we are using a monorepo, we want to update the same package
+    # in all directories at the same time.
+    # Currently dependabot does not support this, so we limit the number of
+    # open pull requests to 1 to avoid conflicts.
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Allows dependabot to create PRs for pub updates that are not compatible with the current version range.

Configures the versioning strategy to `widen` which means dependabot will atempt to widen the allowed dependency range to include the new release.

Since we are a library mono-repo we need to keep the same version for a dependency across all packages. Dependabot doesn't seem to support that sort of grouping. As a workaround we will limit the number of open pull requests to 1, this makes it easy for us to find all instances of that dependency and update it in all packages without getting spammed.

Asked a question in the Dependabot discussions around the possibility to group a dependency update for all packages here: https://github.com/dependabot/dependabot-core/discussions/10454

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.