### PR TITLE
feat: Add ability to modify maxFileSize and expiration time for gcp and aws buckets.

### DIFF
--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -153,13 +153,21 @@ class GCPS3Uploader {
 
     /// The filename to upload as. If null, defaults to the given file's current filename.
     required String uploadDst,
+    Duration expires = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
     bool public = true,
   }) async {
     final endpoint = 'https://storage.googleapis.com/$bucket';
 
     final policy = Policy.fromS3PresignedPost(
-        uploadDst, bucket, accessKey, 15, 10 * 1024 * 1024,
-        region: region, public: public);
+      uploadDst,
+      bucket,
+      accessKey,
+      expires.inMinutes,
+      maxFileSize,
+      region: region,
+      public: public,
+    );
     final key =
         SigV4.calculateSigningKey(secretKey, policy.datetime, region, 's3');
     final signature = SigV4.calculateSignature(key, policy.encode());

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/cloud_storage/google_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/cloud_storage/google_cloud_storage.dart
@@ -118,6 +118,7 @@ class GoogleCloudStorage extends CloudStorage {
     required Session session,
     required String path,
     Duration expirationDuration = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
   }) async {
     return await GCPS3Uploader.getDirectUploadDescription(
       accessKey: _hmacAccessKeyId,
@@ -125,6 +126,8 @@ class GoogleCloudStorage extends CloudStorage {
       bucket: bucket,
       region: region,
       uploadDst: path,
+      expires: expirationDuration,
+      maxFileSize: maxFileSize,
     );
   }
 

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -156,35 +156,24 @@ class AwsS3Uploader {
 
     /// The filename to upload as. If null, defaults to the given file's current filename.
     required String uploadDst,
+    Duration expires = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
     bool public = true,
   }) async {
     final endpoint = 'https://$bucket.s3-$region.amazonaws.com';
-    // final uploadDest = '$destDir/${filename ?? path.basename(file.path)}';
-
-    // final stream = http.ByteStream.fromBytes(data.buffer.asUint8List());
-
-    // final stream = http.ByteStream(Stream.castFrom(file.openRead()));
-    // final length = data.lengthInBytes;
-
-    // final uri = Uri.parse(endpoint);
-    // final req = http.MultipartRequest("POST", uri);
-    // final multipartFile = http.MultipartFile('file', stream, length, filename: path.basename(uploadDst));
 
     final policy = Policy.fromS3PresignedPost(
-        uploadDst, bucket, accessKey, 15, 10 * 1024 * 1024,
-        region: region, public: public);
+      uploadDst,
+      bucket,
+      accessKey,
+      expires.inMinutes,
+      maxFileSize,
+      region: region,
+      public: public,
+    );
     final key =
         SigV4.calculateSigningKey(secretKey, policy.datetime, region, 's3');
     final signature = SigV4.calculateSignature(key, policy.encode());
-
-    // req.files.add(multipartFile);
-    // req.fields['key'] = policy.key;
-    // req.fields['acl'] = public ? 'public-read' : 'private';
-    // req.fields['X-Amz-Credential'] = policy.credential;
-    // req.fields['X-Amz-Algorithm'] = 'AWS4-HMAC-SHA256';
-    // req.fields['X-Amz-Date'] = policy.datetime;
-    // req.fields['Policy'] = policy.encode();
-    // req.fields['X-Amz-Signature'] = signature;
 
     var uploadDescriptionData = {
       'url': endpoint,
@@ -203,15 +192,5 @@ class AwsS3Uploader {
     };
 
     return jsonEncode(uploadDescriptionData);
-
-    // try {
-    //   final res = await req.send();
-    //
-    //   if (res.statusCode == 204) return '$endpoint/$uploadDst';
-    // } catch (e) {
-    //   print('Failed to upload to AWS, with exception:');
-    //   print(e);
-    //   return null;
-    // }
   }
 }

--- a/integrations/serverpod_cloud_storage_s3/lib/src/cloud_storage.dart/s3_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/cloud_storage.dart/s3_cloud_storage.dart
@@ -118,6 +118,7 @@ class S3CloudStorage extends CloudStorage {
     required Session session,
     required String path,
     Duration expirationDuration = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
   }) async {
     return await AwsS3Uploader.getDirectUploadDescription(
       accessKey: _awsAccessKeyId,
@@ -125,6 +126,8 @@ class S3CloudStorage extends CloudStorage {
       bucket: bucket,
       region: region,
       uploadDst: path,
+      expires: expirationDuration,
+      maxFileSize: maxFileSize,
     );
   }
 

--- a/packages/serverpod/lib/src/cloud_storage/cloud_storage.dart
+++ b/packages/serverpod/lib/src/cloud_storage/cloud_storage.dart
@@ -70,6 +70,7 @@ abstract class CloudStorage {
     required Session session,
     required String path,
     Duration expirationDuration = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
   });
 
   /// Call this method once a direct file upload is completed. Failure to call

--- a/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
+++ b/packages/serverpod/lib/src/cloud_storage/database_cloud_storage.dart
@@ -108,6 +108,7 @@ class DatabaseCloudStorage extends CloudStorage {
     required Session session,
     required String path,
     Duration expirationDuration = const Duration(minutes: 10),
+    int maxFileSize = 10 * 1024 * 1024,
   }) async {
     var config = session.server.serverpod.config;
 


### PR DESCRIPTION
# Changes

Use the expiration time input in the bucket and use it when creating the upload URL for s3 and gcp buckets.
Expose the maxFileSize variable for end users, this was previously hard coded at 10mb with no ability to modify this value.


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._