### PR TITLE
fix: updated script shebangs to `/bin/bash` from `/bin/sh`.

### DIFF
--- a/examples/auth_example/auth_example_server/aws/scripts/run_serverpod
+++ b/examples/auth_example/auth_example_server/aws/scripts/run_serverpod
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 RUNMODE=$(cat /home/ec2-user/runmode)
 SERVER_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 cd /home/ec2-user/serverpod/active/auth_example_server

--- a/examples/chat/chat_server/aws/scripts/run_serverpod
+++ b/examples/chat/chat_server/aws/scripts/run_serverpod
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 RUNMODE=$(cat /home/ec2-user/runmode)
 SERVER_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 cd /home/ec2-user/serverpod/active/chat_server

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/run_serverpod
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/aws/scripts/run_serverpod
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 RUNMODE=$(cat /home/ec2-user/runmode)
 SERVER_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 cd /home/ec2-user/serverpod/active/projectname_server

--- a/templates/serverpod_templates/projectname_server_upgrade/deploy/gcp/console_gcr/cloud-run-deploy.sh
+++ b/templates/serverpod_templates/projectname_server_upgrade/deploy/gcp/console_gcr/cloud-run-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # These are the variables that need to be set to be able to deploy to cloud run.
 # You can find the values in the Google Cloud Console.

--- a/tests/docker/tests_e2e/run-tests.sh
+++ b/tests/docker/tests_e2e/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Makes script exit on first non-zero error code
 set -e

--- a/tests/docker/tests_e2e/start-server.sh
+++ b/tests/docker/tests_e2e/start-server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Wait for database to be up (timeout after 60 seconds)
 echo "### Wait for Postgres"

--- a/tests/docker/tests_e2e_migrations/run-tests.sh
+++ b/tests/docker/tests_e2e_migrations/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Makes script exit on first non-zero error code
 set -e

--- a/tests/docker/tests_e2e_migrations/start-server.sh
+++ b/tests/docker/tests_e2e_migrations/start-server.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Wait for database to be up (timeout after 60 seconds)
 echo "### Wait for Postgres"

--- a/tests/docker/tests_integration/run_tests.sh
+++ b/tests/docker/tests_integration/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Wait for database to be up (timeout after 60 seconds)
 echo "### Wait for Postgres"

--- a/util/generate_all
+++ b/util/generate_all
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/pub_get_all
+++ b/util/pub_get_all
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/publish_all
+++ b/util/publish_all
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/recreate_all_migrations
+++ b/util/recreate_all_migrations
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests
+++ b/util/run_tests
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests_analyze
+++ b/util/run_tests_analyze
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests_bootstrap
+++ b/util/run_tests_bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests_e2e
+++ b/util/run_tests_e2e
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests_integration
+++ b/util/run_tests_integration
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests_migrations_e2e
+++ b/util/run_tests_migrations_e2e
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests_serverpod_generate
+++ b/util/run_tests_serverpod_generate
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Makes script exit on first non-zero error code
 set -e

--- a/util/run_tests_unit
+++ b/util/run_tests_unit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"

--- a/util/run_tests_update_pubspecs
+++ b/util/run_tests_update_pubspecs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Makes script exit on first non-zero error code
 set -e

--- a/util/update_pubspecs
+++ b/util/update_pubspecs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f util/.serverpod_util_root ]; then
     echo "Run this script from the root of the Serverpod repository"


### PR DESCRIPTION
As described in [2743](https://github.com/serverpod/serverpod/issues/2743), the use of array declarations in some scripts breaks when using some `bash` versions.

_List which issues are fixed by this PR. You must list at least one issue._
[2743](https://github.com/serverpod/serverpod/issues/2743)

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Testing

Since this is internal tooling, the scripts needs to be tested in the corresponding CI/CD pipes to make sure that everything works as expected.