### PR TITLE
fix: Add missing optional transaction in database relational methods

### DIFF
--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empy_model.dart
@@ -373,8 +373,9 @@ class EmptyModelAttachRepository {
   Future<void> items(
     _i1.Session session,
     EmptyModel emptyModel,
-    List<_i2.EmptyModelRelationItem> emptyModelRelationItem,
-  ) async {
+    List<_i2.EmptyModelRelationItem> emptyModelRelationItem, {
+    _i1.Transaction? transaction,
+  }) async {
     if (emptyModelRelationItem.any((e) => e.id == null)) {
       throw ArgumentError.notNull('emptyModelRelationItem.id');
     }
@@ -391,6 +392,7 @@ class EmptyModelAttachRepository {
     await session.db.update<_i2.EmptyModelRelationItem>(
       $emptyModelRelationItem,
       columns: [_i2.EmptyModelRelationItem.t.$_emptyModelItemsEmptyModelId],
+      transaction: transaction,
     );
   }
 }
@@ -401,8 +403,9 @@ class EmptyModelAttachRowRepository {
   Future<void> items(
     _i1.Session session,
     EmptyModel emptyModel,
-    _i2.EmptyModelRelationItem emptyModelRelationItem,
-  ) async {
+    _i2.EmptyModelRelationItem emptyModelRelationItem, {
+    _i1.Transaction? transaction,
+  }) async {
     if (emptyModelRelationItem.id == null) {
       throw ArgumentError.notNull('emptyModelRelationItem.id');
     }
@@ -417,6 +420,7 @@ class EmptyModelAttachRowRepository {
     await session.db.updateRow<_i2.EmptyModelRelationItem>(
       $emptyModelRelationItem,
       columns: [_i2.EmptyModelRelationItem.t.$_emptyModelItemsEmptyModelId],
+      transaction: transaction,
     );
   }
 }
@@ -426,8 +430,9 @@ class EmptyModelDetachRepository {
 
   Future<void> items(
     _i1.Session session,
-    List<_i2.EmptyModelRelationItem> emptyModelRelationItem,
-  ) async {
+    List<_i2.EmptyModelRelationItem> emptyModelRelationItem, {
+    _i1.Transaction? transaction,
+  }) async {
     if (emptyModelRelationItem.any((e) => e.id == null)) {
       throw ArgumentError.notNull('emptyModelRelationItem.id');
     }
@@ -441,6 +446,7 @@ class EmptyModelDetachRepository {
     await session.db.update<_i2.EmptyModelRelationItem>(
       $emptyModelRelationItem,
       columns: [_i2.EmptyModelRelationItem.t.$_emptyModelItemsEmptyModelId],
+      transaction: transaction,
     );
   }
 }
@@ -450,8 +456,9 @@ class EmptyModelDetachRowRepository {
 
   Future<void> items(
     _i1.Session session,
-    _i2.EmptyModelRelationItem emptyModelRelationItem,
-  ) async {
+    _i2.EmptyModelRelationItem emptyModelRelationItem, {
+    _i1.Transaction? transaction,
+  }) async {
     if (emptyModelRelationItem.id == null) {
       throw ArgumentError.notNull('emptyModelRelationItem.id');
     }
@@ -463,6 +470,7 @@ class EmptyModelDetachRowRepository {
     await session.db.updateRow<_i2.EmptyModelRelationItem>(
       $emptyModelRelationItem,
       columns: [_i2.EmptyModelRelationItem.t.$_emptyModelItemsEmptyModelId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -474,8 +474,9 @@ class CityWithLongTableNameAttachRepository {
   Future<void> citizens(
     _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
-    List<_i2.PersonWithLongTableName> personWithLongTableName,
-  ) async {
+    List<_i2.PersonWithLongTableName> personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -496,14 +497,16 @@ class CityWithLongTableNameAttachRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
-    List<_i2.OrganizationWithLongTableName> organizationWithLongTableName,
-  ) async {
+    List<_i2.OrganizationWithLongTableName> organizationWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organizationWithLongTableName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('organizationWithLongTableName.id');
     }
@@ -517,6 +520,7 @@ class CityWithLongTableNameAttachRepository {
     await session.db.update<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
+      transaction: transaction,
     );
   }
 }
@@ -527,8 +531,9 @@ class CityWithLongTableNameAttachRowRepository {
   Future<void> citizens(
     _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
-    _i2.PersonWithLongTableName personWithLongTableName,
-  ) async {
+    _i2.PersonWithLongTableName personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.id == null) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -547,14 +552,16 @@ class CityWithLongTableNameAttachRowRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
-    _i2.OrganizationWithLongTableName organizationWithLongTableName,
-  ) async {
+    _i2.OrganizationWithLongTableName organizationWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organizationWithLongTableName.id == null) {
       throw ArgumentError.notNull('organizationWithLongTableName.id');
     }
@@ -567,6 +574,7 @@ class CityWithLongTableNameAttachRowRepository {
     await session.db.updateRow<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
+      transaction: transaction,
     );
   }
 }
@@ -576,8 +584,9 @@ class CityWithLongTableNameDetachRepository {
 
   Future<void> citizens(
     _i1.Session session,
-    List<_i2.PersonWithLongTableName> personWithLongTableName,
-  ) async {
+    List<_i2.PersonWithLongTableName> personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -595,13 +604,15 @@ class CityWithLongTableNameDetachRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
-    List<_i2.OrganizationWithLongTableName> organizationWithLongTableName,
-  ) async {
+    List<_i2.OrganizationWithLongTableName> organizationWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organizationWithLongTableName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('organizationWithLongTableName.id');
     }
@@ -612,6 +623,7 @@ class CityWithLongTableNameDetachRepository {
     await session.db.update<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
+      transaction: transaction,
     );
   }
 }
@@ -621,8 +633,9 @@ class CityWithLongTableNameDetachRowRepository {
 
   Future<void> citizens(
     _i1.Session session,
-    _i2.PersonWithLongTableName personWithLongTableName,
-  ) async {
+    _i2.PersonWithLongTableName personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.id == null) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -637,13 +650,15 @@ class CityWithLongTableNameDetachRowRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
-    _i2.OrganizationWithLongTableName organizationWithLongTableName,
-  ) async {
+    _i2.OrganizationWithLongTableName organizationWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organizationWithLongTableName.id == null) {
       throw ArgumentError.notNull('organizationWithLongTableName.id');
     }
@@ -653,6 +668,7 @@ class CityWithLongTableNameDetachRowRepository {
     await session.db.updateRow<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -467,8 +467,9 @@ class OrganizationWithLongTableNameAttachRepository {
   Future<void> people(
     _i1.Session session,
     OrganizationWithLongTableName organizationWithLongTableName,
-    List<_i2.PersonWithLongTableName> personWithLongTableName,
-  ) async {
+    List<_i2.PersonWithLongTableName> personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -483,6 +484,7 @@ class OrganizationWithLongTableNameAttachRepository {
     await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -493,8 +495,9 @@ class OrganizationWithLongTableNameAttachRowRepository {
   Future<void> city(
     _i1.Session session,
     OrganizationWithLongTableName organizationWithLongTableName,
-    _i2.CityWithLongTableName city,
-  ) async {
+    _i2.CityWithLongTableName city, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organizationWithLongTableName.id == null) {
       throw ArgumentError.notNull('organizationWithLongTableName.id');
     }
@@ -507,14 +510,16 @@ class OrganizationWithLongTableNameAttachRowRepository {
     await session.db.updateRow<OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [OrganizationWithLongTableName.t.cityId],
+      transaction: transaction,
     );
   }
 
   Future<void> people(
     _i1.Session session,
     OrganizationWithLongTableName organizationWithLongTableName,
-    _i2.PersonWithLongTableName personWithLongTableName,
-  ) async {
+    _i2.PersonWithLongTableName personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.id == null) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -527,6 +532,7 @@ class OrganizationWithLongTableNameAttachRowRepository {
     await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -536,8 +542,9 @@ class OrganizationWithLongTableNameDetachRepository {
 
   Future<void> people(
     _i1.Session session,
-    List<_i2.PersonWithLongTableName> personWithLongTableName,
-  ) async {
+    List<_i2.PersonWithLongTableName> personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -548,6 +555,7 @@ class OrganizationWithLongTableNameDetachRepository {
     await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -557,8 +565,9 @@ class OrganizationWithLongTableNameDetachRowRepository {
 
   Future<void> city(
     _i1.Session session,
-    OrganizationWithLongTableName organizationwithlongtablename,
-  ) async {
+    OrganizationWithLongTableName organizationwithlongtablename, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organizationwithlongtablename.id == null) {
       throw ArgumentError.notNull('organizationwithlongtablename.id');
     }
@@ -568,13 +577,15 @@ class OrganizationWithLongTableNameDetachRowRepository {
     await session.db.updateRow<OrganizationWithLongTableName>(
       $organizationwithlongtablename,
       columns: [OrganizationWithLongTableName.t.cityId],
+      transaction: transaction,
     );
   }
 
   Future<void> people(
     _i1.Session session,
-    _i2.PersonWithLongTableName personWithLongTableName,
-  ) async {
+    _i2.PersonWithLongTableName personWithLongTableName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.id == null) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -584,6 +595,7 @@ class OrganizationWithLongTableNameDetachRowRepository {
     await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -450,8 +450,9 @@ class PersonWithLongTableNameAttachRowRepository {
   Future<void> organization(
     _i1.Session session,
     PersonWithLongTableName personWithLongTableName,
-    _i2.OrganizationWithLongTableName organization,
-  ) async {
+    _i2.OrganizationWithLongTableName organization, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personWithLongTableName.id == null) {
       throw ArgumentError.notNull('personWithLongTableName.id');
     }
@@ -464,6 +465,7 @@ class PersonWithLongTableNameAttachRowRepository {
     await session.db.updateRow<PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [PersonWithLongTableName.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -473,8 +475,9 @@ class PersonWithLongTableNameDetachRowRepository {
 
   Future<void> organization(
     _i1.Session session,
-    PersonWithLongTableName personwithlongtablename,
-  ) async {
+    PersonWithLongTableName personwithlongtablename, {
+    _i1.Transaction? transaction,
+  }) async {
     if (personwithlongtablename.id == null) {
       throw ArgumentError.notNull('personwithlongtablename.id');
     }
@@ -484,6 +487,7 @@ class PersonWithLongTableNameDetachRowRepository {
     await session.db.updateRow<PersonWithLongTableName>(
       $personwithlongtablename,
       columns: [PersonWithLongTableName.t.organizationId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -441,8 +441,9 @@ class LongImplicitIdFieldCollectionAttachRepository {
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
     _i1.Session session,
     LongImplicitIdFieldCollection longImplicitIdFieldCollection,
-    List<_i2.LongImplicitIdField> longImplicitIdField,
-  ) async {
+    List<_i2.LongImplicitIdField> longImplicitIdField, {
+    _i1.Transaction? transaction,
+  }) async {
     if (longImplicitIdField.any((e) => e.id == null)) {
       throw ArgumentError.notNull('longImplicitIdField.id');
     }
@@ -463,6 +464,7 @@ class LongImplicitIdFieldCollectionAttachRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
+      transaction: transaction,
     );
   }
 }
@@ -473,8 +475,9 @@ class LongImplicitIdFieldCollectionAttachRowRepository {
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
     _i1.Session session,
     LongImplicitIdFieldCollection longImplicitIdFieldCollection,
-    _i2.LongImplicitIdField longImplicitIdField,
-  ) async {
+    _i2.LongImplicitIdField longImplicitIdField, {
+    _i1.Transaction? transaction,
+  }) async {
     if (longImplicitIdField.id == null) {
       throw ArgumentError.notNull('longImplicitIdField.id');
     }
@@ -493,6 +496,7 @@ class LongImplicitIdFieldCollectionAttachRowRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
+      transaction: transaction,
     );
   }
 }
@@ -502,8 +506,9 @@ class LongImplicitIdFieldCollectionDetachRepository {
 
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
     _i1.Session session,
-    List<_i2.LongImplicitIdField> longImplicitIdField,
-  ) async {
+    List<_i2.LongImplicitIdField> longImplicitIdField, {
+    _i1.Transaction? transaction,
+  }) async {
     if (longImplicitIdField.any((e) => e.id == null)) {
       throw ArgumentError.notNull('longImplicitIdField.id');
     }
@@ -521,6 +526,7 @@ class LongImplicitIdFieldCollectionDetachRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
+      transaction: transaction,
     );
   }
 }
@@ -530,8 +536,9 @@ class LongImplicitIdFieldCollectionDetachRowRepository {
 
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
     _i1.Session session,
-    _i2.LongImplicitIdField longImplicitIdField,
-  ) async {
+    _i2.LongImplicitIdField longImplicitIdField, {
+    _i1.Transaction? transaction,
+  }) async {
     if (longImplicitIdField.id == null) {
       throw ArgumentError.notNull('longImplicitIdField.id');
     }
@@ -546,6 +553,7 @@ class LongImplicitIdFieldCollectionDetachRowRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -409,8 +409,9 @@ class RelationToMultipleMaxFieldNameAttachRepository {
   Future<void> multipleMaxFieldNames(
     _i1.Session session,
     RelationToMultipleMaxFieldName relationToMultipleMaxFieldName,
-    List<_i2.MultipleMaxFieldName> multipleMaxFieldName,
-  ) async {
+    List<_i2.MultipleMaxFieldName> multipleMaxFieldName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (multipleMaxFieldName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('multipleMaxFieldName.id');
     }
@@ -431,6 +432,7 @@ class RelationToMultipleMaxFieldNameAttachRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -441,8 +443,9 @@ class RelationToMultipleMaxFieldNameAttachRowRepository {
   Future<void> multipleMaxFieldNames(
     _i1.Session session,
     RelationToMultipleMaxFieldName relationToMultipleMaxFieldName,
-    _i2.MultipleMaxFieldName multipleMaxFieldName,
-  ) async {
+    _i2.MultipleMaxFieldName multipleMaxFieldName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (multipleMaxFieldName.id == null) {
       throw ArgumentError.notNull('multipleMaxFieldName.id');
     }
@@ -461,6 +464,7 @@ class RelationToMultipleMaxFieldNameAttachRowRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -470,8 +474,9 @@ class RelationToMultipleMaxFieldNameDetachRepository {
 
   Future<void> multipleMaxFieldNames(
     _i1.Session session,
-    List<_i2.MultipleMaxFieldName> multipleMaxFieldName,
-  ) async {
+    List<_i2.MultipleMaxFieldName> multipleMaxFieldName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (multipleMaxFieldName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('multipleMaxFieldName.id');
     }
@@ -489,6 +494,7 @@ class RelationToMultipleMaxFieldNameDetachRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -498,8 +504,9 @@ class RelationToMultipleMaxFieldNameDetachRowRepository {
 
   Future<void> multipleMaxFieldNames(
     _i1.Session session,
-    _i2.MultipleMaxFieldName multipleMaxFieldName,
-  ) async {
+    _i2.MultipleMaxFieldName multipleMaxFieldName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (multipleMaxFieldName.id == null) {
       throw ArgumentError.notNull('multipleMaxFieldName.id');
     }
@@ -514,6 +521,7 @@ class RelationToMultipleMaxFieldNameDetachRowRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -404,8 +404,9 @@ class UserNoteCollectionAttachRepository {
   Future<void> userNotesPropertyName(
     _i1.Session session,
     UserNoteCollection userNoteCollection,
-    List<_i2.UserNote> userNote,
-  ) async {
+    List<_i2.UserNote> userNote, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNote.any((e) => e.id == null)) {
       throw ArgumentError.notNull('userNote.id');
     }
@@ -426,6 +427,7 @@ class UserNoteCollectionAttachRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -436,8 +438,9 @@ class UserNoteCollectionAttachRowRepository {
   Future<void> userNotesPropertyName(
     _i1.Session session,
     UserNoteCollection userNoteCollection,
-    _i2.UserNote userNote,
-  ) async {
+    _i2.UserNote userNote, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNote.id == null) {
       throw ArgumentError.notNull('userNote.id');
     }
@@ -456,6 +459,7 @@ class UserNoteCollectionAttachRowRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -465,8 +469,9 @@ class UserNoteCollectionDetachRepository {
 
   Future<void> userNotesPropertyName(
     _i1.Session session,
-    List<_i2.UserNote> userNote,
-  ) async {
+    List<_i2.UserNote> userNote, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNote.any((e) => e.id == null)) {
       throw ArgumentError.notNull('userNote.id');
     }
@@ -484,6 +489,7 @@ class UserNoteCollectionDetachRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -493,8 +499,9 @@ class UserNoteCollectionDetachRowRepository {
 
   Future<void> userNotesPropertyName(
     _i1.Session session,
-    _i2.UserNote userNote,
-  ) async {
+    _i2.UserNote userNote, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNote.id == null) {
       throw ArgumentError.notNull('userNote.id');
     }
@@ -509,6 +516,7 @@ class UserNoteCollectionDetachRowRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -404,8 +404,9 @@ class UserNoteCollectionWithALongNameAttachRepository {
   Future<void> notes(
     _i1.Session session,
     UserNoteCollectionWithALongName userNoteCollectionWithALongName,
-    List<_i2.UserNoteWithALongName> userNoteWithALongName,
-  ) async {
+    List<_i2.UserNoteWithALongName> userNoteWithALongName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNoteWithALongName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('userNoteWithALongName.id');
     }
@@ -426,6 +427,7 @@ class UserNoteCollectionWithALongNameAttachRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -436,8 +438,9 @@ class UserNoteCollectionWithALongNameAttachRowRepository {
   Future<void> notes(
     _i1.Session session,
     UserNoteCollectionWithALongName userNoteCollectionWithALongName,
-    _i2.UserNoteWithALongName userNoteWithALongName,
-  ) async {
+    _i2.UserNoteWithALongName userNoteWithALongName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNoteWithALongName.id == null) {
       throw ArgumentError.notNull('userNoteWithALongName.id');
     }
@@ -456,6 +459,7 @@ class UserNoteCollectionWithALongNameAttachRowRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -465,8 +469,9 @@ class UserNoteCollectionWithALongNameDetachRepository {
 
   Future<void> notes(
     _i1.Session session,
-    List<_i2.UserNoteWithALongName> userNoteWithALongName,
-  ) async {
+    List<_i2.UserNoteWithALongName> userNoteWithALongName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNoteWithALongName.any((e) => e.id == null)) {
       throw ArgumentError.notNull('userNoteWithALongName.id');
     }
@@ -484,6 +489,7 @@ class UserNoteCollectionWithALongNameDetachRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
+      transaction: transaction,
     );
   }
 }
@@ -493,8 +499,9 @@ class UserNoteCollectionWithALongNameDetachRowRepository {
 
   Future<void> notes(
     _i1.Session session,
-    _i2.UserNoteWithALongName userNoteWithALongName,
-  ) async {
+    _i2.UserNoteWithALongName userNoteWithALongName, {
+    _i1.Transaction? transaction,
+  }) async {
     if (userNoteWithALongName.id == null) {
       throw ArgumentError.notNull('userNoteWithALongName.id');
     }
@@ -509,6 +516,7 @@ class UserNoteCollectionWithALongNameDetachRowRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -465,8 +465,9 @@ class CityAttachRepository {
   Future<void> citizens(
     _i1.Session session,
     City city,
-    List<_i2.Person> person,
-  ) async {
+    List<_i2.Person> person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.any((e) => e.id == null)) {
       throw ArgumentError.notNull('person.id');
     }
@@ -483,14 +484,16 @@ class CityAttachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
     City city,
-    List<_i2.Organization> organization,
-  ) async {
+    List<_i2.Organization> organization, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organization.any((e) => e.id == null)) {
       throw ArgumentError.notNull('organization.id');
     }
@@ -503,6 +506,7 @@ class CityAttachRepository {
     await session.db.update<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
+      transaction: transaction,
     );
   }
 }
@@ -513,8 +517,9 @@ class CityAttachRowRepository {
   Future<void> citizens(
     _i1.Session session,
     City city,
-    _i2.Person person,
-  ) async {
+    _i2.Person person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.id == null) {
       throw ArgumentError.notNull('person.id');
     }
@@ -529,14 +534,16 @@ class CityAttachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
     City city,
-    _i2.Organization organization,
-  ) async {
+    _i2.Organization organization, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organization.id == null) {
       throw ArgumentError.notNull('organization.id');
     }
@@ -548,6 +555,7 @@ class CityAttachRowRepository {
     await session.db.updateRow<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
+      transaction: transaction,
     );
   }
 }
@@ -557,8 +565,9 @@ class CityDetachRepository {
 
   Future<void> citizens(
     _i1.Session session,
-    List<_i2.Person> person,
-  ) async {
+    List<_i2.Person> person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.any((e) => e.id == null)) {
       throw ArgumentError.notNull('person.id');
     }
@@ -572,13 +581,15 @@ class CityDetachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
-    List<_i2.Organization> organization,
-  ) async {
+    List<_i2.Organization> organization, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organization.any((e) => e.id == null)) {
       throw ArgumentError.notNull('organization.id');
     }
@@ -588,6 +599,7 @@ class CityDetachRepository {
     await session.db.update<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
+      transaction: transaction,
     );
   }
 }
@@ -597,8 +609,9 @@ class CityDetachRowRepository {
 
   Future<void> citizens(
     _i1.Session session,
-    _i2.Person person,
-  ) async {
+    _i2.Person person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.id == null) {
       throw ArgumentError.notNull('person.id');
     }
@@ -610,13 +623,15 @@ class CityDetachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
+      transaction: transaction,
     );
   }
 
   Future<void> organizations(
     _i1.Session session,
-    _i2.Organization organization,
-  ) async {
+    _i2.Organization organization, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organization.id == null) {
       throw ArgumentError.notNull('organization.id');
     }
@@ -625,6 +640,7 @@ class CityDetachRowRepository {
     await session.db.updateRow<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -461,8 +461,9 @@ class OrganizationAttachRepository {
   Future<void> people(
     _i1.Session session,
     Organization organization,
-    List<_i2.Person> person,
-  ) async {
+    List<_i2.Person> person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.any((e) => e.id == null)) {
       throw ArgumentError.notNull('person.id');
     }
@@ -475,6 +476,7 @@ class OrganizationAttachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -485,8 +487,9 @@ class OrganizationAttachRowRepository {
   Future<void> city(
     _i1.Session session,
     Organization organization,
-    _i2.City city,
-  ) async {
+    _i2.City city, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organization.id == null) {
       throw ArgumentError.notNull('organization.id');
     }
@@ -498,14 +501,16 @@ class OrganizationAttachRowRepository {
     await session.db.updateRow<Organization>(
       $organization,
       columns: [Organization.t.cityId],
+      transaction: transaction,
     );
   }
 
   Future<void> people(
     _i1.Session session,
     Organization organization,
-    _i2.Person person,
-  ) async {
+    _i2.Person person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.id == null) {
       throw ArgumentError.notNull('person.id');
     }
@@ -517,6 +522,7 @@ class OrganizationAttachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -526,8 +532,9 @@ class OrganizationDetachRepository {
 
   Future<void> people(
     _i1.Session session,
-    List<_i2.Person> person,
-  ) async {
+    List<_i2.Person> person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.any((e) => e.id == null)) {
       throw ArgumentError.notNull('person.id');
     }
@@ -536,6 +543,7 @@ class OrganizationDetachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -545,8 +553,9 @@ class OrganizationDetachRowRepository {
 
   Future<void> city(
     _i1.Session session,
-    Organization organization,
-  ) async {
+    Organization organization, {
+    _i1.Transaction? transaction,
+  }) async {
     if (organization.id == null) {
       throw ArgumentError.notNull('organization.id');
     }
@@ -555,13 +564,15 @@ class OrganizationDetachRowRepository {
     await session.db.updateRow<Organization>(
       $organization,
       columns: [Organization.t.cityId],
+      transaction: transaction,
     );
   }
 
   Future<void> people(
     _i1.Session session,
-    _i2.Person person,
-  ) async {
+    _i2.Person person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.id == null) {
       throw ArgumentError.notNull('person.id');
     }
@@ -570,6 +581,7 @@ class OrganizationDetachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -437,8 +437,9 @@ class PersonAttachRowRepository {
   Future<void> organization(
     _i1.Session session,
     Person person,
-    _i2.Organization organization,
-  ) async {
+    _i2.Organization organization, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.id == null) {
       throw ArgumentError.notNull('person.id');
     }
@@ -450,6 +451,7 @@ class PersonAttachRowRepository {
     await session.db.updateRow<Person>(
       $person,
       columns: [Person.t.organizationId],
+      transaction: transaction,
     );
   }
 }
@@ -459,8 +461,9 @@ class PersonDetachRowRepository {
 
   Future<void> organization(
     _i1.Session session,
-    Person person,
-  ) async {
+    Person person, {
+    _i1.Transaction? transaction,
+  }) async {
     if (person.id == null) {
       throw ArgumentError.notNull('person.id');
     }
@@ -469,6 +472,7 @@ class PersonDetachRowRepository {
     await session.db.updateRow<Person>(
       $person,
       columns: [Person.t.organizationId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -395,8 +395,9 @@ class CourseAttachRepository {
   Future<void> enrollments(
     _i1.Session session,
     Course course,
-    List<_i2.Enrollment> enrollment,
-  ) async {
+    List<_i2.Enrollment> enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.any((e) => e.id == null)) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -409,6 +410,7 @@ class CourseAttachRepository {
     await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
+      transaction: transaction,
     );
   }
 }
@@ -419,8 +421,9 @@ class CourseAttachRowRepository {
   Future<void> enrollments(
     _i1.Session session,
     Course course,
-    _i2.Enrollment enrollment,
-  ) async {
+    _i2.Enrollment enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.id == null) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -432,6 +435,7 @@ class CourseAttachRowRepository {
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
+      transaction: transaction,
     );
   }
 }
@@ -441,8 +445,9 @@ class CourseDetachRepository {
 
   Future<void> enrollments(
     _i1.Session session,
-    List<_i2.Enrollment> enrollment,
-  ) async {
+    List<_i2.Enrollment> enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.any((e) => e.id == null)) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -452,6 +457,7 @@ class CourseDetachRepository {
     await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
+      transaction: transaction,
     );
   }
 }
@@ -461,8 +467,9 @@ class CourseDetachRowRepository {
 
   Future<void> enrollments(
     _i1.Session session,
-    _i2.Enrollment enrollment,
-  ) async {
+    _i2.Enrollment enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.id == null) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -471,6 +478,7 @@ class CourseDetachRowRepository {
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -431,8 +431,9 @@ class EnrollmentAttachRowRepository {
   Future<void> student(
     _i1.Session session,
     Enrollment enrollment,
-    _i2.Student student,
-  ) async {
+    _i2.Student student, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.id == null) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -444,14 +445,16 @@ class EnrollmentAttachRowRepository {
     await session.db.updateRow<Enrollment>(
       $enrollment,
       columns: [Enrollment.t.studentId],
+      transaction: transaction,
     );
   }
 
   Future<void> course(
     _i1.Session session,
     Enrollment enrollment,
-    _i2.Course course,
-  ) async {
+    _i2.Course course, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.id == null) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -463,6 +466,7 @@ class EnrollmentAttachRowRepository {
     await session.db.updateRow<Enrollment>(
       $enrollment,
       columns: [Enrollment.t.courseId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -391,8 +391,9 @@ class StudentAttachRepository {
   Future<void> enrollments(
     _i1.Session session,
     Student student,
-    List<_i2.Enrollment> enrollment,
-  ) async {
+    List<_i2.Enrollment> enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.any((e) => e.id == null)) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -405,6 +406,7 @@ class StudentAttachRepository {
     await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.studentId],
+      transaction: transaction,
     );
   }
 }
@@ -415,8 +417,9 @@ class StudentAttachRowRepository {
   Future<void> enrollments(
     _i1.Session session,
     Student student,
-    _i2.Enrollment enrollment,
-  ) async {
+    _i2.Enrollment enrollment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (enrollment.id == null) {
       throw ArgumentError.notNull('enrollment.id');
     }
@@ -428,6 +431,7 @@ class StudentAttachRowRepository {
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.studentId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -384,8 +384,9 @@ class ObjectUserAttachRowRepository {
   Future<void> userInfo(
     _i1.Session session,
     ObjectUser objectUser,
-    _i2.UserInfo userInfo,
-  ) async {
+    _i2.UserInfo userInfo, {
+    _i1.Transaction? transaction,
+  }) async {
     if (objectUser.id == null) {
       throw ArgumentError.notNull('objectUser.id');
     }
@@ -397,6 +398,7 @@ class ObjectUserAttachRowRepository {
     await session.db.updateRow<ObjectUser>(
       $objectUser,
       columns: [ObjectUser.t.userInfoId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -365,8 +365,9 @@ class ArenaAttachRowRepository {
   Future<void> team(
     _i1.Session session,
     Arena arena,
-    _i2.Team team,
-  ) async {
+    _i2.Team team, {
+    _i1.Transaction? transaction,
+  }) async {
     if (team.id == null) {
       throw ArgumentError.notNull('team.id');
     }
@@ -378,6 +379,7 @@ class ArenaAttachRowRepository {
     await session.db.updateRow<_i2.Team>(
       $team,
       columns: [_i2.Team.t.arenaId],
+      transaction: transaction,
     );
   }
 }
@@ -387,8 +389,9 @@ class ArenaDetachRowRepository {
 
   Future<void> team(
     _i1.Session session,
-    Arena arena,
-  ) async {
+    Arena arena, {
+    _i1.Transaction? transaction,
+  }) async {
     var $team = arena.team;
 
     if ($team == null) {
@@ -405,6 +408,7 @@ class ArenaDetachRowRepository {
     await session.db.updateRow<_i2.Team>(
       $$team,
       columns: [_i2.Team.t.arenaId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -385,8 +385,9 @@ class PlayerAttachRowRepository {
   Future<void> team(
     _i1.Session session,
     Player player,
-    _i2.Team team,
-  ) async {
+    _i2.Team team, {
+    _i1.Transaction? transaction,
+  }) async {
     if (player.id == null) {
       throw ArgumentError.notNull('player.id');
     }
@@ -398,6 +399,7 @@ class PlayerAttachRowRepository {
     await session.db.updateRow<Player>(
       $player,
       columns: [Player.t.teamId],
+      transaction: transaction,
     );
   }
 }
@@ -407,8 +409,9 @@ class PlayerDetachRowRepository {
 
   Future<void> team(
     _i1.Session session,
-    Player player,
-  ) async {
+    Player player, {
+    _i1.Transaction? transaction,
+  }) async {
     if (player.id == null) {
       throw ArgumentError.notNull('player.id');
     }
@@ -417,6 +420,7 @@ class PlayerDetachRowRepository {
     await session.db.updateRow<Player>(
       $player,
       columns: [Player.t.teamId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -460,8 +460,9 @@ class TeamAttachRepository {
   Future<void> players(
     _i1.Session session,
     Team team,
-    List<_i2.Player> player,
-  ) async {
+    List<_i2.Player> player, {
+    _i1.Transaction? transaction,
+  }) async {
     if (player.any((e) => e.id == null)) {
       throw ArgumentError.notNull('player.id');
     }
@@ -473,6 +474,7 @@ class TeamAttachRepository {
     await session.db.update<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
+      transaction: transaction,
     );
   }
 }
@@ -483,8 +485,9 @@ class TeamAttachRowRepository {
   Future<void> arena(
     _i1.Session session,
     Team team,
-    _i2.Arena arena,
-  ) async {
+    _i2.Arena arena, {
+    _i1.Transaction? transaction,
+  }) async {
     if (team.id == null) {
       throw ArgumentError.notNull('team.id');
     }
@@ -496,14 +499,16 @@ class TeamAttachRowRepository {
     await session.db.updateRow<Team>(
       $team,
       columns: [Team.t.arenaId],
+      transaction: transaction,
     );
   }
 
   Future<void> players(
     _i1.Session session,
     Team team,
-    _i2.Player player,
-  ) async {
+    _i2.Player player, {
+    _i1.Transaction? transaction,
+  }) async {
     if (player.id == null) {
       throw ArgumentError.notNull('player.id');
     }
@@ -515,6 +520,7 @@ class TeamAttachRowRepository {
     await session.db.updateRow<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
+      transaction: transaction,
     );
   }
 }
@@ -524,8 +530,9 @@ class TeamDetachRepository {
 
   Future<void> players(
     _i1.Session session,
-    List<_i2.Player> player,
-  ) async {
+    List<_i2.Player> player, {
+    _i1.Transaction? transaction,
+  }) async {
     if (player.any((e) => e.id == null)) {
       throw ArgumentError.notNull('player.id');
     }
@@ -534,6 +541,7 @@ class TeamDetachRepository {
     await session.db.update<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
+      transaction: transaction,
     );
   }
 }
@@ -543,8 +551,9 @@ class TeamDetachRowRepository {
 
   Future<void> arena(
     _i1.Session session,
-    Team team,
-  ) async {
+    Team team, {
+    _i1.Transaction? transaction,
+  }) async {
     if (team.id == null) {
       throw ArgumentError.notNull('team.id');
     }
@@ -553,13 +562,15 @@ class TeamDetachRowRepository {
     await session.db.updateRow<Team>(
       $team,
       columns: [Team.t.arenaId],
+      transaction: transaction,
     );
   }
 
   Future<void> players(
     _i1.Session session,
-    _i2.Player player,
-  ) async {
+    _i2.Player player, {
+    _i1.Transaction? transaction,
+  }) async {
     if (player.id == null) {
       throw ArgumentError.notNull('player.id');
     }
@@ -568,6 +579,7 @@ class TeamDetachRowRepository {
     await session.db.updateRow<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -383,8 +383,9 @@ class CommentAttachRowRepository {
   Future<void> order(
     _i1.Session session,
     Comment comment,
-    _i2.Order order,
-  ) async {
+    _i2.Order order, {
+    _i1.Transaction? transaction,
+  }) async {
     if (comment.id == null) {
       throw ArgumentError.notNull('comment.id');
     }
@@ -396,6 +397,7 @@ class CommentAttachRowRepository {
     await session.db.updateRow<Comment>(
       $comment,
       columns: [Comment.t.orderId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -394,8 +394,9 @@ class CustomerAttachRepository {
   Future<void> orders(
     _i1.Session session,
     Customer customer,
-    List<_i2.Order> order,
-  ) async {
+    List<_i2.Order> order, {
+    _i1.Transaction? transaction,
+  }) async {
     if (order.any((e) => e.id == null)) {
       throw ArgumentError.notNull('order.id');
     }
@@ -407,6 +408,7 @@ class CustomerAttachRepository {
     await session.db.update<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
+      transaction: transaction,
     );
   }
 }
@@ -417,8 +419,9 @@ class CustomerAttachRowRepository {
   Future<void> orders(
     _i1.Session session,
     Customer customer,
-    _i2.Order order,
-  ) async {
+    _i2.Order order, {
+    _i1.Transaction? transaction,
+  }) async {
     if (order.id == null) {
       throw ArgumentError.notNull('order.id');
     }
@@ -430,6 +433,7 @@ class CustomerAttachRowRepository {
     await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
+      transaction: transaction,
     );
   }
 }
@@ -439,8 +443,9 @@ class CustomerDetachRepository {
 
   Future<void> orders(
     _i1.Session session,
-    List<_i2.Order> order,
-  ) async {
+    List<_i2.Order> order, {
+    _i1.Transaction? transaction,
+  }) async {
     if (order.any((e) => e.id == null)) {
       throw ArgumentError.notNull('order.id');
     }
@@ -449,6 +454,7 @@ class CustomerDetachRepository {
     await session.db.update<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
+      transaction: transaction,
     );
   }
 }
@@ -458,8 +464,9 @@ class CustomerDetachRowRepository {
 
   Future<void> orders(
     _i1.Session session,
-    _i2.Order order,
-  ) async {
+    _i2.Order order, {
+    _i1.Transaction? transaction,
+  }) async {
     if (order.id == null) {
       throw ArgumentError.notNull('order.id');
     }
@@ -468,6 +475,7 @@ class CustomerDetachRowRepository {
     await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -457,8 +457,9 @@ class OrderAttachRepository {
   Future<void> comments(
     _i1.Session session,
     Order order,
-    List<_i2.Comment> comment,
-  ) async {
+    List<_i2.Comment> comment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (comment.any((e) => e.id == null)) {
       throw ArgumentError.notNull('comment.id');
     }
@@ -470,6 +471,7 @@ class OrderAttachRepository {
     await session.db.update<_i2.Comment>(
       $comment,
       columns: [_i2.Comment.t.orderId],
+      transaction: transaction,
     );
   }
 }
@@ -480,8 +482,9 @@ class OrderAttachRowRepository {
   Future<void> customer(
     _i1.Session session,
     Order order,
-    _i2.Customer customer,
-  ) async {
+    _i2.Customer customer, {
+    _i1.Transaction? transaction,
+  }) async {
     if (order.id == null) {
       throw ArgumentError.notNull('order.id');
     }
@@ -493,14 +496,16 @@ class OrderAttachRowRepository {
     await session.db.updateRow<Order>(
       $order,
       columns: [Order.t.customerId],
+      transaction: transaction,
     );
   }
 
   Future<void> comments(
     _i1.Session session,
     Order order,
-    _i2.Comment comment,
-  ) async {
+    _i2.Comment comment, {
+    _i1.Transaction? transaction,
+  }) async {
     if (comment.id == null) {
       throw ArgumentError.notNull('comment.id');
     }
@@ -512,6 +517,7 @@ class OrderAttachRowRepository {
     await session.db.updateRow<_i2.Comment>(
       $comment,
       columns: [_i2.Comment.t.orderId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -386,8 +386,9 @@ class AddressAttachRowRepository {
   Future<void> inhabitant(
     _i1.Session session,
     Address address,
-    _i2.Citizen inhabitant,
-  ) async {
+    _i2.Citizen inhabitant, {
+    _i1.Transaction? transaction,
+  }) async {
     if (address.id == null) {
       throw ArgumentError.notNull('address.id');
     }
@@ -399,6 +400,7 @@ class AddressAttachRowRepository {
     await session.db.updateRow<Address>(
       $address,
       columns: [Address.t.inhabitantId],
+      transaction: transaction,
     );
   }
 }
@@ -408,8 +410,9 @@ class AddressDetachRowRepository {
 
   Future<void> inhabitant(
     _i1.Session session,
-    Address address,
-  ) async {
+    Address address, {
+    _i1.Transaction? transaction,
+  }) async {
     if (address.id == null) {
       throw ArgumentError.notNull('address.id');
     }
@@ -418,6 +421,7 @@ class AddressDetachRowRepository {
     await session.db.updateRow<Address>(
       $address,
       columns: [Address.t.inhabitantId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -493,8 +493,9 @@ class CitizenAttachRowRepository {
   Future<void> address(
     _i1.Session session,
     Citizen citizen,
-    _i2.Address address,
-  ) async {
+    _i2.Address address, {
+    _i1.Transaction? transaction,
+  }) async {
     if (address.id == null) {
       throw ArgumentError.notNull('address.id');
     }
@@ -506,14 +507,16 @@ class CitizenAttachRowRepository {
     await session.db.updateRow<_i2.Address>(
       $address,
       columns: [_i2.Address.t.inhabitantId],
+      transaction: transaction,
     );
   }
 
   Future<void> company(
     _i1.Session session,
     Citizen citizen,
-    _i2.Company company,
-  ) async {
+    _i2.Company company, {
+    _i1.Transaction? transaction,
+  }) async {
     if (citizen.id == null) {
       throw ArgumentError.notNull('citizen.id');
     }
@@ -525,14 +528,16 @@ class CitizenAttachRowRepository {
     await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.companyId],
+      transaction: transaction,
     );
   }
 
   Future<void> oldCompany(
     _i1.Session session,
     Citizen citizen,
-    _i2.Company oldCompany,
-  ) async {
+    _i2.Company oldCompany, {
+    _i1.Transaction? transaction,
+  }) async {
     if (citizen.id == null) {
       throw ArgumentError.notNull('citizen.id');
     }
@@ -544,6 +549,7 @@ class CitizenAttachRowRepository {
     await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.oldCompanyId],
+      transaction: transaction,
     );
   }
 }
@@ -553,8 +559,9 @@ class CitizenDetachRowRepository {
 
   Future<void> address(
     _i1.Session session,
-    Citizen citizen,
-  ) async {
+    Citizen citizen, {
+    _i1.Transaction? transaction,
+  }) async {
     var $address = citizen.address;
 
     if ($address == null) {
@@ -571,13 +578,15 @@ class CitizenDetachRowRepository {
     await session.db.updateRow<_i2.Address>(
       $$address,
       columns: [_i2.Address.t.inhabitantId],
+      transaction: transaction,
     );
   }
 
   Future<void> oldCompany(
     _i1.Session session,
-    Citizen citizen,
-  ) async {
+    Citizen citizen, {
+    _i1.Transaction? transaction,
+  }) async {
     if (citizen.id == null) {
       throw ArgumentError.notNull('citizen.id');
     }
@@ -586,6 +595,7 @@ class CitizenDetachRowRepository {
     await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.oldCompanyId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -383,8 +383,9 @@ class CompanyAttachRowRepository {
   Future<void> town(
     _i1.Session session,
     Company company,
-    _i2.Town town,
-  ) async {
+    _i2.Town town, {
+    _i1.Transaction? transaction,
+  }) async {
     if (company.id == null) {
       throw ArgumentError.notNull('company.id');
     }
@@ -396,6 +397,7 @@ class CompanyAttachRowRepository {
     await session.db.updateRow<Company>(
       $company,
       columns: [Company.t.townId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -384,8 +384,9 @@ class TownAttachRowRepository {
   Future<void> mayor(
     _i1.Session session,
     Town town,
-    _i2.Citizen mayor,
-  ) async {
+    _i2.Citizen mayor, {
+    _i1.Transaction? transaction,
+  }) async {
     if (town.id == null) {
       throw ArgumentError.notNull('town.id');
     }
@@ -397,6 +398,7 @@ class TownAttachRowRepository {
     await session.db.updateRow<Town>(
       $town,
       columns: [Town.t.mayorId],
+      transaction: transaction,
     );
   }
 }
@@ -406,8 +408,9 @@ class TownDetachRowRepository {
 
   Future<void> mayor(
     _i1.Session session,
-    Town town,
-  ) async {
+    Town town, {
+    _i1.Transaction? transaction,
+  }) async {
     if (town.id == null) {
       throw ArgumentError.notNull('town.id');
     }
@@ -416,6 +419,7 @@ class TownDetachRowRepository {
     await session.db.updateRow<Town>(
       $town,
       columns: [Town.t.mayorId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -432,8 +432,9 @@ class BlockingAttachRowRepository {
   Future<void> blocked(
     _i1.Session session,
     Blocking blocking,
-    _i2.Member blocked,
-  ) async {
+    _i2.Member blocked, {
+    _i1.Transaction? transaction,
+  }) async {
     if (blocking.id == null) {
       throw ArgumentError.notNull('blocking.id');
     }
@@ -445,14 +446,16 @@ class BlockingAttachRowRepository {
     await session.db.updateRow<Blocking>(
       $blocking,
       columns: [Blocking.t.blockedId],
+      transaction: transaction,
     );
   }
 
   Future<void> blockedBy(
     _i1.Session session,
     Blocking blocking,
-    _i2.Member blockedBy,
-  ) async {
+    _i2.Member blockedBy, {
+    _i1.Transaction? transaction,
+  }) async {
     if (blocking.id == null) {
       throw ArgumentError.notNull('blocking.id');
     }
@@ -464,6 +467,7 @@ class BlockingAttachRowRepository {
     await session.db.updateRow<Blocking>(
       $blocking,
       columns: [Blocking.t.blockedById],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -462,8 +462,9 @@ class MemberAttachRepository {
   Future<void> blocking(
     _i1.Session session,
     Member member,
-    List<_i2.Blocking> blocking,
-  ) async {
+    List<_i2.Blocking> blocking, {
+    _i1.Transaction? transaction,
+  }) async {
     if (blocking.any((e) => e.id == null)) {
       throw ArgumentError.notNull('blocking.id');
     }
@@ -476,14 +477,16 @@ class MemberAttachRepository {
     await session.db.update<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedById],
+      transaction: transaction,
     );
   }
 
   Future<void> blockedBy(
     _i1.Session session,
     Member member,
-    List<_i2.Blocking> blocking,
-  ) async {
+    List<_i2.Blocking> blocking, {
+    _i1.Transaction? transaction,
+  }) async {
     if (blocking.any((e) => e.id == null)) {
       throw ArgumentError.notNull('blocking.id');
     }
@@ -496,6 +499,7 @@ class MemberAttachRepository {
     await session.db.update<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedId],
+      transaction: transaction,
     );
   }
 }
@@ -506,8 +510,9 @@ class MemberAttachRowRepository {
   Future<void> blocking(
     _i1.Session session,
     Member member,
-    _i2.Blocking blocking,
-  ) async {
+    _i2.Blocking blocking, {
+    _i1.Transaction? transaction,
+  }) async {
     if (blocking.id == null) {
       throw ArgumentError.notNull('blocking.id');
     }
@@ -519,14 +524,16 @@ class MemberAttachRowRepository {
     await session.db.updateRow<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedById],
+      transaction: transaction,
     );
   }
 
   Future<void> blockedBy(
     _i1.Session session,
     Member member,
-    _i2.Blocking blocking,
-  ) async {
+    _i2.Blocking blocking, {
+    _i1.Transaction? transaction,
+  }) async {
     if (blocking.id == null) {
       throw ArgumentError.notNull('blocking.id');
     }
@@ -538,6 +545,7 @@ class MemberAttachRowRepository {
     await session.db.updateRow<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -460,8 +460,9 @@ class CatAttachRepository {
   Future<void> kittens(
     _i1.Session session,
     Cat cat,
-    List<_i2.Cat> nestedCat,
-  ) async {
+    List<_i2.Cat> nestedCat, {
+    _i1.Transaction? transaction,
+  }) async {
     if (nestedCat.any((e) => e.id == null)) {
       throw ArgumentError.notNull('nestedCat.id');
     }
@@ -474,6 +475,7 @@ class CatAttachRepository {
     await session.db.update<_i2.Cat>(
       $nestedCat,
       columns: [_i2.Cat.t.motherId],
+      transaction: transaction,
     );
   }
 }
@@ -484,8 +486,9 @@ class CatAttachRowRepository {
   Future<void> mother(
     _i1.Session session,
     Cat cat,
-    _i2.Cat mother,
-  ) async {
+    _i2.Cat mother, {
+    _i1.Transaction? transaction,
+  }) async {
     if (cat.id == null) {
       throw ArgumentError.notNull('cat.id');
     }
@@ -497,14 +500,16 @@ class CatAttachRowRepository {
     await session.db.updateRow<Cat>(
       $cat,
       columns: [Cat.t.motherId],
+      transaction: transaction,
     );
   }
 
   Future<void> kittens(
     _i1.Session session,
     Cat cat,
-    _i2.Cat nestedCat,
-  ) async {
+    _i2.Cat nestedCat, {
+    _i1.Transaction? transaction,
+  }) async {
     if (nestedCat.id == null) {
       throw ArgumentError.notNull('nestedCat.id');
     }
@@ -516,6 +521,7 @@ class CatAttachRowRepository {
     await session.db.updateRow<_i2.Cat>(
       $nestedCat,
       columns: [_i2.Cat.t.motherId],
+      transaction: transaction,
     );
   }
 }
@@ -525,8 +531,9 @@ class CatDetachRepository {
 
   Future<void> kittens(
     _i1.Session session,
-    List<_i2.Cat> cat,
-  ) async {
+    List<_i2.Cat> cat, {
+    _i1.Transaction? transaction,
+  }) async {
     if (cat.any((e) => e.id == null)) {
       throw ArgumentError.notNull('cat.id');
     }
@@ -535,6 +542,7 @@ class CatDetachRepository {
     await session.db.update<_i2.Cat>(
       $cat,
       columns: [_i2.Cat.t.motherId],
+      transaction: transaction,
     );
   }
 }
@@ -544,8 +552,9 @@ class CatDetachRowRepository {
 
   Future<void> mother(
     _i1.Session session,
-    Cat cat,
-  ) async {
+    Cat cat, {
+    _i1.Transaction? transaction,
+  }) async {
     if (cat.id == null) {
       throw ArgumentError.notNull('cat.id');
     }
@@ -554,13 +563,15 @@ class CatDetachRowRepository {
     await session.db.updateRow<Cat>(
       $cat,
       columns: [Cat.t.motherId],
+      transaction: transaction,
     );
   }
 
   Future<void> kittens(
     _i1.Session session,
-    _i2.Cat cat,
-  ) async {
+    _i2.Cat cat, {
+    _i1.Transaction? transaction,
+  }) async {
     if (cat.id == null) {
       throw ArgumentError.notNull('cat.id');
     }
@@ -569,6 +580,7 @@ class CatDetachRowRepository {
     await session.db.updateRow<_i2.Cat>(
       $cat,
       columns: [_i2.Cat.t.motherId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -432,8 +432,9 @@ class PostAttachRowRepository {
   Future<void> previous(
     _i1.Session session,
     Post post,
-    _i2.Post previous,
-  ) async {
+    _i2.Post previous, {
+    _i1.Transaction? transaction,
+  }) async {
     if (previous.id == null) {
       throw ArgumentError.notNull('previous.id');
     }
@@ -445,14 +446,16 @@ class PostAttachRowRepository {
     await session.db.updateRow<_i2.Post>(
       $previous,
       columns: [_i2.Post.t.nextId],
+      transaction: transaction,
     );
   }
 
   Future<void> next(
     _i1.Session session,
     Post post,
-    _i2.Post next,
-  ) async {
+    _i2.Post next, {
+    _i1.Transaction? transaction,
+  }) async {
     if (post.id == null) {
       throw ArgumentError.notNull('post.id');
     }
@@ -464,6 +467,7 @@ class PostAttachRowRepository {
     await session.db.updateRow<Post>(
       $post,
       columns: [Post.t.nextId],
+      transaction: transaction,
     );
   }
 }
@@ -473,8 +477,9 @@ class PostDetachRowRepository {
 
   Future<void> previous(
     _i1.Session session,
-    Post post,
-  ) async {
+    Post post, {
+    _i1.Transaction? transaction,
+  }) async {
     var $previous = post.previous;
 
     if ($previous == null) {
@@ -491,13 +496,15 @@ class PostDetachRowRepository {
     await session.db.updateRow<_i2.Post>(
       $$previous,
       columns: [_i2.Post.t.nextId],
+      transaction: transaction,
     );
   }
 
   Future<void> next(
     _i1.Session session,
-    Post post,
-  ) async {
+    Post post, {
+    _i1.Transaction? transaction,
+  }) async {
     if (post.id == null) {
       throw ArgumentError.notNull('post.id');
     }
@@ -506,6 +513,7 @@ class PostDetachRowRepository {
     await session.db.updateRow<Post>(
       $post,
       columns: [Post.t.nextId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -386,8 +386,9 @@ class RelatedUniqueDataAttachRowRepository {
   Future<void> uniqueData(
     _i1.Session session,
     RelatedUniqueData relatedUniqueData,
-    _i2.UniqueData uniqueData,
-  ) async {
+    _i2.UniqueData uniqueData, {
+    _i1.Transaction? transaction,
+  }) async {
     if (relatedUniqueData.id == null) {
       throw ArgumentError.notNull('relatedUniqueData.id');
     }
@@ -400,6 +401,7 @@ class RelatedUniqueDataAttachRowRepository {
     await session.db.updateRow<RelatedUniqueData>(
       $relatedUniqueData,
       columns: [RelatedUniqueData.t.uniqueDataId],
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
@@ -169,20 +169,17 @@ void main() async {
   });
 
   test(
-      'Given a nested transaction when calling `cancel` on the nested transaction then only the top level transaction is committed',
+      'Given a nested transaction when calling `cancel` on the nested transaction then no rows are inserted.',
       () async {
     var data = UniqueData(number: 1, email: 'test@serverpod.dev');
-    var data2 = UniqueData(number: 2, email: 'test2@serverpod.dev');
 
     await session.db.transaction<void>(
       (transaction) async {
-        await UniqueData.db.insertRow(session, data, transaction: transaction);
-
         await session.db.transaction<void>(
           (nestedTransaction) async {
             await UniqueData.db.insertRow(
               session,
-              data2,
+              data,
               transaction: nestedTransaction,
             );
 
@@ -193,7 +190,6 @@ void main() async {
     );
 
     var fetchedData = await UniqueData.db.find(session);
-    expect(fetchedData, hasLength(1));
-    expect(fetchedData.elementAtOrNull(0)?.number, data.number);
+    expect(fetchedData, hasLength(0));
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/transactions/transaction_test.dart
@@ -81,6 +81,7 @@ void main() async {
       reason: 'Row was inserted even though transaction was canceled.',
     );
   });
+
   test(
       'Given a transaction that is canceled when inserting row after transaction is canceled then insertion has no effect',
       () async {
@@ -117,9 +118,6 @@ void main() async {
     var data = UniqueData(number: 1, email: 'test@serverpod.dev');
     var data2 = UniqueData(number: 2, email: 'test2@serverpod.dev');
     var data3 = UniqueData(number: 3, email: 'test3@serverpod.dev');
-    var data4 = UniqueData(number: 3, email: 'test4@serverpod.dev');
-    var data5 = UniqueData(number: 3, email: 'test5@serverpod.dev');
-
     await session.db.transaction<void>(
       (transaction) async {
         await UniqueData.db.insertRow(session, data, transaction: transaction);
@@ -133,20 +131,7 @@ void main() async {
           'ROLLBACK TO SAVEPOINT savepoint1;',
           transaction: transaction,
         );
-        await session.db.transaction((transaction2) async {
-          await session.db.unsafeExecute(
-            'SAVEPOINT savepoint2;',
-            transaction: transaction2,
-          );
-          await UniqueData.db
-              .insertRow(session, data4, transaction: transaction2);
-          await session.db.unsafeExecute(
-            'ROLLBACK TO SAVEPOINT savepoint2;',
-            transaction: transaction2,
-          );
-          await UniqueData.db
-              .insertRow(session, data5, transaction: transaction);
-        });
+
         await UniqueData.db.insertRow(session, data3, transaction: transaction);
       },
     );
@@ -154,9 +139,8 @@ void main() async {
     var fetchedData = await UniqueData.db.find(session);
 
     expect(fetchedData, isNotEmpty);
-    expect(fetchedData, hasLength(3));
+    expect(fetchedData, hasLength(2));
     expect(fetchedData.elementAtOrNull(0)?.number, data.number);
     expect(fetchedData.elementAtOrNull(1)?.number, data3.number);
-    expect(fetchedData.elementAtOrNull(2)?.number, data5.number);
   });
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -915,8 +915,17 @@ class BuildRepositoryClass {
                 subDirParts: classDefinition.subDirParts,
                 config: config,
               );
-          })
+          }),
         ])
+        ..optionalParameters.add(
+          Parameter((p) => p
+            ..type = TypeReference((b) => b
+              ..isNullable = true
+              ..symbol = 'Transaction'
+              ..url = 'package:serverpod/serverpod.dart')
+            ..name = 'transaction'
+            ..named = true),
+        )
         ..modifier = MethodModifier.async
         ..body = relation.implicitForeignField
             ? _buildAttachImplementationBlockImplicitListRelation(
@@ -974,8 +983,17 @@ class BuildRepositoryClass {
             parameterBuilder
               ..name = otherClassFieldName
               ..type = foreignType;
-          })
+          }),
         ])
+        ..optionalParameters.add(
+          Parameter((p) => p
+            ..type = TypeReference((b) => b
+              ..isNullable = true
+              ..symbol = 'Transaction'
+              ..url = 'package:serverpod/serverpod.dart')
+            ..name = 'transaction'
+            ..named = true),
+        )
         ..modifier = MethodModifier.async
         ..body = relation.implicitForeignField
             ? _buildAttachRowImplementationBlockImplicit(
@@ -1032,8 +1050,17 @@ class BuildRepositoryClass {
             parameterBuilder
               ..name = otherClassFieldName
               ..type = foreignType;
-          })
+          }),
         ])
+        ..optionalParameters.add(
+          Parameter((p) => p
+            ..type = TypeReference((b) => b
+              ..isNullable = true
+              ..symbol = 'Transaction'
+              ..url = 'package:serverpod/serverpod.dart')
+            ..name = 'transaction'
+            ..named = true),
+        )
         ..modifier = MethodModifier.async
         ..body = relation.isForeignKeyOrigin
             ? _buildAttachRowImplementationBlockExplicit(
@@ -1235,8 +1262,17 @@ class BuildRepositoryClass {
                 config: config,
               );
             refer(classFieldName, 'package:serverpod/serverpod.dart');
-          })
+          }),
         ])
+        ..optionalParameters.add(
+          Parameter((p) => p
+            ..type = TypeReference((b) => b
+              ..isNullable = true
+              ..symbol = 'Transaction'
+              ..url = 'package:serverpod/serverpod.dart')
+            ..name = 'transaction'
+            ..named = true),
+        )
         ..returns = refer('Future<void>')
         ..modifier = MethodModifier.async
         ..body = relation.implicitForeignField
@@ -1292,8 +1328,17 @@ class BuildRepositoryClass {
                 subDirParts: classDefinition.subDirParts,
                 config: config,
               );
-          })
+          }),
         ])
+        ..optionalParameters.add(
+          Parameter((p) => p
+            ..type = TypeReference((b) => b
+              ..isNullable = true
+              ..symbol = 'Transaction'
+              ..url = 'package:serverpod/serverpod.dart')
+            ..name = 'transaction'
+            ..named = true),
+        )
         ..returns = refer('Future<void>')
         ..modifier = MethodModifier.async
         ..body = relation.implicitForeignField
@@ -1336,8 +1381,17 @@ class BuildRepositoryClass {
             parameterBuilder
               ..name = classFieldName
               ..type = refer(className);
-          })
+          }),
         ])
+        ..optionalParameters.add(
+          Parameter((p) => p
+            ..type = TypeReference((b) => b
+              ..isNullable = true
+              ..symbol = 'Transaction'
+              ..url = 'package:serverpod/serverpod.dart')
+            ..name = 'transaction'
+            ..named = true),
+        )
         ..returns = refer('Future<void>')
         ..modifier = MethodModifier.async
         ..body = relation.isForeignKeyOrigin
@@ -1730,7 +1784,8 @@ class BuildRepositoryClass {
                 ], {
                   'columns': literalList(
                     [classReference.property('t').property(fieldName)],
-                  )
+                  ),
+                  'transaction': refer('transaction'),
                 }, [
                   classReference,
                 ])

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
@@ -261,10 +261,11 @@ void main() {
         expect(peopleMethod, isNotNull, reason: 'Missing people method.');
       });
 
-      test('people method has the input params of session, person', () {
+      test('people method has the input params of session, person, transaction',
+          () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          '(_i1.Session session, Person person)',
+          '(_i1.Session session, Person person, {_i1.Transaction? transaction})',
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryClass == null);
@@ -462,10 +463,12 @@ void main() {
         expect(citizenMethod, isNotNull, reason: 'Missing citizens method.');
       });
 
-      test('citizens method has the input params of session, person', () {
+      test(
+          'citizens method has the input params of session, person, transaction',
+          () {
         expect(
           citizenMethod?.parameters?.toSource(),
-          '(_i1.Session session, Person person)',
+          '(_i1.Session session, Person person, {_i1.Transaction? transaction})',
         );
       }, skip: citizenMethod == null);
     });

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
@@ -176,7 +176,8 @@ void main() {
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          r'(_i1.Session session, Example example, Person person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Example example, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     });
@@ -226,7 +227,8 @@ void main() {
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          r'(_i1.Session session, Example example, List<Person> person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Example example, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -264,7 +266,8 @@ void main() {
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          '(_i1.Session session, Person person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryClass == null);
@@ -314,7 +317,8 @@ void main() {
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          r'(_i1.Session session, List<Person> person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -371,7 +375,8 @@ void main() {
           () {
         expect(
           citizensMethod?.parameters?.toSource(),
-          r'(_i1.Session session, Example example, List<Person> person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Example example, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizensMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -397,7 +402,8 @@ void main() {
           () {
         expect(
           citizenMethod?.parameters?.toSource(),
-          r'(_i1.Session session, Example example, Person person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Example example, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizenMethod == null);
     });
@@ -434,7 +440,8 @@ void main() {
           () {
         expect(
           citizensMethod?.parameters?.toSource(),
-          r'(_i1.Session session, List<Person> person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizensMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -460,7 +467,8 @@ void main() {
           () {
         expect(
           citizenMethod?.parameters?.toSource(),
-          '(_i1.Session session, Person person, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizenMethod == null);
     });

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
@@ -171,13 +171,12 @@ void main() {
         expect(peopleMethod, isNotNull, reason: 'Missing people method.');
       });
 
-      test('people method has the input params of session, example and person',
+      test(
+          'people method has the input params of session, example, person and named param transaction',
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, Example example, Person person)',
-          ),
+          r'(_i1.Session session, Example example, Person person, {_i1.Transaction? transaction})',
         );
       }, skip: peopleMethod == null);
     });
@@ -222,13 +221,12 @@ void main() {
         expect(peopleMethod, isNotNull, reason: 'Missing people method.');
       });
 
-      test('people method has the input params of session, example and person',
+      test(
+          'people method has the input params of session, example, person and named param transaction',
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, Example example, List<Person> person)',
-          ),
+          r'(_i1.Session session, Example example, List<Person> person, {_i1.Transaction? transaction})',
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -261,7 +259,8 @@ void main() {
         expect(peopleMethod, isNotNull, reason: 'Missing people method.');
       });
 
-      test('people method has the input params of session, person, transaction',
+      test(
+          'people method has the input params of session, person and named param transaction',
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
@@ -310,13 +309,12 @@ void main() {
         expect(peopleMethod, isNotNull, reason: 'Missing people method.');
       });
 
-      test('people method has the input params of session, example and person',
+      test(
+          'people method has the input params of session, example, person and named param transaction',
           () {
         expect(
           peopleMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, List<Person> person)',
-          ),
+          r'(_i1.Session session, List<Person> person, {_i1.Transaction? transaction})',
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -369,13 +367,11 @@ void main() {
       });
 
       test(
-          'citizens method has the input params of session, example and person',
+          'citizens method has the input params of session, example, person and named param transaction',
           () {
         expect(
           citizensMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, Example example, List<Person> person)',
-          ),
+          r'(_i1.Session session, Example example, List<Person> person, {_i1.Transaction? transaction})',
         );
       }, skip: citizensMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -397,13 +393,11 @@ void main() {
       });
 
       test(
-          'citizens method has the input params of session, example and person',
+          'citizens method has the input params of session, example, person and named param transaction',
           () {
         expect(
           citizenMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, Example example, Person person)',
-          ),
+          r'(_i1.Session session, Example example, Person person, {_i1.Transaction? transaction})',
         );
       }, skip: citizenMethod == null);
     });
@@ -436,13 +430,11 @@ void main() {
       });
 
       test(
-          'citizens method has the input params of session, example and person',
+          'citizens method has the input params of session, example, person and named param transaction',
           () {
         expect(
           citizensMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, List<Person> person)',
-          ),
+          r'(_i1.Session session, List<Person> person, {_i1.Transaction? transaction})',
         );
       }, skip: citizensMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -464,7 +456,7 @@ void main() {
       });
 
       test(
-          'citizens method has the input params of session, person, transaction',
+          'citizens method has the input params of session, person and named param transaction',
           () {
         expect(
           citizenMethod?.parameters?.toSource(),

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
@@ -264,10 +264,12 @@ void main() {
         expect(companyMethod, isNotNull, reason: 'Missing company method.');
       });
 
-      test('company method has the input params of session, example', () {
+      test(
+          'company method has the input params of session, example, transaction',
+          () {
         expect(
           companyMethod?.parameters?.toSource(),
-          '(_i1.Session session, Example example)',
+          '(_i1.Session session, Example example, {_i1.Transaction? transaction})',
         );
       }, skip: companyMethod == null);
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
@@ -182,7 +182,7 @@ void main() {
       });
 
       test(
-          'the address method has the input params of session, example and address',
+          'the address method has the input params of session, example, address and named param transaction',
           () {
         expect(
           addressMethod?.parameters?.toSource(),

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
@@ -164,13 +164,11 @@ void main() {
       });
 
       test(
-          'company method has the input params of session, example and company',
+          'company method has the input params of session, example, company and named param transaction',
           () {
         expect(
           companyMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, Example example, Company company)',
-          ),
+          '(_i1.Session session, Example example, Company company, {_i1.Transaction? transaction})',
         );
       }, skip: companyMethod == null);
 
@@ -188,9 +186,7 @@ void main() {
           () {
         expect(
           addressMethod?.parameters?.toSource(),
-          matches(
-            r'(_i\d.Session session, Example example, Address address)',
-          ),
+          r'(_i1.Session session, Example example, Address address, {_i1.Transaction? transaction})',
         );
       }, skip: addressMethod == null);
 
@@ -265,7 +261,7 @@ void main() {
       });
 
       test(
-          'company method has the input params of session, example, transaction',
+          'company method has the input params of session, example and named param transaction',
           () {
         expect(
           companyMethod?.parameters?.toSource(),

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
@@ -168,7 +168,8 @@ void main() {
           () {
         expect(
           companyMethod?.parameters?.toSource(),
-          '(_i1.Session session, Example example, Company company, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Example example, Company company, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: companyMethod == null);
 
@@ -186,7 +187,8 @@ void main() {
           () {
         expect(
           addressMethod?.parameters?.toSource(),
-          r'(_i1.Session session, Example example, Address address, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Example example, Address address, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: addressMethod == null);
 
@@ -265,7 +267,8 @@ void main() {
           () {
         expect(
           companyMethod?.parameters?.toSource(),
-          '(_i1.Session session, Example example, {_i1.Transaction? transaction})',
+          matches(
+              r'\(_i\d\.Session session, Example example, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: companyMethod == null);
 


### PR DESCRIPTION
## Description
- The `transaction` parameter was not exposed in all database methods which means they could not be used in the context of a transaction (see #2442 for an example).
- There might be tests missing (please point out if you think so) but primarily the existing test had an incorrect expectation where transaction was missing from expected parameters.

## Changes
- Adds an optional `transaction` parameter to all database methods where it was missing, which fixes #2442

## Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
