### PR TITLE
fix(authentication): Correctly checks settings before letting a user change name or image.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/user_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/endpoints/user_endpoint.dart
@@ -17,12 +17,20 @@ class UserEndpoint extends Endpoint {
   /// Removes the users uploaded image, replacing it with the default user
   /// image.
   Future<bool> removeUserImage(Session session) async {
+    if (!AuthConfig.current.userCanEditUserImage) {
+      return false;
+    }
+
     var userId = (await session.authenticated)?.userId;
     return await UserImages.setDefaultUserImage(session, userId!);
   }
 
   /// Sets a new user image for the signed in user.
   Future<bool> setUserImage(Session session, ByteData image) async {
+    if (!AuthConfig.current.userCanEditUserImage) {
+      return false;
+    }
+
     var userId = (await session.authenticated)?.userId;
     return await UserImages.setUserImageFromBytes(
         session, userId!, image.buffer.asUint8List());
@@ -30,6 +38,10 @@ class UserEndpoint extends Endpoint {
 
   /// Changes the name of a user.
   Future<bool> changeUserName(Session session, String userName) async {
+    if (!AuthConfig.current.userCanEditUserName) {
+      return false;
+    }
+
     userName = userName.trim();
     if (userName == '') return false;
 
@@ -41,6 +53,10 @@ class UserEndpoint extends Endpoint {
 
   /// Changes the full name of a user.
   Future<bool> changeFullName(Session session, String fullName) async {
+    if (!AuthConfig.current.userCanEditFullName) {
+      return false;
+    }
+
     fullName = fullName.trim();
     if (fullName == '') return false;
 

--- a/tests/serverpod_test_server/lib/server.dart
+++ b/tests/serverpod_test_server/lib/server.dart
@@ -41,6 +41,7 @@ void run(List<String> args) async {
       print('Sending reset email to ${userInfo.email} with code $resetCode');
       return true;
     },
+    userCanEditFullName: true,
   ));
 
   // Add route to web server


### PR DESCRIPTION
Respect the auth configuration allowing users to change their userName, fullName and userImage.

Closes: https://github.com/serverpod/serverpod/issues/2746

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

Bugfix that fixes a security issue.