### PR TITLE
fix: Clarify the missing table exception from postgres.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -390,10 +390,26 @@ class DatabaseConnection {
       );
       return result;
     } catch (exception, trace) {
-      if (exception is pg.PgException) {
-        var serverpodException = DatabaseException(
-          exception.message,
+      if (exception is pg.ServerException) {
+        var message = switch (exception.code) {
+          ('42P01') =>
+            'Table not found, have you applied the database migration? (${exception.message})',
+          (_) => exception.message,
+        };
+
+        var serverpodException = DatabaseException(message);
+        _logQuery(
+          session,
+          query,
+          startTime,
+          exception: serverpodException,
+          trace: trace,
         );
+        throw serverpodException;
+      }
+
+      if (exception is pg.PgException) {
+        var serverpodException = DatabaseException(exception.message);
         _logQuery(
           session,
           query,

--- a/tests/serverpod_test_server/test_integration/database_operations/exceptions/missing_table_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/exceptions/missing_table_test.dart
@@ -1,0 +1,25 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var session = await IntegrationTestServer().session();
+  test(
+      'Given that a table does not exist in the database when querying that table then the database exception prompt the user to check if a migration was applied.',
+      () async {
+    var randomName = 't_${Uuid().v4().replaceAll('-', '_')}';
+
+    await expectLater(
+      session.db.unsafeQuery('SELECT * FROM $randomName'),
+      throwsA(
+        allOf(
+          isA<DatabaseException>(),
+          predicate<DatabaseException>(
+            (e) => e.message.contains(
+                'Table not found, have you applied the database migration? ('),
+          ),
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
# Changes

Improve the error message if a database table is missing. Motivation, if you are using our ORM you are not able to write the wrong table name (except with raw queries), and therefore the most common problem will be that you did not apply the migration before running the code.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none