### PR TITLE
fix: Make it possible to restart Serverpod server.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -27,13 +27,12 @@ class DatabaseConnection {
   final DatabasePoolManager _poolManager;
 
   /// Access to the raw Postgresql connection pool.
-  final pg.Pool _postgresConnection;
+  pg.Pool get _postgresConnection => _poolManager.pool;
 
   /// Creates a new database connection from the configuration. For most cases
   /// this shouldn't be called directly, use the db object in the [Session] to
   /// access the database.
-  DatabaseConnection(this._poolManager)
-      : _postgresConnection = _poolManager.pool;
+  DatabaseConnection(this._poolManager);
 
   /// Tests the database connection.
   /// Throws an exception if the connection is not working.

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -70,7 +70,7 @@ class Server {
   /// True if the server is currently running.
   bool get running => _running;
 
-  late final HttpServer _httpServer;
+  late HttpServer _httpServer;
 
   /// The [HttpServer] responsible for handling calls.
   HttpServer get httpServer => _httpServer;

--- a/tests/serverpod_test_server/test_integration/server_restart_test.dart
+++ b/tests/serverpod_test_server/test_integration/server_restart_test.dart
@@ -17,18 +17,17 @@ void main() {
   });
 
   test(
-      'Given running Serverpod server when it is shutdown and started then it can be successfully started again.',
+      'Given a running Serverpod server when it is shutdown and restarted then it can be successfully started again.',
       () async {
     await serverpod.start();
 
     await serverpod.shutdown(exitProcess: false);
-    var start = serverpod.start();
 
-    await expectLater(start, completes);
+    await expectLater(serverpod.start(), completes);
   });
 
   test(
-      'Given running Serverpod server when it is shutdown and started then database request can be made.',
+      'Given a running Serverpod server when it is shutdown and started then database request can be made.',
       () async {
     await serverpod.start();
 
@@ -40,16 +39,15 @@ void main() {
   });
 
   test(
-      'Given running Serverpod server when it is shutdown and started then no error is written to stderr.',
+      'Given a running Serverpod server when it is shutdown and started then no error is written to stderr.',
       () async {
     var record = MockStdout();
     await IOOverrides.runZoned(() async {
       await serverpod.start();
 
       await serverpod.shutdown(exitProcess: false);
-      var start = serverpod.start();
 
-      await expectLater(start, completes);
+      await expectLater(serverpod.start(), completes);
     }, stderr: () => record);
 
     expect(record.output, isEmpty);

--- a/tests/serverpod_test_server/test_integration/server_restart_test.dart
+++ b/tests/serverpod_test_server/test_integration/server_restart_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/mock_stdout.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Serverpod serverpod;
+
+  setUp(() {
+    serverpod = IntegrationTestServer.create();
+  });
+
+  tearDown(() async {
+    await serverpod.shutdown(exitProcess: false);
+  });
+
+  test(
+      'Given running Serverpod server when it is shutdown and started then it can be successfully started again.',
+      () async {
+    await serverpod.start();
+
+    await serverpod.shutdown(exitProcess: false);
+    var start = serverpod.start();
+
+    await expectLater(start, completes);
+  });
+
+  test(
+      'Given running Serverpod server when it is shutdown and started then database request can be made.',
+      () async {
+    await serverpod.start();
+
+    await serverpod.shutdown(exitProcess: false);
+    await serverpod.start();
+
+    var session = await serverpod.createSession();
+    await expectLater(session.db.testConnection(), completion(true));
+  });
+
+  test(
+      'Given running Serverpod server when it is shutdown and started then no error is written to stderr.',
+      () async {
+    var record = MockStdout();
+    await IOOverrides.runZoned(() async {
+      await serverpod.start();
+
+      await serverpod.shutdown(exitProcess: false);
+      var start = serverpod.start();
+
+      await expectLater(start, completes);
+    }, stderr: () => record);
+
+    expect(record.output, isEmpty);
+  });
+}


### PR DESCRIPTION
Fixes two issues that prevented us from restarting a Serverpod server.

### Issue 1
In the `database_connection` we used to create a copy of the database pool and store it locally. This caused issue when we stopped the existing database pool through the `DatabasePoolManager` since the copied reference would then be preserved towards stopped instance.

To fix the issue we now always fetch the pool from the pool manager.

### Issue 2
As part of the server start we set the _httpServer field. This was a `late final` field, but since it was assigned every time we started the server we would get a `LateInitializationError` on the second assignment.

To fix the `final` declaration was removed since the field in essence is not final.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - the changes should be completely backwards compatible.