### PR TITLE
refactor(tests): Change from deprecated member to Namespace.nil for UUID.

### DIFF
--- a/packages/serverpod/test/database/columns/column_uuid_test.dart
+++ b/packages/serverpod/test/database/columns/column_uuid_test.dart
@@ -33,7 +33,7 @@ void main() {
           'when equals compared to uuid value then output is equals expression.',
           () {
         var comparisonExpression = column.equals(
-          UuidValue.fromString(Uuid.NAMESPACE_NIL),
+          Namespace.nil.uuidValue,
         );
 
         expect(
@@ -53,8 +53,7 @@ void main() {
       test(
           'when NOT equals compared to uuid value then output is NOT equals expression.',
           () {
-        var comparisonExpression =
-            column.notEquals(UuidValue.fromString(Uuid.NAMESPACE_NIL));
+        var comparisonExpression = column.notEquals(Namespace.nil.uuidValue);
 
         expect(comparisonExpression.toString(),
             '$column IS DISTINCT FROM \'00000000-0000-0000-0000-000000000000\'');

--- a/packages/serverpod/test/database/columns/column_uuid_test.dart
+++ b/packages/serverpod/test/database/columns/column_uuid_test.dart
@@ -33,7 +33,7 @@ void main() {
           'when equals compared to uuid value then output is equals expression.',
           () {
         var comparisonExpression = column.equals(
-          Namespace.nil.uuidValue,
+          UuidValue.fromString(Uuid.NAMESPACE_NIL),
         );
 
         expect(
@@ -53,7 +53,8 @@ void main() {
       test(
           'when NOT equals compared to uuid value then output is NOT equals expression.',
           () {
-        var comparisonExpression = column.notEquals(Namespace.nil.uuidValue);
+        var comparisonExpression =
+            column.notEquals(UuidValue.fromString(Uuid.NAMESPACE_NIL));
 
         expect(comparisonExpression.toString(),
             '$column IS DISTINCT FROM \'00000000-0000-0000-0000-000000000000\'');

--- a/packages/serverpod/test/database/columns/column_uuid_test.dart
+++ b/packages/serverpod/test/database/columns/column_uuid_test.dart
@@ -33,6 +33,7 @@ void main() {
           'when equals compared to uuid value then output is equals expression.',
           () {
         var comparisonExpression = column.equals(
+          // ignore: deprecated_member_use
           UuidValue.fromString(Uuid.NAMESPACE_NIL),
         );
 
@@ -53,8 +54,10 @@ void main() {
       test(
           'when NOT equals compared to uuid value then output is NOT equals expression.',
           () {
-        var comparisonExpression =
-            column.notEquals(UuidValue.fromString(Uuid.NAMESPACE_NIL));
+        var comparisonExpression = column.notEquals(
+          // ignore: deprecated_member_use
+          UuidValue.fromString(Uuid.NAMESPACE_NIL),
+        );
 
         expect(comparisonExpression.toString(),
             '$column IS DISTINCT FROM \'00000000-0000-0000-0000-000000000000\'');

--- a/tests/serverpod_test_client/test/copy_with_mutable_test.dart
+++ b/tests/serverpod_test_client/test/copy_with_mutable_test.dart
@@ -99,6 +99,7 @@ void main() {
     test(
         'Given an object with an Uuid and a copy of that object when mutating the original then the copy is unmodified.',
         () {
+      // ignore: deprecated_member_use
       var uuid = UuidValue.fromString(Uuid.NAMESPACE_NIL);
 
       var types = Types(aUuid: uuid);
@@ -107,6 +108,7 @@ void main() {
 
       expect(
         typesCopy.aUuid?.uuid,
+        // ignore: deprecated_member_use
         UuidValue.fromString(Uuid.NAMESPACE_NIL).uuid,
       );
     });

--- a/tests/serverpod_test_client/test/copy_with_mutable_test.dart
+++ b/tests/serverpod_test_client/test/copy_with_mutable_test.dart
@@ -99,7 +99,7 @@ void main() {
     test(
         'Given an object with an Uuid and a copy of that object when mutating the original then the copy is unmodified.',
         () {
-      var uuid = UuidValue.fromString(Uuid.NAMESPACE_NIL);
+      var uuid = Namespace.nil.uuidValue;
 
       var types = Types(aUuid: uuid);
       var typesCopy = types.copyWith();
@@ -107,7 +107,7 @@ void main() {
 
       expect(
         typesCopy.aUuid?.uuid,
-        UuidValue.fromString(Uuid.NAMESPACE_NIL).uuid,
+        Namespace.nil.uuidValue.uuid,
       );
     });
 

--- a/tests/serverpod_test_client/test/copy_with_mutable_test.dart
+++ b/tests/serverpod_test_client/test/copy_with_mutable_test.dart
@@ -99,7 +99,7 @@ void main() {
     test(
         'Given an object with an Uuid and a copy of that object when mutating the original then the copy is unmodified.',
         () {
-      var uuid = Namespace.nil.uuidValue;
+      var uuid = UuidValue.fromString(Uuid.NAMESPACE_NIL);
 
       var types = Types(aUuid: uuid);
       var typesCopy = types.copyWith();
@@ -107,7 +107,7 @@ void main() {
 
       expect(
         typesCopy.aUuid?.uuid,
-        Namespace.nil.uuidValue.uuid,
+        UuidValue.fromString(Uuid.NAMESPACE_NIL).uuid,
       );
     });
 

--- a/tests/serverpod_test_server/test/generated_methods/copy_with_mutable_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/copy_with_mutable_test.dart
@@ -100,13 +100,14 @@ void main() {
     test(
         'Given an object with an Uuid and a copy of that object when mutating the original then the copy is unmodified.',
         () {
-      var uuid = Namespace.nil.uuidValue;
+      var uuid = UuidValue.fromString(Uuid.NAMESPACE_NIL);
 
       var types = Types(aUuid: uuid);
       var typesCopy = types.copyWith();
       types.aUuid = UuidValue.fromString(Uuid().v4());
 
-      expect(typesCopy.aUuid?.uuid, Namespace.nil.uuidValue.uuid);
+      expect(
+          typesCopy.aUuid?.uuid, UuidValue.fromString(Uuid.NAMESPACE_NIL).uuid);
     });
 
     test(

--- a/tests/serverpod_test_server/test/generated_methods/copy_with_mutable_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/copy_with_mutable_test.dart
@@ -100,6 +100,7 @@ void main() {
     test(
         'Given an object with an Uuid and a copy of that object when mutating the original then the copy is unmodified.',
         () {
+      // ignore: deprecated_member_use
       var uuid = UuidValue.fromString(Uuid.NAMESPACE_NIL);
 
       var types = Types(aUuid: uuid);
@@ -107,7 +108,9 @@ void main() {
       types.aUuid = UuidValue.fromString(Uuid().v4());
 
       expect(
-          typesCopy.aUuid?.uuid, UuidValue.fromString(Uuid.NAMESPACE_NIL).uuid);
+          typesCopy.aUuid?.uuid,
+          // ignore: deprecated_member_use
+          UuidValue.fromString(Uuid.NAMESPACE_NIL).uuid);
     });
 
     test(

--- a/tests/serverpod_test_server/test/generated_methods/copy_with_mutable_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/copy_with_mutable_test.dart
@@ -100,14 +100,13 @@ void main() {
     test(
         'Given an object with an Uuid and a copy of that object when mutating the original then the copy is unmodified.',
         () {
-      var uuid = UuidValue.fromString(Uuid.NAMESPACE_NIL);
+      var uuid = Namespace.nil.uuidValue;
 
       var types = Types(aUuid: uuid);
       var typesCopy = types.copyWith();
       types.aUuid = UuidValue.fromString(Uuid().v4());
 
-      expect(
-          typesCopy.aUuid?.uuid, UuidValue.fromString(Uuid.NAMESPACE_NIL).uuid);
+      expect(typesCopy.aUuid?.uuid, Namespace.nil.uuidValue.uuid);
     });
 
     test(

--- a/tests/serverpod_test_server/test/generated_methods/to_json_for_protocol.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_for_protocol.dart
@@ -78,7 +78,7 @@ void main() {
   test(
       'Given a class with only nullable fields with a Uuid defined when calling toJsonForProtocol then the key and value is set.',
       () {
-    var types = Types(aUuid: UuidValue.nil);
+    var types = Types(aUuid: Namespace.nil.uuidValue);
 
     var jsonMap = types.toJsonForProtocol();
 
@@ -215,7 +215,7 @@ void main() {
       'Given a class with a List with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
       () {
     var object = TypesList(
-      aUuid: [UuidValue.nil],
+      aUuid: [Namespace.nil.uuidValue],
     );
 
     var jsonMap = object.toJsonForProtocol();
@@ -358,7 +358,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidValue: {'key': UuidValue.nil},
+        aUuidValue: {'key': Namespace.nil.uuidValue},
       );
 
       var jsonMap = object.toJsonForProtocol();
@@ -515,7 +515,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidKey: {UuidValue.nil: 'value'},
+        aUuidKey: {Namespace.nil.uuidValue: 'value'},
       );
 
       var jsonMap = object.toJsonForProtocol();

--- a/tests/serverpod_test_server/test/generated_methods/to_json_for_protocol.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_for_protocol.dart
@@ -78,7 +78,7 @@ void main() {
   test(
       'Given a class with only nullable fields with a Uuid defined when calling toJsonForProtocol then the key and value is set.',
       () {
-    var types = Types(aUuid: Namespace.nil.uuidValue);
+    var types = Types(aUuid: UuidValue.nil);
 
     var jsonMap = types.toJsonForProtocol();
 
@@ -215,7 +215,7 @@ void main() {
       'Given a class with a List with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
       () {
     var object = TypesList(
-      aUuid: [Namespace.nil.uuidValue],
+      aUuid: [UuidValue.nil],
     );
 
     var jsonMap = object.toJsonForProtocol();
@@ -358,7 +358,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidValue: {'key': Namespace.nil.uuidValue},
+        aUuidValue: {'key': UuidValue.nil},
       );
 
       var jsonMap = object.toJsonForProtocol();
@@ -515,7 +515,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidKey: {Namespace.nil.uuidValue: 'value'},
+        aUuidKey: {UuidValue.nil: 'value'},
       );
 
       var jsonMap = object.toJsonForProtocol();

--- a/tests/serverpod_test_server/test/generated_methods/to_json_for_protocol.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_for_protocol.dart
@@ -78,6 +78,7 @@ void main() {
   test(
       'Given a class with only nullable fields with a Uuid defined when calling toJsonForProtocol then the key and value is set.',
       () {
+    // ignore: deprecated_member_use
     var types = Types(aUuid: UuidValue.nil);
 
     var jsonMap = types.toJsonForProtocol();
@@ -215,6 +216,7 @@ void main() {
       'Given a class with a List with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
       () {
     var object = TypesList(
+      // ignore: deprecated_member_use
       aUuid: [UuidValue.nil],
     );
 
@@ -358,6 +360,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
         () {
       var object = TypesMap(
+        // ignore: deprecated_member_use
         aUuidValue: {'key': UuidValue.nil},
       );
 
@@ -515,6 +518,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJsonForProtocol the entire nested structure is converted.',
         () {
       var object = TypesMap(
+        // ignore: deprecated_member_use
         aUuidKey: {UuidValue.nil: 'value'},
       );
 

--- a/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
@@ -78,7 +78,7 @@ void main() {
   test(
       'Given a class with only nullable fields with a Uuid defined when calling toJson then the key and value is set.',
       () {
-    var types = Types(aUuid: UuidValue.nil);
+    var types = Types(aUuid: Namespace.nil.uuidValue);
 
     var jsonMap = types.toJson();
 
@@ -215,7 +215,7 @@ void main() {
       'Given a class with a List with a nested Uuid when calling toJson the entire nested structure is converted.',
       () {
     var object = TypesList(
-      aUuid: [UuidValue.nil],
+      aUuid: [Namespace.nil.uuidValue],
     );
 
     var jsonMap = object.toJson();
@@ -358,7 +358,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidValue: {'key': UuidValue.nil},
+        aUuidValue: {'key': Namespace.nil.uuidValue},
       );
 
       var jsonMap = object.toJson();
@@ -515,7 +515,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidKey: {UuidValue.nil: 'value'},
+        aUuidKey: {Namespace.nil.uuidValue: 'value'},
       );
 
       var jsonMap = object.toJson();

--- a/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
@@ -78,6 +78,7 @@ void main() {
   test(
       'Given a class with only nullable fields with a Uuid defined when calling toJson then the key and value is set.',
       () {
+    // ignore: deprecated_member_use
     var types = Types(aUuid: UuidValue.nil);
 
     var jsonMap = types.toJson();
@@ -215,6 +216,7 @@ void main() {
       'Given a class with a List with a nested Uuid when calling toJson the entire nested structure is converted.',
       () {
     var object = TypesList(
+      // ignore: deprecated_member_use
       aUuid: [UuidValue.nil],
     );
 
@@ -358,6 +360,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
+        // ignore: deprecated_member_use
         aUuidValue: {'key': UuidValue.nil},
       );
 
@@ -515,6 +518,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
+        // ignore: deprecated_member_use
         aUuidKey: {UuidValue.nil: 'value'},
       );
 

--- a/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
+++ b/tests/serverpod_test_server/test/generated_methods/to_json_test.dart
@@ -78,7 +78,7 @@ void main() {
   test(
       'Given a class with only nullable fields with a Uuid defined when calling toJson then the key and value is set.',
       () {
-    var types = Types(aUuid: Namespace.nil.uuidValue);
+    var types = Types(aUuid: UuidValue.nil);
 
     var jsonMap = types.toJson();
 
@@ -215,7 +215,7 @@ void main() {
       'Given a class with a List with a nested Uuid when calling toJson the entire nested structure is converted.',
       () {
     var object = TypesList(
-      aUuid: [Namespace.nil.uuidValue],
+      aUuid: [UuidValue.nil],
     );
 
     var jsonMap = object.toJson();
@@ -358,7 +358,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidValue: {'key': Namespace.nil.uuidValue},
+        aUuidValue: {'key': UuidValue.nil},
       );
 
       var jsonMap = object.toJson();
@@ -515,7 +515,7 @@ void main() {
         'Given a class with a Map with a nested Uuid when calling toJson the entire nested structure is converted.',
         () {
       var object = TypesMap(
-        aUuidKey: {Namespace.nil.uuidValue: 'value'},
+        aUuidKey: {UuidValue.nil: 'value'},
       );
 
       var jsonMap = object.toJson();

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -84,14 +84,14 @@ void main() {
   test(
       'Given a UuidValue as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
-    var object = TypesMap(aUuidKey: {UuidValue.nil: 'value'});
+    var object = TypesMap(aUuidKey: {Namespace.nil.uuidValue: 'value'});
 
     var encodedString = SerializationManager.encode(object);
     var typesMap = Protocol().decode<TypesMap>(encodedString);
 
     expect(
       typesMap.aUuidKey?.entries.first.key,
-      UuidValue.nil,
+      Namespace.nil.uuidValue,
     );
   });
 

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -84,14 +84,14 @@ void main() {
   test(
       'Given a UuidValue as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
-    var object = TypesMap(aUuidKey: {Namespace.nil.uuidValue: 'value'});
+    var object = TypesMap(aUuidKey: {UuidValue.nil: 'value'});
 
     var encodedString = SerializationManager.encode(object);
     var typesMap = Protocol().decode<TypesMap>(encodedString);
 
     expect(
       typesMap.aUuidKey?.entries.first.key,
-      Namespace.nil.uuidValue,
+      UuidValue.nil,
     );
   });
 

--- a/tests/serverpod_test_server/test/serialization_test.dart
+++ b/tests/serverpod_test_server/test/serialization_test.dart
@@ -84,6 +84,7 @@ void main() {
   test(
       'Given a UuidValue as a key in a map when serializing and unpacking the original object remains unchanged.',
       () {
+    // ignore: deprecated_member_use
     var object = TypesMap(aUuidKey: {UuidValue.nil: 'value'});
 
     var encodedString = SerializationManager.encode(object);
@@ -91,6 +92,7 @@ void main() {
 
     expect(
       typesMap.aUuidKey?.entries.first.key,
+      // ignore: deprecated_member_use
       UuidValue.nil,
     );
   });


### PR DESCRIPTION
The UUID package added a deprecation warning to the `Uuid.NAMESPACE_NIL` and `UuidValue.nil` variables.

It is now recommended to use the `Namespace.nil` value from the `Enums.dart` file in the same package.

<img width="701" alt="Screenshot 2024-09-02 at 08 57 12" src="https://github.com/user-attachments/assets/71b1c20a-e30e-478e-8da7-001afe6d6dab">

But since the downgrade version of serverpod doesn't have these values added we ignore this warning for now.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.