### PR TITLE
fix: Allow users on AWS to set/upgrade dart version.

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/install_dependencies
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/install_dependencies
@@ -29,7 +29,7 @@ After=multi-user.target
 [Service]
 User=ec2-user
 WorkingDirectory=/home/ec2-user
-ExecStart=/home/ec2-user/serverpod/active/mypod_server/deploy/aws/scripts/run_serverpod
+ExecStart=/home/ec2-user/serverpod/active/projectname_server/deploy/aws/scripts/run_serverpod
 Restart=always
 
 [Install]

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/install_dependencies
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/install_dependencies
@@ -1,4 +1,26 @@
 #!/bin/bash
+DART_VERSION=3.5.1
+
+## Uncomment the following code if you have already generated the project with the older version of serverpod cli
+## What this code do is to remove our previous way of setting dart version in the launch template
+#if [ -f "/etc/profile.d/script.sh" ]; then
+#    sudo rm /etc/profile.d/script.sh
+#fi
+
+## install specified dart version if it is not present on the machine
+
+if [ ! -d "/usr/lib/dart$DART_VERSION" ]; then
+  wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/$DART_VERSION/sdk/dartsdk-linux-x64-release.zip -P /tmp
+  cd /tmp || exit
+  unzip -q dartsdk-linux-x64-release.zip
+  sudo mv dart-sdk/ /usr/lib/dart$DART_VERSION/
+  sudo chmod -R 755 /usr/lib/dart$DART_VERSION/
+  rm -rf dartsdk-linux-x64-release.zip
+fi
+
+## make symlink to use this dart as default
+sudo ln -sf "/usr/lib/dart$DART_VERSION/bin/dart" /usr/local/bin/dart
+
 cat > /lib/systemd/system/serverpod.service << EOF
 [Unit]
 Description=Serverpod server
@@ -7,7 +29,7 @@ After=multi-user.target
 [Service]
 User=ec2-user
 WorkingDirectory=/home/ec2-user
-ExecStart=/home/ec2-user/serverpod/active/projectname_server/deploy/aws/scripts/run_serverpod
+ExecStart=/home/ec2-user/serverpod/active/mypod_server/deploy/aws/scripts/run_serverpod
 Restart=always
 
 [Install]

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/run_serverpod
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/run_serverpod
@@ -2,4 +2,4 @@
 RUNMODE=$(cat /home/ec2-user/runmode)
 SERVER_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 cd /home/ec2-user/serverpod/active/projectname_server
-/usr/lib/dart/bin/dart --old_gen_heap_size=0  run bin/main.dill --mode $RUNMODE --server-id $SERVER_ID > /home/ec2-user/serverpod.log 2> /home/ec2-user/serverpod.err
+dart --old_gen_heap_size=0  run bin/main.dill --mode $RUNMODE --server-id $SERVER_ID > /home/ec2-user/serverpod.log 2> /home/ec2-user/serverpod.err

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/start_server
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/start_server
@@ -5,7 +5,7 @@ chown -R ec2-user:ec2-user /home/ec2-user/serverpod
 
 # Run pub get as ec2-user
 cd /home/ec2-user/serverpod/upload/projectname_server/
-sudo -u ec2-user /usr/lib/dart/bin/dart pub get
+sudo -u ec2-user dart pub get
 
 # Set correct permissions for start script
 chmod 755 deploy/aws/scripts/run_serverpod

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/init-script.sh
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/terraform/init-script.sh
@@ -8,14 +8,6 @@ yum install ruby -y
 echo "Installing wget"
 yum install wget -y
 
-# Install Dart
-echo "Installing dart"
-wget -q https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.1/sdk/dartsdk-linux-x64-release.zip
-unzip -q dartsdk-linux-x64-release.zip
-sudo mv dart-sdk/ /usr/lib/dart/
-sudo chmod -R 755 /usr/lib/dart/
-echo 'export PATH="$PATH:/usr/lib/dart/bin"' >> /etc/profile.d/script.sh
-
 # Install CodeDeploy agent
 echo "Installing CodeDeploy agent"
 cd /home/ec2-user


### PR DESCRIPTION
This removes the installation of dart from launch template and install during code deploy. The purpose for this:
1. launch template only loads once an old instance is deleted, which means for upgrading dart, users need to delete the old machine and launch a new one which causes significant downtime
2. this allows multiple versions of dart to be installed on the instance, but only the specified one will be used to run code

For users using prior version of serverpod cli, we have commented out a section of the code in `install_dependencies`. Users can uncomment the code and upgrade their dart version on running instance. The downtime will be approximately the same as rolling out a code release

_Replace this paragraph with a description of what this PR is changing or adding, and why._

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

N/A