### PR TITLE
fix: Rename and export `MethodStreamException`

### DIFF
--- a/packages/serverpod_client/lib/serverpod_client.dart
+++ b/packages/serverpod_client/lib/serverpod_client.dart
@@ -8,5 +8,6 @@ export 'src/auth_key_manager.dart';
 export 'src/connectivity_monitor.dart';
 export 'src/serverpod_client_exception.dart';
 export 'src/serverpod_client_shared.dart';
+export 'src/method_stream/method_stream_manager_exceptions.dart';
 export 'src/streaming_connection_handler.dart';
 export 'src/file_uploader.dart';

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:serverpod_client/serverpod_client.dart';
 import 'package:serverpod_client/src/method_stream/method_stream_connection_details.dart';
-import 'package:serverpod_client/src/method_stream/method_stream_manager_exceptions.dart';
 import 'package:serverpod_client/src/util/lock.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -435,7 +435,7 @@ final class ClientMethodStreamManager {
 
   Future<void> _listenToWebSocketStream(WebSocketChannel webSocket) async {
     _webSocketListenerCompleter = Completer();
-    MethodStreamExceptions closeException = const WebSocketClosedException();
+    MethodStreamException closeException = const WebSocketClosedException();
     try {
       await for (String jsonData in webSocket.stream) {
         if (!_handshakeComplete.isCompleted) {

--- a/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
+++ b/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
@@ -1,13 +1,13 @@
 import 'package:serverpod_client/serverpod_client.dart';
 
 /// Exceptions thrown by the [ClientMethodStreamManager].
-abstract class MethodStreamExceptions implements Exception {
-  /// Creates a new [MethodStreamExceptions].
-  const MethodStreamExceptions();
+abstract class MethodStreamException implements Exception {
+  /// Creates a new [MethodStreamException].
+  const MethodStreamException();
 }
 
 /// Thrown if the WebSocket connection fails.
-class WebSocketConnectException extends MethodStreamExceptions {
+class WebSocketConnectException extends MethodStreamException {
   /// The error that caused the exception.
   final Object? error;
 
@@ -19,10 +19,10 @@ class WebSocketConnectException extends MethodStreamExceptions {
 }
 
 /// Thrown if connection attempt timed out.
-class ConnectionAttemptTimedOutException extends MethodStreamExceptions {}
+class ConnectionAttemptTimedOutException extends MethodStreamException {}
 
 /// Thrown if an error occurs when listening to the WebSocket connection.
-class WebSocketListenException extends MethodStreamExceptions {
+class WebSocketListenException extends MethodStreamException {
   /// The error that caused the exception.
   final Object? error;
 
@@ -34,13 +34,13 @@ class WebSocketListenException extends MethodStreamExceptions {
 }
 
 /// Thrown if the WebSocket connection is closed.
-class WebSocketClosedException extends MethodStreamExceptions {
+class WebSocketClosedException extends MethodStreamException {
   /// Creates a new [WebSocketClosedException].
   const WebSocketClosedException();
 }
 
 /// Thrown if opening a method stream fails.
-class OpenMethodStreamException extends MethodStreamExceptions {
+class OpenMethodStreamException extends MethodStreamException {
   /// The response type that caused the exception.
   final OpenMethodStreamResponseType responseType;
 

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'package:serverpod_client/serverpod_client.dart';
 import 'package:serverpod_client/src/client_method_stream_manager.dart';
 import 'package:serverpod_client/src/method_stream/method_stream_connection_details.dart';
-import 'package:serverpod_client/src/method_stream/method_stream_manager_exceptions.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// A callback with no parameters or return value.

--- a/packages/serverpod_client/test/integration/method_stream_manager_connection_test.dart
+++ b/packages/serverpod_client/test/integration/method_stream_manager_connection_test.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'package:serverpod_client/serverpod_client.dart';
 import 'package:serverpod_client/src/client_method_stream_manager.dart';
 import 'package:serverpod_client/src/method_stream/method_stream_connection_details.dart';
-import 'package:serverpod_client/src/method_stream/method_stream_manager_exceptions.dart';
 import 'package:test/test.dart';
 
 import '../test_utils/method_stream_connection_details_builder.dart';

--- a/tests/serverpod_test_server/test_e2e/method_streaming/close_connection_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/close_connection_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:serverpod_client/src/method_stream/method_stream_manager_exceptions.dart';
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:serverpod_test_server/test_util/config.dart';
 import 'package:serverpod_test_server/test_util/test_key_manager.dart';

--- a/tests/serverpod_test_server/test_e2e/method_streaming/connectivity_monitor_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/connectivity_monitor_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:serverpod_client/src/method_stream/method_stream_manager_exceptions.dart';
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:serverpod_test_server/test_util/config.dart';
 import 'package:serverpod_test_server/test_util/test_key_manager.dart';


### PR DESCRIPTION
# Changes
- Renames and exports `MethodStreamException`; fixes #2624  and #2625 

## Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
