### PR TITLE
fix: Respect authentication changes in method streams.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_authentication.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_authentication.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/module.dart';
 import 'package:serverpod_auth_server/src/business/authentication_util.dart';
@@ -9,8 +10,12 @@ class UserAuthentication {
   /// before signing them in. Send the AuthKey.id and key to the client and
   /// use that to authenticate in future calls. In most situations you should
   /// use one of the auth providers instead of this method.
-  static Future<AuthKey> signInUser(Session session, int userId, String method,
-      {Set<Scope> scopes = const {}}) async {
+  static Future<AuthKey> signInUser(
+    Session session,
+    int userId,
+    String method, {
+    Set<Scope> scopes = const {},
+  }) async {
     var signInSalt = session.passwords['authKeySalt'] ?? defaultAuthKeySalt;
 
     var key = generateRandomString();
@@ -42,6 +47,8 @@ class UserAuthentication {
 
     await session.db
         .deleteWhere<AuthKey>(where: AuthKey.t.userId.equals(userId));
+    await session.messages
+        .revokedAuthentication(userId, RevokedAuthenticationUser());
     session.updateAuthenticated(null);
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_authentication.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/user_authentication.dart
@@ -48,7 +48,7 @@ class UserAuthentication {
     await session.db
         .deleteWhere<AuthKey>(where: AuthKey.t.userId.equals(userId));
     await session.messages
-        .revokedAuthentication(userId, RevokedAuthenticationUser());
+        .authenticationRevoked(userId, RevokedAuthenticationUser());
     session.updateAuthenticated(null);
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod/protocol.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/src/business/config.dart';
 import 'package:serverpod_auth_server/src/business/user_authentication.dart';
@@ -109,10 +110,8 @@ class Users {
     var userInfo = await findUserByUserId(session, userId, useCache: false);
     if (userInfo == null) return null;
 
-    var scopeStrs = <String>[];
-    for (var scope in newScopes) {
-      if (scope.name != null) scopeStrs.add(scope.name!);
-    }
+    var removedScopes = userInfo.scopes.difference(newScopes);
+    var scopeStrs = newScopes.map((s) => s.name).whereType<String>().toList();
     userInfo.scopeNames = scopeStrs;
     await UserInfo.db.updateRow(session, userInfo);
 
@@ -123,6 +122,18 @@ class Users {
 
     if (AuthConfig.current.onUserUpdated != null) {
       await AuthConfig.current.onUserUpdated!(session, userInfo);
+    }
+
+    // Notify if any scopes are revoked for user.
+    if (removedScopes.isNotEmpty) {
+      var removedScopesList =
+          removedScopes.map((s) => s.name).whereType<String>().toList();
+      await session.messages.revokedAuthentication(
+        userId,
+        RevokedAuthenticationScope(
+          scopes: removedScopesList,
+        ),
+      );
     }
 
     await invalidateCacheForUser(session, userId);

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -124,8 +124,8 @@ class Users {
       await AuthConfig.current.onUserUpdated!(session, userInfo);
     }
 
-    // Notify if any scopes are revoked for user.
-    if (removedScopes.isNotEmpty) {
+    var scopesHaveBeenRevoked = removedScopes.isNotEmpty;
+    if (scopesHaveBeenRevoked) {
       var removedScopesList =
           removedScopes.map((s) => s.name).whereType<String>().toList();
       await session.messages.authenticationRevoked(

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -128,7 +128,7 @@ class Users {
     if (removedScopes.isNotEmpty) {
       var removedScopesList =
           removedScopes.map((s) => s.name).whereType<String>().toList();
-      await session.messages.revokedAuthentication(
+      await session.messages.authenticationRevoked(
         userId,
         RevokedAuthenticationScope(
           scopes: removedScopesList,

--- a/packages/serverpod/lib/src/authentication/authentication_info.dart
+++ b/packages/serverpod/lib/src/authentication/authentication_info.dart
@@ -17,6 +17,9 @@ class AuthenticationInfo {
   /// The scopes that the user can access.
   final Set<Scope> scopes;
 
+  /// The authentication key id.
+  final String? authId;
+
   /// Creates a new [AuthenticationInfo].
-  AuthenticationInfo(this.userId, this.scopes);
+  AuthenticationInfo(this.userId, this.scopes, {this.authId});
 }

--- a/packages/serverpod/lib/src/generated/authentication/revoked_authentication_auth_id.dart
+++ b/packages/serverpod/lib/src/generated/authentication/revoked_authentication_auth_id.dart
@@ -1,0 +1,54 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+/// Message sent when an authentication key id is revoked.
+abstract class RevokedAuthenticationAuthId
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  RevokedAuthenticationAuthId._({required this.authId});
+
+  factory RevokedAuthenticationAuthId({required String authId}) =
+      _RevokedAuthenticationAuthIdImpl;
+
+  factory RevokedAuthenticationAuthId.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return RevokedAuthenticationAuthId(
+        authId: jsonSerialization['authId'] as String);
+  }
+
+  String authId;
+
+  RevokedAuthenticationAuthId copyWith({String? authId});
+  @override
+  Map<String, dynamic> toJson() {
+    return {'authId': authId};
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {};
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _RevokedAuthenticationAuthIdImpl extends RevokedAuthenticationAuthId {
+  _RevokedAuthenticationAuthIdImpl({required String authId})
+      : super._(authId: authId);
+
+  @override
+  RevokedAuthenticationAuthId copyWith({String? authId}) {
+    return RevokedAuthenticationAuthId(authId: authId ?? this.authId);
+  }
+}

--- a/packages/serverpod/lib/src/generated/authentication/revoked_authentication_scope.dart
+++ b/packages/serverpod/lib/src/generated/authentication/revoked_authentication_scope.dart
@@ -1,0 +1,58 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+/// Message sent when authentication scopes for a user are revoked.
+abstract class RevokedAuthenticationScope
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  RevokedAuthenticationScope._({required this.scopes});
+
+  factory RevokedAuthenticationScope({required List<String> scopes}) =
+      _RevokedAuthenticationScopeImpl;
+
+  factory RevokedAuthenticationScope.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return RevokedAuthenticationScope(
+        scopes: (jsonSerialization['scopes'] as List)
+            .map((e) => e as String)
+            .toList());
+  }
+
+  List<String> scopes;
+
+  RevokedAuthenticationScope copyWith({List<String>? scopes});
+  @override
+  Map<String, dynamic> toJson() {
+    return {'scopes': scopes.toJson()};
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {};
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _RevokedAuthenticationScopeImpl extends RevokedAuthenticationScope {
+  _RevokedAuthenticationScopeImpl({required List<String> scopes})
+      : super._(scopes: scopes);
+
+  @override
+  RevokedAuthenticationScope copyWith({List<String>? scopes}) {
+    return RevokedAuthenticationScope(
+        scopes: scopes ?? this.scopes.map((e0) => e0).toList());
+  }
+}

--- a/packages/serverpod/lib/src/generated/authentication/revoked_authentication_user.dart
+++ b/packages/serverpod/lib/src/generated/authentication/revoked_authentication_user.dart
@@ -1,0 +1,49 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: implementation_imports
+// ignore_for_file: use_super_parameters
+// ignore_for_file: type_literal_in_constant_pattern
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+/// Message sent when all authentication for a user is revoked.
+abstract class RevokedAuthenticationUser
+    implements _i1.SerializableModel, _i1.ProtocolSerialization {
+  RevokedAuthenticationUser._();
+
+  factory RevokedAuthenticationUser() = _RevokedAuthenticationUserImpl;
+
+  factory RevokedAuthenticationUser.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return RevokedAuthenticationUser();
+  }
+
+  RevokedAuthenticationUser copyWith();
+  @override
+  Map<String, dynamic> toJson() {
+    return {};
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {};
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _RevokedAuthenticationUserImpl extends RevokedAuthenticationUser {
+  _RevokedAuthenticationUserImpl() : super._();
+
+  @override
+  RevokedAuthenticationUser copyWith() {
+    return RevokedAuthenticationUser();
+  }
+}

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -11,63 +11,69 @@ library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixe
 
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
-import 'cache_info.dart' as _i3;
-import 'caches_info.dart' as _i4;
-import 'cloud_storage.dart' as _i5;
-import 'cloud_storage_direct_upload.dart' as _i6;
-import 'cluster_info.dart' as _i7;
-import 'cluster_server_info.dart' as _i8;
-import 'database/bulk_data.dart' as _i9;
-import 'database/bulk_data_exception.dart' as _i10;
-import 'database/bulk_query_column_description.dart' as _i11;
-import 'database/bulk_query_result.dart' as _i12;
-import 'database/column_definition.dart' as _i13;
-import 'database/column_migration.dart' as _i14;
-import 'database/column_type.dart' as _i15;
-import 'database/database_definition.dart' as _i16;
-import 'database/database_definitions.dart' as _i17;
-import 'database/database_migration.dart' as _i18;
-import 'database/database_migration_action.dart' as _i19;
-import 'database/database_migration_action_type.dart' as _i20;
-import 'database/database_migration_version.dart' as _i21;
-import 'database/database_migration_warning.dart' as _i22;
-import 'database/database_migration_warning_type.dart' as _i23;
-import 'database/enum_serialization.dart' as _i24;
-import 'database/filter/filter.dart' as _i25;
-import 'database/filter/filter_constraint.dart' as _i26;
-import 'database/filter/filter_constraint_type.dart' as _i27;
-import 'database/foreign_key_action.dart' as _i28;
-import 'database/foreign_key_definition.dart' as _i29;
-import 'database/foreign_key_match_type.dart' as _i30;
-import 'database/index_definition.dart' as _i31;
-import 'database/index_element_definition.dart' as _i32;
-import 'database/index_element_definition_type.dart' as _i33;
-import 'database/table_definition.dart' as _i34;
-import 'database/table_migration.dart' as _i35;
-import 'distributed_cache_entry.dart' as _i36;
-import 'exceptions/access_denied.dart' as _i37;
-import 'exceptions/file_not_found.dart' as _i38;
-import 'future_call_entry.dart' as _i39;
-import 'log_entry.dart' as _i40;
-import 'log_level.dart' as _i41;
-import 'log_result.dart' as _i42;
-import 'log_settings.dart' as _i43;
-import 'log_settings_override.dart' as _i44;
-import 'message_log_entry.dart' as _i45;
-import 'method_info.dart' as _i46;
-import 'query_log_entry.dart' as _i47;
-import 'readwrite_test.dart' as _i48;
-import 'runtime_settings.dart' as _i49;
-import 'server_health_connection_info.dart' as _i50;
-import 'server_health_metric.dart' as _i51;
-import 'server_health_result.dart' as _i52;
-import 'serverpod_sql_exception.dart' as _i53;
-import 'session_log_entry.dart' as _i54;
-import 'session_log_filter.dart' as _i55;
-import 'session_log_info.dart' as _i56;
-import 'session_log_result.dart' as _i57;
-import 'protocol.dart' as _i58;
-import 'package:serverpod/src/generated/database/table_definition.dart' as _i59;
+import 'authentication/revoked_authentication_auth_id.dart' as _i3;
+import 'authentication/revoked_authentication_scope.dart' as _i4;
+import 'authentication/revoked_authentication_user.dart' as _i5;
+import 'cache_info.dart' as _i6;
+import 'caches_info.dart' as _i7;
+import 'cloud_storage.dart' as _i8;
+import 'cloud_storage_direct_upload.dart' as _i9;
+import 'cluster_info.dart' as _i10;
+import 'cluster_server_info.dart' as _i11;
+import 'database/bulk_data.dart' as _i12;
+import 'database/bulk_data_exception.dart' as _i13;
+import 'database/bulk_query_column_description.dart' as _i14;
+import 'database/bulk_query_result.dart' as _i15;
+import 'database/column_definition.dart' as _i16;
+import 'database/column_migration.dart' as _i17;
+import 'database/column_type.dart' as _i18;
+import 'database/database_definition.dart' as _i19;
+import 'database/database_definitions.dart' as _i20;
+import 'database/database_migration.dart' as _i21;
+import 'database/database_migration_action.dart' as _i22;
+import 'database/database_migration_action_type.dart' as _i23;
+import 'database/database_migration_version.dart' as _i24;
+import 'database/database_migration_warning.dart' as _i25;
+import 'database/database_migration_warning_type.dart' as _i26;
+import 'database/enum_serialization.dart' as _i27;
+import 'database/filter/filter.dart' as _i28;
+import 'database/filter/filter_constraint.dart' as _i29;
+import 'database/filter/filter_constraint_type.dart' as _i30;
+import 'database/foreign_key_action.dart' as _i31;
+import 'database/foreign_key_definition.dart' as _i32;
+import 'database/foreign_key_match_type.dart' as _i33;
+import 'database/index_definition.dart' as _i34;
+import 'database/index_element_definition.dart' as _i35;
+import 'database/index_element_definition_type.dart' as _i36;
+import 'database/table_definition.dart' as _i37;
+import 'database/table_migration.dart' as _i38;
+import 'distributed_cache_entry.dart' as _i39;
+import 'exceptions/access_denied.dart' as _i40;
+import 'exceptions/file_not_found.dart' as _i41;
+import 'future_call_entry.dart' as _i42;
+import 'log_entry.dart' as _i43;
+import 'log_level.dart' as _i44;
+import 'log_result.dart' as _i45;
+import 'log_settings.dart' as _i46;
+import 'log_settings_override.dart' as _i47;
+import 'message_log_entry.dart' as _i48;
+import 'method_info.dart' as _i49;
+import 'query_log_entry.dart' as _i50;
+import 'readwrite_test.dart' as _i51;
+import 'runtime_settings.dart' as _i52;
+import 'server_health_connection_info.dart' as _i53;
+import 'server_health_metric.dart' as _i54;
+import 'server_health_result.dart' as _i55;
+import 'serverpod_sql_exception.dart' as _i56;
+import 'session_log_entry.dart' as _i57;
+import 'session_log_filter.dart' as _i58;
+import 'session_log_info.dart' as _i59;
+import 'session_log_result.dart' as _i60;
+import 'protocol.dart' as _i61;
+import 'package:serverpod/src/generated/database/table_definition.dart' as _i62;
+export 'authentication/revoked_authentication_auth_id.dart';
+export 'authentication/revoked_authentication_scope.dart';
+export 'authentication/revoked_authentication_user.dart';
 export 'cache_info.dart';
 export 'caches_info.dart';
 export 'cloud_storage.dart';
@@ -1302,473 +1308,497 @@ class Protocol extends _i1.SerializationManagerServer {
     Type? t,
   ]) {
     t ??= T;
-    if (t == _i3.CacheInfo) {
-      return _i3.CacheInfo.fromJson(data) as T;
+    if (t == _i3.RevokedAuthenticationAuthId) {
+      return _i3.RevokedAuthenticationAuthId.fromJson(data) as T;
     }
-    if (t == _i4.CachesInfo) {
-      return _i4.CachesInfo.fromJson(data) as T;
+    if (t == _i4.RevokedAuthenticationScope) {
+      return _i4.RevokedAuthenticationScope.fromJson(data) as T;
     }
-    if (t == _i5.CloudStorageEntry) {
-      return _i5.CloudStorageEntry.fromJson(data) as T;
+    if (t == _i5.RevokedAuthenticationUser) {
+      return _i5.RevokedAuthenticationUser.fromJson(data) as T;
     }
-    if (t == _i6.CloudStorageDirectUploadEntry) {
-      return _i6.CloudStorageDirectUploadEntry.fromJson(data) as T;
+    if (t == _i6.CacheInfo) {
+      return _i6.CacheInfo.fromJson(data) as T;
     }
-    if (t == _i7.ClusterInfo) {
-      return _i7.ClusterInfo.fromJson(data) as T;
+    if (t == _i7.CachesInfo) {
+      return _i7.CachesInfo.fromJson(data) as T;
     }
-    if (t == _i8.ClusterServerInfo) {
-      return _i8.ClusterServerInfo.fromJson(data) as T;
+    if (t == _i8.CloudStorageEntry) {
+      return _i8.CloudStorageEntry.fromJson(data) as T;
     }
-    if (t == _i9.BulkData) {
-      return _i9.BulkData.fromJson(data) as T;
+    if (t == _i9.CloudStorageDirectUploadEntry) {
+      return _i9.CloudStorageDirectUploadEntry.fromJson(data) as T;
     }
-    if (t == _i10.BulkDataException) {
-      return _i10.BulkDataException.fromJson(data) as T;
+    if (t == _i10.ClusterInfo) {
+      return _i10.ClusterInfo.fromJson(data) as T;
     }
-    if (t == _i11.BulkQueryColumnDescription) {
-      return _i11.BulkQueryColumnDescription.fromJson(data) as T;
+    if (t == _i11.ClusterServerInfo) {
+      return _i11.ClusterServerInfo.fromJson(data) as T;
     }
-    if (t == _i12.BulkQueryResult) {
-      return _i12.BulkQueryResult.fromJson(data) as T;
+    if (t == _i12.BulkData) {
+      return _i12.BulkData.fromJson(data) as T;
     }
-    if (t == _i13.ColumnDefinition) {
-      return _i13.ColumnDefinition.fromJson(data) as T;
+    if (t == _i13.BulkDataException) {
+      return _i13.BulkDataException.fromJson(data) as T;
     }
-    if (t == _i14.ColumnMigration) {
-      return _i14.ColumnMigration.fromJson(data) as T;
+    if (t == _i14.BulkQueryColumnDescription) {
+      return _i14.BulkQueryColumnDescription.fromJson(data) as T;
     }
-    if (t == _i15.ColumnType) {
-      return _i15.ColumnType.fromJson(data) as T;
+    if (t == _i15.BulkQueryResult) {
+      return _i15.BulkQueryResult.fromJson(data) as T;
     }
-    if (t == _i16.DatabaseDefinition) {
-      return _i16.DatabaseDefinition.fromJson(data) as T;
+    if (t == _i16.ColumnDefinition) {
+      return _i16.ColumnDefinition.fromJson(data) as T;
     }
-    if (t == _i17.DatabaseDefinitions) {
-      return _i17.DatabaseDefinitions.fromJson(data) as T;
+    if (t == _i17.ColumnMigration) {
+      return _i17.ColumnMigration.fromJson(data) as T;
     }
-    if (t == _i18.DatabaseMigration) {
-      return _i18.DatabaseMigration.fromJson(data) as T;
+    if (t == _i18.ColumnType) {
+      return _i18.ColumnType.fromJson(data) as T;
     }
-    if (t == _i19.DatabaseMigrationAction) {
-      return _i19.DatabaseMigrationAction.fromJson(data) as T;
+    if (t == _i19.DatabaseDefinition) {
+      return _i19.DatabaseDefinition.fromJson(data) as T;
     }
-    if (t == _i20.DatabaseMigrationActionType) {
-      return _i20.DatabaseMigrationActionType.fromJson(data) as T;
+    if (t == _i20.DatabaseDefinitions) {
+      return _i20.DatabaseDefinitions.fromJson(data) as T;
     }
-    if (t == _i21.DatabaseMigrationVersion) {
-      return _i21.DatabaseMigrationVersion.fromJson(data) as T;
+    if (t == _i21.DatabaseMigration) {
+      return _i21.DatabaseMigration.fromJson(data) as T;
     }
-    if (t == _i22.DatabaseMigrationWarning) {
-      return _i22.DatabaseMigrationWarning.fromJson(data) as T;
+    if (t == _i22.DatabaseMigrationAction) {
+      return _i22.DatabaseMigrationAction.fromJson(data) as T;
     }
-    if (t == _i23.DatabaseMigrationWarningType) {
-      return _i23.DatabaseMigrationWarningType.fromJson(data) as T;
+    if (t == _i23.DatabaseMigrationActionType) {
+      return _i23.DatabaseMigrationActionType.fromJson(data) as T;
     }
-    if (t == _i24.EnumSerialization) {
-      return _i24.EnumSerialization.fromJson(data) as T;
+    if (t == _i24.DatabaseMigrationVersion) {
+      return _i24.DatabaseMigrationVersion.fromJson(data) as T;
     }
-    if (t == _i25.Filter) {
-      return _i25.Filter.fromJson(data) as T;
+    if (t == _i25.DatabaseMigrationWarning) {
+      return _i25.DatabaseMigrationWarning.fromJson(data) as T;
     }
-    if (t == _i26.FilterConstraint) {
-      return _i26.FilterConstraint.fromJson(data) as T;
+    if (t == _i26.DatabaseMigrationWarningType) {
+      return _i26.DatabaseMigrationWarningType.fromJson(data) as T;
     }
-    if (t == _i27.FilterConstraintType) {
-      return _i27.FilterConstraintType.fromJson(data) as T;
+    if (t == _i27.EnumSerialization) {
+      return _i27.EnumSerialization.fromJson(data) as T;
     }
-    if (t == _i28.ForeignKeyAction) {
-      return _i28.ForeignKeyAction.fromJson(data) as T;
+    if (t == _i28.Filter) {
+      return _i28.Filter.fromJson(data) as T;
     }
-    if (t == _i29.ForeignKeyDefinition) {
-      return _i29.ForeignKeyDefinition.fromJson(data) as T;
+    if (t == _i29.FilterConstraint) {
+      return _i29.FilterConstraint.fromJson(data) as T;
     }
-    if (t == _i30.ForeignKeyMatchType) {
-      return _i30.ForeignKeyMatchType.fromJson(data) as T;
+    if (t == _i30.FilterConstraintType) {
+      return _i30.FilterConstraintType.fromJson(data) as T;
     }
-    if (t == _i31.IndexDefinition) {
-      return _i31.IndexDefinition.fromJson(data) as T;
+    if (t == _i31.ForeignKeyAction) {
+      return _i31.ForeignKeyAction.fromJson(data) as T;
     }
-    if (t == _i32.IndexElementDefinition) {
-      return _i32.IndexElementDefinition.fromJson(data) as T;
+    if (t == _i32.ForeignKeyDefinition) {
+      return _i32.ForeignKeyDefinition.fromJson(data) as T;
     }
-    if (t == _i33.IndexElementDefinitionType) {
-      return _i33.IndexElementDefinitionType.fromJson(data) as T;
+    if (t == _i33.ForeignKeyMatchType) {
+      return _i33.ForeignKeyMatchType.fromJson(data) as T;
     }
-    if (t == _i34.TableDefinition) {
-      return _i34.TableDefinition.fromJson(data) as T;
+    if (t == _i34.IndexDefinition) {
+      return _i34.IndexDefinition.fromJson(data) as T;
     }
-    if (t == _i35.TableMigration) {
-      return _i35.TableMigration.fromJson(data) as T;
+    if (t == _i35.IndexElementDefinition) {
+      return _i35.IndexElementDefinition.fromJson(data) as T;
     }
-    if (t == _i36.DistributedCacheEntry) {
-      return _i36.DistributedCacheEntry.fromJson(data) as T;
+    if (t == _i36.IndexElementDefinitionType) {
+      return _i36.IndexElementDefinitionType.fromJson(data) as T;
     }
-    if (t == _i37.AccessDeniedException) {
-      return _i37.AccessDeniedException.fromJson(data) as T;
+    if (t == _i37.TableDefinition) {
+      return _i37.TableDefinition.fromJson(data) as T;
     }
-    if (t == _i38.FileNotFoundException) {
-      return _i38.FileNotFoundException.fromJson(data) as T;
+    if (t == _i38.TableMigration) {
+      return _i38.TableMigration.fromJson(data) as T;
     }
-    if (t == _i39.FutureCallEntry) {
-      return _i39.FutureCallEntry.fromJson(data) as T;
+    if (t == _i39.DistributedCacheEntry) {
+      return _i39.DistributedCacheEntry.fromJson(data) as T;
     }
-    if (t == _i40.LogEntry) {
-      return _i40.LogEntry.fromJson(data) as T;
+    if (t == _i40.AccessDeniedException) {
+      return _i40.AccessDeniedException.fromJson(data) as T;
     }
-    if (t == _i41.LogLevel) {
-      return _i41.LogLevel.fromJson(data) as T;
+    if (t == _i41.FileNotFoundException) {
+      return _i41.FileNotFoundException.fromJson(data) as T;
     }
-    if (t == _i42.LogResult) {
-      return _i42.LogResult.fromJson(data) as T;
+    if (t == _i42.FutureCallEntry) {
+      return _i42.FutureCallEntry.fromJson(data) as T;
     }
-    if (t == _i43.LogSettings) {
-      return _i43.LogSettings.fromJson(data) as T;
+    if (t == _i43.LogEntry) {
+      return _i43.LogEntry.fromJson(data) as T;
     }
-    if (t == _i44.LogSettingsOverride) {
-      return _i44.LogSettingsOverride.fromJson(data) as T;
+    if (t == _i44.LogLevel) {
+      return _i44.LogLevel.fromJson(data) as T;
     }
-    if (t == _i45.MessageLogEntry) {
-      return _i45.MessageLogEntry.fromJson(data) as T;
+    if (t == _i45.LogResult) {
+      return _i45.LogResult.fromJson(data) as T;
     }
-    if (t == _i46.MethodInfo) {
-      return _i46.MethodInfo.fromJson(data) as T;
+    if (t == _i46.LogSettings) {
+      return _i46.LogSettings.fromJson(data) as T;
     }
-    if (t == _i47.QueryLogEntry) {
-      return _i47.QueryLogEntry.fromJson(data) as T;
+    if (t == _i47.LogSettingsOverride) {
+      return _i47.LogSettingsOverride.fromJson(data) as T;
     }
-    if (t == _i48.ReadWriteTestEntry) {
-      return _i48.ReadWriteTestEntry.fromJson(data) as T;
+    if (t == _i48.MessageLogEntry) {
+      return _i48.MessageLogEntry.fromJson(data) as T;
     }
-    if (t == _i49.RuntimeSettings) {
-      return _i49.RuntimeSettings.fromJson(data) as T;
+    if (t == _i49.MethodInfo) {
+      return _i49.MethodInfo.fromJson(data) as T;
     }
-    if (t == _i50.ServerHealthConnectionInfo) {
-      return _i50.ServerHealthConnectionInfo.fromJson(data) as T;
+    if (t == _i50.QueryLogEntry) {
+      return _i50.QueryLogEntry.fromJson(data) as T;
     }
-    if (t == _i51.ServerHealthMetric) {
-      return _i51.ServerHealthMetric.fromJson(data) as T;
+    if (t == _i51.ReadWriteTestEntry) {
+      return _i51.ReadWriteTestEntry.fromJson(data) as T;
     }
-    if (t == _i52.ServerHealthResult) {
-      return _i52.ServerHealthResult.fromJson(data) as T;
+    if (t == _i52.RuntimeSettings) {
+      return _i52.RuntimeSettings.fromJson(data) as T;
     }
-    if (t == _i53.ServerpodSqlException) {
-      return _i53.ServerpodSqlException.fromJson(data) as T;
+    if (t == _i53.ServerHealthConnectionInfo) {
+      return _i53.ServerHealthConnectionInfo.fromJson(data) as T;
     }
-    if (t == _i54.SessionLogEntry) {
-      return _i54.SessionLogEntry.fromJson(data) as T;
+    if (t == _i54.ServerHealthMetric) {
+      return _i54.ServerHealthMetric.fromJson(data) as T;
     }
-    if (t == _i55.SessionLogFilter) {
-      return _i55.SessionLogFilter.fromJson(data) as T;
+    if (t == _i55.ServerHealthResult) {
+      return _i55.ServerHealthResult.fromJson(data) as T;
     }
-    if (t == _i56.SessionLogInfo) {
-      return _i56.SessionLogInfo.fromJson(data) as T;
+    if (t == _i56.ServerpodSqlException) {
+      return _i56.ServerpodSqlException.fromJson(data) as T;
     }
-    if (t == _i57.SessionLogResult) {
-      return _i57.SessionLogResult.fromJson(data) as T;
+    if (t == _i57.SessionLogEntry) {
+      return _i57.SessionLogEntry.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i3.CacheInfo?>()) {
-      return (data != null ? _i3.CacheInfo.fromJson(data) : null) as T;
+    if (t == _i58.SessionLogFilter) {
+      return _i58.SessionLogFilter.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i4.CachesInfo?>()) {
-      return (data != null ? _i4.CachesInfo.fromJson(data) : null) as T;
+    if (t == _i59.SessionLogInfo) {
+      return _i59.SessionLogInfo.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i5.CloudStorageEntry?>()) {
-      return (data != null ? _i5.CloudStorageEntry.fromJson(data) : null) as T;
+    if (t == _i60.SessionLogResult) {
+      return _i60.SessionLogResult.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i6.CloudStorageDirectUploadEntry?>()) {
+    if (t == _i1.getType<_i3.RevokedAuthenticationAuthId?>()) {
       return (data != null
-          ? _i6.CloudStorageDirectUploadEntry.fromJson(data)
+          ? _i3.RevokedAuthenticationAuthId.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i7.ClusterInfo?>()) {
-      return (data != null ? _i7.ClusterInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i8.ClusterServerInfo?>()) {
-      return (data != null ? _i8.ClusterServerInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i9.BulkData?>()) {
-      return (data != null ? _i9.BulkData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i10.BulkDataException?>()) {
-      return (data != null ? _i10.BulkDataException.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i11.BulkQueryColumnDescription?>()) {
+    if (t == _i1.getType<_i4.RevokedAuthenticationScope?>()) {
       return (data != null
-          ? _i11.BulkQueryColumnDescription.fromJson(data)
+          ? _i4.RevokedAuthenticationScope.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i12.BulkQueryResult?>()) {
-      return (data != null ? _i12.BulkQueryResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i13.ColumnDefinition?>()) {
-      return (data != null ? _i13.ColumnDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i14.ColumnMigration?>()) {
-      return (data != null ? _i14.ColumnMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i15.ColumnType?>()) {
-      return (data != null ? _i15.ColumnType.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i16.DatabaseDefinition?>()) {
-      return (data != null ? _i16.DatabaseDefinition.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i17.DatabaseDefinitions?>()) {
-      return (data != null ? _i17.DatabaseDefinitions.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.DatabaseMigration?>()) {
-      return (data != null ? _i18.DatabaseMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i19.DatabaseMigrationAction?>()) {
-      return (data != null ? _i19.DatabaseMigrationAction.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i20.DatabaseMigrationActionType?>()) {
+    if (t == _i1.getType<_i5.RevokedAuthenticationUser?>()) {
       return (data != null
-          ? _i20.DatabaseMigrationActionType.fromJson(data)
+          ? _i5.RevokedAuthenticationUser.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i21.DatabaseMigrationVersion?>()) {
+    if (t == _i1.getType<_i6.CacheInfo?>()) {
+      return (data != null ? _i6.CacheInfo.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i7.CachesInfo?>()) {
+      return (data != null ? _i7.CachesInfo.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i8.CloudStorageEntry?>()) {
+      return (data != null ? _i8.CloudStorageEntry.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i9.CloudStorageDirectUploadEntry?>()) {
       return (data != null
-          ? _i21.DatabaseMigrationVersion.fromJson(data)
+          ? _i9.CloudStorageDirectUploadEntry.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i22.DatabaseMigrationWarning?>()) {
+    if (t == _i1.getType<_i10.ClusterInfo?>()) {
+      return (data != null ? _i10.ClusterInfo.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i11.ClusterServerInfo?>()) {
+      return (data != null ? _i11.ClusterServerInfo.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i12.BulkData?>()) {
+      return (data != null ? _i12.BulkData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i13.BulkDataException?>()) {
+      return (data != null ? _i13.BulkDataException.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i14.BulkQueryColumnDescription?>()) {
       return (data != null
-          ? _i22.DatabaseMigrationWarning.fromJson(data)
+          ? _i14.BulkQueryColumnDescription.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i23.DatabaseMigrationWarningType?>()) {
+    if (t == _i1.getType<_i15.BulkQueryResult?>()) {
+      return (data != null ? _i15.BulkQueryResult.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i16.ColumnDefinition?>()) {
+      return (data != null ? _i16.ColumnDefinition.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i17.ColumnMigration?>()) {
+      return (data != null ? _i17.ColumnMigration.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i18.ColumnType?>()) {
+      return (data != null ? _i18.ColumnType.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i19.DatabaseDefinition?>()) {
+      return (data != null ? _i19.DatabaseDefinition.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i20.DatabaseDefinitions?>()) {
+      return (data != null ? _i20.DatabaseDefinitions.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i21.DatabaseMigration?>()) {
+      return (data != null ? _i21.DatabaseMigration.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i22.DatabaseMigrationAction?>()) {
+      return (data != null ? _i22.DatabaseMigrationAction.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i23.DatabaseMigrationActionType?>()) {
       return (data != null
-          ? _i23.DatabaseMigrationWarningType.fromJson(data)
+          ? _i23.DatabaseMigrationActionType.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i24.EnumSerialization?>()) {
-      return (data != null ? _i24.EnumSerialization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.Filter?>()) {
-      return (data != null ? _i25.Filter.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.FilterConstraint?>()) {
-      return (data != null ? _i26.FilterConstraint.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i27.FilterConstraintType?>()) {
-      return (data != null ? _i27.FilterConstraintType.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i28.ForeignKeyAction?>()) {
-      return (data != null ? _i28.ForeignKeyAction.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i29.ForeignKeyDefinition?>()) {
-      return (data != null ? _i29.ForeignKeyDefinition.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i30.ForeignKeyMatchType?>()) {
-      return (data != null ? _i30.ForeignKeyMatchType.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i31.IndexDefinition?>()) {
-      return (data != null ? _i31.IndexDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i32.IndexElementDefinition?>()) {
-      return (data != null ? _i32.IndexElementDefinition.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i33.IndexElementDefinitionType?>()) {
+    if (t == _i1.getType<_i24.DatabaseMigrationVersion?>()) {
       return (data != null
-          ? _i33.IndexElementDefinitionType.fromJson(data)
+          ? _i24.DatabaseMigrationVersion.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i34.TableDefinition?>()) {
-      return (data != null ? _i34.TableDefinition.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i35.TableMigration?>()) {
-      return (data != null ? _i35.TableMigration.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i36.DistributedCacheEntry?>()) {
-      return (data != null ? _i36.DistributedCacheEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i37.AccessDeniedException?>()) {
-      return (data != null ? _i37.AccessDeniedException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i38.FileNotFoundException?>()) {
-      return (data != null ? _i38.FileNotFoundException.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i39.FutureCallEntry?>()) {
-      return (data != null ? _i39.FutureCallEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i40.LogEntry?>()) {
-      return (data != null ? _i40.LogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i41.LogLevel?>()) {
-      return (data != null ? _i41.LogLevel.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i42.LogResult?>()) {
-      return (data != null ? _i42.LogResult.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i43.LogSettings?>()) {
-      return (data != null ? _i43.LogSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i44.LogSettingsOverride?>()) {
-      return (data != null ? _i44.LogSettingsOverride.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i45.MessageLogEntry?>()) {
-      return (data != null ? _i45.MessageLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i46.MethodInfo?>()) {
-      return (data != null ? _i46.MethodInfo.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i47.QueryLogEntry?>()) {
-      return (data != null ? _i47.QueryLogEntry.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i48.ReadWriteTestEntry?>()) {
-      return (data != null ? _i48.ReadWriteTestEntry.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i49.RuntimeSettings?>()) {
-      return (data != null ? _i49.RuntimeSettings.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i50.ServerHealthConnectionInfo?>()) {
+    if (t == _i1.getType<_i25.DatabaseMigrationWarning?>()) {
       return (data != null
-          ? _i50.ServerHealthConnectionInfo.fromJson(data)
+          ? _i25.DatabaseMigrationWarning.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i51.ServerHealthMetric?>()) {
-      return (data != null ? _i51.ServerHealthMetric.fromJson(data) : null)
+    if (t == _i1.getType<_i26.DatabaseMigrationWarningType?>()) {
+      return (data != null
+          ? _i26.DatabaseMigrationWarningType.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i27.EnumSerialization?>()) {
+      return (data != null ? _i27.EnumSerialization.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i28.Filter?>()) {
+      return (data != null ? _i28.Filter.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i29.FilterConstraint?>()) {
+      return (data != null ? _i29.FilterConstraint.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i30.FilterConstraintType?>()) {
+      return (data != null ? _i30.FilterConstraintType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i52.ServerHealthResult?>()) {
-      return (data != null ? _i52.ServerHealthResult.fromJson(data) : null)
+    if (t == _i1.getType<_i31.ForeignKeyAction?>()) {
+      return (data != null ? _i31.ForeignKeyAction.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i32.ForeignKeyDefinition?>()) {
+      return (data != null ? _i32.ForeignKeyDefinition.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i53.ServerpodSqlException?>()) {
-      return (data != null ? _i53.ServerpodSqlException.fromJson(data) : null)
+    if (t == _i1.getType<_i33.ForeignKeyMatchType?>()) {
+      return (data != null ? _i33.ForeignKeyMatchType.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i54.SessionLogEntry?>()) {
-      return (data != null ? _i54.SessionLogEntry.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i34.IndexDefinition?>()) {
+      return (data != null ? _i34.IndexDefinition.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i55.SessionLogFilter?>()) {
-      return (data != null ? _i55.SessionLogFilter.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i35.IndexElementDefinition?>()) {
+      return (data != null ? _i35.IndexElementDefinition.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i56.SessionLogInfo?>()) {
-      return (data != null ? _i56.SessionLogInfo.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i36.IndexElementDefinitionType?>()) {
+      return (data != null
+          ? _i36.IndexElementDefinitionType.fromJson(data)
+          : null) as T;
     }
-    if (t == _i1.getType<_i57.SessionLogResult?>()) {
-      return (data != null ? _i57.SessionLogResult.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i37.TableDefinition?>()) {
+      return (data != null ? _i37.TableDefinition.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i38.TableMigration?>()) {
+      return (data != null ? _i38.TableMigration.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i39.DistributedCacheEntry?>()) {
+      return (data != null ? _i39.DistributedCacheEntry.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i40.AccessDeniedException?>()) {
+      return (data != null ? _i40.AccessDeniedException.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i41.FileNotFoundException?>()) {
+      return (data != null ? _i41.FileNotFoundException.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i42.FutureCallEntry?>()) {
+      return (data != null ? _i42.FutureCallEntry.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i43.LogEntry?>()) {
+      return (data != null ? _i43.LogEntry.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i44.LogLevel?>()) {
+      return (data != null ? _i44.LogLevel.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i45.LogResult?>()) {
+      return (data != null ? _i45.LogResult.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i46.LogSettings?>()) {
+      return (data != null ? _i46.LogSettings.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i47.LogSettingsOverride?>()) {
+      return (data != null ? _i47.LogSettingsOverride.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i48.MessageLogEntry?>()) {
+      return (data != null ? _i48.MessageLogEntry.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i49.MethodInfo?>()) {
+      return (data != null ? _i49.MethodInfo.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i50.QueryLogEntry?>()) {
+      return (data != null ? _i50.QueryLogEntry.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i51.ReadWriteTestEntry?>()) {
+      return (data != null ? _i51.ReadWriteTestEntry.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i52.RuntimeSettings?>()) {
+      return (data != null ? _i52.RuntimeSettings.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i53.ServerHealthConnectionInfo?>()) {
+      return (data != null
+          ? _i53.ServerHealthConnectionInfo.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i54.ServerHealthMetric?>()) {
+      return (data != null ? _i54.ServerHealthMetric.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i55.ServerHealthResult?>()) {
+      return (data != null ? _i55.ServerHealthResult.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i56.ServerpodSqlException?>()) {
+      return (data != null ? _i56.ServerpodSqlException.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i57.SessionLogEntry?>()) {
+      return (data != null ? _i57.SessionLogEntry.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i58.SessionLogFilter?>()) {
+      return (data != null ? _i58.SessionLogFilter.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i59.SessionLogInfo?>()) {
+      return (data != null ? _i59.SessionLogInfo.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i60.SessionLogResult?>()) {
+      return (data != null ? _i60.SessionLogResult.fromJson(data) : null) as T;
+    }
+    if (t == List<String>) {
+      return (data as List).map((e) => deserialize<String>(e)).toList()
+          as dynamic;
     }
     if (t == _i1.getType<List<String>?>()) {
       return (data != null
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i58.ClusterServerInfo>) {
+    if (t == List<_i61.ClusterServerInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i58.ClusterServerInfo>(e))
+          .map((e) => deserialize<_i61.ClusterServerInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.BulkQueryColumnDescription>) {
+    if (t == List<_i61.BulkQueryColumnDescription>) {
       return (data as List)
-          .map((e) => deserialize<_i58.BulkQueryColumnDescription>(e))
+          .map((e) => deserialize<_i61.BulkQueryColumnDescription>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.TableDefinition>) {
+    if (t == List<_i61.TableDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i58.TableDefinition>(e))
+          .map((e) => deserialize<_i61.TableDefinition>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.DatabaseMigrationVersion>) {
+    if (t == List<_i61.DatabaseMigrationVersion>) {
       return (data as List)
-          .map((e) => deserialize<_i58.DatabaseMigrationVersion>(e))
+          .map((e) => deserialize<_i61.DatabaseMigrationVersion>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.DatabaseMigrationAction>) {
+    if (t == List<_i61.DatabaseMigrationAction>) {
       return (data as List)
-          .map((e) => deserialize<_i58.DatabaseMigrationAction>(e))
+          .map((e) => deserialize<_i61.DatabaseMigrationAction>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.DatabaseMigrationWarning>) {
+    if (t == List<_i61.DatabaseMigrationWarning>) {
       return (data as List)
-          .map((e) => deserialize<_i58.DatabaseMigrationWarning>(e))
+          .map((e) => deserialize<_i61.DatabaseMigrationWarning>(e))
           .toList() as dynamic;
     }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList()
+    if (t == List<_i61.FilterConstraint>) {
+      return (data as List)
+          .map((e) => deserialize<_i61.FilterConstraint>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i61.IndexElementDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i61.IndexElementDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i61.ColumnDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i61.ColumnDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i61.ForeignKeyDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i61.ForeignKeyDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i61.IndexDefinition>) {
+      return (data as List)
+          .map((e) => deserialize<_i61.IndexDefinition>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i61.ColumnMigration>) {
+      return (data as List)
+          .map((e) => deserialize<_i61.ColumnMigration>(e))
+          .toList() as dynamic;
+    }
+    if (t == List<_i61.LogEntry>) {
+      return (data as List).map((e) => deserialize<_i61.LogEntry>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i58.FilterConstraint>) {
+    if (t == List<_i61.LogSettingsOverride>) {
       return (data as List)
-          .map((e) => deserialize<_i58.FilterConstraint>(e))
+          .map((e) => deserialize<_i61.LogSettingsOverride>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.IndexElementDefinition>) {
+    if (t == List<_i61.ServerHealthMetric>) {
       return (data as List)
-          .map((e) => deserialize<_i58.IndexElementDefinition>(e))
+          .map((e) => deserialize<_i61.ServerHealthMetric>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.ColumnDefinition>) {
+    if (t == List<_i61.ServerHealthConnectionInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i58.ColumnDefinition>(e))
+          .map((e) => deserialize<_i61.ServerHealthConnectionInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.ForeignKeyDefinition>) {
+    if (t == List<_i61.QueryLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i58.ForeignKeyDefinition>(e))
+          .map((e) => deserialize<_i61.QueryLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.IndexDefinition>) {
+    if (t == List<_i61.MessageLogEntry>) {
       return (data as List)
-          .map((e) => deserialize<_i58.IndexDefinition>(e))
+          .map((e) => deserialize<_i61.MessageLogEntry>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.ColumnMigration>) {
+    if (t == List<_i61.SessionLogInfo>) {
       return (data as List)
-          .map((e) => deserialize<_i58.ColumnMigration>(e))
+          .map((e) => deserialize<_i61.SessionLogInfo>(e))
           .toList() as dynamic;
     }
-    if (t == List<_i58.LogEntry>) {
-      return (data as List).map((e) => deserialize<_i58.LogEntry>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<_i58.LogSettingsOverride>) {
+    if (t == List<_i62.TableDefinition>) {
       return (data as List)
-          .map((e) => deserialize<_i58.LogSettingsOverride>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.ServerHealthMetric>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.ServerHealthMetric>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.ServerHealthConnectionInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.ServerHealthConnectionInfo>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.QueryLogEntry>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.QueryLogEntry>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.MessageLogEntry>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.MessageLogEntry>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i58.SessionLogInfo>) {
-      return (data as List)
-          .map((e) => deserialize<_i58.SessionLogInfo>(e))
-          .toList() as dynamic;
-    }
-    if (t == List<_i59.TableDefinition>) {
-      return (data as List)
-          .map((e) => deserialize<_i59.TableDefinition>(e))
+          .map((e) => deserialize<_i62.TableDefinition>(e))
           .toList() as dynamic;
     }
     if (t == List<String>) {
@@ -1782,169 +1812,178 @@ class Protocol extends _i1.SerializationManagerServer {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i3.CacheInfo) {
+    if (data is _i3.RevokedAuthenticationAuthId) {
+      return 'RevokedAuthenticationAuthId';
+    }
+    if (data is _i4.RevokedAuthenticationScope) {
+      return 'RevokedAuthenticationScope';
+    }
+    if (data is _i5.RevokedAuthenticationUser) {
+      return 'RevokedAuthenticationUser';
+    }
+    if (data is _i6.CacheInfo) {
       return 'CacheInfo';
     }
-    if (data is _i4.CachesInfo) {
+    if (data is _i7.CachesInfo) {
       return 'CachesInfo';
     }
-    if (data is _i5.CloudStorageEntry) {
+    if (data is _i8.CloudStorageEntry) {
       return 'CloudStorageEntry';
     }
-    if (data is _i6.CloudStorageDirectUploadEntry) {
+    if (data is _i9.CloudStorageDirectUploadEntry) {
       return 'CloudStorageDirectUploadEntry';
     }
-    if (data is _i7.ClusterInfo) {
+    if (data is _i10.ClusterInfo) {
       return 'ClusterInfo';
     }
-    if (data is _i8.ClusterServerInfo) {
+    if (data is _i11.ClusterServerInfo) {
       return 'ClusterServerInfo';
     }
-    if (data is _i9.BulkData) {
+    if (data is _i12.BulkData) {
       return 'BulkData';
     }
-    if (data is _i10.BulkDataException) {
+    if (data is _i13.BulkDataException) {
       return 'BulkDataException';
     }
-    if (data is _i11.BulkQueryColumnDescription) {
+    if (data is _i14.BulkQueryColumnDescription) {
       return 'BulkQueryColumnDescription';
     }
-    if (data is _i12.BulkQueryResult) {
+    if (data is _i15.BulkQueryResult) {
       return 'BulkQueryResult';
     }
-    if (data is _i13.ColumnDefinition) {
+    if (data is _i16.ColumnDefinition) {
       return 'ColumnDefinition';
     }
-    if (data is _i14.ColumnMigration) {
+    if (data is _i17.ColumnMigration) {
       return 'ColumnMigration';
     }
-    if (data is _i15.ColumnType) {
+    if (data is _i18.ColumnType) {
       return 'ColumnType';
     }
-    if (data is _i16.DatabaseDefinition) {
+    if (data is _i19.DatabaseDefinition) {
       return 'DatabaseDefinition';
     }
-    if (data is _i17.DatabaseDefinitions) {
+    if (data is _i20.DatabaseDefinitions) {
       return 'DatabaseDefinitions';
     }
-    if (data is _i18.DatabaseMigration) {
+    if (data is _i21.DatabaseMigration) {
       return 'DatabaseMigration';
     }
-    if (data is _i19.DatabaseMigrationAction) {
+    if (data is _i22.DatabaseMigrationAction) {
       return 'DatabaseMigrationAction';
     }
-    if (data is _i20.DatabaseMigrationActionType) {
+    if (data is _i23.DatabaseMigrationActionType) {
       return 'DatabaseMigrationActionType';
     }
-    if (data is _i21.DatabaseMigrationVersion) {
+    if (data is _i24.DatabaseMigrationVersion) {
       return 'DatabaseMigrationVersion';
     }
-    if (data is _i22.DatabaseMigrationWarning) {
+    if (data is _i25.DatabaseMigrationWarning) {
       return 'DatabaseMigrationWarning';
     }
-    if (data is _i23.DatabaseMigrationWarningType) {
+    if (data is _i26.DatabaseMigrationWarningType) {
       return 'DatabaseMigrationWarningType';
     }
-    if (data is _i24.EnumSerialization) {
+    if (data is _i27.EnumSerialization) {
       return 'EnumSerialization';
     }
-    if (data is _i25.Filter) {
+    if (data is _i28.Filter) {
       return 'Filter';
     }
-    if (data is _i26.FilterConstraint) {
+    if (data is _i29.FilterConstraint) {
       return 'FilterConstraint';
     }
-    if (data is _i27.FilterConstraintType) {
+    if (data is _i30.FilterConstraintType) {
       return 'FilterConstraintType';
     }
-    if (data is _i28.ForeignKeyAction) {
+    if (data is _i31.ForeignKeyAction) {
       return 'ForeignKeyAction';
     }
-    if (data is _i29.ForeignKeyDefinition) {
+    if (data is _i32.ForeignKeyDefinition) {
       return 'ForeignKeyDefinition';
     }
-    if (data is _i30.ForeignKeyMatchType) {
+    if (data is _i33.ForeignKeyMatchType) {
       return 'ForeignKeyMatchType';
     }
-    if (data is _i31.IndexDefinition) {
+    if (data is _i34.IndexDefinition) {
       return 'IndexDefinition';
     }
-    if (data is _i32.IndexElementDefinition) {
+    if (data is _i35.IndexElementDefinition) {
       return 'IndexElementDefinition';
     }
-    if (data is _i33.IndexElementDefinitionType) {
+    if (data is _i36.IndexElementDefinitionType) {
       return 'IndexElementDefinitionType';
     }
-    if (data is _i34.TableDefinition) {
+    if (data is _i37.TableDefinition) {
       return 'TableDefinition';
     }
-    if (data is _i35.TableMigration) {
+    if (data is _i38.TableMigration) {
       return 'TableMigration';
     }
-    if (data is _i36.DistributedCacheEntry) {
+    if (data is _i39.DistributedCacheEntry) {
       return 'DistributedCacheEntry';
     }
-    if (data is _i37.AccessDeniedException) {
+    if (data is _i40.AccessDeniedException) {
       return 'AccessDeniedException';
     }
-    if (data is _i38.FileNotFoundException) {
+    if (data is _i41.FileNotFoundException) {
       return 'FileNotFoundException';
     }
-    if (data is _i39.FutureCallEntry) {
+    if (data is _i42.FutureCallEntry) {
       return 'FutureCallEntry';
     }
-    if (data is _i40.LogEntry) {
+    if (data is _i43.LogEntry) {
       return 'LogEntry';
     }
-    if (data is _i41.LogLevel) {
+    if (data is _i44.LogLevel) {
       return 'LogLevel';
     }
-    if (data is _i42.LogResult) {
+    if (data is _i45.LogResult) {
       return 'LogResult';
     }
-    if (data is _i43.LogSettings) {
+    if (data is _i46.LogSettings) {
       return 'LogSettings';
     }
-    if (data is _i44.LogSettingsOverride) {
+    if (data is _i47.LogSettingsOverride) {
       return 'LogSettingsOverride';
     }
-    if (data is _i45.MessageLogEntry) {
+    if (data is _i48.MessageLogEntry) {
       return 'MessageLogEntry';
     }
-    if (data is _i46.MethodInfo) {
+    if (data is _i49.MethodInfo) {
       return 'MethodInfo';
     }
-    if (data is _i47.QueryLogEntry) {
+    if (data is _i50.QueryLogEntry) {
       return 'QueryLogEntry';
     }
-    if (data is _i48.ReadWriteTestEntry) {
+    if (data is _i51.ReadWriteTestEntry) {
       return 'ReadWriteTestEntry';
     }
-    if (data is _i49.RuntimeSettings) {
+    if (data is _i52.RuntimeSettings) {
       return 'RuntimeSettings';
     }
-    if (data is _i50.ServerHealthConnectionInfo) {
+    if (data is _i53.ServerHealthConnectionInfo) {
       return 'ServerHealthConnectionInfo';
     }
-    if (data is _i51.ServerHealthMetric) {
+    if (data is _i54.ServerHealthMetric) {
       return 'ServerHealthMetric';
     }
-    if (data is _i52.ServerHealthResult) {
+    if (data is _i55.ServerHealthResult) {
       return 'ServerHealthResult';
     }
-    if (data is _i53.ServerpodSqlException) {
+    if (data is _i56.ServerpodSqlException) {
       return 'ServerpodSqlException';
     }
-    if (data is _i54.SessionLogEntry) {
+    if (data is _i57.SessionLogEntry) {
       return 'SessionLogEntry';
     }
-    if (data is _i55.SessionLogFilter) {
+    if (data is _i58.SessionLogFilter) {
       return 'SessionLogFilter';
     }
-    if (data is _i56.SessionLogInfo) {
+    if (data is _i59.SessionLogInfo) {
       return 'SessionLogInfo';
     }
-    if (data is _i57.SessionLogResult) {
+    if (data is _i60.SessionLogResult) {
       return 'SessionLogResult';
     }
     return null;
@@ -1952,170 +1991,179 @@ class Protocol extends _i1.SerializationManagerServer {
 
   @override
   dynamic deserializeByClassName(Map<String, dynamic> data) {
+    if (data['className'] == 'RevokedAuthenticationAuthId') {
+      return deserialize<_i3.RevokedAuthenticationAuthId>(data['data']);
+    }
+    if (data['className'] == 'RevokedAuthenticationScope') {
+      return deserialize<_i4.RevokedAuthenticationScope>(data['data']);
+    }
+    if (data['className'] == 'RevokedAuthenticationUser') {
+      return deserialize<_i5.RevokedAuthenticationUser>(data['data']);
+    }
     if (data['className'] == 'CacheInfo') {
-      return deserialize<_i3.CacheInfo>(data['data']);
+      return deserialize<_i6.CacheInfo>(data['data']);
     }
     if (data['className'] == 'CachesInfo') {
-      return deserialize<_i4.CachesInfo>(data['data']);
+      return deserialize<_i7.CachesInfo>(data['data']);
     }
     if (data['className'] == 'CloudStorageEntry') {
-      return deserialize<_i5.CloudStorageEntry>(data['data']);
+      return deserialize<_i8.CloudStorageEntry>(data['data']);
     }
     if (data['className'] == 'CloudStorageDirectUploadEntry') {
-      return deserialize<_i6.CloudStorageDirectUploadEntry>(data['data']);
+      return deserialize<_i9.CloudStorageDirectUploadEntry>(data['data']);
     }
     if (data['className'] == 'ClusterInfo') {
-      return deserialize<_i7.ClusterInfo>(data['data']);
+      return deserialize<_i10.ClusterInfo>(data['data']);
     }
     if (data['className'] == 'ClusterServerInfo') {
-      return deserialize<_i8.ClusterServerInfo>(data['data']);
+      return deserialize<_i11.ClusterServerInfo>(data['data']);
     }
     if (data['className'] == 'BulkData') {
-      return deserialize<_i9.BulkData>(data['data']);
+      return deserialize<_i12.BulkData>(data['data']);
     }
     if (data['className'] == 'BulkDataException') {
-      return deserialize<_i10.BulkDataException>(data['data']);
+      return deserialize<_i13.BulkDataException>(data['data']);
     }
     if (data['className'] == 'BulkQueryColumnDescription') {
-      return deserialize<_i11.BulkQueryColumnDescription>(data['data']);
+      return deserialize<_i14.BulkQueryColumnDescription>(data['data']);
     }
     if (data['className'] == 'BulkQueryResult') {
-      return deserialize<_i12.BulkQueryResult>(data['data']);
+      return deserialize<_i15.BulkQueryResult>(data['data']);
     }
     if (data['className'] == 'ColumnDefinition') {
-      return deserialize<_i13.ColumnDefinition>(data['data']);
+      return deserialize<_i16.ColumnDefinition>(data['data']);
     }
     if (data['className'] == 'ColumnMigration') {
-      return deserialize<_i14.ColumnMigration>(data['data']);
+      return deserialize<_i17.ColumnMigration>(data['data']);
     }
     if (data['className'] == 'ColumnType') {
-      return deserialize<_i15.ColumnType>(data['data']);
+      return deserialize<_i18.ColumnType>(data['data']);
     }
     if (data['className'] == 'DatabaseDefinition') {
-      return deserialize<_i16.DatabaseDefinition>(data['data']);
+      return deserialize<_i19.DatabaseDefinition>(data['data']);
     }
     if (data['className'] == 'DatabaseDefinitions') {
-      return deserialize<_i17.DatabaseDefinitions>(data['data']);
+      return deserialize<_i20.DatabaseDefinitions>(data['data']);
     }
     if (data['className'] == 'DatabaseMigration') {
-      return deserialize<_i18.DatabaseMigration>(data['data']);
+      return deserialize<_i21.DatabaseMigration>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationAction') {
-      return deserialize<_i19.DatabaseMigrationAction>(data['data']);
+      return deserialize<_i22.DatabaseMigrationAction>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationActionType') {
-      return deserialize<_i20.DatabaseMigrationActionType>(data['data']);
+      return deserialize<_i23.DatabaseMigrationActionType>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationVersion') {
-      return deserialize<_i21.DatabaseMigrationVersion>(data['data']);
+      return deserialize<_i24.DatabaseMigrationVersion>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationWarning') {
-      return deserialize<_i22.DatabaseMigrationWarning>(data['data']);
+      return deserialize<_i25.DatabaseMigrationWarning>(data['data']);
     }
     if (data['className'] == 'DatabaseMigrationWarningType') {
-      return deserialize<_i23.DatabaseMigrationWarningType>(data['data']);
+      return deserialize<_i26.DatabaseMigrationWarningType>(data['data']);
     }
     if (data['className'] == 'EnumSerialization') {
-      return deserialize<_i24.EnumSerialization>(data['data']);
+      return deserialize<_i27.EnumSerialization>(data['data']);
     }
     if (data['className'] == 'Filter') {
-      return deserialize<_i25.Filter>(data['data']);
+      return deserialize<_i28.Filter>(data['data']);
     }
     if (data['className'] == 'FilterConstraint') {
-      return deserialize<_i26.FilterConstraint>(data['data']);
+      return deserialize<_i29.FilterConstraint>(data['data']);
     }
     if (data['className'] == 'FilterConstraintType') {
-      return deserialize<_i27.FilterConstraintType>(data['data']);
+      return deserialize<_i30.FilterConstraintType>(data['data']);
     }
     if (data['className'] == 'ForeignKeyAction') {
-      return deserialize<_i28.ForeignKeyAction>(data['data']);
+      return deserialize<_i31.ForeignKeyAction>(data['data']);
     }
     if (data['className'] == 'ForeignKeyDefinition') {
-      return deserialize<_i29.ForeignKeyDefinition>(data['data']);
+      return deserialize<_i32.ForeignKeyDefinition>(data['data']);
     }
     if (data['className'] == 'ForeignKeyMatchType') {
-      return deserialize<_i30.ForeignKeyMatchType>(data['data']);
+      return deserialize<_i33.ForeignKeyMatchType>(data['data']);
     }
     if (data['className'] == 'IndexDefinition') {
-      return deserialize<_i31.IndexDefinition>(data['data']);
+      return deserialize<_i34.IndexDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinition') {
-      return deserialize<_i32.IndexElementDefinition>(data['data']);
+      return deserialize<_i35.IndexElementDefinition>(data['data']);
     }
     if (data['className'] == 'IndexElementDefinitionType') {
-      return deserialize<_i33.IndexElementDefinitionType>(data['data']);
+      return deserialize<_i36.IndexElementDefinitionType>(data['data']);
     }
     if (data['className'] == 'TableDefinition') {
-      return deserialize<_i34.TableDefinition>(data['data']);
+      return deserialize<_i37.TableDefinition>(data['data']);
     }
     if (data['className'] == 'TableMigration') {
-      return deserialize<_i35.TableMigration>(data['data']);
+      return deserialize<_i38.TableMigration>(data['data']);
     }
     if (data['className'] == 'DistributedCacheEntry') {
-      return deserialize<_i36.DistributedCacheEntry>(data['data']);
+      return deserialize<_i39.DistributedCacheEntry>(data['data']);
     }
     if (data['className'] == 'AccessDeniedException') {
-      return deserialize<_i37.AccessDeniedException>(data['data']);
+      return deserialize<_i40.AccessDeniedException>(data['data']);
     }
     if (data['className'] == 'FileNotFoundException') {
-      return deserialize<_i38.FileNotFoundException>(data['data']);
+      return deserialize<_i41.FileNotFoundException>(data['data']);
     }
     if (data['className'] == 'FutureCallEntry') {
-      return deserialize<_i39.FutureCallEntry>(data['data']);
+      return deserialize<_i42.FutureCallEntry>(data['data']);
     }
     if (data['className'] == 'LogEntry') {
-      return deserialize<_i40.LogEntry>(data['data']);
+      return deserialize<_i43.LogEntry>(data['data']);
     }
     if (data['className'] == 'LogLevel') {
-      return deserialize<_i41.LogLevel>(data['data']);
+      return deserialize<_i44.LogLevel>(data['data']);
     }
     if (data['className'] == 'LogResult') {
-      return deserialize<_i42.LogResult>(data['data']);
+      return deserialize<_i45.LogResult>(data['data']);
     }
     if (data['className'] == 'LogSettings') {
-      return deserialize<_i43.LogSettings>(data['data']);
+      return deserialize<_i46.LogSettings>(data['data']);
     }
     if (data['className'] == 'LogSettingsOverride') {
-      return deserialize<_i44.LogSettingsOverride>(data['data']);
+      return deserialize<_i47.LogSettingsOverride>(data['data']);
     }
     if (data['className'] == 'MessageLogEntry') {
-      return deserialize<_i45.MessageLogEntry>(data['data']);
+      return deserialize<_i48.MessageLogEntry>(data['data']);
     }
     if (data['className'] == 'MethodInfo') {
-      return deserialize<_i46.MethodInfo>(data['data']);
+      return deserialize<_i49.MethodInfo>(data['data']);
     }
     if (data['className'] == 'QueryLogEntry') {
-      return deserialize<_i47.QueryLogEntry>(data['data']);
+      return deserialize<_i50.QueryLogEntry>(data['data']);
     }
     if (data['className'] == 'ReadWriteTestEntry') {
-      return deserialize<_i48.ReadWriteTestEntry>(data['data']);
+      return deserialize<_i51.ReadWriteTestEntry>(data['data']);
     }
     if (data['className'] == 'RuntimeSettings') {
-      return deserialize<_i49.RuntimeSettings>(data['data']);
+      return deserialize<_i52.RuntimeSettings>(data['data']);
     }
     if (data['className'] == 'ServerHealthConnectionInfo') {
-      return deserialize<_i50.ServerHealthConnectionInfo>(data['data']);
+      return deserialize<_i53.ServerHealthConnectionInfo>(data['data']);
     }
     if (data['className'] == 'ServerHealthMetric') {
-      return deserialize<_i51.ServerHealthMetric>(data['data']);
+      return deserialize<_i54.ServerHealthMetric>(data['data']);
     }
     if (data['className'] == 'ServerHealthResult') {
-      return deserialize<_i52.ServerHealthResult>(data['data']);
+      return deserialize<_i55.ServerHealthResult>(data['data']);
     }
     if (data['className'] == 'ServerpodSqlException') {
-      return deserialize<_i53.ServerpodSqlException>(data['data']);
+      return deserialize<_i56.ServerpodSqlException>(data['data']);
     }
     if (data['className'] == 'SessionLogEntry') {
-      return deserialize<_i54.SessionLogEntry>(data['data']);
+      return deserialize<_i57.SessionLogEntry>(data['data']);
     }
     if (data['className'] == 'SessionLogFilter') {
-      return deserialize<_i55.SessionLogFilter>(data['data']);
+      return deserialize<_i58.SessionLogFilter>(data['data']);
     }
     if (data['className'] == 'SessionLogInfo') {
-      return deserialize<_i56.SessionLogInfo>(data['data']);
+      return deserialize<_i59.SessionLogInfo>(data['data']);
     }
     if (data['className'] == 'SessionLogResult') {
-      return deserialize<_i57.SessionLogResult>(data['data']);
+      return deserialize<_i60.SessionLogResult>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -2123,32 +2171,32 @@ class Protocol extends _i1.SerializationManagerServer {
   @override
   _i1.Table? getTableForType(Type t) {
     switch (t) {
-      case _i5.CloudStorageEntry:
-        return _i5.CloudStorageEntry.t;
-      case _i6.CloudStorageDirectUploadEntry:
-        return _i6.CloudStorageDirectUploadEntry.t;
-      case _i21.DatabaseMigrationVersion:
-        return _i21.DatabaseMigrationVersion.t;
-      case _i39.FutureCallEntry:
-        return _i39.FutureCallEntry.t;
-      case _i40.LogEntry:
-        return _i40.LogEntry.t;
-      case _i45.MessageLogEntry:
-        return _i45.MessageLogEntry.t;
-      case _i46.MethodInfo:
-        return _i46.MethodInfo.t;
-      case _i47.QueryLogEntry:
-        return _i47.QueryLogEntry.t;
-      case _i48.ReadWriteTestEntry:
-        return _i48.ReadWriteTestEntry.t;
-      case _i49.RuntimeSettings:
-        return _i49.RuntimeSettings.t;
-      case _i50.ServerHealthConnectionInfo:
-        return _i50.ServerHealthConnectionInfo.t;
-      case _i51.ServerHealthMetric:
-        return _i51.ServerHealthMetric.t;
-      case _i54.SessionLogEntry:
-        return _i54.SessionLogEntry.t;
+      case _i8.CloudStorageEntry:
+        return _i8.CloudStorageEntry.t;
+      case _i9.CloudStorageDirectUploadEntry:
+        return _i9.CloudStorageDirectUploadEntry.t;
+      case _i24.DatabaseMigrationVersion:
+        return _i24.DatabaseMigrationVersion.t;
+      case _i42.FutureCallEntry:
+        return _i42.FutureCallEntry.t;
+      case _i43.LogEntry:
+        return _i43.LogEntry.t;
+      case _i48.MessageLogEntry:
+        return _i48.MessageLogEntry.t;
+      case _i49.MethodInfo:
+        return _i49.MethodInfo.t;
+      case _i50.QueryLogEntry:
+        return _i50.QueryLogEntry.t;
+      case _i51.ReadWriteTestEntry:
+        return _i51.ReadWriteTestEntry.t;
+      case _i52.RuntimeSettings:
+        return _i52.RuntimeSettings.t;
+      case _i53.ServerHealthConnectionInfo:
+        return _i53.ServerHealthConnectionInfo.t;
+      case _i54.ServerHealthMetric:
+        return _i54.ServerHealthMetric.t;
+      case _i57.SessionLogEntry:
+        return _i57.SessionLogEntry.t;
     }
     return null;
   }

--- a/packages/serverpod/lib/src/models/authentication/revoked_authentication_auth_id.spy.yaml
+++ b/packages/serverpod/lib/src/models/authentication/revoked_authentication_auth_id.spy.yaml
@@ -1,0 +1,5 @@
+### Message sent when an authentication key id is revoked.
+class: RevokedAuthenticationAuthId
+serverOnly: true
+fields:
+    authId: String

--- a/packages/serverpod/lib/src/models/authentication/revoked_authentication_scope.spy.yaml
+++ b/packages/serverpod/lib/src/models/authentication/revoked_authentication_scope.spy.yaml
@@ -1,0 +1,5 @@
+### Message sent when authentication scopes for a user are revoked.
+class: RevokedAuthenticationScope
+serverOnly: true
+fields:
+    scopes: List<String>

--- a/packages/serverpod/lib/src/models/authentication/revoked_authentication_user.spy.yaml
+++ b/packages/serverpod/lib/src/models/authentication/revoked_authentication_user.spy.yaml
@@ -1,0 +1,3 @@
+### Message sent when all authentication for a user is revoked.
+class: RevokedAuthenticationUser
+serverOnly: true

--- a/packages/serverpod/lib/src/server/message_central.dart
+++ b/packages/serverpod/lib/src/server/message_central.dart
@@ -2,6 +2,17 @@ import 'dart:async';
 
 import 'package:serverpod/serverpod.dart';
 
+/// Channels that are listened to by the Serverpod Framework.
+abstract class MessageCentralServerpodChannels {
+  /// Used to revoke authentication tokens.
+  /// The message should be of type [RevokedAuthenticationUser],
+  /// [RevokedAuthenticationAuthId] or [RevokedAuthenticationScope].
+  /// The [userId] should be the [AuthenticationInfo.userId] for the concerned
+  /// user.
+  static String revokedAuthentication(int userId) =>
+      '_serverpod_revoked_authentication_$userId';
+}
+
 // TODO: Support for server clusters.
 
 /// The callback used by listeners of the [MessageCentral].

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -631,7 +631,7 @@ class MessageCentralAccess {
   ///
   /// [RevokedAuthenticationScope] is used to communicate that a specific
   /// scope or scopes have been revoked for the user.
-  Future<bool> revokedAuthentication(
+  Future<bool> authenticationRevoked(
     int userId,
     SerializableModel message,
   ) async {

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/protocol.dart';
 import 'package:serverpod/src/server/features.dart';
 import 'package:serverpod/src/server/log_manager/log_manager.dart';
 import 'package:serverpod/src/server/log_manager/log_settings.dart';
@@ -612,6 +613,42 @@ class MessageCentralAccess {
   /// emit an error.
   Stream<T> createStream<T>(String channelName) =>
       _session.server.messageCentral.createStream<T>(_session, channelName);
+
+  /// Broadcasts revoked authentication events to the Serverpod framework.
+  /// This message ensures authenticated connections to the user are closed.
+  ///
+  /// The [userId] should be the [AuthenticationInfo.userId] for the concerned
+  /// user.
+  ///
+  /// The [message] must be of type [RevokedAuthenticationUser],
+  /// [RevokedAuthenticationAuthId], or [RevokedAuthenticationScope].
+  ///
+  /// [RevokedAuthenticationUser] is used to communicate that all the user's
+  /// authentication is revoked.
+  ///
+  /// [RevokedAuthenticationAuthId] is used to communicate that a specific
+  /// authentication id has been revoked for a user.
+  ///
+  /// [RevokedAuthenticationScope] is used to communicate that a specific
+  /// scope or scopes have been revoked for the user.
+  Future<bool> revokedAuthentication(
+    int userId,
+    SerializableModel message,
+  ) async {
+    if (message is! RevokedAuthenticationUser &&
+        message is! RevokedAuthenticationAuthId &&
+        message is! RevokedAuthenticationScope) {
+      throw ArgumentError(
+        'Message must be of type RevokedAuthenticationUser, '
+        'RevokedAuthenticationAuthId, or RevokedAuthenticationScope',
+      );
+    }
+    return _session.server.messageCentral.postMessage(
+      MessageCentralServerpodChannels.revokedAuthentication(userId),
+      message,
+      global: true,
+    );
+  }
 }
 
 /// Internal methods for [Session].

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -415,7 +415,7 @@ class _MethodStreamManager {
     SerializationManager serializationManager,
     _RequiredAuthentication? requiredAuthentication,
   ) {
-    late void Function(SerializableModel) revokedAuthenticationCallback;
+    void Function(SerializableModel)? revokedAuthenticationCallback;
 
     if (requiredAuthentication != null) {
       revokedAuthenticationCallback = (event) async {
@@ -457,7 +457,8 @@ class _MethodStreamManager {
       /// or a request from the client.
       if (isCanceled) return;
       isCanceled = true;
-      if (requiredAuthentication != null) {
+      if (requiredAuthentication != null &&
+          revokedAuthenticationCallback != null) {
         session.messages.removeListener(
           MessageCentralServerpodChannels.revokedAuthentication(
             requiredAuthentication.authInfo.userId,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -314,6 +314,7 @@ class _MethodStreamManager {
       }
 
       // Immediate close of the stream
+      _updateCloseReason(streamKey, reason);
       await context.controller.onCancel?.call();
       unawaited(context.subscription.cancel());
     } else {

--- a/packages/serverpod_client/lib/src/client_method_stream_manager.dart
+++ b/packages/serverpod_client/lib/src/client_method_stream_manager.dart
@@ -332,10 +332,7 @@ final class ClientMethodStreamManager {
 
     if (reason == CloseReason.error) {
       inboundStreamContext.controller.addError(
-        const ServerpodClientException(
-          'Stream closed with error reason',
-          -1,
-        ),
+        const ConnectionClosedException(),
       );
     }
 

--- a/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
+++ b/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
@@ -47,3 +47,9 @@ class OpenMethodStreamException extends MethodStreamException {
   /// Creates a new [OpenMethodStreamException].
   const OpenMethodStreamException(this.responseType);
 }
+
+/// Thrown if the connection is closed with an error.
+class ConnectionClosedException extends MethodStreamException {
+  /// Creates a new [ConnectionClosedException].
+  const ConnectionClosedException();
+}

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1686,6 +1686,15 @@ class EndpointAuthenticatedMethodStreaming extends _i1.EndpointRef {
         {},
         {},
       );
+
+  /// Warning: Streaming methods are still experimental.
+  _i2.Stream<int> intEchoStream(_i2.Stream<int> stream) =>
+      caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
+        'authenticatedMethodStreaming',
+        'intEchoStream',
+        {},
+        {'stream': stream},
+      );
 }
 
 /// {@category Endpoint}

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -116,6 +116,19 @@ class EndpointAuthentication extends _i1.EndpointRef {
         'signOut',
         {},
       );
+
+  _i2.Future<void> updateScopes(
+    int userId,
+    List<String> scopes,
+  ) =>
+      caller.callServerEndpoint<void>(
+        'authentication',
+        'updateScopes',
+        {
+          'userId': userId,
+          'scopes': scopes,
+        },
+      );
 }
 
 /// {@category Endpoint}

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -1546,6 +1546,10 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
+    if (t == List<String>) {
+      return (data as List).map((e) => deserialize<String>(e)).toList()
+          as dynamic;
+    }
     if (t == List<_i109.SimpleData>) {
       return (data as List)
           .map((e) => deserialize<_i109.SimpleData>(e))
@@ -1620,10 +1624,6 @@ class Protocol extends _i1.SerializationManager {
     }
     if (t == List<bool?>) {
       return (data as List).map((e) => deserialize<bool?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
     if (t == List<String?>) {

--- a/tests/serverpod_test_server/lib/src/endpoints/authentication.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/authentication.dart
@@ -40,7 +40,7 @@ class AuthenticationEndpoint extends Endpoint {
           email: email,
           userName: 'Test',
           created: DateTime.now(),
-          scopeNames: [],
+          scopeNames: scopes ?? [],
           blocked: false,
         );
         userInfo = await Users.createUser(session, userInfo);
@@ -67,5 +67,14 @@ class AuthenticationEndpoint extends Endpoint {
 
   Future<void> signOut(Session session) async {
     await UserAuthentication.signOutUser(session);
+  }
+
+  Future<void> updateScopes(
+    Session session,
+    int userId,
+    List<String> scopes,
+  ) async {
+    var newScopes = scopes.map((e) => Scope(e)).toSet();
+    await Users.updateUserScopes(session, userId, newScopes);
   }
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -356,4 +356,10 @@ class AuthenticatedMethodStreaming extends Endpoint {
       yield i;
     }
   }
+
+  Stream<int> intEchoStream(Session session, Stream<int> stream) async* {
+    await for (var value in stream) {
+      yield value;
+    }
+  }
 }

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -3737,7 +3737,29 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['authenticatedMethodStreaming']
                       as _i21.AuthenticatedMethodStreaming)
                   .simpleStream(session),
-        )
+        ),
+        'intEchoStream': _i1.MethodStreamConnector(
+          name: 'intEchoStream',
+          params: {},
+          streamParams: {
+            'stream': _i1.StreamParameterDescription<int>(
+              name: 'stream',
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['authenticatedMethodStreaming']
+                      as _i21.AuthenticatedMethodStreaming)
+                  .intEchoStream(
+            session,
+            streamParams['stream']!.cast<int>(),
+          ),
+        ),
       },
     );
     connectors['moduleSerialization'] = _i1.EndpointConnector(

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -413,6 +413,31 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['authentication'] as _i3.AuthenticationEndpoint)
                   .signOut(session),
         ),
+        'updateScopes': _i1.MethodConnector(
+          name: 'updateScopes',
+          params: {
+            'userId': _i1.ParameterDescription(
+              name: 'userId',
+              type: _i1.getType<int>(),
+              nullable: false,
+            ),
+            'scopes': _i1.ParameterDescription(
+              name: 'scopes',
+              type: _i1.getType<List<String>>(),
+              nullable: false,
+            ),
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['authentication'] as _i3.AuthenticationEndpoint)
+                  .updateScopes(
+            session,
+            params['userId'],
+            params['scopes'],
+          ),
+        ),
       },
     );
     connectors['basicTypes'] = _i1.EndpointConnector(

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -5952,6 +5952,10 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
+    if (t == List<String>) {
+      return (data as List).map((e) => deserialize<String>(e)).toList()
+          as dynamic;
+    }
     if (t == List<_i113.SimpleData>) {
       return (data as List)
           .map((e) => deserialize<_i113.SimpleData>(e))
@@ -6026,10 +6030,6 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (t == List<bool?>) {
       return (data as List).map((e) => deserialize<bool?>(e)).toList()
-          as dynamic;
-    }
-    if (t == List<String>) {
-      return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
     if (t == List<String?>) {

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -203,6 +203,7 @@ methodStreaming:
   - didInputStreamHaveSerializableExceptionError:
 authenticatedMethodStreaming:
   - simpleStream:
+  - intEchoStream:
 moduleSerialization:
   - serializeModuleObject:
   - modifyModuleObject:

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -7,6 +7,7 @@ authentication:
   - createUser:
   - authenticate:
   - signOut:
+  - updateScopes:
 basicTypes:
   - testInt:
   - testDouble:

--- a/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
+++ b/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
@@ -14,13 +14,17 @@ class IntegrationTestServer extends TestServerpod {
           Endpoints(),
         );
 
-  static Serverpod create({ServerpodConfig? config}) {
+  static Serverpod create({
+    ServerpodConfig? config,
+    AuthenticationHandler? authenticationHandler,
+  }) {
     return Serverpod(
       _integrationTestFlags,
       Protocol(),
       Endpoints(),
       config: config,
-      authenticationHandler: auth.authenticationHandler,
+      authenticationHandler:
+          authenticationHandler ?? auth.authenticationHandler,
     );
   }
 }

--- a/tests/serverpod_test_server/test_e2e/method_streaming/authenticated_streaming_method_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/authenticated_streaming_method_test.dart
@@ -165,7 +165,7 @@ void main() {
 
       await expectLater(
         streamErrorCompleter.future,
-        completion(isA<ServerpodClientException>()),
+        completion(isA<ConnectionClosedException>()),
       );
     });
 
@@ -190,7 +190,7 @@ void main() {
 
       await expectLater(
         streamErrorCompleter.future,
-        completion(isA<ServerpodClientException>()),
+        completion(isA<ConnectionClosedException>()),
       );
     });
 

--- a/tests/serverpod_test_server/test_e2e/method_streaming/out_future_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/out_future_test.dart
@@ -35,9 +35,9 @@ void main() {
     var stream = Stream<int>.fromIterable([1, 2, 3]);
     var responseFuture = client.methodStreaming.throwsException(stream);
     await expectLater(
-        responseFuture,
-        throwsA(isA<ServerpodClientException>()
-            .having((e) => e.statusCode, 'statusCode', -1)));
+      responseFuture,
+      throwsA(isA<ConnectionClosedException>()),
+    );
   });
 
   test(
@@ -55,9 +55,9 @@ void main() {
     var stream = Stream<int>.fromIterable([1, 2, 3]);
     var responseFuture = client.methodStreaming.throwsExceptionVoid(stream);
     await expectLater(
-        responseFuture,
-        throwsA(isA<ServerpodClientException>()
-            .having((e) => e.statusCode, 'statusCode', -1)));
+      responseFuture,
+      throwsA(isA<ConnectionClosedException>()),
+    );
   });
 
   test(

--- a/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
@@ -56,8 +56,7 @@ void main() {
 
     await expectLater(
       await streamComplete.future,
-      isA<ServerpodClientException>()
-          .having((e) => e.statusCode, 'statusCode', -1),
+      isA<ConnectionClosedException>(),
     );
   });
 

--- a/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
+++ b/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:serverpod/protocol.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_client/serverpod_test_client.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  late Session session;
+  late Serverpod server;
+
+  setUp(() async {
+    server = IntegrationTestServer.create();
+    await server.start();
+    session = await server.createSession();
+  });
+
+  tearDown(() async {
+    await session.close();
+    await server.shutdown(exitProcess: false);
+  });
+
+  test(
+      'Given a non valid message type when broadcasting revoked authentication event then exception is thrown',
+      () {
+    expect(
+      () => session.messages.revokedAuthentication(1, EmptyModel()),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
+
+  test(
+      'Given a valid message type when broadcasting revoked authentication event then event is broadcasted',
+      () async {
+    var eventCompleter = Completer<RevokedAuthenticationUser>();
+    session.messages
+        .createStream(MessageCentralServerpodChannels.revokedAuthentication(1))
+        .listen(
+          (event) => eventCompleter.complete(event),
+        );
+
+    var message = RevokedAuthenticationUser();
+    var event = await session.messages.revokedAuthentication(1, message);
+
+    expect(event, isTrue);
+    await expectLater(
+      eventCompleter.future,
+      completion(isA<RevokedAuthenticationUser>()),
+    );
+  });
+}

--- a/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
+++ b/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
@@ -25,7 +25,7 @@ void main() async {
       'Given a non valid message type when broadcasting revoked authentication event then exception is thrown',
       () {
     expect(
-      () => session.messages.revokedAuthentication(1, EmptyModel()),
+      () => session.messages.authenticationRevoked(1, EmptyModel()),
       throwsA(isA<ArgumentError>()),
     );
   });
@@ -41,7 +41,7 @@ void main() async {
         );
 
     var message = RevokedAuthenticationUser();
-    var event = await session.messages.revokedAuthentication(1, message);
+    var event = await session.messages.authenticationRevoked(1, message);
 
     expect(event, isTrue);
     await expectLater(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
@@ -84,7 +84,7 @@ void main() {
           'when the authenticated user is revoked then the stream is closed with error.',
           () async {
         await expectLater(
-          session.messages.revokedAuthentication(
+          session.messages.authenticationRevoked(
             authenticatedUserId,
             RevokedAuthenticationUser(),
           ),
@@ -100,7 +100,7 @@ void main() {
           'when the authentication id is revoked then the stream is closed with error.',
           () async {
         await expectLater(
-          session.messages.revokedAuthentication(
+          session.messages.authenticationRevoked(
             authenticatedUserId,
             RevokedAuthenticationAuthId(authId: 'token-$tokenCounter'),
           ),
@@ -116,7 +116,7 @@ void main() {
           'when an unrelated authentication id is revoked then the stream can still be used.',
           () async {
         await expectLater(
-          session.messages.revokedAuthentication(
+          session.messages.authenticationRevoked(
             authenticatedUserId,
             RevokedAuthenticationAuthId(authId: 'token-${tokenCounter + 100}'),
           ),
@@ -135,7 +135,7 @@ void main() {
           'when the required scope for endpoint is revoked the stream is closed with error.',
           () async {
         await expectLater(
-          session.messages.revokedAuthentication(
+          session.messages.authenticationRevoked(
             authenticatedUserId,
             RevokedAuthenticationScope(scopes: [Scope.admin.name!]),
           ),
@@ -151,7 +151,7 @@ void main() {
           'when a scope not required for the endpoint is revoked then the stream can still be used.',
           () async {
         await expectLater(
-          session.messages.revokedAuthentication(
+          session.messages.authenticationRevoked(
             authenticatedUserId,
             RevokedAuthenticationScope(scopes: ['unrelated-scope']),
           ),
@@ -222,7 +222,7 @@ void main() {
           'when the authenticated user is revoked then the authenticated stream is closed',
           () async {
         await expectLater(
-          session.messages.revokedAuthentication(
+          session.messages.authenticationRevoked(
             authenticatedUserId,
             RevokedAuthenticationUser(),
           ),
@@ -236,7 +236,7 @@ void main() {
           'when the authenticated user is revoked then the unauthenticated stream can still be used',
           () async {
         await expectLater(
-          session.messages.revokedAuthentication(
+          session.messages.authenticationRevoked(
             authenticatedUserId,
             RevokedAuthenticationUser(),
           ),

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+
+import 'package:serverpod/protocol.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_client/serverpod_test_client.dart' as c;
+import 'package:serverpod_test_client/serverpod_test_client.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_key_manager.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Serverpod server;
+  late Session session;
+  late c.Client client;
+  late TestAuthKeyManager authKeyManager;
+  var authenticatedUserId = 1;
+  var tokenCounter = 0;
+
+  setUp(() async {
+    // This creates a server with an authentication handler that always returns
+    // a user with Admin scope.
+    var tokenCounter = 0;
+    server = IntegrationTestServer.create(
+      authenticationHandler: (session, token) async => AuthenticationInfo(
+        authenticatedUserId,
+        {Scope.admin},
+        authId: 'token-${tokenCounter++}',
+      ),
+    );
+    await server.start();
+    session = await server.createSession();
+
+    authKeyManager = TestAuthKeyManager();
+    client = c.Client(
+      serverUrl,
+      authenticationKeyManager: authKeyManager,
+    );
+  });
+
+  tearDown(() async {
+    await session.close();
+    client.closeStreamingMethodConnections(exception: null);
+    await server.shutdown(exitProcess: false);
+    client.close();
+  });
+
+  group('Given an authenticated user', () {
+    late String authToken;
+    setUp(() async {
+      authToken = const Uuid().v4();
+      authKeyManager.put(authToken);
+    });
+    group('connected to an authenticated streaming method', () {
+      late Completer<dynamic> streamClosedCompleter;
+      late Completer<int> valueReceivedCompleter;
+      late StreamController<int> inStream;
+
+      setUp(() async {
+        streamClosedCompleter = Completer<dynamic>();
+        inStream = StreamController<int>();
+        Stream<int> outStream;
+        {
+          outStream = client.authenticatedMethodStreaming
+              .intEchoStream(inStream.stream);
+          valueReceivedCompleter = Completer<int>();
+          outStream.listen((event) {
+            if (valueReceivedCompleter.isCompleted) {
+              return;
+            }
+            valueReceivedCompleter.complete(event);
+          }, onError: (e) {
+            streamClosedCompleter.complete(e);
+          });
+
+          inStream.add(1);
+          // Validate that the stream works
+          await valueReceivedCompleter.future;
+          assert(valueReceivedCompleter.isCompleted);
+        }
+      });
+
+      test(
+          'when the authenticated user is revoked then the stream is closed with error.',
+          () async {
+        await expectLater(
+          session.messages.revokedAuthentication(
+            authenticatedUserId,
+            RevokedAuthenticationUser(),
+          ),
+          completion(true),
+        );
+
+        await expectLater(streamClosedCompleter.future, completes);
+        var exception = await streamClosedCompleter.future;
+        expect(exception, isA<ServerpodClientException>());
+      });
+
+      test(
+          'when the authentication id is revoked then the stream is closed with error.',
+          () async {
+        await expectLater(
+          session.messages.revokedAuthentication(
+            authenticatedUserId,
+            RevokedAuthenticationAuthId(authId: 'token-$tokenCounter'),
+          ),
+          completion(true),
+        );
+
+        await expectLater(streamClosedCompleter.future, completes);
+        var exception = await streamClosedCompleter.future;
+        expect(exception, isA<ServerpodClientException>());
+      });
+
+      test(
+          'when an unrelated authentication id is revoked then the stream can still be used.',
+          () async {
+        await expectLater(
+          session.messages.revokedAuthentication(
+            authenticatedUserId,
+            RevokedAuthenticationAuthId(authId: 'token-${tokenCounter + 100}'),
+          ),
+          completion(true),
+        );
+
+        valueReceivedCompleter = Completer<int>();
+        inStream.add(2);
+        await expectLater(
+          valueReceivedCompleter.future,
+          completion(2),
+        );
+      });
+
+      test(
+          'when the required scope for endpoint is revoked the stream is closed with error.',
+          () async {
+        await expectLater(
+          session.messages.revokedAuthentication(
+            authenticatedUserId,
+            RevokedAuthenticationScope(scopes: [Scope.admin.name!]),
+          ),
+          completion(true),
+        );
+
+        await expectLater(streamClosedCompleter.future, completes);
+        var exception = await streamClosedCompleter.future;
+        expect(exception, isA<ServerpodClientException>());
+      });
+
+      test(
+          'when a scope not required for the endpoint is revoked then the stream can still be used.',
+          () async {
+        await expectLater(
+          session.messages.revokedAuthentication(
+            authenticatedUserId,
+            RevokedAuthenticationScope(scopes: ['unrelated-scope']),
+          ),
+          completion(true),
+        );
+
+        valueReceivedCompleter = Completer<int>();
+        inStream.add(2);
+        await expectLater(
+          valueReceivedCompleter.future,
+          completion(2),
+        );
+      });
+    });
+
+    group(
+        'connected to both an authenticated an unauthenticated streaming method',
+        () {
+      late Completer authenticatedStreamClosedCompleter;
+      late Completer<int> unauthenticatedValueReceivedCompleter;
+      late StreamController<int> unauthenticatedInStream;
+
+      setUp(() async {
+        authenticatedStreamClosedCompleter = Completer<dynamic>();
+        var authenticatedInStream = StreamController<int>();
+        Stream<int> authenticatedOutStream;
+        {
+          authenticatedOutStream = client.authenticatedMethodStreaming
+              .intEchoStream(authenticatedInStream.stream);
+          var valueReceivedCompleter = Completer<int>();
+          authenticatedOutStream.listen((event) {
+            if (valueReceivedCompleter.isCompleted) {
+              return;
+            }
+            valueReceivedCompleter.complete(event);
+          }, onError: (e) {
+            authenticatedStreamClosedCompleter.complete(e);
+          });
+
+          authenticatedInStream.add(1);
+          // Validate that the stream works
+          await valueReceivedCompleter.future;
+          assert(valueReceivedCompleter.isCompleted);
+        }
+
+        unauthenticatedInStream = StreamController<int>();
+        Stream<int> unauthenticatedOutStream;
+        unauthenticatedValueReceivedCompleter = Completer<int>();
+        {
+          unauthenticatedOutStream = client.methodStreaming.intEchoStream(
+            unauthenticatedInStream.stream,
+          );
+          unauthenticatedOutStream.listen((event) {
+            if (unauthenticatedValueReceivedCompleter.isCompleted) {
+              return;
+            }
+            unauthenticatedValueReceivedCompleter.complete(event);
+          });
+
+          unauthenticatedInStream.add(1);
+          // Validate that the stream works
+          await unauthenticatedValueReceivedCompleter.future;
+          assert(unauthenticatedValueReceivedCompleter.isCompleted);
+        }
+      });
+
+      test(
+          'when the authenticated user is revoked then the authenticated stream is closed',
+          () async {
+        await expectLater(
+          session.messages.revokedAuthentication(
+            authenticatedUserId,
+            RevokedAuthenticationUser(),
+          ),
+          completion(true),
+        );
+
+        await expectLater(authenticatedStreamClosedCompleter.future, completes);
+      });
+
+      test(
+          'when the authenticated user is revoked then the unauthenticated stream can still be used',
+          () async {
+        await expectLater(
+          session.messages.revokedAuthentication(
+            authenticatedUserId,
+            RevokedAuthenticationUser(),
+          ),
+          completion(true),
+        );
+
+        unauthenticatedValueReceivedCompleter = Completer<int>();
+        unauthenticatedInStream.add(2);
+        await expectLater(
+          unauthenticatedValueReceivedCompleter.future,
+          completion(2),
+        );
+      });
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
@@ -93,7 +93,7 @@ void main() {
 
         await expectLater(streamClosedCompleter.future, completes);
         var exception = await streamClosedCompleter.future;
-        expect(exception, isA<ServerpodClientException>());
+        expect(exception, isA<ConnectionClosedException>());
       });
 
       test(
@@ -109,7 +109,7 @@ void main() {
 
         await expectLater(streamClosedCompleter.future, completes);
         var exception = await streamClosedCompleter.future;
-        expect(exception, isA<ServerpodClientException>());
+        expect(exception, isA<ConnectionClosedException>());
       });
 
       test(
@@ -144,7 +144,7 @@ void main() {
 
         await expectLater(streamClosedCompleter.future, completes);
         var exception = await streamClosedCompleter.future;
-        expect(exception, isA<ServerpodClientException>());
+        expect(exception, isA<c.ConnectionClosedException>());
       });
 
       test(

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
@@ -81,7 +81,7 @@ void main() {
       });
 
       test(
-          'when the authenticated user is revoked then the stream is closed with error.',
+          'when the authenticated user is revoked then the stream is closed with an error.',
           () async {
         await expectLater(
           session.messages.authenticationRevoked(
@@ -97,7 +97,7 @@ void main() {
       });
 
       test(
-          'when the authentication id is revoked then the stream is closed with error.',
+          'when the authentication id is revoked then the stream is closed with an error.',
           () async {
         await expectLater(
           session.messages.authenticationRevoked(
@@ -132,7 +132,7 @@ void main() {
       });
 
       test(
-          'when the required scope for endpoint is revoked the stream is closed with error.',
+          'when the required scope for an endpoint is revoked then the stream is closed with an error.',
           () async {
         await expectLater(
           session.messages.authenticationRevoked(
@@ -148,7 +148,7 @@ void main() {
       });
 
       test(
-          'when a scope not required for the endpoint is revoked then the stream can still be used.',
+          'when a scope not required for an endpoint is revoked then the stream can still be used.',
           () async {
         await expectLater(
           session.messages.authenticationRevoked(
@@ -168,7 +168,7 @@ void main() {
     });
 
     group(
-        'connected to both an authenticated an unauthenticated streaming method',
+        'connected to both an authenticated and an unauthenticated streaming method',
         () {
       late Completer authenticatedStreamClosedCompleter;
       late Completer<int> unauthenticatedValueReceivedCompleter;


### PR DESCRIPTION
### Background:
For the new streaming methods, authentication for each streaming method call is done on the open stream request.
After that no further validation is required.

However, since authentication for a user can be revoked at any time, there needs to exist a way to close any stream that are utalizing a revoked authentication 

Connected to: #2338

### Fix:
This PR introduced a new channel (or one for each authenticated user) used for communicating revoked authentications. The Serverpod framework will then listen to updates on the authenticated information and close streams if authentication has been changed in a way that would make the streaming method unavailable for the user.

The channel is prefixed with the user ID, and three types of events can be broadcasted on the channel.
- `RevokedAuthenticationUser` -  is used to communicate that all the user's authentication is
- `RevokedAuthenticationAuthId` - is used to communicate that a specific authentication id has been revoked for a user.
- `RevokedAuthenticationScope` is used to communicate that a specific scope (or scopes) have been revoked for the user.

### Additional changes:
***AuthenticatedInfo***
The AuthenticatedInfo object has also been extended with an optional `authId` field that is a `String`. The purpose of this string is to uniquely identify an authentiction key. This opens up the possibility to revoke access for single authentication keys and not a full user or a scope.

***Specific exception on connection closed error***
On the client, if a stream is closed with an exception, a specific stream closed error is thrown instead of the general client error. The purpose of this is to make it possible to build reconnect logic.

### Guidance for review
Best reviewed commit by commit. Changes have been grouped together with the tests to make it clear what has been validated.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Since this is only used in the new streaming interface these can be considered non breaking changes.
However, documentation around this will need to be added along with instructions on how to post information to these channels for users that have built their own authentication solutions.