### PR TITLE
 fix: warn if dependencies are missing when generating

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -36,7 +36,8 @@ class GenerateCommand extends ServerpodCommand {
     GeneratorConfig config;
     try {
       config = await GeneratorConfig.load();
-    } catch (_) {
+    } catch (e) {
+      log.error('An error occurred while parsing the server config file: $e');
       throw ExitException(ExitCodeType.commandInvokedCannotExecute);
     }
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -216,7 +216,21 @@ class GeneratorConfig {
       );
     }
 
-    await _warnIfDependenciesAreNotInstalled(serverRootDir, pubspec);
+    var packageConfig = await findPackageConfig(Directory(serverRootDir));
+
+    if (packageConfig == null) {
+      throw const ServerpodProjectNotFoundException(
+        'Failed to read your server\'s package configuration. Have you run '
+        '`dart pub get` in your server directory?',
+      );
+    }
+
+    var allPackagesAreInstalled = pubspec.dependencies.keys
+        .every((dependencyName) => packageConfig[dependencyName] != null);
+    if (!allPackagesAreInstalled) {
+      log.warning(
+          'Not all dependencies are installed, which might cause errors in your Serverpod code. Run `dart pub get`.');
+    }
 
     var manualModules = <String, String?>{};
     if (generatorConfig['modules'] != null) {
@@ -273,25 +287,6 @@ class GeneratorConfig {
       extraClasses: extraClasses,
       enabledFeatures: enabledFeatures,
     );
-  }
-
-  static Future<void> _warnIfDependenciesAreNotInstalled(
-      String serverRootDir, Pubspec pubspec) async {
-    var packageConfig = await findPackageConfig(Directory(serverRootDir));
-
-    if (packageConfig == null) {
-      throw const ServerpodProjectNotFoundException(
-        'Failed to read your server\'s package configuration. Have you run '
-        '`dart pub get` in your server directory?',
-      );
-    }
-
-    var allPackagesAreInstalled = pubspec.dependencies.keys
-        .every((dependencyName) => packageConfig[dependencyName] != null);
-    if (!allPackagesAreInstalled) {
-      log.warning(
-          'Not all dependencies are installed, which might cause errors in your Serverpod code. Run `dart pub get`.');
-    }
   }
 
   static List<ServerpodFeature> _enabledFeatures(File file, Map config) {


### PR DESCRIPTION
## Description
Warns if there are packages in the `<app>_server` module that are not installed, which fixes [#2384](https://github.com/serverpod/serverpod/issues/2384).

Also captures exceptions at the top level and surfaces sad-paths that were failing silently.

## Changes
- Adds a warning if packages are not installed
- Prints out exceptions

## Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
