### PR TITLE
fix: Post revoked authentication events locally if redis is disabled.

### DIFF
--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -643,10 +643,22 @@ class MessageCentralAccess {
         'RevokedAuthenticationAuthId, or RevokedAuthenticationScope',
       );
     }
+
+    try {
+      return await _session.server.messageCentral.postMessage(
+        MessageCentralServerpodChannels.revokedAuthentication(userId),
+        message,
+        global: true,
+      );
+    } on StateError catch (_) {
+      // Throws StateError if Redis is not enabled that is ignored.
+    }
+
+    // If Redis is not enabled, send the message locally.
     return _session.server.messageCentral.postMessage(
       MessageCentralServerpodChannels.revokedAuthentication(userId),
       message,
-      global: true,
+      global: false,
     );
   }
 }

--- a/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
+++ b/tests/serverpod_test_server/test_integration/session/revoked_authentication_test.dart
@@ -7,46 +7,92 @@ import 'package:serverpod_test_server/test_util/test_serverpod.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  late Session session;
-  late Serverpod server;
+  group('Given redis is enabled', () {
+    late Session session;
+    late Serverpod server;
+    setUp(() async {
+      server = IntegrationTestServer.create();
+      await server.start();
+      session = await server.createSession();
+    });
 
-  setUp(() async {
-    server = IntegrationTestServer.create();
-    await server.start();
-    session = await server.createSession();
+    tearDown(() async {
+      await session.close();
+      await server.shutdown(exitProcess: false);
+    });
+
+    test(
+        'and a non valid message type when broadcasting revoked authentication event then exception is thrown',
+        () {
+      expect(
+        () => session.messages.authenticationRevoked(1, EmptyModel()),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+        'and a valid message type when broadcasting revoked authentication event then event is broadcasted',
+        () async {
+      var eventCompleter = Completer<RevokedAuthenticationUser>();
+      session.messages
+          .createStream(
+              MessageCentralServerpodChannels.revokedAuthentication(1))
+          .listen(
+            (event) => eventCompleter.complete(event),
+          );
+
+      var message = RevokedAuthenticationUser();
+      var event = await session.messages.authenticationRevoked(1, message);
+
+      expect(event, isTrue);
+      await expectLater(
+        eventCompleter.future,
+        completion(isA<RevokedAuthenticationUser>()),
+      );
+    });
   });
 
-  tearDown(() async {
-    await session.close();
-    await server.shutdown(exitProcess: false);
-  });
+  group('Given redis is disabled', () {
+    late Session session;
+    late Serverpod server;
+    setUp(() async {
+      server = IntegrationTestServer.create(
+          config: ServerpodConfig(
+              apiServer: ServerConfig(
+        port: 8080,
+        publicHost: 'localhost',
+        publicPort: 8080,
+        publicScheme: 'http',
+      )));
 
-  test(
-      'Given a non valid message type when broadcasting revoked authentication event then exception is thrown',
-      () {
-    expect(
-      () => session.messages.authenticationRevoked(1, EmptyModel()),
-      throwsA(isA<ArgumentError>()),
-    );
-  });
+      await server.start();
+      session = await server.createSession();
+    });
 
-  test(
-      'Given a valid message type when broadcasting revoked authentication event then event is broadcasted',
-      () async {
-    var eventCompleter = Completer<RevokedAuthenticationUser>();
-    session.messages
-        .createStream(MessageCentralServerpodChannels.revokedAuthentication(1))
-        .listen(
-          (event) => eventCompleter.complete(event),
-        );
+    tearDown(() async {
+      await session.close();
+      await server.shutdown(exitProcess: false);
+    });
 
-    var message = RevokedAuthenticationUser();
-    var event = await session.messages.authenticationRevoked(1, message);
+    test(
+        'and a valid message type when broadcasting revoked authentication event then event is broadcasted',
+        () async {
+      var eventCompleter = Completer<RevokedAuthenticationUser>();
+      session.messages
+          .createStream(
+              MessageCentralServerpodChannels.revokedAuthentication(1))
+          .listen(
+            (event) => eventCompleter.complete(event),
+          );
 
-    expect(event, isTrue);
-    await expectLater(
-      eventCompleter.future,
-      completion(isA<RevokedAuthenticationUser>()),
-    );
+      var message = RevokedAuthenticationUser();
+      var event = await session.messages.authenticationRevoked(1, message);
+
+      expect(event, isTrue);
+      await expectLater(
+        eventCompleter.future,
+        completion(isA<RevokedAuthenticationUser>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod/issues/2730

Fixes an issue where authentication revoked messages caused would throw if Redis was disabled.

These messages are now communicated locally if they can not be posted globally.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple fix.