### PR TITLE
fix: Allow event listeners to remove themselves inside their handler

### DIFF
--- a/packages/serverpod/lib/src/server/message_central.dart
+++ b/packages/serverpod/lib/src/server/message_central.dart
@@ -58,7 +58,7 @@ class MessageCentral {
       var channel = _channels[channelName];
       if (channel == null) return true;
 
-      for (var callback in channel) {
+      for (var callback in channel.toList()) {
         callback(message);
       }
       return true;


### PR DESCRIPTION
## Description
Fixes #2754. The revoked authentication handler removed itself inside its event handler, causing an exception to be thrown:
```log
Concurrent modification during iteration: _Set len:0.
#0      _CompactIterator.moveNext (dart:collection-patch/compact_hash.dart:714:7)
#1      MessageCentral.postMessage (package:serverpod/src/server/message_central.dart:61:28)
```
This stopped the iteration and prevented all handlers to be called. 

💡 Note that this exception was silently failing because the server will not shutdown on exceptions, but it was visible in the server log

## Changes
- Simply adds `.toList` to the callback list to create a copy. This allows the event handler to remove itself (or indeed add new handlers).
- Adds test cases which were failing before the fix (by timeout, since the second stream was never closed).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.