### PR TITLE
feat: endpoint and methods for letting a user change its full name.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/client.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/client.dart
@@ -281,6 +281,14 @@ class EndpointUser extends _i1.EndpointRef {
         'changeUserName',
         {'userName': userName},
       );
+
+  /// Changes the full name of a user.
+  _i2.Future<bool> changeFullName(String fullName) =>
+      caller.callServerEndpoint<bool>(
+        'serverpod_auth.user',
+        'changeFullName',
+        {'fullName': fullName},
+      );
 }
 
 class Caller extends _i1.ModuleEndpointCaller {

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/business/users.dart
@@ -39,7 +39,9 @@ class Users {
 
   /// Finds a user by its email address. Returns null if no user is found.
   static Future<UserInfo?> findUserByEmail(
-      Session session, String email) async {
+    Session session,
+    String email,
+  ) async {
     return await UserInfo.db.findFirstRow(
       session,
       where: (t) => t.email.equals(email),
@@ -50,7 +52,9 @@ class Users {
   /// email address. For Apple sign ins, this is a unique identifying string.
   /// Returns null if no user is found.
   static Future<UserInfo?> findUserByIdentifier(
-      Session session, String identifier) async {
+    Session session,
+    String identifier,
+  ) async {
     return await UserInfo.db.findFirstRow(
       session,
       where: (t) => t.userIdentifier.equals(identifier),
@@ -86,7 +90,10 @@ class Users {
 
   /// Updates a users name, returns null if unsuccessful.
   static Future<UserInfo?> changeUserName(
-      Session session, int userId, String newUserName) async {
+    Session session,
+    int userId,
+    String newUserName,
+  ) async {
     var userInfo = await findUserByUserId(session, userId, useCache: false);
     if (userInfo == null) return null;
 
@@ -103,7 +110,10 @@ class Users {
 
   /// Updates a users name, returns null if unsuccessful.
   static Future<UserInfo?> changeFullName(
-      Session session, int userId, String newFullName) async {
+    Session session,
+    int userId,
+    String newFullName,
+  ) async {
     var userInfo = await findUserByUserId(session, userId, useCache: false);
     if (userInfo == null) return null;
 
@@ -159,7 +169,10 @@ class Users {
 
   /// Marks a user as blocked so that they can't log in, and invalidates the
   /// cache for the user, and signs the user out.
-  static Future<void> blockUser(Session session, int userId) async {
+  static Future<void> blockUser(
+    Session session,
+    int userId,
+  ) async {
     var userInfo = await findUserByUserId(session, userId);
     if (userInfo == null) {
       throw 'userId $userId not found';
@@ -175,7 +188,10 @@ class Users {
   }
 
   /// Unblocks a user so that they can log in again.
-  static Future<void> unblockUser(Session session, int userId) async {
+  static Future<void> unblockUser(
+    Session session,
+    int userId,
+  ) async {
     var userInfo = await findUserByUserId(session, userId);
     if (userInfo == null) {
       throw 'userId $userId not found';
@@ -189,7 +205,9 @@ class Users {
   /// Invalidates the cache for a user and makes sure the next time a user info
   /// is fetched it's fresh from the database.
   static Future<void> invalidateCacheForUser(
-      Session session, int userId) async {
+    Session session,
+    int userId,
+  ) async {
     var cacheKey = 'serverpod_auth_userinfo_$userId';
     await session.caches.local.invalidateKey(cacheKey);
   }
@@ -206,10 +224,14 @@ extension UserInfoMethods on UserInfo {
   }
 
   /// Updates the name of this user, returns true if successful.
-  Future<bool> changeUserName(Session session, String newUserName) async {
-    if (id == null) return false;
+  Future<bool> changeUserName(
+    Session session,
+    String newUserName,
+  ) async {
+    var userId = id;
+    if (userId == null) return false;
 
-    var updatedUser = await Users.changeUserName(session, id!, newUserName);
+    var updatedUser = await Users.changeUserName(session, userId, newUserName);
     if (updatedUser == null) return false;
 
     userName = newUserName;
@@ -217,10 +239,14 @@ extension UserInfoMethods on UserInfo {
   }
 
   /// Updates the full name of this user, returns true if successful.
-  Future<bool> changeFullName(Session session, String newUserName) async {
-    if (id == null) return false;
+  Future<bool> changeFullName(
+    Session session,
+    String newUserName,
+  ) async {
+    var userId = id;
+    if (userId == null) return false;
 
-    var updatedUser = await Users.changeFullName(session, id!, newUserName);
+    var updatedUser = await Users.changeFullName(session, userId, newUserName);
     if (updatedUser == null) return false;
 
     userName = newUserName;
@@ -237,7 +263,10 @@ extension UserInfoMethods on UserInfo {
   }
 
   /// Updates the scopes for a user, returns true if successful.
-  Future<bool> updateScopes(Session session, Set<Scope> newScopes) async {
+  Future<bool> updateScopes(
+    Session session,
+    Set<Scope> newScopes,
+  ) async {
     if (id == null) return false;
 
     var updatedUser = await Users.updateUserScopes(session, id!, newScopes);

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/user_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/user_endpoint.dart
@@ -38,4 +38,15 @@ class UserEndpoint extends Endpoint {
 
     return (await Users.changeUserName(session, userId, userName)) != null;
   }
+
+  /// Changes the full name of a user.
+  Future<bool> changeFullName(Session session, String fullName) async {
+    fullName = fullName.trim();
+    if (fullName == '') return false;
+
+    var userId = (await session.authenticated)?.userId;
+    if (userId == null) return false;
+
+    return (await Users.changeFullName(session, userId, fullName)) != null;
+  }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/endpoints.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/endpoints.dart
@@ -467,6 +467,24 @@ class Endpoints extends _i1.EndpointDispatch {
             params['userName'],
           ),
         ),
+        'changeFullName': _i1.MethodConnector(
+          name: 'changeFullName',
+          params: {
+            'fullName': _i1.ParameterDescription(
+              name: 'fullName',
+              type: _i1.getType<String>(),
+              nullable: false,
+            )
+          },
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['user'] as _i8.UserEndpoint).changeFullName(
+            session,
+            params['fullName'],
+          ),
+        ),
       },
     );
   }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.yaml
@@ -25,3 +25,4 @@ user:
   - removeUserImage:
   - setUserImage:
   - changeUserName:
+  - changeFullName:

--- a/tests/serverpod_test_server/test_e2e/auth_module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_module_test.dart
@@ -195,37 +195,37 @@ void main() {
         'Still signed in after teardown',
       );
     });
+
     test('when changing its user name then user name is updated.', () async {
       final currentUserInfo = await client.modules.auth.status.getUserInfo();
       expect(currentUserInfo, isNotNull,
           reason: 'We expect to get UserInfo back from the auth module');
-      final String updatedFullName = '${currentUserInfo?.fullName}updated';
-      expect(currentUserInfo?.userName, isNot(equals(updatedFullName)),
-          reason: 'The new name should not be the same as the current for the '
-              'test to acutally test something.');
+      final String updatedUserName = '${currentUserInfo?.userName}updated';
+
       final result =
-          await client.modules.auth.user.changeUserName(updatedFullName);
+          await client.modules.auth.user.changeUserName(updatedUserName);
       expect(result, equals(true),
           reason: 'The call to changeUserName should return true.');
+
       final updatedUserInfo = await client.modules.auth.status.getUserInfo();
       expect(updatedUserInfo, isNotNull,
           reason: 'We expect to get user Info back from the auth module');
-      expect(updatedUserInfo?.userName, equals(updatedFullName),
+      expect(updatedUserInfo?.userName, equals(updatedUserName),
           reason: 'We expect that the updated name is returned from '
               'the auth module');
     });
+
     test('when changing its full name  then full name is updated.', () async {
       final currentUserInfo = await client.modules.auth.status.getUserInfo();
       expect(currentUserInfo, isNotNull,
           reason: 'We expect to get user Info back from the auth module');
       final String updatedFullName = '${currentUserInfo?.fullName}updated';
-      expect(currentUserInfo?.fullName, isNot(equals(updatedFullName)),
-          reason: 'The new name should not be the same as the current for the '
-              'test to acutally test something.');
+
       final result =
           await client.modules.auth.user.changeFullName(updatedFullName);
       expect(result, equals(true),
           reason: 'The call to changeUserName should return true.');
+
       final updatedUserInfo = await client.modules.auth.status.getUserInfo();
       expect(updatedUserInfo, isNotNull,
           reason: 'We expect to get user Info back from the auth module');

--- a/tests/serverpod_test_server/test_e2e/auth_module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_module_test.dart
@@ -172,4 +172,50 @@ void main() {
       expect(result, equals(true));
     });
   });
+
+  group('Given signed in user that wants to alter its user info', () {
+    setUp(() async {
+      var response = await client.authentication.authenticate(
+        'test@foo.bar',
+        'password',
+      );
+      assert(response.success, 'Failed to authenticate user');
+      await client.authenticationKeyManager
+          ?.put('${response.keyId}:${response.key}');
+      assert(
+          await client.modules.auth.status.isSignedIn(), 'Failed to sign in');
+    });
+
+    tearDown(() async {
+      await client.authenticationKeyManager?.remove();
+      await client.authentication.removeAllUsers();
+      await client.authentication.signOut();
+      assert(
+        await client.modules.auth.status.isSignedIn() == false,
+        'Still signed in after teardown',
+      );
+    });
+    test('when changing its user name it should succeed.', () async {
+      final String newUserName = 'newUserName';
+      var currentUserInfo = await client.modules.auth.status.getUserInfo();
+      var result = await client.modules.auth.user.changeUserName(newUserName);
+      var updatedUserInfo = await client.modules.auth.status.getUserInfo();
+      expect(result, equals(true));
+      expect(currentUserInfo?.userName, isNot(equals(newUserName)),
+          reason: 'The new name should not be the same as the current for the '
+              'test to acutally test something.');
+      expect(updatedUserInfo?.userName, equals(newUserName));
+    });
+    test('when changing its full name it should succeed.', () async {
+      final String newFullName = 'newFullName';
+      var currentUserInfo = await client.modules.auth.status.getUserInfo();
+      var result = await client.modules.auth.user.changeFullName(newFullName);
+      var updatedUserInfo = await client.modules.auth.status.getUserInfo();
+      expect(result, equals(true));
+      expect(currentUserInfo?.fullName, isNot(equals(newFullName)),
+          reason: 'The new name should not be the same as the current for the '
+              'test to acutally test something.');
+      expect(updatedUserInfo?.fullName, equals(newFullName));
+    });
+  });
 }

--- a/tests/serverpod_test_server/test_e2e/auth_module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_module_test.dart
@@ -195,27 +195,43 @@ void main() {
         'Still signed in after teardown',
       );
     });
-    test('when changing its user name it should succeed.', () async {
-      final String newUserName = 'newUserName';
-      var currentUserInfo = await client.modules.auth.status.getUserInfo();
-      var result = await client.modules.auth.user.changeUserName(newUserName);
-      var updatedUserInfo = await client.modules.auth.status.getUserInfo();
-      expect(result, equals(true));
-      expect(currentUserInfo?.userName, isNot(equals(newUserName)),
+    test('when changing its user name then user name is updated.', () async {
+      final currentUserInfo = await client.modules.auth.status.getUserInfo();
+      expect(currentUserInfo, isNotNull,
+          reason: 'We expect to get UserInfo back from the auth module');
+      final String updatedFullName = '${currentUserInfo?.fullName}updated';
+      expect(currentUserInfo?.userName, isNot(equals(updatedFullName)),
           reason: 'The new name should not be the same as the current for the '
               'test to acutally test something.');
-      expect(updatedUserInfo?.userName, equals(newUserName));
+      final result =
+          await client.modules.auth.user.changeUserName(updatedFullName);
+      expect(result, equals(true),
+          reason: 'The call to changeUserName should return true.');
+      final updatedUserInfo = await client.modules.auth.status.getUserInfo();
+      expect(updatedUserInfo, isNotNull,
+          reason: 'We expect to get user Info back from the auth module');
+      expect(updatedUserInfo?.userName, equals(updatedFullName),
+          reason: 'We expect that the updated name is returned from '
+              'the auth module');
     });
-    test('when changing its full name it should succeed.', () async {
-      final String newFullName = 'newFullName';
-      var currentUserInfo = await client.modules.auth.status.getUserInfo();
-      var result = await client.modules.auth.user.changeFullName(newFullName);
-      var updatedUserInfo = await client.modules.auth.status.getUserInfo();
-      expect(result, equals(true));
-      expect(currentUserInfo?.fullName, isNot(equals(newFullName)),
+    test('when changing its full name  then full name is updated.', () async {
+      final currentUserInfo = await client.modules.auth.status.getUserInfo();
+      expect(currentUserInfo, isNotNull,
+          reason: 'We expect to get user Info back from the auth module');
+      final String updatedFullName = '${currentUserInfo?.fullName}updated';
+      expect(currentUserInfo?.fullName, isNot(equals(updatedFullName)),
           reason: 'The new name should not be the same as the current for the '
               'test to acutally test something.');
-      expect(updatedUserInfo?.fullName, equals(newFullName));
+      final result =
+          await client.modules.auth.user.changeFullName(updatedFullName);
+      expect(result, equals(true),
+          reason: 'The call to changeUserName should return true.');
+      final updatedUserInfo = await client.modules.auth.status.getUserInfo();
+      expect(updatedUserInfo, isNotNull,
+          reason: 'We expect to get user Info back from the auth module');
+      expect(updatedUserInfo?.fullName, equals(updatedFullName),
+          reason: 'We expect that the updated name is returned from '
+              'the auth module');
     });
   });
 }


### PR DESCRIPTION
`UserInfo` has the `fullName` instance property, but there is no method of change it in the current version of `serverpod_auth`. This PR adds this functionality.

- [#2723](https://github.com/serverpod/serverpod/issues/2723)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes.