### PR TITLE
fix: When sending HTTP 400 Bad Request error message to the client, an error message may now be included in the client side exception.

### DIFF
--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -339,6 +339,9 @@ class Server {
       return;
     } else if (result is ResultStatusCode) {
       request.response.statusCode = result.statusCode;
+      if (result.message != null) {
+        request.response.writeln(result.message);
+      }
       await request.response.close();
       return;
     } else if (result is ExceptionResult) {

--- a/packages/serverpod_client/lib/src/serverpod_client_exception.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_exception.dart
@@ -21,7 +21,11 @@ class ServerpodClientException implements Exception {
 /// to the server.
 class ServerpodClientBadRequest extends ServerpodClientException {
   /// Creates a Bad Request Exception
-  ServerpodClientBadRequest() : super('Bad request', HttpStatus.badRequest);
+  ServerpodClientBadRequest([String? message])
+      : super(
+          message != null && message != '' ? message : 'Bad request',
+          HttpStatus.badRequest,
+        );
 }
 
 /// Thrown if the client fails to authenticate and is therefore

--- a/packages/serverpod_client/lib/src/serverpod_client_exception.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_exception.dart
@@ -23,7 +23,7 @@ class ServerpodClientBadRequest extends ServerpodClientException {
   /// Creates a Bad Request Exception
   ServerpodClientBadRequest([String? message])
       : super(
-          message != null && message != '' ? message : 'Bad request',
+          'Bad request${message != null && message != '' ? ': $message' : ''}',
           HttpStatus.badRequest,
         );
 }

--- a/packages/serverpod_client/lib/src/serverpod_client_shared_private.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared_private.dart
@@ -44,7 +44,7 @@ dynamic getExceptionFrom({
   }
 
   return switch (statusCode) {
-    HttpStatus.badRequest => ServerpodClientBadRequest(),
+    HttpStatus.badRequest => ServerpodClientBadRequest(data),
     HttpStatus.unauthorized => ServerpodClientUnauthorized(),
     HttpStatus.forbidden => ServerpodClientForbidden(),
     HttpStatus.notFound => ServerpodClientNotFound(),

--- a/packages/serverpod_client/test/exception_from_test.dart
+++ b/packages/serverpod_client/test/exception_from_test.dart
@@ -87,7 +87,7 @@ void main() {
     });
 
     test('then the message is a bad request', () {
-      expect(exception.message, 'Bad request');
+      expect(exception.message, 'Bad request: malformed data');
     });
   });
 

--- a/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
@@ -137,7 +137,10 @@ void main() async {
       }
       expect(clientException, isNotNull);
       expect(clientException!.statusCode, equals(400));
-      expect(clientException.message, isNotEmpty);
+      expect(
+        clientException.message,
+        startsWith('Bad request: '),
+      );
     });
   });
 }

--- a/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
@@ -137,6 +137,7 @@ void main() async {
       }
       expect(clientException, isNotNull);
       expect(clientException!.statusCode, equals(400));
+      expect(clientException.message, isNotEmpty);
     });
   });
 }


### PR DESCRIPTION
When sending HTTP 400 Bad Request error message to the client, an error message may now be included in the client side exception.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a