### PR TITLE
fix: Deliver method stream exceptions through the output stream.

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -443,21 +443,25 @@ abstract class ServerpodClientShared extends EndpointCaller {
       authenticationProvider: () async => authenticationKeyManager?.get(),
     );
 
-    _methodStreamManager
-        .openMethodStream(connectionDetails)
-        .onError<OpenMethodStreamException>((e, _) {
-      var error = switch (e.responseType) {
-        OpenMethodStreamResponseType.endpointNotFound =>
-          ServerpodClientNotFound(),
-        OpenMethodStreamResponseType.authenticationFailed =>
-          ServerpodClientUnauthorized(),
-        OpenMethodStreamResponseType.authorizationDeclined =>
-          ServerpodClientForbidden(),
-        OpenMethodStreamResponseType.invalidArguments =>
-          ServerpodClientBadRequest(),
-        OpenMethodStreamResponseType.success =>
-          ServerpodClientException('Unknown error, data: $e', -1),
-      };
+    _methodStreamManager.openMethodStream(connectionDetails).catchError((e, _) {
+      Object error;
+      if (e is OpenMethodStreamException) {
+        error = switch (e.responseType) {
+          OpenMethodStreamResponseType.endpointNotFound =>
+            ServerpodClientNotFound(),
+          OpenMethodStreamResponseType.authenticationFailed =>
+            ServerpodClientUnauthorized(),
+          OpenMethodStreamResponseType.authorizationDeclined =>
+            ServerpodClientForbidden(),
+          OpenMethodStreamResponseType.invalidArguments =>
+            ServerpodClientBadRequest(),
+          OpenMethodStreamResponseType.success =>
+            ServerpodClientException('Unknown error, data: $e', -1),
+        };
+      } else {
+        error = e;
+      }
+
       connectionDetails.outputController.addError(error);
       connectionDetails.outputController.close();
     });

--- a/tests/serverpod_test_client/test/method_stream_call_test.dart
+++ b/tests/serverpod_test_client/test/method_stream_call_test.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:serverpod_test_client/serverpod_test_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Creates a client with a URL that doesn't exist
+  // This will cause an WebSocketConnectException when the client tries to
+  // connect to the server.
+  var client = Client(
+    'http://localhost:123456789/',
+  );
+
+  test(
+      'Given method call with stream response when exception occurs during call setup then exception is received in stream.',
+      () async {
+    var stream = Stream<int>.fromIterable([1, 2, 3]);
+    var methodStream = client.methodStreaming.intEchoStream(stream);
+
+    var errorCompleter = Completer<dynamic>();
+    methodStream.listen(
+      (event) {},
+      onError: (e) => errorCompleter.complete(e),
+    );
+
+    await expectLater(errorCompleter.future, completes);
+    var error = await errorCompleter.future;
+    expect(error, isA<WebSocketConnectException>());
+  });
+
+  test(
+      'Given method call with future response when exception occurs during call setup then future is resolved with exception.',
+      () async {
+    var stream = Stream<int>.fromIterable([1, 2, 3]);
+
+    await expectLater(
+      client.methodStreaming.intReturnFromStream(stream),
+      throwsA(isA<WebSocketConnectException>()),
+    );
+  });
+}


### PR DESCRIPTION
Fixes an issue where not all method stream exceptions would be captured and delivered through the output `Future` or `Stream`.

Added test that simulates when no server is available.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple bugfix.