### PR TITLE
fix: Register cloud storage endpoint for any storageId with db storage.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -417,8 +417,11 @@ class Serverpod {
 
     await runZonedGuarded(() async {
       // Register cloud store endpoint if we're using the database cloud store
-      if (storage['public'] is DatabaseCloudStorage ||
-          storage['private'] is DatabaseCloudStorage) {
+      var hasDatabaseStorage = storage.entries.any(
+        (storage) => storage.value is DatabaseCloudStorage,
+      );
+
+      if (hasDatabaseStorage) {
         CloudStoragePublicEndpoint().register(this);
       }
 


### PR DESCRIPTION
# Fix

Now allows the cloud storage endpoint to be registered even if the database storage is used in a none "private" or "public" id.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none