### PR TITLE
fix: makes _buildClassTypeFromJson not typed

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
@@ -380,7 +380,7 @@ Expression _buildClassTypeFromJson(
           config: config,
         )
         .property('fromJson')
-        .call([valueExpression.asA(refer('Map<String, dynamic>'))])
+        .call([valueExpression.asA(refer('dynamic'))])
         .checkIfNull(type, valueExpression: valueExpression)
         .code,
   );


### PR DESCRIPTION
Serverpod should not be opinionated on the `fromJson` parameter type of custom classes.

This PR fix the issue https://github.com/serverpod/serverpod/issues/2715

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes