### PR TITLE
fix: Add log for when uploads to buckets fails.

### DIFF
--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -61,9 +61,13 @@ class GCPS3Uploader {
     try {
       final res = await req.send();
 
+      if (res.statusCode >= 400 && res.statusCode < 500) {
+        print('Failed to upload to GCP, with reason: ${res.reasonPhrase}');
+      }
+
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {
-      print('Failed to upload to AWS, with exception:');
+      print('Failed to upload to GCP, with exception:');
       print(e);
       return null;
     }
@@ -126,9 +130,13 @@ class GCPS3Uploader {
     try {
       final res = await req.send();
 
+      if (res.statusCode >= 400 && res.statusCode < 500) {
+        print('Failed to upload to GCP, with reason: ${res.reasonPhrase}');
+      }
+
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {
-      print('Failed to upload to AWS, with exception:');
+      print('Failed to upload to GCP, with exception:');
       print(e);
       return null;
     }

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -62,13 +62,14 @@ class GCPS3Uploader {
       final res = await req.send();
 
       if (res.statusCode >= 400 && res.statusCode < 500) {
-        print('Failed to upload to GCP, with reason: ${res.reasonPhrase}');
+        stderr.writeln(
+            'Failed to upload to GCP, with reason: ${res.reasonPhrase}');
       }
 
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {
-      print('Failed to upload to GCP, with exception:');
-      print(e);
+      stderr.writeln('Failed to upload to GCP, with exception:');
+      stderr.writeln(e);
       return null;
     }
     return null;
@@ -131,13 +132,14 @@ class GCPS3Uploader {
       final res = await req.send();
 
       if (res.statusCode >= 400 && res.statusCode < 500) {
-        print('Failed to upload to GCP, with reason: ${res.reasonPhrase}');
+        stderr.writeln(
+            'Failed to upload to GCP, with reason: ${res.reasonPhrase}');
       }
 
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {
-      print('Failed to upload to GCP, with exception:');
-      print(e);
+      stderr.writeln('Failed to upload to GCP, with exception:');
+      stderr.writeln(e);
       return null;
     }
     return null;

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -62,13 +62,15 @@ class AwsS3Uploader {
       final res = await req.send();
 
       if (res.statusCode >= 400 && res.statusCode < 500) {
-        print('Failed to upload to AWS, with reason: ${res.reasonPhrase}');
+        stderr.writeln(
+          'Failed to upload to AWS, with reason: ${res.reasonPhrase}',
+        );
       }
 
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {
-      print('Failed to upload to AWS, with exception:');
-      print(e);
+      stderr.writeln('Failed to upload to AWS, with exception:');
+      stderr.writeln(e);
       return null;
     }
     return null;
@@ -131,13 +133,14 @@ class AwsS3Uploader {
       final res = await req.send();
 
       if (res.statusCode >= 400 && res.statusCode < 500) {
-        print('Failed to upload to AWS, with reason: ${res.reasonPhrase}');
+        stderr.writeln(
+            'Failed to upload to AWS, with reason: ${res.reasonPhrase}');
       }
 
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {
-      print('Failed to upload to AWS, with exception:');
-      print(e);
+      stderr.writeln('Failed to upload to AWS, with exception:');
+      stderr.writeln(e);
       return null;
     }
     return null;

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -61,6 +61,10 @@ class AwsS3Uploader {
     try {
       final res = await req.send();
 
+      if (res.statusCode >= 400 && res.statusCode < 500) {
+        print('Failed to upload to AWS, with reason: ${res.reasonPhrase}');
+      }
+
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {
       print('Failed to upload to AWS, with exception:');
@@ -125,6 +129,10 @@ class AwsS3Uploader {
 
     try {
       final res = await req.send();
+
+      if (res.statusCode >= 400 && res.statusCode < 500) {
+        print('Failed to upload to AWS, with reason: ${res.reasonPhrase}');
+      }
 
       if (res.statusCode == 204) return '$endpoint/$uploadDst';
     } catch (e) {


### PR DESCRIPTION
# Changes

Prints a log when the status code is 4xx when uploading files to a bucket.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none