### PR TITLE
feat: Ability to register custom environment variables to be loaded as a password.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -744,7 +744,7 @@ class Serverpod {
   void loadCustomPasswords(
     List<({String envName, String alias})> envPasswords,
   ) {
-    _passwords = _passwordManager.mergeCustomPasswords(
+    _passwords = _passwordManager.mergePasswords(
       envPasswords,
       _passwords,
       environment: Platform.environment,

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -739,6 +739,8 @@ class Serverpod {
   /// contains the password. The alias is the key used to access the
   /// the password with the [getPassword] method.
   /// The alias also maps to the name in the config/passwords.yaml file.
+  /// This method may throw a [ArgumentError] if any Serverpod reserved passwords
+  /// are used as aliases or environment variables.
   void loadCustomPasswords(
     List<({String envName, String alias})> envPasswords,
   ) {

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -65,7 +65,10 @@ class Serverpod {
 
   /// The server configuration, as read from the config/ directory.
   late ServerpodConfig config;
+
   Map<String, String> _passwords = <String, String>{};
+
+  late PasswordManager _passwordManager;
 
   /// Custom [AuthenticationHandler] used to authenticate users.
   final AuthenticationHandler? authenticationHandler;
@@ -297,7 +300,8 @@ class Serverpod {
     serverId = commandLineArgs.serverId;
 
     // Load passwords
-    _passwords = PasswordManager(runMode: runMode).loadPasswords() ?? {};
+    _passwordManager = PasswordManager(runMode: runMode);
+    _passwords = _passwordManager.loadPasswords() ?? {};
 
     // Load config
     this.config = config ??
@@ -727,6 +731,22 @@ class Serverpod {
   /// config/passwords.yaml file.
   String? getPassword(String key) {
     return _passwords[key];
+  }
+
+  /// Registers passwords to be loaded from the env variables.
+  /// The password can be accessed with the [getPassword] method.
+  /// The envName is the name of the environment variable that
+  /// contains the password. The alias is the key used to access the
+  /// the password with the [getPassword] method.
+  /// The alias also maps to the name in the config/passwords.yaml file.
+  void loadCustomPasswords(
+    List<({String envName, String alias})> envPasswords,
+  ) {
+    _passwords = _passwordManager.mergeCustomPasswords(
+      envPasswords,
+      _passwords,
+      environment: Platform.environment,
+    );
   }
 
   /// Creates a new [InternalSession]. Used to access the database and do

--- a/packages/serverpod_shared/lib/src/password_manager.dart
+++ b/packages/serverpod_shared/lib/src/password_manager.dart
@@ -75,7 +75,7 @@ class PasswordManager {
   /// Merge custom passwords with the existing password collection.
   /// Custom passwords are loaded from the environment variables.
   /// Throws an [ArgumentError] if the custom password configuration contains reserved keywords
-  Map<String, String> mergeCustomPasswords(
+  Map<String, String> mergePasswords(
     List<({String envName, String alias})> config,
     Map<String, String> passwords, {
     Map<String, String> environment = const {},

--- a/packages/serverpod_shared/test/password_manager_test.dart
+++ b/packages/serverpod_shared/test/password_manager_test.dart
@@ -182,23 +182,35 @@ development:
       () {
     var passwordManager = PasswordManager(runMode: 'development');
 
-    var reservedEnvVariables = [
-      'SERVERPOD_DATABASE_PASSWORD',
-      'SERVERPOD_SERVICE_SECRET',
-      'SERVERPOD_REDIS_PASSWORD',
-    ];
+    test('SERVERPOD_DATABASE_PASSWORD', () {
+      expect(
+        () => passwordManager.mergeCustomPasswords(
+          [(envName: 'SERVERPOD_DATABASE_PASSWORD', alias: 'any')],
+          {},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
 
-    for (var envName in reservedEnvVariables) {
-      test(envName, () {
-        expect(
-          () => passwordManager.mergeCustomPasswords(
-            [(envName: envName, alias: 'any')],
-            {},
-          ),
-          throwsA(isA<ArgumentError>()),
-        );
-      });
-    }
+    test('SERVERPOD_SERVICE_SECRET', () {
+      expect(
+        () => passwordManager.mergeCustomPasswords(
+          [(envName: 'SERVERPOD_SERVICE_SECRET', alias: 'any')],
+          {},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('SERVERPOD_REDIS_PASSWORD', () {
+      expect(
+        () => passwordManager.mergeCustomPasswords(
+          [(envName: 'SERVERPOD_REDIS_PASSWORD', alias: 'any')],
+          {},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 
   group(
@@ -206,23 +218,35 @@ development:
       () {
     var passwordManager = PasswordManager(runMode: 'development');
 
-    var reservedAliases = [
-      'database',
-      'serviceSecret',
-      'redis',
-    ];
+    test('database', () {
+      expect(
+        () => passwordManager.mergeCustomPasswords(
+          [(envName: 'ANY_CUSTOM_ENV', alias: 'database')],
+          {},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
 
-    for (var alias in reservedAliases) {
-      test(alias, () {
-        expect(
-          () => passwordManager.mergeCustomPasswords(
-            [(envName: 'ANY_CUSTOM_ENV', alias: alias)],
-            {},
-          ),
-          throwsA(isA<ArgumentError>()),
-        );
-      });
-    }
+    test('serviceSecret', () {
+      expect(
+        () => passwordManager.mergeCustomPasswords(
+          [(envName: 'ANY_CUSTOM_ENV', alias: 'serviceSecret')],
+          {},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('redis', () {
+      expect(
+        () => passwordManager.mergeCustomPasswords(
+          [(envName: 'ANY_CUSTOM_ENV', alias: 'redis')],
+          {},
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 
   test(

--- a/packages/serverpod_shared/test/password_manager_test.dart
+++ b/packages/serverpod_shared/test/password_manager_test.dart
@@ -184,7 +184,7 @@ development:
 
     test('SERVERPOD_DATABASE_PASSWORD', () {
       expect(
-        () => passwordManager.mergeCustomPasswords(
+        () => passwordManager.mergePasswords(
           [(envName: 'SERVERPOD_DATABASE_PASSWORD', alias: 'any')],
           {},
         ),
@@ -194,7 +194,7 @@ development:
 
     test('SERVERPOD_SERVICE_SECRET', () {
       expect(
-        () => passwordManager.mergeCustomPasswords(
+        () => passwordManager.mergePasswords(
           [(envName: 'SERVERPOD_SERVICE_SECRET', alias: 'any')],
           {},
         ),
@@ -204,7 +204,7 @@ development:
 
     test('SERVERPOD_REDIS_PASSWORD', () {
       expect(
-        () => passwordManager.mergeCustomPasswords(
+        () => passwordManager.mergePasswords(
           [(envName: 'SERVERPOD_REDIS_PASSWORD', alias: 'any')],
           {},
         ),
@@ -220,7 +220,7 @@ development:
 
     test('database', () {
       expect(
-        () => passwordManager.mergeCustomPasswords(
+        () => passwordManager.mergePasswords(
           [(envName: 'ANY_CUSTOM_ENV', alias: 'database')],
           {},
         ),
@@ -230,7 +230,7 @@ development:
 
     test('serviceSecret', () {
       expect(
-        () => passwordManager.mergeCustomPasswords(
+        () => passwordManager.mergePasswords(
           [(envName: 'ANY_CUSTOM_ENV', alias: 'serviceSecret')],
           {},
         ),
@@ -240,7 +240,7 @@ development:
 
     test('redis', () {
       expect(
-        () => passwordManager.mergeCustomPasswords(
+        () => passwordManager.mergePasswords(
           [(envName: 'ANY_CUSTOM_ENV', alias: 'redis')],
           {},
         ),
@@ -254,7 +254,7 @@ development:
       () {
     var passwordManager = PasswordManager(runMode: 'development');
 
-    var passwords = passwordManager.mergeCustomPasswords(
+    var passwords = passwordManager.mergePasswords(
       [(envName: 'CUSTOM_PASSWORD_1', alias: 'customPassword1')],
       {},
       environment: {
@@ -270,7 +270,7 @@ development:
       () {
     var passwordManager = PasswordManager(runMode: 'development');
 
-    var passwords = passwordManager.mergeCustomPasswords(
+    var passwords = passwordManager.mergePasswords(
       [(envName: 'CUSTOM_PASSWORD_1', alias: 'customPassword1')],
       {
         'customPassword1': 'default',
@@ -286,7 +286,7 @@ development:
       () {
     var passwordManager = PasswordManager(runMode: 'development');
 
-    var passwords = passwordManager.mergeCustomPasswords(
+    var passwords = passwordManager.mergePasswords(
       [(envName: 'CUSTOM_PASSWORD_1', alias: 'customPassword1')],
       {
         'customPassword1': 'default',
@@ -304,7 +304,7 @@ development:
       () {
     var passwordManager = PasswordManager(runMode: 'development');
 
-    var passwords = passwordManager.mergeCustomPasswords(
+    var passwords = passwordManager.mergePasswords(
       [(envName: 'CUSTOM_PASSWORD_1', alias: 'customPassword1')],
       {
         'database': 'password',


### PR DESCRIPTION
# Adds:

- Ability to register custom environment variable to be loaded into the passwords map managed by serverpod.
- Add custom envs for gcp buckets
- Add custom envs for s3 buckets

Motivation, we need to be able to load our bucket secrets from env and we want to keep these variables outside of the serverpod core. With this solution we can still centralize the logic in Serverpod without adding an implicit dependency to other packages. This also makes it possible for our users to add their own custom envs for passwords. 

Closes: #2691 

Review notes: 
Review commit by commit.
Naming on the public method `loadCustomPasswords` is important to discuss. 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none