### PR TITLE
fix: Minimize method stream message protocol keys.

### DIFF
--- a/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
@@ -13,7 +13,7 @@ abstract class WebSocketMessageTypeKey {
   static const String methodStreamMessage = 'msm';
   static const String methodStreamSerializableException = 'msse';
   static const String openMethodStreamCommand = 'omsc';
-  static const String openMethodStreamResponse = 'open_method_stream_response';
+  static const String openMethodStreamResponse = 'omsr';
   static const String pingCommand = 'ping';
   static const String pongCommand = 'pong';
 }

--- a/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
@@ -2,33 +2,33 @@
 
 /// Keys used in the top level of messages.
 abstract class WebSocketMessageKey {
-  static const String messageTypeKey = 'type';
-  static const String messageDataKey = 'data';
+  static const String type = 'type';
+  static const String data = 'data';
 }
 
 /// Keys used to identify message types.
 abstract class WebSocketMessageTypeKey {
-  static const String badRequestMessageTypeKey = 'brm';
-  static const String closeMethodStreamCommandTypeKey = 'cmsc';
-  static const String methodStreamMessageTypeKey = 'msm';
-  static const String methodStreamSerializableExceptionTypeKey = 'msse';
-  static const String openMethodStreamCommandTypeKey = 'omsc';
-  static const String pingCommandTypeKey = 'ping';
-  static const String pongCommandTypeKey = 'pong';
+  static const String badRequestMessage = 'brm';
+  static const String closeMethodStreamCommand = 'cmsc';
+  static const String methodStreamMessage = 'msm';
+  static const String methodStreamSerializableException = 'msse';
+  static const String openMethodStreamCommand = 'omsc';
+  static const String pingCommand = 'ping';
+  static const String pongCommand = 'pong';
 }
 
 /// Keys used inside the "data" part of messages.
 abstract class WebSocketMessageDataKey {
-  static const String argsKey = 'args';
-  static const String authenticationKey = 'auth';
-  static const String closeReasonKey = 'cr';
-  static const String connectionIdKey = 'cid';
-  static const String endpointKey = 'en';
-  static const String exceptionKey = 'ex';
-  static const String inputStreamsKey = 'is';
-  static const String methodKey = 'm';
-  static const String objectKey = 'o';
-  static const String parameterKey = 'p';
-  static const String requestKey = 'req';
-  static const String responseTypeKey = 'res';
+  static const String args = 'args';
+  static const String authentication = 'auth';
+  static const String closeReason = 'cr';
+  static const String connectionId = 'cid';
+  static const String endpoint = 'en';
+  static const String exception = 'ex';
+  static const String inputStreams = 'is';
+  static const String method = 'm';
+  static const String object = 'o';
+  static const String parameter = 'p';
+  static const String request = 'req';
+  static const String responseType = 'res';
 }

--- a/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
@@ -13,6 +13,7 @@ abstract class WebSocketMessageTypeKey {
   static const String methodStreamMessage = 'msm';
   static const String methodStreamSerializableException = 'msse';
   static const String openMethodStreamCommand = 'omsc';
+  static const String openMethodStreamResponse = 'open_method_stream_response';
   static const String pingCommand = 'ping';
   static const String pongCommand = 'pong';
 }

--- a/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
@@ -1,0 +1,37 @@
+// ignore_for_file: public_member_api_docs
+
+/// Keys used in the top level of messages.
+abstract class WebSocketMessageKey {
+  static const String messageTypeKey = 'type';
+  static const String messageDataKey = 'data';
+}
+
+/// Keys used to identify message types.
+abstract class WebSocketMessageTypeKey {
+  static const String badRequestMessageTypeKey = 'bad_request_message';
+  static const String closeMethodStreamCommandTypeKey =
+      'close_method_stream_command';
+  static const String methodStreamMessageTypeKey = 'method_message';
+  static const String methodStreamSerializableExceptionTypeKey =
+      'method_stream_serializable_exception';
+  static const String openMethodStreamCommandTypeKey =
+      'open_method_stream_command';
+  static const String pingCommandTypeKey = 'ping_command';
+  static const String pongCommandTypeKey = 'pong_command';
+}
+
+/// Keys used inside the "data" part of messages.
+abstract class WebSocketMessageDataKey {
+  static const String argsKey = 'args';
+  static const String authenticationKey = 'authentication';
+  static const String closeReasonKey = 'reason';
+  static const String connectionIdKey = 'connectionId';
+  static const String endpointKey = 'endpoint';
+  static const String exceptionKey = 'exception';
+  static const String inputStreamsKey = 'inputStreams';
+  static const String methodKey = 'method';
+  static const String objectKey = 'object';
+  static const String parameterKey = 'parameter';
+  static const String requestKey = 'request';
+  static const String responseTypeKey = 'responseType';
+}

--- a/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
@@ -2,7 +2,12 @@
 
 /// Keys used in the top level of messages.
 abstract class WebSocketMessageKey {
+  /// Contains the type of the message described by
+  /// the [WebSocketMessageTypeKey].
   static const String type = 'type';
+
+  /// Contains a json structure with the data of the message.
+  /// If no data is included with the message this field is omitted.
   static const String data = 'data';
 }
 

--- a/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_message_keys.dart
@@ -8,30 +8,27 @@ abstract class WebSocketMessageKey {
 
 /// Keys used to identify message types.
 abstract class WebSocketMessageTypeKey {
-  static const String badRequestMessageTypeKey = 'bad_request_message';
-  static const String closeMethodStreamCommandTypeKey =
-      'close_method_stream_command';
-  static const String methodStreamMessageTypeKey = 'method_message';
-  static const String methodStreamSerializableExceptionTypeKey =
-      'method_stream_serializable_exception';
-  static const String openMethodStreamCommandTypeKey =
-      'open_method_stream_command';
-  static const String pingCommandTypeKey = 'ping_command';
-  static const String pongCommandTypeKey = 'pong_command';
+  static const String badRequestMessageTypeKey = 'brm';
+  static const String closeMethodStreamCommandTypeKey = 'cmsc';
+  static const String methodStreamMessageTypeKey = 'msm';
+  static const String methodStreamSerializableExceptionTypeKey = 'msse';
+  static const String openMethodStreamCommandTypeKey = 'omsc';
+  static const String pingCommandTypeKey = 'ping';
+  static const String pongCommandTypeKey = 'pong';
 }
 
 /// Keys used inside the "data" part of messages.
 abstract class WebSocketMessageDataKey {
   static const String argsKey = 'args';
-  static const String authenticationKey = 'authentication';
-  static const String closeReasonKey = 'reason';
-  static const String connectionIdKey = 'connectionId';
-  static const String endpointKey = 'endpoint';
-  static const String exceptionKey = 'exception';
-  static const String inputStreamsKey = 'inputStreams';
-  static const String methodKey = 'method';
-  static const String objectKey = 'object';
-  static const String parameterKey = 'parameter';
-  static const String requestKey = 'request';
-  static const String responseTypeKey = 'responseType';
+  static const String authenticationKey = 'auth';
+  static const String closeReasonKey = 'cr';
+  static const String connectionIdKey = 'cid';
+  static const String endpointKey = 'en';
+  static const String exceptionKey = 'ex';
+  static const String inputStreamsKey = 'is';
+  static const String methodKey = 'm';
+  static const String objectKey = 'o';
+  static const String parameterKey = 'p';
+  static const String requestKey = 'req';
+  static const String responseTypeKey = 'res';
 }

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -6,10 +6,10 @@ import 'package:serverpod_serialization/src/websocket_message_keys.dart';
 /// Base class for messages sent over a WebSocket connection.
 sealed class WebSocketMessage {
   /// The keyword used for the message type in the websocket message.
-  static const String _messageTypeKeyword = WebSocketMessageKey.messageTypeKey;
+  static const String _messageTypeKeyword = WebSocketMessageKey.type;
 
   /// The keyword used for the message data in the websocket message.
-  static const String _messageDataKeyword = WebSocketMessageKey.messageDataKey;
+  static const String _messageDataKeyword = WebSocketMessageKey.data;
 
   static String _buildMessage(
     String messageType, [
@@ -118,11 +118,11 @@ class OpenMethodStreamResponse extends WebSocketMessage {
   /// Creates a new [OpenMethodStreamResponse].
   OpenMethodStreamResponse(Map data)
       : connectionId = UuidValueJsonExtension.fromJson(
-            data[WebSocketMessageDataKey.connectionIdKey]),
-        endpoint = data[WebSocketMessageDataKey.endpointKey],
-        method = data[WebSocketMessageDataKey.methodKey],
+            data[WebSocketMessageDataKey.connectionId]),
+        endpoint = data[WebSocketMessageDataKey.endpoint],
+        method = data[WebSocketMessageDataKey.method],
         responseType = OpenMethodStreamResponseType.tryParse(
-          data[WebSocketMessageDataKey.responseTypeKey],
+          data[WebSocketMessageDataKey.responseType],
         );
 
   /// Builds a new [OpenMethodStreamResponse] message.
@@ -135,10 +135,10 @@ class OpenMethodStreamResponse extends WebSocketMessage {
     return WebSocketMessage._buildMessage(
       _messageType,
       {
-        WebSocketMessageDataKey.connectionIdKey: connectionId,
-        WebSocketMessageDataKey.responseTypeKey: responseType.name,
-        WebSocketMessageDataKey.endpointKey: endpoint,
-        WebSocketMessageDataKey.methodKey: method,
+        WebSocketMessageDataKey.connectionId: connectionId,
+        WebSocketMessageDataKey.responseType: responseType.name,
+        WebSocketMessageDataKey.endpoint: endpoint,
+        WebSocketMessageDataKey.method: method,
       },
     );
   }
@@ -158,7 +158,7 @@ class OpenMethodStreamResponse extends WebSocketMessage {
 /// An [OpenMethodStreamResponse] should be sent in response to this message.
 class OpenMethodStreamCommand extends WebSocketMessage {
   static const String _messageType =
-      WebSocketMessageTypeKey.openMethodStreamCommandTypeKey;
+      WebSocketMessageTypeKey.openMethodStreamCommand;
 
   /// The endpoint to call.
   final String endpoint;
@@ -180,14 +180,14 @@ class OpenMethodStreamCommand extends WebSocketMessage {
 
   /// Creates a new [OpenMethodStreamCommand] message.
   OpenMethodStreamCommand(Map data)
-      : endpoint = data[WebSocketMessageDataKey.endpointKey],
-        method = data[WebSocketMessageDataKey.methodKey],
-        args = data[WebSocketMessageDataKey.argsKey],
+      : endpoint = data[WebSocketMessageDataKey.endpoint],
+        method = data[WebSocketMessageDataKey.method],
+        args = data[WebSocketMessageDataKey.args],
         connectionId = UuidValueJsonExtension.fromJson(
-            data[WebSocketMessageDataKey.connectionIdKey]),
-        authentication = data[WebSocketMessageDataKey.authenticationKey],
+            data[WebSocketMessageDataKey.connectionId]),
+        authentication = data[WebSocketMessageDataKey.authentication],
         inputStreams =
-            List<String>.from(data[WebSocketMessageDataKey.inputStreamsKey]);
+            List<String>.from(data[WebSocketMessageDataKey.inputStreams]);
 
   /// Creates a new [OpenMethodStreamCommand].
   static String buildMessage({
@@ -199,27 +199,27 @@ class OpenMethodStreamCommand extends WebSocketMessage {
     String? authentication,
   }) {
     return WebSocketMessage._buildMessage(_messageType, {
-      WebSocketMessageDataKey.endpointKey: endpoint,
-      WebSocketMessageDataKey.methodKey: method,
-      WebSocketMessageDataKey.connectionIdKey: connectionId,
-      WebSocketMessageDataKey.argsKey:
+      WebSocketMessageDataKey.endpoint: endpoint,
+      WebSocketMessageDataKey.method: method,
+      WebSocketMessageDataKey.connectionId: connectionId,
+      WebSocketMessageDataKey.args:
           SerializationManager.encodeForProtocol(args),
-      WebSocketMessageDataKey.inputStreamsKey: inputStreams,
+      WebSocketMessageDataKey.inputStreams: inputStreams,
       if (authentication != null)
-        WebSocketMessageDataKey.authenticationKey: authentication,
+        WebSocketMessageDataKey.authentication: authentication,
     });
   }
 
   @override
   String toString() => WebSocketMessage._buildMessage(_messageType, {
-        WebSocketMessageDataKey.endpointKey: endpoint,
-        WebSocketMessageDataKey.methodKey: method,
-        WebSocketMessageDataKey.connectionIdKey:
+        WebSocketMessageDataKey.endpoint: endpoint,
+        WebSocketMessageDataKey.method: method,
+        WebSocketMessageDataKey.connectionId:
             SerializationManager.encodeForProtocol(connectionId),
-        WebSocketMessageDataKey.argsKey: args,
-        WebSocketMessageDataKey.inputStreamsKey: inputStreams,
+        WebSocketMessageDataKey.args: args,
+        WebSocketMessageDataKey.inputStreams: inputStreams,
         if (authentication != null)
-          WebSocketMessageDataKey.authenticationKey: authentication,
+          WebSocketMessageDataKey.authentication: authentication,
       }).toString();
 }
 
@@ -244,7 +244,7 @@ enum CloseReason {
 /// data to an endpoint method.
 class CloseMethodStreamCommand extends WebSocketMessage {
   static const String _messageType =
-      WebSocketMessageTypeKey.closeMethodStreamCommandTypeKey;
+      WebSocketMessageTypeKey.closeMethodStreamCommand;
 
   /// The endpoint associated with the stream.
   final String endpoint;
@@ -264,13 +264,13 @@ class CloseMethodStreamCommand extends WebSocketMessage {
 
   /// Creates a new [CloseMethodStreamCommand].
   CloseMethodStreamCommand(Map data)
-      : endpoint = data[WebSocketMessageDataKey.endpointKey],
-        method = data[WebSocketMessageDataKey.methodKey],
+      : endpoint = data[WebSocketMessageDataKey.endpoint],
+        method = data[WebSocketMessageDataKey.method],
         connectionId = UuidValueJsonExtension.fromJson(
-            data[WebSocketMessageDataKey.connectionIdKey]),
-        parameter = data[WebSocketMessageDataKey.parameterKey],
+            data[WebSocketMessageDataKey.connectionId]),
+        parameter = data[WebSocketMessageDataKey.parameter],
         reason =
-            CloseReason.tryParse(data[WebSocketMessageDataKey.closeReasonKey]);
+            CloseReason.tryParse(data[WebSocketMessageDataKey.closeReason]);
 
   /// Creates a new [CloseMethodStreamCommand] message.
   static String buildMessage({
@@ -281,11 +281,11 @@ class CloseMethodStreamCommand extends WebSocketMessage {
     required CloseReason reason,
   }) {
     return WebSocketMessage._buildMessage(_messageType, {
-      WebSocketMessageDataKey.endpointKey: endpoint,
-      WebSocketMessageDataKey.methodKey: method,
-      WebSocketMessageDataKey.connectionIdKey: connectionId,
-      if (parameter != null) WebSocketMessageDataKey.parameterKey: parameter,
-      WebSocketMessageDataKey.closeReasonKey: reason.name,
+      WebSocketMessageDataKey.endpoint: endpoint,
+      WebSocketMessageDataKey.method: method,
+      WebSocketMessageDataKey.connectionId: connectionId,
+      if (parameter != null) WebSocketMessageDataKey.parameter: parameter,
+      WebSocketMessageDataKey.closeReason: reason.name,
     });
   }
 
@@ -302,7 +302,7 @@ class CloseMethodStreamCommand extends WebSocketMessage {
 /// A message sent over a websocket connection to check if the connection is
 /// still alive. The other end should respond with a [PongCommand].
 class PingCommand extends WebSocketMessage {
-  static const String _messageType = WebSocketMessageTypeKey.pingCommandTypeKey;
+  static const String _messageType = WebSocketMessageTypeKey.pingCommand;
 
   /// Builds a [PingCommand] message.
   static String buildMessage() {
@@ -315,7 +315,7 @@ class PingCommand extends WebSocketMessage {
 
 /// A response to a [PingCommand].
 class PongCommand extends WebSocketMessage {
-  static const String _messageType = WebSocketMessageTypeKey.pongCommandTypeKey;
+  static const String _messageType = WebSocketMessageTypeKey.pongCommand;
 
   /// Builds a [PongCommand] message.
   static String buildMessage() {
@@ -329,7 +329,7 @@ class PongCommand extends WebSocketMessage {
 /// A serializable exception sent over a method stream.
 class MethodStreamSerializableException extends WebSocketMessage {
   static const String _messageType =
-      WebSocketMessageTypeKey.methodStreamSerializableExceptionTypeKey;
+      WebSocketMessageTypeKey.methodStreamSerializableException;
 
   /// The endpoint the message is sent to.
   final String endpoint;
@@ -353,13 +353,13 @@ class MethodStreamSerializableException extends WebSocketMessage {
   MethodStreamSerializableException(
     Map data,
     SerializationManager serializationManager,
-  )   : endpoint = data[WebSocketMessageDataKey.endpointKey],
-        method = data[WebSocketMessageDataKey.methodKey],
+  )   : endpoint = data[WebSocketMessageDataKey.endpoint],
+        method = data[WebSocketMessageDataKey.method],
         connectionId = UuidValueJsonExtension.fromJson(
-            data[WebSocketMessageDataKey.connectionIdKey]),
-        parameter = data[WebSocketMessageDataKey.parameterKey],
+            data[WebSocketMessageDataKey.connectionId]),
+        parameter = data[WebSocketMessageDataKey.parameter],
         exception = serializationManager
-            .deserializeByClassName(data[WebSocketMessageDataKey.exceptionKey]);
+            .deserializeByClassName(data[WebSocketMessageDataKey.exception]);
 
   /// Builds a [MethodStreamSerializableException] message.
   /// The [exception] must be a serializable exception processed by the
@@ -375,11 +375,11 @@ class MethodStreamSerializableException extends WebSocketMessage {
     return WebSocketMessage._buildMessage(
       _messageType,
       {
-        WebSocketMessageDataKey.endpointKey: endpoint,
-        WebSocketMessageDataKey.methodKey: method,
-        WebSocketMessageDataKey.connectionIdKey: connectionId,
-        if (parameter != null) WebSocketMessageDataKey.parameterKey: parameter,
-        WebSocketMessageDataKey.exceptionKey:
+        WebSocketMessageDataKey.endpoint: endpoint,
+        WebSocketMessageDataKey.method: method,
+        WebSocketMessageDataKey.connectionId: connectionId,
+        if (parameter != null) WebSocketMessageDataKey.parameter: parameter,
+        WebSocketMessageDataKey.exception:
             serializationManager.wrapWithClassName(object),
       },
     );
@@ -389,12 +389,11 @@ class MethodStreamSerializableException extends WebSocketMessage {
   String toString() => WebSocketMessage._buildMessage(
         _messageType,
         {
-          WebSocketMessageDataKey.endpointKey: endpoint,
-          WebSocketMessageDataKey.methodKey: method,
-          WebSocketMessageDataKey.connectionIdKey: connectionId,
-          if (parameter != null)
-            WebSocketMessageDataKey.parameterKey: parameter,
-          WebSocketMessageDataKey.exceptionKey: exception,
+          WebSocketMessageDataKey.endpoint: endpoint,
+          WebSocketMessageDataKey.method: method,
+          WebSocketMessageDataKey.connectionId: connectionId,
+          if (parameter != null) WebSocketMessageDataKey.parameter: parameter,
+          WebSocketMessageDataKey.exception: exception,
         },
       ).toString();
 }
@@ -402,7 +401,7 @@ class MethodStreamSerializableException extends WebSocketMessage {
 /// A message sent to a method stream.
 class MethodStreamMessage extends WebSocketMessage {
   static const String _messageType =
-      WebSocketMessageTypeKey.methodStreamMessageTypeKey;
+      WebSocketMessageTypeKey.methodStreamMessage;
 
   /// The endpoint the message is sent to.
   final String endpoint;
@@ -424,13 +423,13 @@ class MethodStreamMessage extends WebSocketMessage {
   /// The [object] must be an object processed by the
   /// [SerializationManager.wrapWithClassName] method.
   MethodStreamMessage(Map data, SerializationManager serializationManager)
-      : endpoint = data[WebSocketMessageDataKey.endpointKey],
-        method = data[WebSocketMessageDataKey.methodKey],
+      : endpoint = data[WebSocketMessageDataKey.endpoint],
+        method = data[WebSocketMessageDataKey.method],
         connectionId = UuidValueJsonExtension.fromJson(
-            data[WebSocketMessageDataKey.connectionIdKey]),
-        parameter = data[WebSocketMessageDataKey.parameterKey],
+            data[WebSocketMessageDataKey.connectionId]),
+        parameter = data[WebSocketMessageDataKey.parameter],
         object = serializationManager
-            .deserializeByClassName(data[WebSocketMessageDataKey.objectKey]);
+            .deserializeByClassName(data[WebSocketMessageDataKey.object]);
 
   /// Builds a [MethodStreamMessage] message.
   static String buildMessage({
@@ -442,11 +441,11 @@ class MethodStreamMessage extends WebSocketMessage {
     required SerializationManager serializationManager,
   }) {
     return WebSocketMessage._buildMessage(_messageType, {
-      WebSocketMessageDataKey.endpointKey: endpoint,
-      WebSocketMessageDataKey.methodKey: method,
-      WebSocketMessageDataKey.connectionIdKey: connectionId,
-      if (parameter != null) WebSocketMessageDataKey.parameterKey: parameter,
-      WebSocketMessageDataKey.objectKey:
+      WebSocketMessageDataKey.endpoint: endpoint,
+      WebSocketMessageDataKey.method: method,
+      WebSocketMessageDataKey.connectionId: connectionId,
+      if (parameter != null) WebSocketMessageDataKey.parameter: parameter,
+      WebSocketMessageDataKey.object:
           serializationManager.wrapWithClassName(object),
     });
   }
@@ -455,34 +454,31 @@ class MethodStreamMessage extends WebSocketMessage {
   String toString() => WebSocketMessage._buildMessage(
         _messageType,
         {
-          WebSocketMessageDataKey.endpointKey: endpoint,
-          WebSocketMessageDataKey.methodKey: method,
-          WebSocketMessageDataKey.connectionIdKey: connectionId,
-          if (parameter != null)
-            WebSocketMessageDataKey.parameterKey: parameter,
-          WebSocketMessageDataKey.objectKey: object,
+          WebSocketMessageDataKey.endpoint: endpoint,
+          WebSocketMessageDataKey.method: method,
+          WebSocketMessageDataKey.connectionId: connectionId,
+          if (parameter != null) WebSocketMessageDataKey.parameter: parameter,
+          WebSocketMessageDataKey.object: object,
         },
       ).toString();
 }
 
 /// A message sent when a bad request is received.
 class BadRequestMessage extends WebSocketMessage {
-  static const String _messageType =
-      WebSocketMessageTypeKey.badRequestMessageTypeKey;
+  static const String _messageType = WebSocketMessageTypeKey.badRequestMessage;
 
   /// The request that was bad.
   final String request;
 
   /// Creates a new [BadRequestMessage].
-  BadRequestMessage(Map data)
-      : request = data[WebSocketMessageDataKey.requestKey];
+  BadRequestMessage(Map data) : request = data[WebSocketMessageDataKey.request];
 
   /// Builds a [BadRequestMessage] message.
   static String buildMessage(String request) {
     return WebSocketMessage._buildMessage(
       _messageType,
       {
-        WebSocketMessageDataKey.requestKey: request,
+        WebSocketMessageDataKey.request: request,
       },
     );
   }

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -6,18 +6,18 @@ import 'package:serverpod_serialization/src/websocket_message_keys.dart';
 /// Base class for messages sent over a WebSocket connection.
 sealed class WebSocketMessage {
   /// The keyword used for the message type in the websocket message.
-  static const String messageTypeKeyword = WebSocketMessageKey.messageTypeKey;
+  static const String _messageTypeKeyword = WebSocketMessageKey.messageTypeKey;
 
   /// The keyword used for the message data in the websocket message.
-  static const String messageDataKeyword = WebSocketMessageKey.messageDataKey;
+  static const String _messageDataKeyword = WebSocketMessageKey.messageDataKey;
 
   static String _buildMessage(
     String messageType, [
     Map<String, dynamic>? data,
   ]) {
     return SerializationManager.encodeForProtocol({
-      messageTypeKeyword: messageType,
-      if (data != null) messageDataKeyword: data,
+      _messageTypeKeyword: messageType,
+      if (data != null) _messageDataKeyword: data,
     });
   }
 
@@ -31,8 +31,8 @@ sealed class WebSocketMessage {
     try {
       Map data = jsonDecode(jsonString) as Map;
 
-      var messageType = data[messageTypeKeyword];
-      var messageData = data[messageDataKeyword];
+      var messageType = data[_messageTypeKeyword];
+      var messageData = data[_messageDataKeyword];
 
       switch (messageType) {
         case PingCommand._messageType:

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -101,7 +101,8 @@ enum OpenMethodStreamResponseType {
 /// A message sent over a websocket connection to respond to an
 /// [OpenMethodStreamCommand].
 class OpenMethodStreamResponse extends WebSocketMessage {
-  static const String _messageType = 'open_method_stream_response';
+  static const String _messageType =
+      WebSocketMessageTypeKey.openMethodStreamResponse;
 
   /// The connection id that uniquely identifies the stream.
   final UuidValue connectionId;

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -16,7 +16,7 @@ sealed class WebSocketMessage {
   ]) {
     return SerializationManager.encodeForProtocol({
       messageTypeKeyword: messageType,
-      messageDataKeyword: data,
+      if (data != null) messageDataKeyword: data,
     });
   }
 

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -5,19 +5,13 @@ import 'package:serverpod_serialization/src/websocket_message_keys.dart';
 
 /// Base class for messages sent over a WebSocket connection.
 sealed class WebSocketMessage {
-  /// The keyword used for the message type in the websocket message.
-  static const String _messageTypeKeyword = WebSocketMessageKey.type;
-
-  /// The keyword used for the message data in the websocket message.
-  static const String _messageDataKeyword = WebSocketMessageKey.data;
-
   static String _buildMessage(
     String messageType, [
     Map<String, dynamic>? data,
   ]) {
     return SerializationManager.encodeForProtocol({
-      _messageTypeKeyword: messageType,
-      if (data != null) _messageDataKeyword: data,
+      WebSocketMessageKey.type: messageType,
+      if (data != null) WebSocketMessageKey.data: data,
     });
   }
 
@@ -31,8 +25,8 @@ sealed class WebSocketMessage {
     try {
       Map data = jsonDecode(jsonString) as Map;
 
-      var messageType = data[_messageTypeKeyword];
-      var messageData = data[_messageDataKeyword];
+      var messageType = data[WebSocketMessageKey.type];
+      var messageData = data[WebSocketMessageKey.data];
 
       switch (messageType) {
         case PingCommand._messageType:

--- a/packages/serverpod_serialization/lib/src/websocket_messages.dart
+++ b/packages/serverpod_serialization/lib/src/websocket_messages.dart
@@ -1,14 +1,15 @@
 import 'dart:convert';
 
 import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:serverpod_serialization/src/websocket_message_keys.dart';
 
 /// Base class for messages sent over a WebSocket connection.
 sealed class WebSocketMessage {
   /// The keyword used for the message type in the websocket message.
-  static const String messageTypeKeyword = 'type';
+  static const String messageTypeKeyword = WebSocketMessageKey.messageTypeKey;
 
   /// The keyword used for the message data in the websocket message.
-  static const String messageDataKeyword = 'data';
+  static const String messageDataKeyword = WebSocketMessageKey.messageDataKey;
 
   static String _buildMessage(
     String messageType, [
@@ -116,11 +117,12 @@ class OpenMethodStreamResponse extends WebSocketMessage {
 
   /// Creates a new [OpenMethodStreamResponse].
   OpenMethodStreamResponse(Map data)
-      : connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
-        endpoint = data['endpoint'],
-        method = data['method'],
+      : connectionId = UuidValueJsonExtension.fromJson(
+            data[WebSocketMessageDataKey.connectionIdKey]),
+        endpoint = data[WebSocketMessageDataKey.endpointKey],
+        method = data[WebSocketMessageDataKey.methodKey],
         responseType = OpenMethodStreamResponseType.tryParse(
-          data['responseType'],
+          data[WebSocketMessageDataKey.responseTypeKey],
         );
 
   /// Builds a new [OpenMethodStreamResponse] message.
@@ -133,10 +135,10 @@ class OpenMethodStreamResponse extends WebSocketMessage {
     return WebSocketMessage._buildMessage(
       _messageType,
       {
-        'connectionId': connectionId,
-        'responseType': responseType.name,
-        'endpoint': endpoint,
-        'method': method,
+        WebSocketMessageDataKey.connectionIdKey: connectionId,
+        WebSocketMessageDataKey.responseTypeKey: responseType.name,
+        WebSocketMessageDataKey.endpointKey: endpoint,
+        WebSocketMessageDataKey.methodKey: method,
       },
     );
   }
@@ -155,7 +157,8 @@ class OpenMethodStreamResponse extends WebSocketMessage {
 ///
 /// An [OpenMethodStreamResponse] should be sent in response to this message.
 class OpenMethodStreamCommand extends WebSocketMessage {
-  static const String _messageType = 'open_method_stream_command';
+  static const String _messageType =
+      WebSocketMessageTypeKey.openMethodStreamCommandTypeKey;
 
   /// The endpoint to call.
   final String endpoint;
@@ -177,12 +180,14 @@ class OpenMethodStreamCommand extends WebSocketMessage {
 
   /// Creates a new [OpenMethodStreamCommand] message.
   OpenMethodStreamCommand(Map data)
-      : endpoint = data['endpoint'],
-        method = data['method'],
-        args = data['args'],
-        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
-        authentication = data['authentication'],
-        inputStreams = List<String>.from(data['inputStreams']);
+      : endpoint = data[WebSocketMessageDataKey.endpointKey],
+        method = data[WebSocketMessageDataKey.methodKey],
+        args = data[WebSocketMessageDataKey.argsKey],
+        connectionId = UuidValueJsonExtension.fromJson(
+            data[WebSocketMessageDataKey.connectionIdKey]),
+        authentication = data[WebSocketMessageDataKey.authenticationKey],
+        inputStreams =
+            List<String>.from(data[WebSocketMessageDataKey.inputStreamsKey]);
 
   /// Creates a new [OpenMethodStreamCommand].
   static String buildMessage({
@@ -194,23 +199,27 @@ class OpenMethodStreamCommand extends WebSocketMessage {
     String? authentication,
   }) {
     return WebSocketMessage._buildMessage(_messageType, {
-      'endpoint': endpoint,
-      'method': method,
-      'connectionId': connectionId,
-      'args': SerializationManager.encodeForProtocol(args),
-      'inputStreams': inputStreams,
-      if (authentication != null) 'authentication': authentication,
+      WebSocketMessageDataKey.endpointKey: endpoint,
+      WebSocketMessageDataKey.methodKey: method,
+      WebSocketMessageDataKey.connectionIdKey: connectionId,
+      WebSocketMessageDataKey.argsKey:
+          SerializationManager.encodeForProtocol(args),
+      WebSocketMessageDataKey.inputStreamsKey: inputStreams,
+      if (authentication != null)
+        WebSocketMessageDataKey.authenticationKey: authentication,
     });
   }
 
   @override
   String toString() => WebSocketMessage._buildMessage(_messageType, {
-        'endpoint': endpoint,
-        'method': method,
-        'connectionId': SerializationManager.encodeForProtocol(connectionId),
-        'args': args,
-        'inputStreams': inputStreams,
-        if (authentication != null) 'authentication': authentication,
+        WebSocketMessageDataKey.endpointKey: endpoint,
+        WebSocketMessageDataKey.methodKey: method,
+        WebSocketMessageDataKey.connectionIdKey:
+            SerializationManager.encodeForProtocol(connectionId),
+        WebSocketMessageDataKey.argsKey: args,
+        WebSocketMessageDataKey.inputStreamsKey: inputStreams,
+        if (authentication != null)
+          WebSocketMessageDataKey.authenticationKey: authentication,
       }).toString();
 }
 
@@ -234,7 +243,8 @@ enum CloseReason {
 /// A message sent over a websocket connection to close a websocket stream of
 /// data to an endpoint method.
 class CloseMethodStreamCommand extends WebSocketMessage {
-  static const String _messageType = 'close_method_stream_command';
+  static const String _messageType =
+      WebSocketMessageTypeKey.closeMethodStreamCommandTypeKey;
 
   /// The endpoint associated with the stream.
   final String endpoint;
@@ -254,11 +264,13 @@ class CloseMethodStreamCommand extends WebSocketMessage {
 
   /// Creates a new [CloseMethodStreamCommand].
   CloseMethodStreamCommand(Map data)
-      : endpoint = data['endpoint'],
-        method = data['method'],
-        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
-        parameter = data['parameter'],
-        reason = CloseReason.tryParse(data['reason']);
+      : endpoint = data[WebSocketMessageDataKey.endpointKey],
+        method = data[WebSocketMessageDataKey.methodKey],
+        connectionId = UuidValueJsonExtension.fromJson(
+            data[WebSocketMessageDataKey.connectionIdKey]),
+        parameter = data[WebSocketMessageDataKey.parameterKey],
+        reason =
+            CloseReason.tryParse(data[WebSocketMessageDataKey.closeReasonKey]);
 
   /// Creates a new [CloseMethodStreamCommand] message.
   static String buildMessage({
@@ -269,11 +281,11 @@ class CloseMethodStreamCommand extends WebSocketMessage {
     required CloseReason reason,
   }) {
     return WebSocketMessage._buildMessage(_messageType, {
-      'endpoint': endpoint,
-      'method': method,
-      'connectionId': connectionId,
-      if (parameter != null) 'parameter': parameter,
-      'reason': reason.name,
+      WebSocketMessageDataKey.endpointKey: endpoint,
+      WebSocketMessageDataKey.methodKey: method,
+      WebSocketMessageDataKey.connectionIdKey: connectionId,
+      if (parameter != null) WebSocketMessageDataKey.parameterKey: parameter,
+      WebSocketMessageDataKey.closeReasonKey: reason.name,
     });
   }
 
@@ -290,7 +302,7 @@ class CloseMethodStreamCommand extends WebSocketMessage {
 /// A message sent over a websocket connection to check if the connection is
 /// still alive. The other end should respond with a [PongCommand].
 class PingCommand extends WebSocketMessage {
-  static const String _messageType = 'ping_command';
+  static const String _messageType = WebSocketMessageTypeKey.pingCommandTypeKey;
 
   /// Builds a [PingCommand] message.
   static String buildMessage() {
@@ -303,7 +315,7 @@ class PingCommand extends WebSocketMessage {
 
 /// A response to a [PingCommand].
 class PongCommand extends WebSocketMessage {
-  static const String _messageType = 'pong_command';
+  static const String _messageType = WebSocketMessageTypeKey.pongCommandTypeKey;
 
   /// Builds a [PongCommand] message.
   static String buildMessage() {
@@ -316,7 +328,8 @@ class PongCommand extends WebSocketMessage {
 
 /// A serializable exception sent over a method stream.
 class MethodStreamSerializableException extends WebSocketMessage {
-  static const String _messageType = 'method_stream_serializable_exception';
+  static const String _messageType =
+      WebSocketMessageTypeKey.methodStreamSerializableExceptionTypeKey;
 
   /// The endpoint the message is sent to.
   final String endpoint;
@@ -340,12 +353,13 @@ class MethodStreamSerializableException extends WebSocketMessage {
   MethodStreamSerializableException(
     Map data,
     SerializationManager serializationManager,
-  )   : endpoint = data['endpoint'],
-        method = data['method'],
-        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
-        parameter = data['parameter'],
-        exception =
-            serializationManager.deserializeByClassName(data['exception']);
+  )   : endpoint = data[WebSocketMessageDataKey.endpointKey],
+        method = data[WebSocketMessageDataKey.methodKey],
+        connectionId = UuidValueJsonExtension.fromJson(
+            data[WebSocketMessageDataKey.connectionIdKey]),
+        parameter = data[WebSocketMessageDataKey.parameterKey],
+        exception = serializationManager
+            .deserializeByClassName(data[WebSocketMessageDataKey.exceptionKey]);
 
   /// Builds a [MethodStreamSerializableException] message.
   /// The [exception] must be a serializable exception processed by the
@@ -361,11 +375,12 @@ class MethodStreamSerializableException extends WebSocketMessage {
     return WebSocketMessage._buildMessage(
       _messageType,
       {
-        'endpoint': endpoint,
-        'method': method,
-        'connectionId': connectionId,
-        if (parameter != null) 'parameter': parameter,
-        'exception': serializationManager.wrapWithClassName(object),
+        WebSocketMessageDataKey.endpointKey: endpoint,
+        WebSocketMessageDataKey.methodKey: method,
+        WebSocketMessageDataKey.connectionIdKey: connectionId,
+        if (parameter != null) WebSocketMessageDataKey.parameterKey: parameter,
+        WebSocketMessageDataKey.exceptionKey:
+            serializationManager.wrapWithClassName(object),
       },
     );
   }
@@ -374,18 +389,20 @@ class MethodStreamSerializableException extends WebSocketMessage {
   String toString() => WebSocketMessage._buildMessage(
         _messageType,
         {
-          'endpoint': endpoint,
-          'method': method,
-          'connectionId': connectionId,
-          if (parameter != null) 'parameter': parameter,
-          'exception': exception,
+          WebSocketMessageDataKey.endpointKey: endpoint,
+          WebSocketMessageDataKey.methodKey: method,
+          WebSocketMessageDataKey.connectionIdKey: connectionId,
+          if (parameter != null)
+            WebSocketMessageDataKey.parameterKey: parameter,
+          WebSocketMessageDataKey.exceptionKey: exception,
         },
       ).toString();
 }
 
 /// A message sent to a method stream.
 class MethodStreamMessage extends WebSocketMessage {
-  static const String _messageType = 'method_message';
+  static const String _messageType =
+      WebSocketMessageTypeKey.methodStreamMessageTypeKey;
 
   /// The endpoint the message is sent to.
   final String endpoint;
@@ -407,11 +424,13 @@ class MethodStreamMessage extends WebSocketMessage {
   /// The [object] must be an object processed by the
   /// [SerializationManager.wrapWithClassName] method.
   MethodStreamMessage(Map data, SerializationManager serializationManager)
-      : endpoint = data['endpoint'],
-        method = data['method'],
-        connectionId = UuidValueJsonExtension.fromJson(data['connectionId']),
-        parameter = data['parameter'],
-        object = serializationManager.deserializeByClassName(data['object']);
+      : endpoint = data[WebSocketMessageDataKey.endpointKey],
+        method = data[WebSocketMessageDataKey.methodKey],
+        connectionId = UuidValueJsonExtension.fromJson(
+            data[WebSocketMessageDataKey.connectionIdKey]),
+        parameter = data[WebSocketMessageDataKey.parameterKey],
+        object = serializationManager
+            .deserializeByClassName(data[WebSocketMessageDataKey.objectKey]);
 
   /// Builds a [MethodStreamMessage] message.
   static String buildMessage({
@@ -423,11 +442,12 @@ class MethodStreamMessage extends WebSocketMessage {
     required SerializationManager serializationManager,
   }) {
     return WebSocketMessage._buildMessage(_messageType, {
-      'endpoint': endpoint,
-      'method': method,
-      'connectionId': connectionId,
-      if (parameter != null) 'parameter': parameter,
-      'object': serializationManager.wrapWithClassName(object),
+      WebSocketMessageDataKey.endpointKey: endpoint,
+      WebSocketMessageDataKey.methodKey: method,
+      WebSocketMessageDataKey.connectionIdKey: connectionId,
+      if (parameter != null) WebSocketMessageDataKey.parameterKey: parameter,
+      WebSocketMessageDataKey.objectKey:
+          serializationManager.wrapWithClassName(object),
     });
   }
 
@@ -435,31 +455,34 @@ class MethodStreamMessage extends WebSocketMessage {
   String toString() => WebSocketMessage._buildMessage(
         _messageType,
         {
-          'endpoint': endpoint,
-          'method': method,
-          'connectionId': connectionId,
-          if (parameter != null) 'parameter': parameter,
-          'object': object,
+          WebSocketMessageDataKey.endpointKey: endpoint,
+          WebSocketMessageDataKey.methodKey: method,
+          WebSocketMessageDataKey.connectionIdKey: connectionId,
+          if (parameter != null)
+            WebSocketMessageDataKey.parameterKey: parameter,
+          WebSocketMessageDataKey.objectKey: object,
         },
       ).toString();
 }
 
 /// A message sent when a bad request is received.
 class BadRequestMessage extends WebSocketMessage {
-  static const String _messageType = 'bad_request_message';
+  static const String _messageType =
+      WebSocketMessageTypeKey.badRequestMessageTypeKey;
 
   /// The request that was bad.
   final String request;
 
   /// Creates a new [BadRequestMessage].
-  BadRequestMessage(Map data) : request = data['request'];
+  BadRequestMessage(Map data)
+      : request = data[WebSocketMessageDataKey.requestKey];
 
   /// Builds a [BadRequestMessage] message.
   static String buildMessage(String request) {
     return WebSocketMessage._buildMessage(
       _messageType,
       {
-        'request': request,
+        WebSocketMessageDataKey.requestKey: request,
       },
     );
   }

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:serverpod_serialization/src/websocket_message_keys.dart';
 import 'package:test/test.dart';
 
 class _TestSerializationManager extends SerializationManager {
@@ -92,7 +93,7 @@ void main() {
       'Given message that has no data when building websocket message then data keyword is not included',
       () {
     var message = PingCommand.buildMessage();
-    expect(message, isNot(contains('data')));
+    expect(message, isNot(contains(WebSocketMessageKey.messageDataKey)));
   });
 
   test(
@@ -134,7 +135,8 @@ void main() {
     var message = BadRequestMessage.buildMessage('testRequest');
 
     /// Missing mandatory field 'request'
-    message = message.replaceAll('"request":"testRequest"', '');
+    message = message.replaceAll(
+        '"${WebSocketMessageDataKey.requestKey}":"testRequest"', '');
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -164,7 +166,7 @@ void main() {
       'Given an unknown command json String when building websocket message from string then UnknownMessageException is thrown.',
       () {
     var message =
-        '{"${WebSocketMessage.messageTypeKeyword}": "this is not a known message type"}';
+        '{"${WebSocketMessageKey.messageTypeKey}": "this is not a known message type"}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -194,7 +196,7 @@ void main() {
   test(
       'Given a null messageType when building websocket message from string then UnknownMessageException is thrown.',
       () {
-    var message = '{"${WebSocketMessage.messageTypeKeyword}": null}';
+    var message = '{"${WebSocketMessageKey.messageTypeKey}": null}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -262,7 +264,8 @@ void main() {
     );
 
     // This message is missing the mandatory endpoint field.
-    message = message.replaceAll('"endpoint":"endpoint",', '');
+    message = message.replaceAll(
+        '"${WebSocketMessageDataKey.endpointKey}":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -347,7 +350,7 @@ void main() {
 
     // This message is missing the mandatory connectionId field.
     message = message.replaceAll(
-      '"connectionId":${SerializationManager.encodeForProtocol(connectionId)},',
+      '"${WebSocketMessageDataKey.connectionIdKey}":${SerializationManager.encodeForProtocol(connectionId)},',
       '',
     );
 
@@ -434,7 +437,8 @@ void main() {
     );
 
     // This message is missing the mandatory endpoint field.
-    message = message.replaceAll('"endpoint":"endpoint",', '');
+    message = message.replaceAll(
+        '"${WebSocketMessageDataKey.endpointKey}":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -494,7 +498,8 @@ void main() {
     );
 
     // This message is missing the mandatory endpoint field.
-    message = message.replaceAll('"endpoint":"endpoint",', '');
+    message = message.replaceAll(
+        '"${WebSocketMessageDataKey.endpointKey}":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -89,6 +89,13 @@ class _TestSerializableException
 
 void main() {
   test(
+      'Given message that has no data when building websocket message then data keyword is not included',
+      () {
+    var message = PingCommand.buildMessage();
+    expect(message, isNot(contains('data')));
+  });
+
+  test(
       'Given a Ping command message when building websocket message from string then PingCommand is returned.',
       () {
     var message = PingCommand.buildMessage();

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -93,7 +93,7 @@ void main() {
       'Given message that has no data when building websocket message then data keyword is not included',
       () {
     var message = PingCommand.buildMessage();
-    expect(message, isNot(contains(WebSocketMessageKey.messageDataKey)));
+    expect(message, isNot(contains(WebSocketMessageKey.data)));
   });
 
   test(
@@ -136,7 +136,7 @@ void main() {
 
     /// Missing mandatory field 'request'
     message = message.replaceAll(
-        '"${WebSocketMessageDataKey.requestKey}":"testRequest"', '');
+        '"${WebSocketMessageDataKey.request}":"testRequest"', '');
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -166,7 +166,7 @@ void main() {
       'Given an unknown command json String when building websocket message from string then UnknownMessageException is thrown.',
       () {
     var message =
-        '{"${WebSocketMessageKey.messageTypeKey}": "this is not a known message type"}';
+        '{"${WebSocketMessageKey.type}": "this is not a known message type"}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -196,7 +196,7 @@ void main() {
   test(
       'Given a null messageType when building websocket message from string then UnknownMessageException is thrown.',
       () {
-    var message = '{"${WebSocketMessageKey.messageTypeKey}": null}';
+    var message = '{"${WebSocketMessageKey.type}": null}';
     expect(
       () => WebSocketMessage.fromJsonString(
         message,
@@ -265,7 +265,7 @@ void main() {
 
     // This message is missing the mandatory endpoint field.
     message = message.replaceAll(
-        '"${WebSocketMessageDataKey.endpointKey}":"endpoint",', '');
+        '"${WebSocketMessageDataKey.endpoint}":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -350,7 +350,7 @@ void main() {
 
     // This message is missing the mandatory connectionId field.
     message = message.replaceAll(
-      '"${WebSocketMessageDataKey.connectionIdKey}":${SerializationManager.encodeForProtocol(connectionId)},',
+      '"${WebSocketMessageDataKey.connectionId}":${SerializationManager.encodeForProtocol(connectionId)},',
       '',
     );
 
@@ -438,7 +438,7 @@ void main() {
 
     // This message is missing the mandatory endpoint field.
     message = message.replaceAll(
-        '"${WebSocketMessageDataKey.endpointKey}":"endpoint",', '');
+        '"${WebSocketMessageDataKey.endpoint}":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(
@@ -499,7 +499,7 @@ void main() {
 
     // This message is missing the mandatory endpoint field.
     message = message.replaceAll(
-        '"${WebSocketMessageDataKey.endpointKey}":"endpoint",', '');
+        '"${WebSocketMessageDataKey.endpoint}":"endpoint",', '');
 
     expect(
       () => WebSocketMessage.fromJsonString(

--- a/packages/serverpod_serialization/test/websocket_messages_test.dart
+++ b/packages/serverpod_serialization/test/websocket_messages_test.dart
@@ -234,7 +234,7 @@ void main() {
       inputStreams: ['input1'],
     );
 
-    // This message is missing the mandatory endpoint field.
+    // This message uses an unsupported type for input stream.
     message = message.replaceAll('"input1"', '1');
 
     expect(


### PR DESCRIPTION
This PR minimizes the keys used in the method stream message protocol.

The purpose is to reduce the data footprint of each message delivered on the protocol without sacrificing readability completely.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

This is a breaking change to a feature that has only been released in a Beta and that is marked Experimental. Therefore we can ship breaking changes without increasing the major version.