### PR TITLE
fix: Allow Serverpod defined models to be encoded and decoded with type.

### DIFF
--- a/examples/auth_example/auth_example_server/lib/src/generated/protocol.dart
+++ b/examples/auth_example/auth_example_server/lib/src/generated/protocol.dart
@@ -55,6 +55,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i4.Example) {
       return 'Example';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
@@ -66,6 +70,10 @@ class Protocol extends _i1.SerializationManagerServer {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'] == 'Example') {
       return deserialize<_i4.Example>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);

--- a/examples/chat/chat_server/lib/src/generated/protocol.dart
+++ b/examples/chat/chat_server/lib/src/generated/protocol.dart
@@ -109,6 +109,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i5.Channel) {
       return 'Channel';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
@@ -124,6 +128,10 @@ class Protocol extends _i1.SerializationManagerServer {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'] == 'Channel') {
       return deserialize<_i5.Channel>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -776,6 +776,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i16.UserSettingsConfig) {
       return 'UserSettingsConfig';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     return null;
   }
 
@@ -822,6 +826,10 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (data['className'] == 'UserSettingsConfig') {
       return deserialize<_i16.UserSettingsConfig>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
@@ -338,6 +338,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i14.ChatRequestMessageChunk) {
       return 'ChatRequestMessageChunk';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
@@ -380,6 +384,10 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (data['className'] == 'ChatRequestMessageChunk') {
       return deserialize<_i14.ChatRequestMessageChunk>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);

--- a/templates/serverpod_templates/modulename_server/lib/src/generated/protocol.dart
+++ b/templates/serverpod_templates/modulename_server/lib/src/generated/protocol.dart
@@ -48,6 +48,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i3.ModuleClass) {
       return 'ModuleClass';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     return null;
   }
 
@@ -55,6 +59,10 @@ class Protocol extends _i1.SerializationManagerServer {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'] == 'ModuleClass') {
       return deserialize<_i3.ModuleClass>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }

--- a/templates/serverpod_templates/projectname_server/lib/src/generated/protocol.dart
+++ b/templates/serverpod_templates/projectname_server/lib/src/generated/protocol.dart
@@ -50,6 +50,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i3.Example) {
       return 'Example';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     return null;
   }
 
@@ -57,6 +61,10 @@ class Protocol extends _i1.SerializationManagerServer {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'] == 'Example') {
       return deserialize<_i3.Example>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -48,6 +48,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i3.ModuleClass) {
       return 'ModuleClass';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     return null;
   }
 
@@ -55,6 +59,10 @@ class Protocol extends _i1.SerializationManagerServer {
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'] == 'ModuleClass') {
       return deserialize<_i3.ModuleClass>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -6275,6 +6275,10 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i102.UniqueData) {
       return 'UniqueData';
     }
+    className = _i2.Protocol().getClassNameForObject(data);
+    if (className != null) {
+      return 'serverpod.$className';
+    }
     className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
@@ -6596,6 +6600,10 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (data['className'] == 'UniqueData') {
       return deserialize<_i102.UniqueData>(data['data']);
+    }
+    if (data['className'].startsWith('serverpod.')) {
+      data['className'] = data['className'].substring(10);
+      return _i2.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);

--- a/tests/serverpod_test_server/test/decode_with_type_test.dart
+++ b/tests/serverpod_test_server/test/decode_with_type_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod/protocol.dart' as serverpod;
 import 'package:test/test.dart';
 
 void main() {
@@ -66,6 +67,19 @@ void main() {
       expect(decoded is SimpleData?, true);
     },
   );
+
+  test(
+      'Given a Serverpod defined model when encoding and decoding with type then output matches input',
+      () {
+    var serverpodDefinedModel =
+        serverpod.ClusterServerInfo(serverId: 'Hello World');
+    var encoded = protocol.encodeWithType(serverpodDefinedModel);
+    var decoded = protocol.decodeWithType(encoded);
+
+    expect(decoded, isA<serverpod.ClusterServerInfo>());
+    expect((decoded as serverpod.ClusterServerInfo).serverId,
+        serverpodDefinedModel.serverId);
+  });
 }
 
 extension _SimpleDataExtension on SimpleData {

--- a/tests/serverpod_test_server/test/encode_with_type_test.dart
+++ b/tests/serverpod_test_server/test/encode_with_type_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:serverpod/protocol.dart' as serverpod;
 import 'package:test/test.dart';
 
 void main() {
@@ -50,5 +51,16 @@ void main() {
     SimpleData? simpleData = null;
     var typeName = protocol.encodeWithType(simpleData);
     expect(typeName, '{"className":"null","data":null}');
+  });
+
+  test(
+      'Given a Serverpod defined model when encoding with type then output is the type name and value as a JSON string',
+      () {
+    var serverpodDefinedModel =
+        serverpod.ClusterServerInfo(serverId: 'Hello World');
+    var typeName = protocol.encodeWithType(serverpodDefinedModel);
+
+    expect(typeName,
+        '{"className":"serverpod.ClusterServerInfo","data":{"serverId":"Hello World"}}');
   });
 }

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:serverpod/protocol.dart' as serverpod;
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart' as server;
 import 'package:test/test.dart';
@@ -220,5 +221,16 @@ void main() {
     var typesMap = Protocol().decode<TypesMap>(encodedString);
 
     expect(typesMap.anObjectKey, {});
+  });
+
+  test(
+      'Given a Serverpod defined model when encoding it with type then it is encoded',
+      () {
+    var serverProtocol = server.Protocol();
+    var serverpodDefinedModel =
+        serverpod.ClusterServerInfo(serverId: 'Hello World');
+    var encoded = serverProtocol.encodeWithType(serverpodDefinedModel);
+
+    expect(encoded, isA<String>());
   });
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -187,6 +187,12 @@ class LibraryGenerator {
           for (var classInfo in models)
             Code.scope((a) =>
                 'if(data is ${a(refer(classInfo.className, classInfo.fileRef()))}) {return \'${classInfo.className}\';}'),
+          if (config.name != 'serverpod' && serverCode)
+            Block.of([
+              Code.scope((a) =>
+                  'className = ${a(refer('Protocol', serverpodProtocolUrl(serverCode)))}().getClassNameForObject(data);'),
+              Code('if(className != null){return \'serverpod.\$className\';}'),
+            ]),
           for (var module in config.modules)
             Block.of([
               Code.scope((a) =>
@@ -212,6 +218,14 @@ class LibraryGenerator {
             Code.scope((a) =>
                 'if(data[\'className\'] == \'${classInfo.className}\'){'
                 'return deserialize<${a(refer(classInfo.className, classInfo.fileRef()))}>(data[\'data\']);}'),
+          if (config.name != 'serverpod' && serverCode)
+            Block.of([
+              Code('if(data[\'className\'].startsWith(\'serverpod.\')){'
+                  'data[\'className\'] = data[\'className\'].substring(${'serverpod'.length + 1});'),
+              Code.scope((a) =>
+                  'return ${a(refer('Protocol', serverpodProtocolUrl(serverCode)))}().deserializeByClassName(data);'),
+              const Code('}'),
+            ]),
           for (var module in config.modules)
             Block.of([
               Code('if(data[\'className\'].startsWith(\'${module.name}.\')){'

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -188,18 +188,11 @@ class LibraryGenerator {
             Code.scope((a) =>
                 'if(data is ${a(refer(classInfo.className, classInfo.fileRef()))}) {return \'${classInfo.className}\';}'),
           if (config.name != 'serverpod' && serverCode)
-            Block.of([
-              Code.scope((a) =>
-                  'className = ${a(refer('Protocol', serverpodProtocolUrl(serverCode)))}().getClassNameForObject(data);'),
-              Code('if(className != null){return \'serverpod.\$className\';}'),
-            ]),
+            _buildGetClassNameForObjectDelegation(
+                serverpodProtocolUrl(serverCode), 'serverpod'),
           for (var module in config.modules)
-            Block.of([
-              Code.scope((a) =>
-                  'className = ${a(refer('Protocol', module.dartImportUrl(serverCode)))}().getClassNameForObject(data);'),
-              Code(
-                  'if(className != null){return \'${module.name}.\$className\';}'),
-            ]),
+            _buildGetClassNameForObjectDelegation(
+                module.dartImportUrl(serverCode), module.name),
           const Code('return null;'),
         ])),
       Method((m) => m
@@ -219,21 +212,15 @@ class LibraryGenerator {
                 'if(data[\'className\'] == \'${classInfo.className}\'){'
                 'return deserialize<${a(refer(classInfo.className, classInfo.fileRef()))}>(data[\'data\']);}'),
           if (config.name != 'serverpod' && serverCode)
-            Block.of([
-              Code('if(data[\'className\'].startsWith(\'serverpod.\')){'
-                  'data[\'className\'] = data[\'className\'].substring(${'serverpod'.length + 1});'),
-              Code.scope((a) =>
-                  'return ${a(refer('Protocol', serverpodProtocolUrl(serverCode)))}().deserializeByClassName(data);'),
-              const Code('}'),
-            ]),
+            _buildDeserializeByClassNameDelegation(
+              serverpodProtocolUrl(serverCode),
+              'serverpod',
+            ),
           for (var module in config.modules)
-            Block.of([
-              Code('if(data[\'className\'].startsWith(\'${module.name}.\')){'
-                  'data[\'className\'] = data[\'className\'].substring(${module.name.length + 1});'),
-              Code.scope((a) =>
-                  'return ${a(refer('Protocol', module.dartImportUrl(serverCode)))}().deserializeByClassName(data);'),
-              const Code('}'),
-            ]),
+            _buildDeserializeByClassNameDelegation(
+              module.dartImportUrl(serverCode),
+              module.name,
+            ),
           const Code('return super.deserializeByClassName(data);'),
         ])),
       if (serverCode)
@@ -298,6 +285,30 @@ class LibraryGenerator {
     library.body.add(protocol.build());
 
     return library.build();
+  }
+
+  Block _buildGetClassNameForObjectDelegation(
+    String protocolImportPath,
+    String projectName,
+  ) {
+    return Block.of([
+      Code.scope((a) =>
+          'className = ${a(refer('Protocol', protocolImportPath))}().getClassNameForObject(data);'),
+      Code('if(className != null){return \'$projectName.\$className\';}'),
+    ]);
+  }
+
+  Block _buildDeserializeByClassNameDelegation(
+    String protocolImportPath,
+    String projectName,
+  ) {
+    return Block.of([
+      Code('if(data[\'className\'].startsWith(\'$projectName.\')){'
+          'data[\'className\'] = data[\'className\'].substring(${projectName.length + 1});'),
+      Code.scope((a) =>
+          'return ${a(refer('Protocol', protocolImportPath))}().deserializeByClassName(data);'),
+      const Code('}'),
+    ]);
   }
 
   /// Generates the EndpointDispatch for the server side.


### PR DESCRIPTION
The generated code on the Server did not properly delegate to the Serverpod Protocol file when for calls to `getClassNameForObject` and `deserialzieByClassName`.

This made it impossible to encode and decode Serverpod-defined models.

Fixes: #2657


### Additional information

An important note here is that we only support encoding and decoding Serverpod defined models on the server side.
The client does not have access to the Serverpod generated client Protocol (referred to as serverpod_service_client).

Therefore no delegated call has been added to the client code.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.