### PR TITLE
fix: Remove experimental warning from method streams.

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1664,7 +1664,6 @@ class EndpointAuthenticatedMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> intEchoStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'authenticatedMethodStreaming',

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1080,7 +1080,6 @@ class EndpointLogging extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> streamEmpty(_i2.Stream<int> input) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'logging',
@@ -1089,7 +1088,6 @@ class EndpointLogging extends _i1.EndpointRef {
         {'input': input},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> streamLogging(_i2.Stream<int> input) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'logging',
@@ -1098,7 +1096,6 @@ class EndpointLogging extends _i1.EndpointRef {
         {'input': input},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> streamQueryLogging(_i2.Stream<int> input) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'logging',
@@ -1341,8 +1338,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
   @override
   String get name => 'methodStreaming';
 
-  /// Warning: Streaming methods are still experimental.
-  ///
   /// Returns a simple stream of integers from 0 to 9.
   _i2.Stream<int> simpleStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
@@ -1352,7 +1347,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> neverEndingStreamWithDelay(int millisecondsDelay) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1367,7 +1361,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> intReturnFromStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1376,7 +1369,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<int?> nullableIntReturnFromStream(_i2.Stream<int?> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int?>, int?>(
         'methodStreaming',
@@ -1385,7 +1377,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> intStreamFromValue(int value) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1394,7 +1385,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> intEchoStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1403,7 +1393,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<dynamic> dynamicEchoStream(_i2.Stream<dynamic> stream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<dynamic>, dynamic>(
         'methodStreaming',
@@ -1412,7 +1401,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int?> nullableIntEchoStream(_i2.Stream<int?> stream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int?>, int?>(
         'methodStreaming',
@@ -1421,7 +1409,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> voidReturnAfterStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1430,7 +1417,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> multipleIntEchoStreams(
     _i2.Stream<int> stream1,
     _i2.Stream<int> stream2,
@@ -1445,7 +1431,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         },
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> directVoidReturnWithStreamInput(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1454,7 +1439,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> directOneIntReturnWithStreamInput(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1463,7 +1447,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> simpleInputReturnStream(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1472,7 +1455,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> simpleStreamWithParameter(int value) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1481,7 +1463,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<_i10.SimpleData> simpleDataStream(int value) =>
       caller.callStreamingServerEndpoint<_i2.Stream<_i10.SimpleData>,
           _i10.SimpleData>(
@@ -1491,7 +1472,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<_i10.SimpleData> simpleInOutDataStream(
           _i2.Stream<_i10.SimpleData> simpleDataStream) =>
       caller.callStreamingServerEndpoint<_i2.Stream<_i10.SimpleData>,
@@ -1530,7 +1510,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'delay': delay},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> delayedStreamResponse(int delay) =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1539,7 +1518,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> delayedNeverListenedInputStream(
     int delay,
     _i2.Stream<int> stream,
@@ -1551,7 +1529,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> delayedPausedInputStream(
     int delay,
     _i2.Stream<int> stream,
@@ -1572,7 +1549,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> inStreamThrowsException(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1581,7 +1557,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> inStreamThrowsSerializableException(
           _i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
@@ -1591,7 +1566,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> outStreamThrowsException() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1600,7 +1574,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> outStreamThrowsSerializableException() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1609,7 +1582,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> throwsExceptionVoid(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1618,7 +1590,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<void> throwsSerializableExceptionVoid(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<void>, void>(
         'methodStreaming',
@@ -1627,7 +1598,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> throwsException(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1636,7 +1606,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<int> throwsSerializableException(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
         'methodStreaming',
@@ -1645,7 +1614,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> throwsExceptionStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1654,7 +1622,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> throwsSerializableExceptionStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',
@@ -1663,7 +1630,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<bool> didInputStreamHaveError(_i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<bool>, bool>(
         'methodStreaming',
@@ -1672,7 +1638,6 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {'stream': stream},
       );
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Future<bool> didInputStreamHaveSerializableExceptionError(
           _i2.Stream<int> stream) =>
       caller.callStreamingServerEndpoint<_i2.Future<bool>, bool>(
@@ -1691,7 +1656,6 @@ class EndpointAuthenticatedMethodStreaming extends _i1.EndpointRef {
   @override
   String get name => 'authenticatedMethodStreaming';
 
-  /// Warning: Streaming methods are still experimental.
   _i2.Stream<int> simpleStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'authenticatedMethodStreaming',

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -408,7 +408,7 @@ class LibraryGenerator {
             endpoint.methods.add(
               Method(
                 (m) => m
-                  ..docs.add(_buildEndpointCallDocumentation(methodDef))
+                  ..docs.add(methodDef.documentationComment ?? '')
                   ..annotations.addAll(_buildEndpointCallAnnotations(methodDef))
                   ..returns = returnType.reference(false, config: config)
                   ..name = methodDef.name
@@ -664,21 +664,6 @@ class LibraryGenerator {
     );
 
     return library.build();
-  }
-
-  String _buildEndpointCallDocumentation(MethodDefinition methodDef) {
-    if (methodDef is! MethodStreamDefinition) {
-      return methodDef.documentationComment ?? '';
-    }
-
-    const experimentalWarning =
-        '/// Warning: Streaming methods are still experimental.';
-    var documentationComment = methodDef.documentationComment;
-    if (documentationComment == null) {
-      return experimentalWarning;
-    }
-
-    return '$experimentalWarning\n///\n$documentationComment';
   }
 
   Iterable<Expression> _buildEndpointCallAnnotations(

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -59,14 +59,6 @@ void main() {
     });
     var endpointsFile = codeMap[expectedFileName];
 
-    test('then client file contains experimental warning for method.', () {
-      expect(
-        endpointsFile,
-        contains(
-          '/// Warning: Streaming methods are still experimental.',
-        ),
-      );
-    });
     test(
         'then client file contains endpoint method for the streaming endpoint.',
         () {
@@ -113,15 +105,6 @@ void main() {
       expect(codeMap, contains(expectedFileName));
     });
     var endpointsFile = codeMap[expectedFileName];
-
-    test('then client file contains experimental warning for method.', () {
-      expect(
-        endpointsFile,
-        contains(
-          '/// Warning: Streaming methods are still experimental.',
-        ),
-      );
-    });
 
     test('then client file endpoint method for the streaming endpoint.', () {
       expect(


### PR DESCRIPTION
Removes the experimental warning from method streams making them ready to be released as stable.

Closes: #2338 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.