### PR TITLE
fix: Hide internal clone extension.

### DIFF
--- a/packages/serverpod/lib/serverpod.dart
+++ b/packages/serverpod/lib/serverpod.dart
@@ -13,7 +13,8 @@ export 'package:serverpod/relic.dart';
 export 'package:serverpod/database.dart';
 
 // Serialization and logging
-export 'package:serverpod_serialization/serverpod_serialization.dart';
+export 'package:serverpod_serialization/serverpod_serialization.dart'
+    hide CloneByteData;
 export 'package:serverpod/src/util/http_request_extension.dart';
 export 'package:serverpod/src/generated/log_level.dart';
 


### PR DESCRIPTION
## Changes
- Hides the `CloneByteData` extension, which fixes #2643 

## Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes
- The removal of `clone` is technically breaking, but it's not intended to be exposed.