### PR TITLE
fix: Enable starting `Serverpod` without exiting process

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -436,6 +436,9 @@ class Serverpod {
       }, onZoneError);
     } else {
       await _unguardedStart();
+      if (_exitCode != 0) {
+        throw ExitException(_exitCode);
+      }
     }
   }
 

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -408,119 +408,139 @@ class Serverpod {
   int _exitCode = 0;
 
   /// Starts the Serverpod and all [Server]s that it manages.
-  Future<void> start() async {
+  ///
+  /// If [runInGuardedZone] is set to true, the start function will be executed inside `runZonedGuarded`.
+  /// Any errors during the start up sequence will cause the process to exit.
+  /// Any runtime errors will be in their own error zone and will not crash the server.
+  /// If [runInGuardedZone] is set to false, the start function will be executed in the same error zone as the caller.
+  /// An [ExitException] will be thrown if the start up sequence fails.
+  Future<void> start({bool runInGuardedZone = true}) async {
     _startedTime = DateTime.now().toUtc();
 
-    await runZonedGuarded(() async {
-      // Register cloud store endpoint if we're using the database cloud store
-      var hasDatabaseStorage = storage.entries.any(
-        (storage) => storage.value is DatabaseCloudStorage,
-      );
-
-      if (hasDatabaseStorage) {
-        CloudStoragePublicEndpoint().register(this);
+    void onZoneError(Object error, StackTrace stackTrace) {
+      if (error is ExitException) {
+        exit(error.exitCode);
       }
 
-      // It is important that we start the database pool manager before
-      // attempting to connect to the database.
-      _databasePoolManager?.start();
-
-      if (_databasePoolManager == null) {
-        _runtimeSettings = _defaultRuntimeSettings;
-      }
-
-      if (Features.enableMigrations) {
-        await _applyMigrations();
-      } else if (commandLineArgs.applyMigrations ||
-          commandLineArgs.applyRepairMigration) {
-        stderr.writeln(
-          'Migrations are disabled in this project, skipping applying migration(s).',
-        );
-        _exitCode = 1;
-      }
-
-      _updateLogSettings(_runtimeSettings ?? _defaultRuntimeSettings);
-
-      // Connect to Redis
-      if (Features.enableRedis) {
-        logVerbose('Connecting to Redis.');
-        await redisController?.start();
-      } else {
-        logVerbose('Redis is disabled, skipping.');
-      }
-
-      // Start servers.
-      if (commandLineArgs.role == ServerpodRole.monolith ||
-          commandLineArgs.role == ServerpodRole.serverless) {
-        var serversStarted = true;
-
-        // Serverpod Insights.
-        if (Features.enableInsights) {
-          if (_isValidSecret(config.serviceSecret)) {
-            serversStarted &= await _startInsightsServer();
-          } else {
-            stderr.write(
-              'Invalid serviceSecret in password file, Insights server disabled.',
-            );
-          }
-        }
-
-        // Main API server.
-        serversStarted &= await server.start();
-
-        /// Web server.
-        if (Features.enableWebServer(_webServer)) {
-          logVerbose('Starting web server.');
-          serversStarted &= await webServer.start();
-        } else {
-          logVerbose('Web server not configured, skipping.');
-        }
-
-        if (!serversStarted) {
-          _exitCode = 1;
-          stderr.writeln('Failed to start servers.');
-          exit(_exitCode);
-        }
-
-        logVerbose('All servers started.');
-      }
-
-      // Start maintenance tasks. If we are running in maintenance mode, we
-      // will only run the maintenance tasks once. If we are applying migrations
-      // no other maintenance tasks will be run.
-      var appliedMigrations = (commandLineArgs.applyMigrations |
-          commandLineArgs.applyRepairMigration);
-      if (commandLineArgs.role == ServerpodRole.monolith ||
-          (commandLineArgs.role == ServerpodRole.maintenance &&
-              !appliedMigrations)) {
-        logVerbose('Starting maintenance tasks.');
-
-        // Start future calls
-        _completedFutureCalls = _futureCallManager == null;
-        _futureCallManager?.start();
-
-        // Start health check manager
-        _completedHealthChecks = _healthCheckManager == null;
-        await _healthCheckManager?.start();
-      }
-
-      logVerbose('Serverpod start complete.');
-
-      if (commandLineArgs.role == ServerpodRole.maintenance &&
-          appliedMigrations) {
-        logVerbose('Finished applying database migrations.');
-        exit(_exitCode);
-      }
-    }, (e, stackTrace) {
       _exitCode = 1;
-      // Last resort error handling
       // TODO: Log to database?
       stderr.writeln(
         '${DateTime.now().toUtc()} Internal server error. Zoned exception.',
       );
-      stderr.writeln('$e');
+      stderr.writeln('$error');
       stderr.writeln('$stackTrace');
-    });
+    }
+
+    if (runInGuardedZone) {
+      await runZonedGuarded(() async {
+        await _unguardedStart();
+      }, onZoneError);
+    } else {
+      await _unguardedStart();
+    }
+  }
+
+  Future<void> _unguardedStart() async {
+    // Register cloud store endpoint if we're using the database cloud store
+    var hasDatabaseStorage = storage.entries.any(
+      (storage) => storage.value is DatabaseCloudStorage,
+    );
+
+    if (hasDatabaseStorage) {
+      CloudStoragePublicEndpoint().register(this);
+    }
+
+    // It is important that we start the database pool manager before
+    // attempting to connect to the database.
+    _databasePoolManager?.start();
+
+    if (_databasePoolManager == null) {
+      _runtimeSettings = _defaultRuntimeSettings;
+    }
+
+    if (Features.enableMigrations) {
+      await _applyMigrations();
+    } else if (commandLineArgs.applyMigrations ||
+        commandLineArgs.applyRepairMigration) {
+      stderr.writeln(
+        'Migrations are disabled in this project, skipping applying migration(s).',
+      );
+      _exitCode = 1;
+    }
+
+    _updateLogSettings(_runtimeSettings ?? _defaultRuntimeSettings);
+
+    // Connect to Redis
+    if (Features.enableRedis) {
+      logVerbose('Connecting to Redis.');
+      await redisController?.start();
+    } else {
+      logVerbose('Redis is disabled, skipping.');
+    }
+
+    // Start servers.
+    if (commandLineArgs.role == ServerpodRole.monolith ||
+        commandLineArgs.role == ServerpodRole.serverless) {
+      var serversStarted = true;
+
+      // Serverpod Insights.
+      if (Features.enableInsights) {
+        if (_isValidSecret(config.serviceSecret)) {
+          serversStarted &= await _startInsightsServer();
+        } else {
+          stderr.write(
+            'Invalid serviceSecret in password file, Insights server disabled.',
+          );
+        }
+      }
+
+      // Main API server.
+      serversStarted &= await server.start();
+
+      /// Web server.
+      if (Features.enableWebServer(_webServer)) {
+        logVerbose('Starting web server.');
+        serversStarted &= await webServer.start();
+      } else {
+        logVerbose('Web server not configured, skipping.');
+      }
+
+      if (!serversStarted) {
+        throw ExitException(
+          1,
+          'Failed to start the Serverpod servers, see logs for details.',
+        );
+      }
+
+      logVerbose('All servers started.');
+    }
+
+    // Start maintenance tasks. If we are running in maintenance mode, we
+    // will only run the maintenance tasks once. If we are applying migrations
+    // no other maintenance tasks will be run.
+    var appliedMigrations = (commandLineArgs.applyMigrations |
+        commandLineArgs.applyRepairMigration);
+    if (commandLineArgs.role == ServerpodRole.monolith ||
+        (commandLineArgs.role == ServerpodRole.maintenance &&
+            !appliedMigrations)) {
+      logVerbose('Starting maintenance tasks.');
+
+      // Start future calls
+      _completedFutureCalls = _futureCallManager == null;
+      _futureCallManager?.start();
+
+      // Start health check manager
+      _completedHealthChecks = _healthCheckManager == null;
+      await _healthCheckManager?.start();
+    }
+
+    logVerbose('Serverpod start complete.');
+
+    if (commandLineArgs.role == ServerpodRole.maintenance &&
+        appliedMigrations) {
+      logVerbose('Finished applying database migrations.');
+      throw ExitException(_exitCode);
+    }
   }
 
   Future<void> _applyMigrations() async {
@@ -533,11 +553,7 @@ class Serverpod {
         maxAttempts: maxAttempts,
       );
     } catch (e) {
-      _exitCode = 1;
-      stderr.writeln(
-        'Failed to connect to the database. $e',
-      );
-      exit(_exitCode);
+      throw ExitException(1, 'Failed to connect to the database: $e');
     }
 
     try {
@@ -630,7 +646,8 @@ class Serverpod {
   void _checkMaintenanceTasksCompletion() {
     if (_completedFutureCalls && _completedHealthChecks) {
       stdout.writeln('All maintenance tasks completed. Exiting.');
-      exit(_exitCode);
+      // This will exit the process in maintenance mode (and only that mode) after future calls and health checks are done.
+      throw ExitException(_exitCode);
     }
   }
 
@@ -826,6 +843,18 @@ class Serverpod {
   bool _isValidSecret(String? secret) {
     return secret != null && secret.isNotEmpty && secret.length > 20;
   }
+}
+
+/// Exception used to signal a
+class ExitException implements Exception {
+  /// Creates an instance of [ExitException].
+  ExitException(this.exitCode, [this.message = '']);
+
+  /// The error message
+  final String message;
+
+  /// The exit code
+  final int exitCode;
 }
 
 /// Internal methods used by the Serverpod. These methods are not intended to

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -423,7 +423,6 @@ class Serverpod {
       }
 
       _exitCode = 1;
-      // TODO: Log to database?
       stderr.writeln(
         '${DateTime.now().toUtc()} Internal server error. Zoned exception.',
       );

--- a/packages/serverpod_test/lib/src/test_serverpod.dart
+++ b/packages/serverpod_test/lib/src/test_serverpod.dart
@@ -28,19 +28,10 @@ class InternalServerpodSession extends Session {
   });
 }
 
-List<String> _getServerpodStartUpArgs(String? runMode) {
-  List<String> runModeFlag = ['-m', runMode ?? ServerpodRunMode.test];
-
-  // Apply migrations only in test mode.
-  // For other environments it might be unexpected that the tests are applying migrations.
-  List<String> applyMigrationsFlag =
-      runMode == ServerpodRunMode.test ? ['--apply-migrations'] : [];
-
-  return [
-    ...runModeFlag,
-    ...applyMigrationsFlag,
-  ];
-}
+List<String> _getServerpodStartUpArgs(String? runMode) => [
+      '-m',
+      runMode ?? ServerpodRunMode.test,
+    ];
 
 /// A facade for the real Serverpod instance.
 class TestServerpod<T extends InternalTestEndpoints> {
@@ -68,13 +59,13 @@ class TestServerpod<T extends InternalTestEndpoints> {
   Future<void> start() async {
     try {
       await _serverpod.start(runInGuardedZone: false);
-    } on ExitException catch (e, stackTrace) {
+    } on ExitException catch (e) {
       throw InitializationException(
-        'Failed to start the serverpod instance: ${e.message} \n\n $stackTrace',
+        'Failed to start the serverpod instance${e.message.isEmpty ? ', check the log for more info.' : ': ${e.message}'}',
       );
-    } catch (e) {
+    } catch (_) {
       throw InitializationException(
-        'Failed to start the serverpod instance ($e)',
+        'Failed to start the serverpod instance, check the log for more info.',
       );
     }
   }

--- a/packages/serverpod_test/lib/src/test_serverpod.dart
+++ b/packages/serverpod_test/lib/src/test_serverpod.dart
@@ -28,9 +28,11 @@ class InternalServerpodSession extends Session {
   });
 }
 
-List<String> _getServerpodStartUpArgs(String? runMode) => [
+List<String> _getServerpodStartUpArgs(String? runMode, bool? applyMigrations) =>
+    [
       '-m',
       runMode ?? ServerpodRunMode.test,
+      if (applyMigrations ?? true) '--apply-migrations',
     ];
 
 /// A facade for the real Serverpod instance.
@@ -46,8 +48,12 @@ class TestServerpod<T extends InternalTestEndpoints> {
     required SerializationManagerServer serializationManager,
     required EndpointDispatch endpoints,
     String? runMode,
+    bool? applyMigrations,
   }) : _serverpod = Serverpod(
-          _getServerpodStartUpArgs(runMode),
+          _getServerpodStartUpArgs(
+            runMode,
+            applyMigrations,
+          ),
           serializationManager,
           endpoints,
         ) {

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -68,6 +68,7 @@ withServerpod(
   _i1.RollbackDatabase? rollbackDatabase,
   String? runMode,
   bool? enableSessionLogging,
+  bool? applyMigrations,
 }) {
   _i1.buildWithServerpod<_InternalTestEndpoints>(
     testGroupName,
@@ -76,6 +77,7 @@ withServerpod(
       endpoints: Endpoints(),
       serializationManager: Protocol(),
       runMode: runMode,
+      applyMigrations: applyMigrations,
     ),
     maybeResetTestSessions: resetTestSessions,
     maybeRollbackDatabase: rollbackDatabase,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -2,6 +2,7 @@ import 'package:code_builder/code_builder.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/generator/shared.dart';
 
 class ServerTestToolsGenerator {
@@ -367,6 +368,11 @@ class ServerTestToolsGenerator {
             ..name = 'enableSessionLogging'
             ..named = true
             ..type = refer('bool?')),
+          if (config.isFeatureEnabled(ServerpodFeature.database))
+            Parameter((p) => p
+              ..name = 'applyMigrations'
+              ..named = true
+              ..type = refer('bool?')),
         ])
         ..body = refer(
                 'buildWithServerpod<_InternalTestEndpoints>', serverpodTestUrl)
@@ -381,6 +387,10 @@ class ServerTestToolsGenerator {
                 'endpoints': refer('Endpoints').newInstance([]),
                 'serializationManager': refer('Protocol').newInstance([]),
                 'runMode': refer('runMode'),
+                'applyMigrations':
+                    config.isFeatureEnabled(ServerpodFeature.database)
+                        ? refer('applyMigrations')
+                        : literalBool(false),
               },
             ),
           ],

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
@@ -75,6 +75,7 @@ void main() {
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  String\? runMode,\n'
               r'  bool\? enableSessionLogging,\n'
+              r'  bool\? applyMigrations,\n'
               r'\}\)',
             ));
       },
@@ -96,6 +97,54 @@ void main() {
             testToolsFile,
             matches(
                 r'class _InternalTestEndpoints extends TestEndpoints\n\s*implements _i\d\.InternalTestEndpoints \{\n'));
+      },
+      skip: testToolsFile == null,
+    );
+  });
+
+  group(
+      'Given protocol definition without endpoints when generating test tools file for Serverpod mini',
+      () {
+    var serverpodMiniConfig = GeneratorConfigBuilder()
+        .withName(projectName)
+        .withRelativeServerTestToolsPathParts(
+      [
+        'integration_test',
+        'test_tools',
+      ],
+    ).withEnabledFeatures([]).build();
+    var protocolDefinition = const ProtocolDefinition(
+      endpoints: [],
+      models: [],
+    );
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: serverpodMiniConfig,
+    );
+
+    test('then test tools file is created.', () {
+      expect(codeMap, contains(expectedFileName));
+    });
+
+    var testToolsFile = codeMap[expectedFileName];
+
+    test(
+      'then test tools file has `withServerpod` function without `applyMigrations` parameter',
+      () {
+        expect(
+            testToolsFile,
+            matches(
+              r'@_i\d\.isTestGroup\n'
+              r'withServerpod\(\n'
+              r'  String testGroupName,\n'
+              r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
+              r'  _i\d\.ResetTestSessions\? resetTestSessions,\n'
+              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
+              r'  String\? runMode,\n'
+              r'  bool\? enableSessionLogging,\n'
+              r'\}\)',
+            ));
       },
       skip: testToolsFile == null,
     );
@@ -140,6 +189,7 @@ void main() {
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  String\? runMode,\n'
               r'  bool\? enableSessionLogging,\n'
+              r'  bool\? applyMigrations,\n'
               r'\}\)',
             ));
       },
@@ -219,6 +269,7 @@ void main() {
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  String\? runMode,\n'
               r'  bool\? enableSessionLogging,\n'
+              r'  bool\? applyMigrations,\n'
               r'\}\)',
             ));
       },


### PR DESCRIPTION
## Description
As a prerequisite to enabling the new `test` run mode, the `withServerpod` test tool helper needs to be able to try to `--apply-migrations` when starting `Serverpod`. This can fail, and if that happens the test should simply fail as well. Currently the process is instead exited and the test runner is closed. 

Closes #2725. 

## Changes
- Adds an optional `runInGuardedZone` flag to `start` that can be set to false. Defaults to `true` to keep behavior.
- When running without the guarded zone, errors will surface to the caller of `start` instead of being kept within the guarded zone
- Adds a demonstrative test that is skipped, since it's not possible to create a test for this case.

## Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.