### PR TITLE
refactor: TableRow implementation

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Represents a chat channel.
 abstract class Channel implements _i1.TableRow, _i1.ProtocolSerialization {
   Channel._({
-    int? id,
+    this.id,
     required this.name,
     required this.channel,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Channel({
     int? id,
@@ -39,23 +37,14 @@ abstract class Channel implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = ChannelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The name of the channel.
   String name;
 
   /// The id of the channel.
   String channel;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -12,13 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Represents a chat channel.
-abstract class Channel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Channel implements _i1.TableRow, _i1.ProtocolSerialization {
   Channel._({
     int? id,
     required this.name,
     required this.channel,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Channel({
     int? id,
@@ -38,11 +39,23 @@ abstract class Channel extends _i1.TableRow
 
   static const db = ChannelRepository._();
 
+  int? _id;
+
   /// The name of the channel.
   String name;
 
   /// The id of the channel.
   String channel;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
@@ -14,15 +14,13 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Provides a method of access for a user to authenticate with the server.
 abstract class AuthKey implements _i1.TableRow, _i1.ProtocolSerialization {
   AuthKey._({
-    int? id,
+    this.id,
     required this.userId,
     required this.hash,
     this.key,
     required this.scopeNames,
     required this.method,
-  }) {
-    _id = id;
-  }
+  });
 
   factory AuthKey({
     int? id,
@@ -50,7 +48,8 @@ abstract class AuthKey implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = AuthKeyRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The id of the user to provide access to.
   int userId;
@@ -67,16 +66,6 @@ abstract class AuthKey implements _i1.TableRow, _i1.ProtocolSerialization {
   /// The method of signing in this key was generated through. This can be email
   /// or different social logins.
   String method;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
@@ -12,8 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Provides a method of access for a user to authenticate with the server.
-abstract class AuthKey extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class AuthKey implements _i1.TableRow, _i1.ProtocolSerialization {
   AuthKey._({
     int? id,
     required this.userId,
@@ -21,7 +20,9 @@ abstract class AuthKey extends _i1.TableRow
     this.key,
     required this.scopeNames,
     required this.method,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory AuthKey({
     int? id,
@@ -49,6 +50,8 @@ abstract class AuthKey extends _i1.TableRow
 
   static const db = AuthKeyRepository._();
 
+  int? _id;
+
   /// The id of the user to provide access to.
   int userId;
 
@@ -64,6 +67,16 @@ abstract class AuthKey extends _i1.TableRow
   /// The method of signing in this key was generated through. This can be email
   /// or different social logins.
   String method;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Database bindings for a sign in with email.
-abstract class EmailAuth extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EmailAuth implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailAuth._({
     int? id,
     required this.userId,
     required this.email,
     required this.hash,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory EmailAuth({
     int? id,
@@ -41,6 +42,8 @@ abstract class EmailAuth extends _i1.TableRow
 
   static const db = EmailAuthRepository._();
 
+  int? _id;
+
   /// The id of the user, corresponds to the id field in [UserInfo].
   int userId;
 
@@ -49,6 +52,16 @@ abstract class EmailAuth extends _i1.TableRow
 
   /// The hashed password of the user.
   String hash;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -14,13 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Database bindings for a sign in with email.
 abstract class EmailAuth implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailAuth._({
-    int? id,
+    this.id,
     required this.userId,
     required this.email,
     required this.hash,
-  }) {
-    _id = id;
-  }
+  });
 
   factory EmailAuth({
     int? id,
@@ -42,7 +40,8 @@ abstract class EmailAuth implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = EmailAuthRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The id of the user, corresponds to the id field in [UserInfo].
   int userId;
@@ -52,16 +51,6 @@ abstract class EmailAuth implements _i1.TableRow, _i1.ProtocolSerialization {
 
   /// The hashed password of the user.
   String hash;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -16,14 +16,12 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class EmailCreateAccountRequest
     implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailCreateAccountRequest._({
-    int? id,
+    this.id,
     required this.userName,
     required this.email,
     required this.hash,
     required this.verificationCode,
-  }) {
-    _id = id;
-  }
+  });
 
   factory EmailCreateAccountRequest({
     int? id,
@@ -48,7 +46,8 @@ abstract class EmailCreateAccountRequest
 
   static const db = EmailCreateAccountRequestRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The name of the user.
   String userName;
@@ -61,16 +60,6 @@ abstract class EmailCreateAccountRequest
 
   /// The verification code sent to the user.
   String verificationCode;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -13,15 +13,17 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 /// A request for creating an email signin. Created during the sign up process
 /// to keep track of the user's details and verification code.
-abstract class EmailCreateAccountRequest extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EmailCreateAccountRequest
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailCreateAccountRequest._({
     int? id,
     required this.userName,
     required this.email,
     required this.hash,
     required this.verificationCode,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory EmailCreateAccountRequest({
     int? id,
@@ -46,6 +48,8 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow
 
   static const db = EmailCreateAccountRequestRepository._();
 
+  int? _id;
+
   /// The name of the user.
   String userName;
 
@@ -57,6 +61,16 @@ abstract class EmailCreateAccountRequest extends _i1.TableRow
 
   /// The verification code sent to the user.
   String verificationCode;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -16,13 +16,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class EmailFailedSignIn
     implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailFailedSignIn._({
-    int? id,
+    this.id,
     required this.email,
     required this.time,
     required this.ipAddress,
-  }) {
-    _id = id;
-  }
+  });
 
   factory EmailFailedSignIn({
     int? id,
@@ -44,7 +42,8 @@ abstract class EmailFailedSignIn
 
   static const db = EmailFailedSignInRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// Email attempting to sign in with.
   String email;
@@ -54,16 +53,6 @@ abstract class EmailFailedSignIn
 
   /// The IP address of the sign in attempt.
   String ipAddress;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -13,14 +13,16 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Database table for tracking failed email sign-ins. Saves IP-address, time,
 /// and email to be prevent brute force attacks.
-abstract class EmailFailedSignIn extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EmailFailedSignIn
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailFailedSignIn._({
     int? id,
     required this.email,
     required this.time,
     required this.ipAddress,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory EmailFailedSignIn({
     int? id,
@@ -42,6 +44,8 @@ abstract class EmailFailedSignIn extends _i1.TableRow
 
   static const db = EmailFailedSignInRepository._();
 
+  int? _id;
+
   /// Email attempting to sign in with.
   String email;
 
@@ -50,6 +54,16 @@ abstract class EmailFailedSignIn extends _i1.TableRow
 
   /// The IP address of the sign in attempt.
   String ipAddress;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -14,13 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Database bindings for an email reset.
 abstract class EmailReset implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailReset._({
-    int? id,
+    this.id,
     required this.userId,
     required this.verificationCode,
     required this.expiration,
-  }) {
-    _id = id;
-  }
+  });
 
   factory EmailReset({
     int? id,
@@ -43,7 +41,8 @@ abstract class EmailReset implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = EmailResetRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The id of the user that is resetting his/her password.
   int userId;
@@ -53,16 +52,6 @@ abstract class EmailReset implements _i1.TableRow, _i1.ProtocolSerialization {
 
   /// The expiration time for the password reset.
   DateTime expiration;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Database bindings for an email reset.
-abstract class EmailReset extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EmailReset implements _i1.TableRow, _i1.ProtocolSerialization {
   EmailReset._({
     int? id,
     required this.userId,
     required this.verificationCode,
     required this.expiration,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory EmailReset({
     int? id,
@@ -42,6 +43,8 @@ abstract class EmailReset extends _i1.TableRow
 
   static const db = EmailResetRepository._();
 
+  int? _id;
+
   /// The id of the user that is resetting his/her password.
   int userId;
 
@@ -50,6 +53,16 @@ abstract class EmailReset extends _i1.TableRow
 
   /// The expiration time for the password reset.
   DateTime expiration;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Database bindings for a Google refresh token.
-abstract class GoogleRefreshToken extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class GoogleRefreshToken
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   GoogleRefreshToken._({
     int? id,
     required this.userId,
     required this.refreshToken,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory GoogleRefreshToken({
     int? id,
@@ -38,11 +40,23 @@ abstract class GoogleRefreshToken extends _i1.TableRow
 
   static const db = GoogleRefreshTokenRepository._();
 
+  int? _id;
+
   /// The user id associated with the token.
   int userId;
 
   /// The token itself.
   String refreshToken;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -15,12 +15,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class GoogleRefreshToken
     implements _i1.TableRow, _i1.ProtocolSerialization {
   GoogleRefreshToken._({
-    int? id,
+    this.id,
     required this.userId,
     required this.refreshToken,
-  }) {
-    _id = id;
-  }
+  });
 
   factory GoogleRefreshToken({
     int? id,
@@ -40,23 +38,14 @@ abstract class GoogleRefreshToken
 
   static const db = GoogleRefreshTokenRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The user id associated with the token.
   int userId;
 
   /// The token itself.
   String refreshToken;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Database bindings for a user image.
-abstract class UserImage extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UserImage implements _i1.TableRow, _i1.ProtocolSerialization {
   UserImage._({
     int? id,
     required this.userId,
     required this.version,
     required this.url,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UserImage({
     int? id,
@@ -41,6 +42,8 @@ abstract class UserImage extends _i1.TableRow
 
   static const db = UserImageRepository._();
 
+  int? _id;
+
   /// The id of the user.
   int userId;
 
@@ -49,6 +52,16 @@ abstract class UserImage extends _i1.TableRow
 
   /// The URL to the image.
   String url;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -14,13 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Database bindings for a user image.
 abstract class UserImage implements _i1.TableRow, _i1.ProtocolSerialization {
   UserImage._({
-    int? id,
+    this.id,
     required this.userId,
     required this.version,
     required this.url,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UserImage({
     int? id,
@@ -42,7 +40,8 @@ abstract class UserImage implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = UserImageRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The id of the user.
   int userId;
@@ -52,16 +51,6 @@ abstract class UserImage implements _i1.TableRow, _i1.ProtocolSerialization {
 
   /// The URL to the image.
   String url;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -16,8 +16,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// If you need to share a user's info with other users, use the
 /// [UserInfoPublic] instead. You can retrieve a [UserInfoPublic] through the
 /// toPublic() method.
-abstract class UserInfo extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UserInfo implements _i1.TableRow, _i1.ProtocolSerialization {
   UserInfo._({
     int? id,
     required this.userIdentifier,
@@ -28,7 +27,9 @@ abstract class UserInfo extends _i1.TableRow
     this.imageUrl,
     required this.scopeNames,
     required this.blocked,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UserInfo({
     int? id,
@@ -62,6 +63,8 @@ abstract class UserInfo extends _i1.TableRow
 
   static const db = UserInfoRepository._();
 
+  int? _id;
+
   /// Unique identifier of the user, may contain different information depending
   /// on how the user was created.
   String userIdentifier;
@@ -86,6 +89,16 @@ abstract class UserInfo extends _i1.TableRow
 
   /// True if the user is blocked from signing in.
   bool blocked;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -18,7 +18,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// toPublic() method.
 abstract class UserInfo implements _i1.TableRow, _i1.ProtocolSerialization {
   UserInfo._({
-    int? id,
+    this.id,
     required this.userIdentifier,
     this.userName,
     this.fullName,
@@ -27,9 +27,7 @@ abstract class UserInfo implements _i1.TableRow, _i1.ProtocolSerialization {
     this.imageUrl,
     required this.scopeNames,
     required this.blocked,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UserInfo({
     int? id,
@@ -63,7 +61,8 @@ abstract class UserInfo implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = UserInfoRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// Unique identifier of the user, may contain different information depending
   /// on how the user was created.
@@ -89,16 +88,6 @@ abstract class UserInfo implements _i1.TableRow, _i1.ProtocolSerialization {
 
   /// True if the user is blocked from signing in.
   bool blocked;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -14,8 +14,7 @@ import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
 import 'protocol.dart' as _i3;
 
 /// A chat message.
-abstract class ChatMessage extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ChatMessage implements _i1.TableRow, _i1.ProtocolSerialization {
   ChatMessage._({
     int? id,
     required this.channel,
@@ -27,7 +26,9 @@ abstract class ChatMessage extends _i1.TableRow
     this.clientMessageId,
     this.sent,
     this.attachments,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ChatMessage({
     int? id,
@@ -67,6 +68,8 @@ abstract class ChatMessage extends _i1.TableRow
 
   static const db = ChatMessageRepository._();
 
+  int? _id;
+
   /// The channel this message was posted to.
   String channel;
 
@@ -93,6 +96,16 @@ abstract class ChatMessage extends _i1.TableRow
 
   /// List of attachments associated with this message.
   List<_i3.ChatMessageAttachment>? attachments;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -16,7 +16,7 @@ import 'protocol.dart' as _i3;
 /// A chat message.
 abstract class ChatMessage implements _i1.TableRow, _i1.ProtocolSerialization {
   ChatMessage._({
-    int? id,
+    this.id,
     required this.channel,
     required this.message,
     required this.time,
@@ -26,9 +26,7 @@ abstract class ChatMessage implements _i1.TableRow, _i1.ProtocolSerialization {
     this.clientMessageId,
     this.sent,
     this.attachments,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ChatMessage({
     int? id,
@@ -68,7 +66,8 @@ abstract class ChatMessage implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = ChatMessageRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The channel this message was posted to.
   String channel;
@@ -96,16 +95,6 @@ abstract class ChatMessage implements _i1.TableRow, _i1.ProtocolSerialization {
 
   /// List of attachments associated with this message.
   List<_i3.ChatMessageAttachment>? attachments;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -15,13 +15,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ChatReadMessage
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ChatReadMessage._({
-    int? id,
+    this.id,
     required this.channel,
     required this.userId,
     required this.lastReadMessageId,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ChatReadMessage({
     int? id,
@@ -43,7 +41,8 @@ abstract class ChatReadMessage
 
   static const db = ChatReadMessageRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The channel this that has been read.
   String channel;
@@ -53,16 +52,6 @@ abstract class ChatReadMessage
 
   /// The id of the last read message.
   int lastReadMessageId;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Message to notify the server that messages have been read.
-abstract class ChatReadMessage extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ChatReadMessage
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ChatReadMessage._({
     int? id,
     required this.channel,
     required this.userId,
     required this.lastReadMessageId,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ChatReadMessage({
     int? id,
@@ -41,6 +43,8 @@ abstract class ChatReadMessage extends _i1.TableRow
 
   static const db = ChatReadMessageRepository._();
 
+  int? _id;
+
   /// The channel this that has been read.
   String channel;
 
@@ -49,6 +53,16 @@ abstract class ChatReadMessage extends _i1.TableRow
 
   /// The id of the last read message.
   int lastReadMessageId;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/database/concepts/table.dart
+++ b/packages/serverpod/lib/src/database/concepts/table.dart
@@ -5,13 +5,11 @@ import 'package:serverpod_serialization/serverpod_serialization.dart';
 /// Holds data corresponding to a row in the database. Concrete classes are
 /// typically generated. Instances of [TableRow] can also be serialized and
 /// either passed to clients or cached.
-abstract class TableRow implements SerializableModel {
-  /// Create a new TableRow object.
-  TableRow([this.id]);
-
+abstract interface class TableRow implements SerializableModel {
   /// The id column of the row. Can be null if this row is not yet stored in
   /// the database.
-  int? id;
+  int? get id;
+  set id(int? value);
 
   /// The table that this row belongs to.
   Table get table;

--- a/packages/serverpod/lib/src/database/concepts/table.dart
+++ b/packages/serverpod/lib/src/database/concepts/table.dart
@@ -8,8 +8,7 @@ import 'package:serverpod_serialization/serverpod_serialization.dart';
 abstract interface class TableRow implements SerializableModel {
   /// The id column of the row. Can be null if this row is not yet stored in
   /// the database.
-  int? get id;
-  set id(int? value);
+  int? id;
 
   /// The table that this row belongs to.
   Table get table;

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -16,16 +16,14 @@ import 'dart:typed_data' as _i2;
 abstract class CloudStorageEntry
     implements _i1.TableRow, _i1.ProtocolSerialization {
   CloudStorageEntry._({
-    int? id,
+    this.id,
     required this.storageId,
     required this.path,
     required this.addedTime,
     this.expiration,
     required this.byteData,
     required this.verified,
-  }) {
-    _id = id;
-  }
+  });
 
   factory CloudStorageEntry({
     int? id,
@@ -57,7 +55,8 @@ abstract class CloudStorageEntry
 
   static const db = CloudStorageEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The storageId, typically `public` or `private`.
   String storageId;
@@ -76,16 +75,6 @@ abstract class CloudStorageEntry
 
   /// True if the file has been verified as uploaded.
   bool verified;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -13,8 +13,8 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
 
 /// An entry in the database for an uploaded file.
-abstract class CloudStorageEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class CloudStorageEntry
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   CloudStorageEntry._({
     int? id,
     required this.storageId,
@@ -23,7 +23,9 @@ abstract class CloudStorageEntry extends _i1.TableRow
     this.expiration,
     required this.byteData,
     required this.verified,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory CloudStorageEntry({
     int? id,
@@ -55,6 +57,8 @@ abstract class CloudStorageEntry extends _i1.TableRow
 
   static const db = CloudStorageEntryRepository._();
 
+  int? _id;
+
   /// The storageId, typically `public` or `private`.
   String storageId;
 
@@ -72,6 +76,16 @@ abstract class CloudStorageEntry extends _i1.TableRow
 
   /// True if the file has been verified as uploaded.
   bool verified;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -15,14 +15,12 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class CloudStorageDirectUploadEntry
     implements _i1.TableRow, _i1.ProtocolSerialization {
   CloudStorageDirectUploadEntry._({
-    int? id,
+    this.id,
     required this.storageId,
     required this.path,
     required this.expiration,
     required this.authKey,
-  }) {
-    _id = id;
-  }
+  });
 
   factory CloudStorageDirectUploadEntry({
     int? id,
@@ -48,7 +46,8 @@ abstract class CloudStorageDirectUploadEntry
 
   static const db = CloudStorageDirectUploadEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The storageId, typically `public` or `private`.
   String storageId;
@@ -61,16 +60,6 @@ abstract class CloudStorageDirectUploadEntry
 
   /// Access key for retrieving a private file.
   String authKey;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -12,15 +12,17 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Connects a table for handling uploading of files.
-abstract class CloudStorageDirectUploadEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class CloudStorageDirectUploadEntry
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   CloudStorageDirectUploadEntry._({
     int? id,
     required this.storageId,
     required this.path,
     required this.expiration,
     required this.authKey,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory CloudStorageDirectUploadEntry({
     int? id,
@@ -46,6 +48,8 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow
 
   static const db = CloudStorageDirectUploadEntryRepository._();
 
+  int? _id;
+
   /// The storageId, typically `public` or `private`.
   String storageId;
 
@@ -57,6 +61,16 @@ abstract class CloudStorageDirectUploadEntry extends _i1.TableRow
 
   /// Access key for retrieving a private file.
   String authKey;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Represents a version of a database migration.
-abstract class DatabaseMigrationVersion extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DatabaseMigrationVersion
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DatabaseMigrationVersion._({
     int? id,
     required this.module,
     required this.version,
     this.timestamp,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory DatabaseMigrationVersion({
     int? id,
@@ -44,6 +46,8 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow
 
   static const db = DatabaseMigrationVersionRepository._();
 
+  int? _id;
+
   /// The module the migration belongs to.
   String module;
 
@@ -52,6 +56,16 @@ abstract class DatabaseMigrationVersion extends _i1.TableRow
 
   /// The timestamp of the migration. Only set if the migration is applied.
   DateTime? timestamp;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -15,13 +15,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DatabaseMigrationVersion
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DatabaseMigrationVersion._({
-    int? id,
+    this.id,
     required this.module,
     required this.version,
     this.timestamp,
-  }) {
-    _id = id;
-  }
+  });
 
   factory DatabaseMigrationVersion({
     int? id,
@@ -46,7 +44,8 @@ abstract class DatabaseMigrationVersion
 
   static const db = DatabaseMigrationVersionRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The module the migration belongs to.
   String module;
@@ -56,16 +55,6 @@ abstract class DatabaseMigrationVersion
 
   /// The timestamp of the migration. Only set if the migration is applied.
   DateTime? timestamp;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// A serialized future call with bindings to the database.
-abstract class FutureCallEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class FutureCallEntry
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   FutureCallEntry._({
     int? id,
     required this.name,
@@ -21,7 +21,9 @@ abstract class FutureCallEntry extends _i1.TableRow
     this.serializedObject,
     required this.serverId,
     this.identifier,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory FutureCallEntry({
     int? id,
@@ -47,6 +49,8 @@ abstract class FutureCallEntry extends _i1.TableRow
 
   static const db = FutureCallEntryRepository._();
 
+  int? _id;
+
   /// Name of the future call. Used to find the correct method to call.
   String name;
 
@@ -61,6 +65,16 @@ abstract class FutureCallEntry extends _i1.TableRow
 
   /// An optional identifier which can be used to cancel the call.
   String? identifier;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -15,15 +15,13 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class FutureCallEntry
     implements _i1.TableRow, _i1.ProtocolSerialization {
   FutureCallEntry._({
-    int? id,
+    this.id,
     required this.name,
     required this.time,
     this.serializedObject,
     required this.serverId,
     this.identifier,
-  }) {
-    _id = id;
-  }
+  });
 
   factory FutureCallEntry({
     int? id,
@@ -49,7 +47,8 @@ abstract class FutureCallEntry
 
   static const db = FutureCallEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// Name of the future call. Used to find the correct method to call.
   String name;
@@ -65,16 +64,6 @@ abstract class FutureCallEntry
 
   /// An optional identifier which can be used to cancel the call.
   String? identifier;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -15,7 +15,7 @@ import 'protocol.dart' as _i2;
 /// Bindings to a log entry in the database.
 abstract class LogEntry implements _i1.TableRow, _i1.ProtocolSerialization {
   LogEntry._({
-    int? id,
+    this.id,
     required this.sessionLogId,
     this.messageId,
     this.reference,
@@ -26,9 +26,7 @@ abstract class LogEntry implements _i1.TableRow, _i1.ProtocolSerialization {
     this.error,
     this.stackTrace,
     required this.order,
-  }) {
-    _id = id;
-  }
+  });
 
   factory LogEntry({
     int? id,
@@ -64,7 +62,8 @@ abstract class LogEntry implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = LogEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The id of the session this log entry is associated with.
   int sessionLogId;
@@ -95,16 +94,6 @@ abstract class LogEntry implements _i1.TableRow, _i1.ProtocolSerialization {
 
   /// The order of this log entry, used for sorting.
   int order;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -13,8 +13,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
 
 /// Bindings to a log entry in the database.
-abstract class LogEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class LogEntry implements _i1.TableRow, _i1.ProtocolSerialization {
   LogEntry._({
     int? id,
     required this.sessionLogId,
@@ -27,7 +26,9 @@ abstract class LogEntry extends _i1.TableRow
     this.error,
     this.stackTrace,
     required this.order,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory LogEntry({
     int? id,
@@ -63,6 +64,8 @@ abstract class LogEntry extends _i1.TableRow
 
   static const db = LogEntryRepository._();
 
+  int? _id;
+
   /// The id of the session this log entry is associated with.
   int sessionLogId;
 
@@ -92,6 +95,16 @@ abstract class LogEntry extends _i1.TableRow
 
   /// The order of this log entry, used for sorting.
   int order;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// A log entry for a message sent in a streaming session.
-abstract class MessageLogEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class MessageLogEntry
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   MessageLogEntry._({
     int? id,
     required this.sessionLogId,
@@ -26,7 +26,9 @@ abstract class MessageLogEntry extends _i1.TableRow
     this.stackTrace,
     required this.slow,
     required this.order,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory MessageLogEntry({
     int? id,
@@ -62,6 +64,8 @@ abstract class MessageLogEntry extends _i1.TableRow
 
   static const db = MessageLogEntryRepository._();
 
+  int? _id;
+
   /// Id of the session this entry is associated with.
   int sessionLogId;
 
@@ -93,6 +97,16 @@ abstract class MessageLogEntry extends _i1.TableRow
 
   /// Used for sorting the message log.
   int order;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -15,7 +15,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class MessageLogEntry
     implements _i1.TableRow, _i1.ProtocolSerialization {
   MessageLogEntry._({
-    int? id,
+    this.id,
     required this.sessionLogId,
     required this.serverId,
     required this.messageId,
@@ -26,9 +26,7 @@ abstract class MessageLogEntry
     this.stackTrace,
     required this.slow,
     required this.order,
-  }) {
-    _id = id;
-  }
+  });
 
   factory MessageLogEntry({
     int? id,
@@ -64,7 +62,8 @@ abstract class MessageLogEntry
 
   static const db = MessageLogEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// Id of the session this entry is associated with.
   int sessionLogId;
@@ -97,16 +96,6 @@ abstract class MessageLogEntry
 
   /// Used for sorting the message log.
   int order;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Information about a server method.
 abstract class MethodInfo implements _i1.TableRow, _i1.ProtocolSerialization {
   MethodInfo._({
-    int? id,
+    this.id,
     required this.endpoint,
     required this.method,
-  }) {
-    _id = id;
-  }
+  });
 
   factory MethodInfo({
     int? id,
@@ -39,23 +37,14 @@ abstract class MethodInfo implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = MethodInfoRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The endpoint of this method.
   String endpoint;
 
   /// The name of this method.
   String method;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -12,13 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Information about a server method.
-abstract class MethodInfo extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class MethodInfo implements _i1.TableRow, _i1.ProtocolSerialization {
   MethodInfo._({
     int? id,
     required this.endpoint,
     required this.method,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory MethodInfo({
     int? id,
@@ -38,11 +39,23 @@ abstract class MethodInfo extends _i1.TableRow
 
   static const db = MethodInfoRepository._();
 
+  int? _id;
+
   /// The endpoint of this method.
   String endpoint;
 
   /// The name of this method.
   String method;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// A log entry for a database query.
-abstract class QueryLogEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class QueryLogEntry
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   QueryLogEntry._({
     int? id,
     required this.serverId,
@@ -26,7 +26,9 @@ abstract class QueryLogEntry extends _i1.TableRow
     this.stackTrace,
     required this.slow,
     required this.order,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory QueryLogEntry({
     int? id,
@@ -62,6 +64,8 @@ abstract class QueryLogEntry extends _i1.TableRow
 
   static const db = QueryLogEntryRepository._();
 
+  int? _id;
+
   /// The id of the server that handled the query.
   String serverId;
 
@@ -93,6 +97,16 @@ abstract class QueryLogEntry extends _i1.TableRow
 
   /// used for sorting the query log.
   int order;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -15,7 +15,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class QueryLogEntry
     implements _i1.TableRow, _i1.ProtocolSerialization {
   QueryLogEntry._({
-    int? id,
+    this.id,
     required this.serverId,
     required this.sessionLogId,
     this.messageId,
@@ -26,9 +26,7 @@ abstract class QueryLogEntry
     this.stackTrace,
     required this.slow,
     required this.order,
-  }) {
-    _id = id;
-  }
+  });
 
   factory QueryLogEntry({
     int? id,
@@ -64,7 +62,8 @@ abstract class QueryLogEntry
 
   static const db = QueryLogEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The id of the server that handled the query.
   String serverId;
@@ -97,16 +96,6 @@ abstract class QueryLogEntry
 
   /// used for sorting the query log.
   int order;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -16,11 +16,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ReadWriteTestEntry
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ReadWriteTestEntry._({
-    int? id,
+    this.id,
     required this.number,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ReadWriteTestEntry({
     int? id,
@@ -38,20 +36,11 @@ abstract class ReadWriteTestEntry
 
   static const db = ReadWriteTestEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// A random number, to verify that the write/read was performed correctly.
   int number;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -13,12 +13,14 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Database mapping for a read/write test that is performed by the default
 /// health checks.
-abstract class ReadWriteTestEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ReadWriteTestEntry
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ReadWriteTestEntry._({
     int? id,
     required this.number,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ReadWriteTestEntry({
     int? id,
@@ -36,8 +38,20 @@ abstract class ReadWriteTestEntry extends _i1.TableRow
 
   static const db = ReadWriteTestEntryRepository._();
 
+  int? _id;
+
   /// A random number, to verify that the write/read was performed correctly.
   int number;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -13,15 +13,17 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
 
 /// Runtime settings of the server.
-abstract class RuntimeSettings extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class RuntimeSettings
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   RuntimeSettings._({
     int? id,
     required this.logSettings,
     required this.logSettingsOverrides,
     required this.logServiceCalls,
     required this.logMalformedCalls,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory RuntimeSettings({
     int? id,
@@ -49,6 +51,8 @@ abstract class RuntimeSettings extends _i1.TableRow
 
   static const db = RuntimeSettingsRepository._();
 
+  int? _id;
+
   /// Log settings.
   _i2.LogSettings logSettings;
 
@@ -60,6 +64,16 @@ abstract class RuntimeSettings extends _i1.TableRow
 
   /// True if malformed calls should be logged.
   bool logMalformedCalls;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -16,14 +16,12 @@ import 'protocol.dart' as _i2;
 abstract class RuntimeSettings
     implements _i1.TableRow, _i1.ProtocolSerialization {
   RuntimeSettings._({
-    int? id,
+    this.id,
     required this.logSettings,
     required this.logSettingsOverrides,
     required this.logServiceCalls,
     required this.logMalformedCalls,
-  }) {
-    _id = id;
-  }
+  });
 
   factory RuntimeSettings({
     int? id,
@@ -51,7 +49,8 @@ abstract class RuntimeSettings
 
   static const db = RuntimeSettingsRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// Log settings.
   _i2.LogSettings logSettings;
@@ -64,16 +63,6 @@ abstract class RuntimeSettings
 
   /// True if malformed calls should be logged.
   bool logMalformedCalls;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -14,8 +14,8 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Represents a snapshot of the number of open connections the server currently
 /// is handling. An entry is written every minute for each server. All health
 /// data can be accessed through Serverpod Insights.
-abstract class ServerHealthConnectionInfo extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ServerHealthConnectionInfo
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ServerHealthConnectionInfo._({
     int? id,
     required this.serverId,
@@ -24,7 +24,9 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow
     required this.closing,
     required this.idle,
     required this.granularity,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ServerHealthConnectionInfo({
     int? id,
@@ -54,6 +56,8 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow
 
   static const db = ServerHealthConnectionInfoRepository._();
 
+  int? _id;
+
   /// The server associated with this connection info.
   String serverId;
 
@@ -72,6 +76,16 @@ abstract class ServerHealthConnectionInfo extends _i1.TableRow
   /// The granularity of this timestamp, null represents 1 minute, other valid
   /// values are 60 minutes and 1440 minutes (one day).
   int granularity;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -17,16 +17,14 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ServerHealthConnectionInfo
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ServerHealthConnectionInfo._({
-    int? id,
+    this.id,
     required this.serverId,
     required this.timestamp,
     required this.active,
     required this.closing,
     required this.idle,
     required this.granularity,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ServerHealthConnectionInfo({
     int? id,
@@ -56,7 +54,8 @@ abstract class ServerHealthConnectionInfo
 
   static const db = ServerHealthConnectionInfoRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The server associated with this connection info.
   String serverId;
@@ -76,16 +75,6 @@ abstract class ServerHealthConnectionInfo
   /// The granularity of this timestamp, null represents 1 minute, other valid
   /// values are 60 minutes and 1440 minutes (one day).
   int granularity;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -17,16 +17,14 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ServerHealthMetric
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ServerHealthMetric._({
-    int? id,
+    this.id,
     required this.name,
     required this.serverId,
     required this.timestamp,
     required this.isHealthy,
     required this.value,
     required this.granularity,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ServerHealthMetric({
     int? id,
@@ -55,7 +53,8 @@ abstract class ServerHealthMetric
 
   static const db = ServerHealthMetricRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The name of the metric.
   String name;
@@ -75,16 +74,6 @@ abstract class ServerHealthMetric
   /// The granularity of this timestamp, null represents 1 minute, other valid
   /// values are 60 minutes and 1440 minutes (one day).
   int granularity;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -14,8 +14,8 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Represents a snapshot of a specific health metric. An entry is written every
 /// minute for each server. All health data can be accessed through Serverpod
 /// Insights.
-abstract class ServerHealthMetric extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ServerHealthMetric
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ServerHealthMetric._({
     int? id,
     required this.name,
@@ -24,7 +24,9 @@ abstract class ServerHealthMetric extends _i1.TableRow
     required this.isHealthy,
     required this.value,
     required this.granularity,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ServerHealthMetric({
     int? id,
@@ -53,6 +55,8 @@ abstract class ServerHealthMetric extends _i1.TableRow
 
   static const db = ServerHealthMetricRepository._();
 
+  int? _id;
+
   /// The name of the metric.
   String name;
 
@@ -71,6 +75,16 @@ abstract class ServerHealthMetric extends _i1.TableRow
   /// The granularity of this timestamp, null represents 1 minute, other valid
   /// values are 60 minutes and 1440 minutes (one day).
   int granularity;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -15,7 +15,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class SessionLogEntry
     implements _i1.TableRow, _i1.ProtocolSerialization {
   SessionLogEntry._({
-    int? id,
+    this.id,
     required this.serverId,
     required this.time,
     this.module,
@@ -29,9 +29,7 @@ abstract class SessionLogEntry
     this.authenticatedUserId,
     this.isOpen,
     required this.touched,
-  }) {
-    _id = id;
-  }
+  });
 
   factory SessionLogEntry({
     int? id,
@@ -73,7 +71,8 @@ abstract class SessionLogEntry
 
   static const db = SessionLogEntryRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The id of the server that handled this session.
   String serverId;
@@ -117,16 +116,6 @@ abstract class SessionLogEntry
 
   /// Timestamp of the last time this record was modified.
   DateTime touched;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Log entry for a session.
-abstract class SessionLogEntry extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class SessionLogEntry
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   SessionLogEntry._({
     int? id,
     required this.serverId,
@@ -29,7 +29,9 @@ abstract class SessionLogEntry extends _i1.TableRow
     this.authenticatedUserId,
     this.isOpen,
     required this.touched,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory SessionLogEntry({
     int? id,
@@ -70,6 +72,8 @@ abstract class SessionLogEntry extends _i1.TableRow
   static final t = SessionLogEntryTable();
 
   static const db = SessionLogEntryRepository._();
+
+  int? _id;
 
   /// The id of the server that handled this session.
   String serverId;
@@ -113,6 +117,16 @@ abstract class SessionLogEntry extends _i1.TableRow
 
   /// Timestamp of the last time this record was modified.
   DateTime touched;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/packages/serverpod/test/database/database_query/insert_sql_query_test.dart
+++ b/packages/serverpod/test/database/database_query/insert_sql_query_test.dart
@@ -15,11 +15,23 @@ class PersonTable extends Table {
   List<Column> get columns => [id, name, age];
 }
 
-class PersonClass extends TableRow {
+class PersonClass implements TableRow {
   final String name;
   final int age;
 
-  PersonClass({required this.name, required this.age}) : super(1);
+  int? _id;
+
+  PersonClass({id, required this.name, required this.age}) : _id = id;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   Table get table => PersonTable();
@@ -34,8 +46,20 @@ class PersonClass extends TableRow {
   }
 }
 
-class OnlyIdClass extends TableRow {
-  OnlyIdClass() : super(1);
+class OnlyIdClass implements TableRow {
+  OnlyIdClass({int? id}) : _id = id;
+
+  int? _id;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   Table get table => Table(tableName: 'only_id');

--- a/packages/serverpod/test/database/database_query/insert_sql_query_test.dart
+++ b/packages/serverpod/test/database/database_query/insert_sql_query_test.dart
@@ -19,19 +19,10 @@ class PersonClass implements TableRow {
   final String name;
   final int age;
 
-  int? _id;
-
-  PersonClass({id, required this.name, required this.age}) : _id = id;
-
   @override
-  int? get id {
-    return _id;
-  }
+  int? id;
 
-  @override
-  set id(int? value) {
-    _id = value;
-  }
+  PersonClass({this.id, required this.name, required this.age});
 
   @override
   Table get table => PersonTable();
@@ -47,19 +38,10 @@ class PersonClass implements TableRow {
 }
 
 class OnlyIdClass implements TableRow {
-  OnlyIdClass({int? id}) : _id = id;
-
-  int? _id;
+  OnlyIdClass({this.id});
 
   @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
+  int? id;
 
   @override
   Table get table => Table(tableName: 'only_id');

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -11,8 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class BoolDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class BoolDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefault._({
     int? id,
     bool? boolDefaultTrue,
@@ -20,8 +19,9 @@ abstract class BoolDefault extends _i1.TableRow
     bool? boolDefaultNullFalse,
   })  : boolDefaultTrue = boolDefaultTrue ?? true,
         boolDefaultFalse = boolDefaultFalse ?? false,
-        boolDefaultNullFalse = boolDefaultNullFalse ?? false,
-        super(id);
+        boolDefaultNullFalse = boolDefaultNullFalse ?? false {
+    _id = id;
+  }
 
   factory BoolDefault({
     int? id,
@@ -43,11 +43,23 @@ abstract class BoolDefault extends _i1.TableRow
 
   static const db = BoolDefaultRepository._();
 
+  int? _id;
+
   bool boolDefaultTrue;
 
   bool boolDefaultFalse;
 
   bool? boolDefaultNullFalse;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -13,15 +13,13 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class BoolDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefault._({
-    int? id,
+    this.id,
     bool? boolDefaultTrue,
     bool? boolDefaultFalse,
     bool? boolDefaultNullFalse,
   })  : boolDefaultTrue = boolDefaultTrue ?? true,
         boolDefaultFalse = boolDefaultFalse ?? false,
-        boolDefaultNullFalse = boolDefaultNullFalse ?? false {
-    _id = id;
-  }
+        boolDefaultNullFalse = boolDefaultNullFalse ?? false;
 
   factory BoolDefault({
     int? id,
@@ -43,23 +41,14 @@ abstract class BoolDefault implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = BoolDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   bool boolDefaultTrue;
 
   bool boolDefaultFalse;
 
   bool? boolDefaultNullFalse;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class BoolDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class BoolDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefaultMix._({
     int? id,
     bool? boolDefaultAndDefaultModel,
@@ -21,8 +21,9 @@ abstract class BoolDefaultMix extends _i1.TableRow
   })  : boolDefaultAndDefaultModel = boolDefaultAndDefaultModel ?? false,
         boolDefaultAndDefaultPersist = boolDefaultAndDefaultPersist ?? true,
         boolDefaultModelAndDefaultPersist =
-            boolDefaultModelAndDefaultPersist ?? true,
-        super(id);
+            boolDefaultModelAndDefaultPersist ?? true {
+    _id = id;
+  }
 
   factory BoolDefaultMix({
     int? id,
@@ -47,11 +48,23 @@ abstract class BoolDefaultMix extends _i1.TableRow
 
   static const db = BoolDefaultMixRepository._();
 
+  int? _id;
+
   bool boolDefaultAndDefaultModel;
 
   bool boolDefaultAndDefaultPersist;
 
   bool boolDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -14,16 +14,14 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class BoolDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefaultMix._({
-    int? id,
+    this.id,
     bool? boolDefaultAndDefaultModel,
     bool? boolDefaultAndDefaultPersist,
     bool? boolDefaultModelAndDefaultPersist,
   })  : boolDefaultAndDefaultModel = boolDefaultAndDefaultModel ?? false,
         boolDefaultAndDefaultPersist = boolDefaultAndDefaultPersist ?? true,
         boolDefaultModelAndDefaultPersist =
-            boolDefaultModelAndDefaultPersist ?? true {
-    _id = id;
-  }
+            boolDefaultModelAndDefaultPersist ?? true;
 
   factory BoolDefaultMix({
     int? id,
@@ -48,23 +46,14 @@ abstract class BoolDefaultMix
 
   static const db = BoolDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   bool boolDefaultAndDefaultModel;
 
   bool boolDefaultAndDefaultPersist;
 
   bool boolDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class BoolDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class BoolDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefaultModel._({
     int? id,
     bool? boolDefaultModelTrue,
@@ -20,8 +20,9 @@ abstract class BoolDefaultModel extends _i1.TableRow
     bool? boolDefaultModelNullFalse,
   })  : boolDefaultModelTrue = boolDefaultModelTrue ?? true,
         boolDefaultModelFalse = boolDefaultModelFalse ?? false,
-        boolDefaultModelNullFalse = boolDefaultModelNullFalse ?? false,
-        super(id);
+        boolDefaultModelNullFalse = boolDefaultModelNullFalse ?? false {
+    _id = id;
+  }
 
   factory BoolDefaultModel({
     int? id,
@@ -44,11 +45,23 @@ abstract class BoolDefaultModel extends _i1.TableRow
 
   static const db = BoolDefaultModelRepository._();
 
+  int? _id;
+
   bool boolDefaultModelTrue;
 
   bool boolDefaultModelFalse;
 
   bool boolDefaultModelNullFalse;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -14,15 +14,13 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class BoolDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefaultModel._({
-    int? id,
+    this.id,
     bool? boolDefaultModelTrue,
     bool? boolDefaultModelFalse,
     bool? boolDefaultModelNullFalse,
   })  : boolDefaultModelTrue = boolDefaultModelTrue ?? true,
         boolDefaultModelFalse = boolDefaultModelFalse ?? false,
-        boolDefaultModelNullFalse = boolDefaultModelNullFalse ?? false {
-    _id = id;
-  }
+        boolDefaultModelNullFalse = boolDefaultModelNullFalse ?? false;
 
   factory BoolDefaultModel({
     int? id,
@@ -45,23 +43,14 @@ abstract class BoolDefaultModel
 
   static const db = BoolDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   bool boolDefaultModelTrue;
 
   bool boolDefaultModelFalse;
 
   bool boolDefaultModelNullFalse;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -11,13 +11,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class BoolDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class BoolDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefaultPersist._({
     int? id,
     this.boolDefaultPersistTrue,
     this.boolDefaultPersistFalse,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory BoolDefaultPersist({
     int? id,
@@ -39,9 +41,21 @@ abstract class BoolDefaultPersist extends _i1.TableRow
 
   static const db = BoolDefaultPersistRepository._();
 
+  int? _id;
+
   bool? boolDefaultPersistTrue;
 
   bool? boolDefaultPersistFalse;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class BoolDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefaultPersist._({
-    int? id,
+    this.id,
     this.boolDefaultPersistTrue,
     this.boolDefaultPersistFalse,
-  }) {
-    _id = id;
-  }
+  });
 
   factory BoolDefaultPersist({
     int? id,
@@ -41,21 +39,12 @@ abstract class BoolDefaultPersist
 
   static const db = BoolDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   bool? boolDefaultPersistTrue;
 
   bool? boolDefaultPersistFalse;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DateTimeDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DateTimeDefault
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefault._({
     int? id,
     DateTime? dateTimeDefaultNow,
@@ -22,8 +22,9 @@ abstract class DateTimeDefault extends _i1.TableRow
         dateTimeDefaultStr =
             dateTimeDefaultStr ?? DateTime.parse('2024-05-24T22:00:00.000Z'),
         dateTimeDefaultStrNull = dateTimeDefaultStrNull ??
-            DateTime.parse('2024-05-24T22:00:00.000Z'),
-        super(id);
+            DateTime.parse('2024-05-24T22:00:00.000Z') {
+    _id = id;
+  }
 
   factory DateTimeDefault({
     int? id,
@@ -51,11 +52,23 @@ abstract class DateTimeDefault extends _i1.TableRow
 
   static const db = DateTimeDefaultRepository._();
 
+  int? _id;
+
   DateTime dateTimeDefaultNow;
 
   DateTime dateTimeDefaultStr;
 
   DateTime? dateTimeDefaultStrNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DateTimeDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefault._({
-    int? id,
+    this.id,
     DateTime? dateTimeDefaultNow,
     DateTime? dateTimeDefaultStr,
     DateTime? dateTimeDefaultStrNull,
@@ -22,9 +22,7 @@ abstract class DateTimeDefault
         dateTimeDefaultStr =
             dateTimeDefaultStr ?? DateTime.parse('2024-05-24T22:00:00.000Z'),
         dateTimeDefaultStrNull = dateTimeDefaultStrNull ??
-            DateTime.parse('2024-05-24T22:00:00.000Z') {
-    _id = id;
-  }
+            DateTime.parse('2024-05-24T22:00:00.000Z');
 
   factory DateTimeDefault({
     int? id,
@@ -52,23 +50,14 @@ abstract class DateTimeDefault
 
   static const db = DateTimeDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   DateTime dateTimeDefaultNow;
 
   DateTime dateTimeDefaultStr;
 
   DateTime? dateTimeDefaultStrNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DateTimeDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DateTimeDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefaultMix._({
     int? id,
     DateTime? dateTimeDefaultAndDefaultModel,
@@ -24,8 +24,9 @@ abstract class DateTimeDefaultMix extends _i1.TableRow
             DateTime.parse('2024-05-01T22:00:00.000Z'),
         dateTimeDefaultModelAndDefaultPersist =
             dateTimeDefaultModelAndDefaultPersist ??
-                DateTime.parse('2024-05-01T22:00:00.000Z'),
-        super(id);
+                DateTime.parse('2024-05-01T22:00:00.000Z') {
+    _id = id;
+  }
 
   factory DateTimeDefaultMix({
     int? id,
@@ -50,11 +51,23 @@ abstract class DateTimeDefaultMix extends _i1.TableRow
 
   static const db = DateTimeDefaultMixRepository._();
 
+  int? _id;
+
   DateTime dateTimeDefaultAndDefaultModel;
 
   DateTime dateTimeDefaultAndDefaultPersist;
 
   DateTime dateTimeDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DateTimeDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefaultMix._({
-    int? id,
+    this.id,
     DateTime? dateTimeDefaultAndDefaultModel,
     DateTime? dateTimeDefaultAndDefaultPersist,
     DateTime? dateTimeDefaultModelAndDefaultPersist,
@@ -24,9 +24,7 @@ abstract class DateTimeDefaultMix
             DateTime.parse('2024-05-01T22:00:00.000Z'),
         dateTimeDefaultModelAndDefaultPersist =
             dateTimeDefaultModelAndDefaultPersist ??
-                DateTime.parse('2024-05-01T22:00:00.000Z') {
-    _id = id;
-  }
+                DateTime.parse('2024-05-01T22:00:00.000Z');
 
   factory DateTimeDefaultMix({
     int? id,
@@ -51,23 +49,14 @@ abstract class DateTimeDefaultMix
 
   static const db = DateTimeDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   DateTime dateTimeDefaultAndDefaultModel;
 
   DateTime dateTimeDefaultAndDefaultPersist;
 
   DateTime dateTimeDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DateTimeDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefaultModel._({
-    int? id,
+    this.id,
     DateTime? dateTimeDefaultModelNow,
     DateTime? dateTimeDefaultModelStr,
     DateTime? dateTimeDefaultModelStrNull,
@@ -22,9 +22,7 @@ abstract class DateTimeDefaultModel
         dateTimeDefaultModelStr = dateTimeDefaultModelStr ??
             DateTime.parse('2024-05-24T22:00:00.000Z'),
         dateTimeDefaultModelStrNull = dateTimeDefaultModelStrNull ??
-            DateTime.parse('2024-05-24T22:00:00.000Z') {
-    _id = id;
-  }
+            DateTime.parse('2024-05-24T22:00:00.000Z');
 
   factory DateTimeDefaultModel({
     int? id,
@@ -53,23 +51,14 @@ abstract class DateTimeDefaultModel
 
   static const db = DateTimeDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   DateTime dateTimeDefaultModelNow;
 
   DateTime dateTimeDefaultModelStr;
 
   DateTime? dateTimeDefaultModelStrNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DateTimeDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DateTimeDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefaultModel._({
     int? id,
     DateTime? dateTimeDefaultModelNow,
@@ -22,8 +22,9 @@ abstract class DateTimeDefaultModel extends _i1.TableRow
         dateTimeDefaultModelStr = dateTimeDefaultModelStr ??
             DateTime.parse('2024-05-24T22:00:00.000Z'),
         dateTimeDefaultModelStrNull = dateTimeDefaultModelStrNull ??
-            DateTime.parse('2024-05-24T22:00:00.000Z'),
-        super(id);
+            DateTime.parse('2024-05-24T22:00:00.000Z') {
+    _id = id;
+  }
 
   factory DateTimeDefaultModel({
     int? id,
@@ -52,11 +53,23 @@ abstract class DateTimeDefaultModel extends _i1.TableRow
 
   static const db = DateTimeDefaultModelRepository._();
 
+  int? _id;
+
   DateTime dateTimeDefaultModelNow;
 
   DateTime dateTimeDefaultModelStr;
 
   DateTime? dateTimeDefaultModelStrNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DateTimeDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefaultPersist._({
-    int? id,
+    this.id,
     this.dateTimeDefaultPersistNow,
     this.dateTimeDefaultPersistStr,
-  }) {
-    _id = id;
-  }
+  });
 
   factory DateTimeDefaultPersist({
     int? id,
@@ -48,21 +46,12 @@ abstract class DateTimeDefaultPersist
 
   static const db = DateTimeDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   DateTime? dateTimeDefaultPersistNow;
 
   DateTime? dateTimeDefaultPersistStr;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -11,13 +11,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DateTimeDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DateTimeDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DateTimeDefaultPersist._({
     int? id,
     this.dateTimeDefaultPersistNow,
     this.dateTimeDefaultPersistStr,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory DateTimeDefaultPersist({
     int? id,
@@ -46,9 +48,21 @@ abstract class DateTimeDefaultPersist extends _i1.TableRow
 
   static const db = DateTimeDefaultPersistRepository._();
 
+  int? _id;
+
   DateTime? dateTimeDefaultPersistNow;
 
   DateTime? dateTimeDefaultPersistStr;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
@@ -14,13 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DoubleDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefault._({
-    int? id,
+    this.id,
     double? doubleDefault,
     double? doubleDefaultNull,
   })  : doubleDefault = doubleDefault ?? 10.5,
-        doubleDefaultNull = doubleDefaultNull ?? 20.5 {
-    _id = id;
-  }
+        doubleDefaultNull = doubleDefaultNull ?? 20.5;
 
   factory DoubleDefault({
     int? id,
@@ -41,21 +39,12 @@ abstract class DoubleDefault
 
   static const db = DoubleDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   double doubleDefault;
 
   double? doubleDefaultNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
@@ -11,15 +11,16 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DoubleDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DoubleDefault
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefault._({
     int? id,
     double? doubleDefault,
     double? doubleDefaultNull,
   })  : doubleDefault = doubleDefault ?? 10.5,
-        doubleDefaultNull = doubleDefaultNull ?? 20.5,
-        super(id);
+        doubleDefaultNull = doubleDefaultNull ?? 20.5 {
+    _id = id;
+  }
 
   factory DoubleDefault({
     int? id,
@@ -40,9 +41,21 @@ abstract class DoubleDefault extends _i1.TableRow
 
   static const db = DoubleDefaultRepository._();
 
+  int? _id;
+
   double doubleDefault;
 
   double? doubleDefaultNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DoubleDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DoubleDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefaultMix._({
     int? id,
     double? doubleDefaultAndDefaultModel,
@@ -21,8 +21,9 @@ abstract class DoubleDefaultMix extends _i1.TableRow
   })  : doubleDefaultAndDefaultModel = doubleDefaultAndDefaultModel ?? 20.5,
         doubleDefaultAndDefaultPersist = doubleDefaultAndDefaultPersist ?? 10.5,
         doubleDefaultModelAndDefaultPersist =
-            doubleDefaultModelAndDefaultPersist ?? 10.5,
-        super(id);
+            doubleDefaultModelAndDefaultPersist ?? 10.5 {
+    _id = id;
+  }
 
   factory DoubleDefaultMix({
     int? id,
@@ -49,11 +50,23 @@ abstract class DoubleDefaultMix extends _i1.TableRow
 
   static const db = DoubleDefaultMixRepository._();
 
+  int? _id;
+
   double doubleDefaultAndDefaultModel;
 
   double doubleDefaultAndDefaultPersist;
 
   double doubleDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -14,16 +14,14 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DoubleDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefaultMix._({
-    int? id,
+    this.id,
     double? doubleDefaultAndDefaultModel,
     double? doubleDefaultAndDefaultPersist,
     double? doubleDefaultModelAndDefaultPersist,
   })  : doubleDefaultAndDefaultModel = doubleDefaultAndDefaultModel ?? 20.5,
         doubleDefaultAndDefaultPersist = doubleDefaultAndDefaultPersist ?? 10.5,
         doubleDefaultModelAndDefaultPersist =
-            doubleDefaultModelAndDefaultPersist ?? 10.5 {
-    _id = id;
-  }
+            doubleDefaultModelAndDefaultPersist ?? 10.5;
 
   factory DoubleDefaultMix({
     int? id,
@@ -50,23 +48,14 @@ abstract class DoubleDefaultMix
 
   static const db = DoubleDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   double doubleDefaultAndDefaultModel;
 
   double doubleDefaultAndDefaultPersist;
 
   double doubleDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -14,13 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DoubleDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefaultModel._({
-    int? id,
+    this.id,
     double? doubleDefaultModel,
     double? doubleDefaultModelNull,
   })  : doubleDefaultModel = doubleDefaultModel ?? 10.5,
-        doubleDefaultModelNull = doubleDefaultModelNull ?? 20.5 {
-    _id = id;
-  }
+        doubleDefaultModelNull = doubleDefaultModelNull ?? 20.5;
 
   factory DoubleDefaultModel({
     int? id,
@@ -42,21 +40,12 @@ abstract class DoubleDefaultModel
 
   static const db = DoubleDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   double doubleDefaultModel;
 
   double doubleDefaultModelNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -11,15 +11,16 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DoubleDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DoubleDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefaultModel._({
     int? id,
     double? doubleDefaultModel,
     double? doubleDefaultModelNull,
   })  : doubleDefaultModel = doubleDefaultModel ?? 10.5,
-        doubleDefaultModelNull = doubleDefaultModelNull ?? 20.5,
-        super(id);
+        doubleDefaultModelNull = doubleDefaultModelNull ?? 20.5 {
+    _id = id;
+  }
 
   factory DoubleDefaultModel({
     int? id,
@@ -41,9 +42,21 @@ abstract class DoubleDefaultModel extends _i1.TableRow
 
   static const db = DoubleDefaultModelRepository._();
 
+  int? _id;
+
   double doubleDefaultModel;
 
   double doubleDefaultModelNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DoubleDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefaultPersist._({
-    int? id,
+    this.id,
     this.doubleDefaultPersist,
-  }) {
-    _id = id;
-  }
+  });
 
   factory DoubleDefaultPersist({
     int? id,
@@ -38,19 +36,10 @@ abstract class DoubleDefaultPersist
 
   static const db = DoubleDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   double? doubleDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DoubleDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DoubleDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DoubleDefaultPersist._({
     int? id,
     this.doubleDefaultPersist,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory DoubleDefaultPersist({
     int? id,
@@ -36,7 +38,19 @@ abstract class DoubleDefaultPersist extends _i1.TableRow
 
   static const db = DoubleDefaultPersistRepository._();
 
+  int? _id;
+
   double? doubleDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DurationDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefault._({
-    int? id,
+    this.id,
     Duration? durationDefault,
     Duration? durationDefaultNull,
   })  : durationDefault = durationDefault ??
@@ -32,9 +32,7 @@ abstract class DurationDefault
               minutes: 20,
               seconds: 40,
               milliseconds: 100,
-            ) {
-    _id = id;
-  }
+            );
 
   factory DurationDefault({
     int? id,
@@ -58,21 +56,12 @@ abstract class DurationDefault
 
   static const db = DurationDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   Duration durationDefault;
 
   Duration? durationDefaultNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DurationDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DurationDefault
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefault._({
     int? id,
     Duration? durationDefault,
@@ -32,8 +32,9 @@ abstract class DurationDefault extends _i1.TableRow
               minutes: 20,
               seconds: 40,
               milliseconds: 100,
-            ),
-        super(id);
+            ) {
+    _id = id;
+  }
 
   factory DurationDefault({
     int? id,
@@ -57,9 +58,21 @@ abstract class DurationDefault extends _i1.TableRow
 
   static const db = DurationDefaultRepository._();
 
+  int? _id;
+
   Duration durationDefault;
 
   Duration? durationDefaultNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DurationDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefaultMix._({
-    int? id,
+    this.id,
     Duration? durationDefaultAndDefaultModel,
     Duration? durationDefaultAndDefaultPersist,
     Duration? durationDefaultModelAndDefaultPersist,
@@ -42,9 +42,7 @@ abstract class DurationDefaultMix
                   minutes: 10,
                   seconds: 30,
                   milliseconds: 100,
-                ) {
-    _id = id;
-  }
+                );
 
   factory DurationDefaultMix({
     int? id,
@@ -69,23 +67,14 @@ abstract class DurationDefaultMix
 
   static const db = DurationDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   Duration durationDefaultAndDefaultModel;
 
   Duration durationDefaultAndDefaultPersist;
 
   Duration durationDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DurationDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DurationDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefaultMix._({
     int? id,
     Duration? durationDefaultAndDefaultModel,
@@ -42,8 +42,9 @@ abstract class DurationDefaultMix extends _i1.TableRow
                   minutes: 10,
                   seconds: 30,
                   milliseconds: 100,
-                ),
-        super(id);
+                ) {
+    _id = id;
+  }
 
   factory DurationDefaultMix({
     int? id,
@@ -68,11 +69,23 @@ abstract class DurationDefaultMix extends _i1.TableRow
 
   static const db = DurationDefaultMixRepository._();
 
+  int? _id;
+
   Duration durationDefaultAndDefaultModel;
 
   Duration durationDefaultAndDefaultPersist;
 
   Duration durationDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DurationDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefaultModel._({
-    int? id,
+    this.id,
     Duration? durationDefaultModel,
     Duration? durationDefaultModelNull,
   })  : durationDefaultModel = durationDefaultModel ??
@@ -32,9 +32,7 @@ abstract class DurationDefaultModel
               minutes: 20,
               seconds: 40,
               milliseconds: 100,
-            ) {
-    _id = id;
-  }
+            );
 
   factory DurationDefaultModel({
     int? id,
@@ -60,21 +58,12 @@ abstract class DurationDefaultModel
 
   static const db = DurationDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   Duration durationDefaultModel;
 
   Duration? durationDefaultModelNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DurationDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DurationDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefaultModel._({
     int? id,
     Duration? durationDefaultModel,
@@ -32,8 +32,9 @@ abstract class DurationDefaultModel extends _i1.TableRow
               minutes: 20,
               seconds: 40,
               milliseconds: 100,
-            ),
-        super(id);
+            ) {
+    _id = id;
+  }
 
   factory DurationDefaultModel({
     int? id,
@@ -59,9 +60,21 @@ abstract class DurationDefaultModel extends _i1.TableRow
 
   static const db = DurationDefaultModelRepository._();
 
+  int? _id;
+
   Duration durationDefaultModel;
 
   Duration? durationDefaultModelNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class DurationDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefaultPersist._({
-    int? id,
+    this.id,
     this.durationDefaultPersist,
-  }) {
-    _id = id;
-  }
+  });
 
   factory DurationDefaultPersist({
     int? id,
@@ -41,19 +39,10 @@ abstract class DurationDefaultPersist
 
   static const db = DurationDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   Duration? durationDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class DurationDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class DurationDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   DurationDefaultPersist._({
     int? id,
     this.durationDefaultPersist,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory DurationDefaultPersist({
     int? id,
@@ -39,7 +41,19 @@ abstract class DurationDefaultPersist extends _i1.TableRow
 
   static const db = DurationDefaultPersistRepository._();
 
+  int? _id;
+
   Duration? durationDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -12,8 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class EnumDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EnumDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefault._({
     int? id,
     _i2.ByNameEnum? byNameEnumDefault,
@@ -24,8 +23,9 @@ abstract class EnumDefault extends _i1.TableRow
         byNameEnumDefaultNull = byNameEnumDefaultNull ?? _i2.ByNameEnum.byName2,
         byIndexEnumDefault = byIndexEnumDefault ?? _i2.ByIndexEnum.byIndex1,
         byIndexEnumDefaultNull =
-            byIndexEnumDefaultNull ?? _i2.ByIndexEnum.byIndex2,
-        super(id);
+            byIndexEnumDefaultNull ?? _i2.ByIndexEnum.byIndex2 {
+    _id = id;
+  }
 
   factory EnumDefault({
     int? id,
@@ -58,6 +58,8 @@ abstract class EnumDefault extends _i1.TableRow
 
   static const db = EnumDefaultRepository._();
 
+  int? _id;
+
   _i2.ByNameEnum byNameEnumDefault;
 
   _i2.ByNameEnum? byNameEnumDefaultNull;
@@ -65,6 +67,16 @@ abstract class EnumDefault extends _i1.TableRow
   _i2.ByIndexEnum byIndexEnumDefault;
 
   _i2.ByIndexEnum? byIndexEnumDefaultNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -14,7 +14,7 @@ import '../../protocol.dart' as _i2;
 
 abstract class EnumDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefault._({
-    int? id,
+    this.id,
     _i2.ByNameEnum? byNameEnumDefault,
     _i2.ByNameEnum? byNameEnumDefaultNull,
     _i2.ByIndexEnum? byIndexEnumDefault,
@@ -23,9 +23,7 @@ abstract class EnumDefault implements _i1.TableRow, _i1.ProtocolSerialization {
         byNameEnumDefaultNull = byNameEnumDefaultNull ?? _i2.ByNameEnum.byName2,
         byIndexEnumDefault = byIndexEnumDefault ?? _i2.ByIndexEnum.byIndex1,
         byIndexEnumDefaultNull =
-            byIndexEnumDefaultNull ?? _i2.ByIndexEnum.byIndex2 {
-    _id = id;
-  }
+            byIndexEnumDefaultNull ?? _i2.ByIndexEnum.byIndex2;
 
   factory EnumDefault({
     int? id,
@@ -58,7 +56,8 @@ abstract class EnumDefault implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = EnumDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i2.ByNameEnum byNameEnumDefault;
 
@@ -67,16 +66,6 @@ abstract class EnumDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   _i2.ByIndexEnum byIndexEnumDefault;
 
   _i2.ByIndexEnum? byIndexEnumDefaultNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -15,7 +15,7 @@ import '../../protocol.dart' as _i2;
 abstract class EnumDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefaultMix._({
-    int? id,
+    this.id,
     _i2.ByNameEnum? byNameEnumDefaultAndDefaultModel,
     _i2.ByNameEnum? byNameEnumDefaultAndDefaultPersist,
     _i2.ByNameEnum? byNameEnumDefaultModelAndDefaultPersist,
@@ -24,9 +24,7 @@ abstract class EnumDefaultMix
         byNameEnumDefaultAndDefaultPersist =
             byNameEnumDefaultAndDefaultPersist ?? _i2.ByNameEnum.byName1,
         byNameEnumDefaultModelAndDefaultPersist =
-            byNameEnumDefaultModelAndDefaultPersist ?? _i2.ByNameEnum.byName1 {
-    _id = id;
-  }
+            byNameEnumDefaultModelAndDefaultPersist ?? _i2.ByNameEnum.byName1;
 
   factory EnumDefaultMix({
     int? id,
@@ -52,23 +50,14 @@ abstract class EnumDefaultMix
 
   static const db = EnumDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i2.ByNameEnum byNameEnumDefaultAndDefaultModel;
 
   _i2.ByNameEnum byNameEnumDefaultAndDefaultPersist;
 
   _i2.ByNameEnum byNameEnumDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class EnumDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EnumDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefaultMix._({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultAndDefaultModel,
@@ -24,8 +24,9 @@ abstract class EnumDefaultMix extends _i1.TableRow
         byNameEnumDefaultAndDefaultPersist =
             byNameEnumDefaultAndDefaultPersist ?? _i2.ByNameEnum.byName1,
         byNameEnumDefaultModelAndDefaultPersist =
-            byNameEnumDefaultModelAndDefaultPersist ?? _i2.ByNameEnum.byName1,
-        super(id);
+            byNameEnumDefaultModelAndDefaultPersist ?? _i2.ByNameEnum.byName1 {
+    _id = id;
+  }
 
   factory EnumDefaultMix({
     int? id,
@@ -51,11 +52,23 @@ abstract class EnumDefaultMix extends _i1.TableRow
 
   static const db = EnumDefaultMixRepository._();
 
+  int? _id;
+
   _i2.ByNameEnum byNameEnumDefaultAndDefaultModel;
 
   _i2.ByNameEnum byNameEnumDefaultAndDefaultPersist;
 
   _i2.ByNameEnum byNameEnumDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class EnumDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EnumDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefaultModel._({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultModel,
@@ -27,8 +27,9 @@ abstract class EnumDefaultModel extends _i1.TableRow
         byIndexEnumDefaultModel =
             byIndexEnumDefaultModel ?? _i2.ByIndexEnum.byIndex1,
         byIndexEnumDefaultModelNull =
-            byIndexEnumDefaultModelNull ?? _i2.ByIndexEnum.byIndex2,
-        super(id);
+            byIndexEnumDefaultModelNull ?? _i2.ByIndexEnum.byIndex2 {
+    _id = id;
+  }
 
   factory EnumDefaultModel({
     int? id,
@@ -62,6 +63,8 @@ abstract class EnumDefaultModel extends _i1.TableRow
 
   static const db = EnumDefaultModelRepository._();
 
+  int? _id;
+
   _i2.ByNameEnum byNameEnumDefaultModel;
 
   _i2.ByNameEnum? byNameEnumDefaultModelNull;
@@ -69,6 +72,16 @@ abstract class EnumDefaultModel extends _i1.TableRow
   _i2.ByIndexEnum byIndexEnumDefaultModel;
 
   _i2.ByIndexEnum? byIndexEnumDefaultModelNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -15,7 +15,7 @@ import '../../protocol.dart' as _i2;
 abstract class EnumDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefaultModel._({
-    int? id,
+    this.id,
     _i2.ByNameEnum? byNameEnumDefaultModel,
     _i2.ByNameEnum? byNameEnumDefaultModelNull,
     _i2.ByIndexEnum? byIndexEnumDefaultModel,
@@ -27,9 +27,7 @@ abstract class EnumDefaultModel
         byIndexEnumDefaultModel =
             byIndexEnumDefaultModel ?? _i2.ByIndexEnum.byIndex1,
         byIndexEnumDefaultModelNull =
-            byIndexEnumDefaultModelNull ?? _i2.ByIndexEnum.byIndex2 {
-    _id = id;
-  }
+            byIndexEnumDefaultModelNull ?? _i2.ByIndexEnum.byIndex2;
 
   factory EnumDefaultModel({
     int? id,
@@ -63,7 +61,8 @@ abstract class EnumDefaultModel
 
   static const db = EnumDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i2.ByNameEnum byNameEnumDefaultModel;
 
@@ -72,16 +71,6 @@ abstract class EnumDefaultModel
   _i2.ByIndexEnum byIndexEnumDefaultModel;
 
   _i2.ByIndexEnum? byIndexEnumDefaultModelNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -15,12 +15,10 @@ import '../../protocol.dart' as _i2;
 abstract class EnumDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefaultPersist._({
-    int? id,
+    this.id,
     this.byNameEnumDefaultPersist,
     this.byIndexEnumDefaultPersist,
-  }) {
-    _id = id;
-  }
+  });
 
   factory EnumDefaultPersist({
     int? id,
@@ -48,21 +46,12 @@ abstract class EnumDefaultPersist
 
   static const db = EnumDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i2.ByNameEnum? byNameEnumDefaultPersist;
 
   _i2.ByIndexEnum? byIndexEnumDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class EnumDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EnumDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefaultPersist._({
     int? id,
     this.byNameEnumDefaultPersist,
     this.byIndexEnumDefaultPersist,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory EnumDefaultPersist({
     int? id,
@@ -46,9 +48,21 @@ abstract class EnumDefaultPersist extends _i1.TableRow
 
   static const db = EnumDefaultPersistRepository._();
 
+  int? _id;
+
   _i2.ByNameEnum? byNameEnumDefaultPersist;
 
   _i2.ByIndexEnum? byIndexEnumDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
@@ -13,13 +13,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class IntDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefault._({
-    int? id,
+    this.id,
     int? intDefault,
     int? intDefaultNull,
   })  : intDefault = intDefault ?? 10,
-        intDefaultNull = intDefaultNull ?? 20 {
-    _id = id;
-  }
+        intDefaultNull = intDefaultNull ?? 20;
 
   factory IntDefault({
     int? id,
@@ -39,21 +37,12 @@ abstract class IntDefault implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = IntDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int intDefault;
 
   int? intDefaultNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
@@ -11,15 +11,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class IntDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class IntDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefault._({
     int? id,
     int? intDefault,
     int? intDefaultNull,
   })  : intDefault = intDefault ?? 10,
-        intDefaultNull = intDefaultNull ?? 20,
-        super(id);
+        intDefaultNull = intDefaultNull ?? 20 {
+    _id = id;
+  }
 
   factory IntDefault({
     int? id,
@@ -39,9 +39,21 @@ abstract class IntDefault extends _i1.TableRow
 
   static const db = IntDefaultRepository._();
 
+  int? _id;
+
   int intDefault;
 
   int? intDefaultNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class IntDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class IntDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefaultMix._({
     int? id,
     int? intDefaultAndDefaultModel,
@@ -21,8 +21,9 @@ abstract class IntDefaultMix extends _i1.TableRow
   })  : intDefaultAndDefaultModel = intDefaultAndDefaultModel ?? 20,
         intDefaultAndDefaultPersist = intDefaultAndDefaultPersist ?? 10,
         intDefaultModelAndDefaultPersist =
-            intDefaultModelAndDefaultPersist ?? 10,
-        super(id);
+            intDefaultModelAndDefaultPersist ?? 10 {
+    _id = id;
+  }
 
   factory IntDefaultMix({
     int? id,
@@ -47,11 +48,23 @@ abstract class IntDefaultMix extends _i1.TableRow
 
   static const db = IntDefaultMixRepository._();
 
+  int? _id;
+
   int intDefaultAndDefaultModel;
 
   int intDefaultAndDefaultPersist;
 
   int intDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -14,16 +14,14 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class IntDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefaultMix._({
-    int? id,
+    this.id,
     int? intDefaultAndDefaultModel,
     int? intDefaultAndDefaultPersist,
     int? intDefaultModelAndDefaultPersist,
   })  : intDefaultAndDefaultModel = intDefaultAndDefaultModel ?? 20,
         intDefaultAndDefaultPersist = intDefaultAndDefaultPersist ?? 10,
         intDefaultModelAndDefaultPersist =
-            intDefaultModelAndDefaultPersist ?? 10 {
-    _id = id;
-  }
+            intDefaultModelAndDefaultPersist ?? 10;
 
   factory IntDefaultMix({
     int? id,
@@ -48,23 +46,14 @@ abstract class IntDefaultMix
 
   static const db = IntDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int intDefaultAndDefaultModel;
 
   int intDefaultAndDefaultPersist;
 
   int intDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -11,15 +11,16 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class IntDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class IntDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefaultModel._({
     int? id,
     int? intDefaultModel,
     int? intDefaultModelNull,
   })  : intDefaultModel = intDefaultModel ?? 10,
-        intDefaultModelNull = intDefaultModelNull ?? 20,
-        super(id);
+        intDefaultModelNull = intDefaultModelNull ?? 20 {
+    _id = id;
+  }
 
   factory IntDefaultModel({
     int? id,
@@ -39,9 +40,21 @@ abstract class IntDefaultModel extends _i1.TableRow
 
   static const db = IntDefaultModelRepository._();
 
+  int? _id;
+
   int intDefaultModel;
 
   int intDefaultModelNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -14,13 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class IntDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefaultModel._({
-    int? id,
+    this.id,
     int? intDefaultModel,
     int? intDefaultModelNull,
   })  : intDefaultModel = intDefaultModel ?? 10,
-        intDefaultModelNull = intDefaultModelNull ?? 20 {
-    _id = id;
-  }
+        intDefaultModelNull = intDefaultModelNull ?? 20;
 
   factory IntDefaultModel({
     int? id,
@@ -40,21 +38,12 @@ abstract class IntDefaultModel
 
   static const db = IntDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int intDefaultModel;
 
   int intDefaultModelNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class IntDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class IntDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefaultPersist._({
     int? id,
     this.intDefaultPersist,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory IntDefaultPersist({
     int? id,
@@ -34,7 +36,19 @@ abstract class IntDefaultPersist extends _i1.TableRow
 
   static const db = IntDefaultPersistRepository._();
 
+  int? _id;
+
   int? intDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class IntDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefaultPersist._({
-    int? id,
+    this.id,
     this.intDefaultPersist,
-  }) {
-    _id = id;
-  }
+  });
 
   factory IntDefaultPersist({
     int? id,
@@ -36,19 +34,10 @@ abstract class IntDefaultPersist
 
   static const db = IntDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int? intDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
@@ -14,14 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class StringDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefault._({
-    int? id,
+    this.id,
     String? stringDefault,
     String? stringDefaultNull,
   })  : stringDefault = stringDefault ?? 'This is a default value',
-        stringDefaultNull =
-            stringDefaultNull ?? 'This is a default null value' {
-    _id = id;
-  }
+        stringDefaultNull = stringDefaultNull ?? 'This is a default null value';
 
   factory StringDefault({
     int? id,
@@ -41,21 +38,12 @@ abstract class StringDefault
 
   static const db = StringDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String stringDefault;
 
   String? stringDefaultNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
@@ -11,15 +11,17 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class StringDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class StringDefault
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefault._({
     int? id,
     String? stringDefault,
     String? stringDefaultNull,
   })  : stringDefault = stringDefault ?? 'This is a default value',
-        stringDefaultNull = stringDefaultNull ?? 'This is a default null value',
-        super(id);
+        stringDefaultNull =
+            stringDefaultNull ?? 'This is a default null value' {
+    _id = id;
+  }
 
   factory StringDefault({
     int? id,
@@ -39,9 +41,21 @@ abstract class StringDefault extends _i1.TableRow
 
   static const db = StringDefaultRepository._();
 
+  int? _id;
+
   String stringDefault;
 
   String? stringDefaultNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class StringDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class StringDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefaultMix._({
     int? id,
     String? stringDefaultAndDefaultModel,
@@ -23,8 +23,9 @@ abstract class StringDefaultMix extends _i1.TableRow
         stringDefaultAndDefaultPersist =
             stringDefaultAndDefaultPersist ?? 'This is a default value',
         stringDefaultModelAndDefaultPersist =
-            stringDefaultModelAndDefaultPersist ?? 'This is a default value',
-        super(id);
+            stringDefaultModelAndDefaultPersist ?? 'This is a default value' {
+    _id = id;
+  }
 
   factory StringDefaultMix({
     int? id,
@@ -49,11 +50,23 @@ abstract class StringDefaultMix extends _i1.TableRow
 
   static const db = StringDefaultMixRepository._();
 
+  int? _id;
+
   String stringDefaultAndDefaultModel;
 
   String stringDefaultAndDefaultPersist;
 
   String stringDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class StringDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefaultMix._({
-    int? id,
+    this.id,
     String? stringDefaultAndDefaultModel,
     String? stringDefaultAndDefaultPersist,
     String? stringDefaultModelAndDefaultPersist,
@@ -23,9 +23,7 @@ abstract class StringDefaultMix
         stringDefaultAndDefaultPersist =
             stringDefaultAndDefaultPersist ?? 'This is a default value',
         stringDefaultModelAndDefaultPersist =
-            stringDefaultModelAndDefaultPersist ?? 'This is a default value' {
-    _id = id;
-  }
+            stringDefaultModelAndDefaultPersist ?? 'This is a default value';
 
   factory StringDefaultMix({
     int? id,
@@ -50,23 +48,14 @@ abstract class StringDefaultMix
 
   static const db = StringDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String stringDefaultAndDefaultModel;
 
   String stringDefaultAndDefaultPersist;
 
   String stringDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -14,15 +14,13 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class StringDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefaultModel._({
-    int? id,
+    this.id,
     String? stringDefaultModel,
     String? stringDefaultModelNull,
   })  : stringDefaultModel =
             stringDefaultModel ?? 'This is a default model value',
         stringDefaultModelNull =
-            stringDefaultModelNull ?? 'This is a default model null value' {
-    _id = id;
-  }
+            stringDefaultModelNull ?? 'This is a default model null value';
 
   factory StringDefaultModel({
     int? id,
@@ -43,21 +41,12 @@ abstract class StringDefaultModel
 
   static const db = StringDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String stringDefaultModel;
 
   String stringDefaultModelNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class StringDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class StringDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefaultModel._({
     int? id,
     String? stringDefaultModel,
@@ -20,8 +20,9 @@ abstract class StringDefaultModel extends _i1.TableRow
   })  : stringDefaultModel =
             stringDefaultModel ?? 'This is a default model value',
         stringDefaultModelNull =
-            stringDefaultModelNull ?? 'This is a default model null value',
-        super(id);
+            stringDefaultModelNull ?? 'This is a default model null value' {
+    _id = id;
+  }
 
   factory StringDefaultModel({
     int? id,
@@ -42,9 +43,21 @@ abstract class StringDefaultModel extends _i1.TableRow
 
   static const db = StringDefaultModelRepository._();
 
+  int? _id;
+
   String stringDefaultModel;
 
   String stringDefaultModelNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class StringDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefaultPersist._({
-    int? id,
+    this.id,
     this.stringDefaultPersist,
     this.stringDefaultPersistSingleQuoteWithOneSingleEscapeQuote,
     this.stringDefaultPersistSingleQuoteWithTwoSingleEscapeQuote,
@@ -24,9 +24,7 @@ abstract class StringDefaultPersist
     this.stringDefaultPersistSingleQuoteWithTwoDoubleQuote,
     this.stringDefaultPersistDoubleQuoteWithOneSingleQuote,
     this.stringDefaultPersistDoubleQuoteWithTwoSingleQuote,
-  }) {
-    _id = id;
-  }
+  });
 
   factory StringDefaultPersist({
     int? id,
@@ -82,7 +80,8 @@ abstract class StringDefaultPersist
 
   static const db = StringDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String? stringDefaultPersist;
 
@@ -101,16 +100,6 @@ abstract class StringDefaultPersist
   String? stringDefaultPersistDoubleQuoteWithOneSingleQuote;
 
   String? stringDefaultPersistDoubleQuoteWithTwoSingleQuote;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class StringDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class StringDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   StringDefaultPersist._({
     int? id,
     this.stringDefaultPersist,
@@ -24,7 +24,9 @@ abstract class StringDefaultPersist extends _i1.TableRow
     this.stringDefaultPersistSingleQuoteWithTwoDoubleQuote,
     this.stringDefaultPersistDoubleQuoteWithOneSingleQuote,
     this.stringDefaultPersistDoubleQuoteWithTwoSingleQuote,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory StringDefaultPersist({
     int? id,
@@ -80,6 +82,8 @@ abstract class StringDefaultPersist extends _i1.TableRow
 
   static const db = StringDefaultPersistRepository._();
 
+  int? _id;
+
   String? stringDefaultPersist;
 
   String? stringDefaultPersistSingleQuoteWithOneSingleEscapeQuote;
@@ -97,6 +101,16 @@ abstract class StringDefaultPersist extends _i1.TableRow
   String? stringDefaultPersistDoubleQuoteWithOneSingleQuote;
 
   String? stringDefaultPersistDoubleQuoteWithTwoSingleQuote;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -14,7 +14,7 @@ import 'package:uuid/uuid.dart' as _i2;
 
 abstract class UuidDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefault._({
-    int? id,
+    this.id,
     _i1.UuidValue? uuidDefaultRandom,
     _i1.UuidValue? uuidDefaultRandomNull,
     _i1.UuidValue? uuidDefaultStr,
@@ -24,9 +24,7 @@ abstract class UuidDefault implements _i1.TableRow, _i1.ProtocolSerialization {
         uuidDefaultStr = uuidDefaultStr ??
             _i1.UuidValue.fromString('550e8400-e29b-41d4-a716-446655440000'),
         uuidDefaultStrNull = uuidDefaultStrNull ??
-            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301') {
-    _id = id;
-  }
+            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301');
 
   factory UuidDefault({
     int? id,
@@ -58,7 +56,8 @@ abstract class UuidDefault implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = UuidDefaultRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i1.UuidValue uuidDefaultRandom;
 
@@ -67,16 +66,6 @@ abstract class UuidDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   _i1.UuidValue uuidDefaultStr;
 
   _i1.UuidValue? uuidDefaultStrNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -12,8 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
 
-abstract class UuidDefault extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UuidDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefault._({
     int? id,
     _i1.UuidValue? uuidDefaultRandom,
@@ -25,8 +24,9 @@ abstract class UuidDefault extends _i1.TableRow
         uuidDefaultStr = uuidDefaultStr ??
             _i1.UuidValue.fromString('550e8400-e29b-41d4-a716-446655440000'),
         uuidDefaultStrNull = uuidDefaultStrNull ??
-            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301'),
-        super(id);
+            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301') {
+    _id = id;
+  }
 
   factory UuidDefault({
     int? id,
@@ -58,6 +58,8 @@ abstract class UuidDefault extends _i1.TableRow
 
   static const db = UuidDefaultRepository._();
 
+  int? _id;
+
   _i1.UuidValue uuidDefaultRandom;
 
   _i1.UuidValue? uuidDefaultRandomNull;
@@ -65,6 +67,16 @@ abstract class UuidDefault extends _i1.TableRow
   _i1.UuidValue uuidDefaultStr;
 
   _i1.UuidValue? uuidDefaultStrNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -14,7 +14,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class UuidDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefaultMix._({
-    int? id,
+    this.id,
     _i1.UuidValue? uuidDefaultAndDefaultModel,
     _i1.UuidValue? uuidDefaultAndDefaultPersist,
     _i1.UuidValue? uuidDefaultModelAndDefaultPersist,
@@ -23,9 +23,7 @@ abstract class UuidDefaultMix
         uuidDefaultAndDefaultPersist = uuidDefaultAndDefaultPersist ??
             _i1.UuidValue.fromString('6fa459ea-ee8a-3ca4-894e-db77e160355e'),
         uuidDefaultModelAndDefaultPersist = uuidDefaultModelAndDefaultPersist ??
-            _i1.UuidValue.fromString('d9428888-122b-11e1-b85c-61cd3cbb3210') {
-    _id = id;
-  }
+            _i1.UuidValue.fromString('d9428888-122b-11e1-b85c-61cd3cbb3210');
 
   factory UuidDefaultMix({
     int? id,
@@ -50,23 +48,14 @@ abstract class UuidDefaultMix
 
   static const db = UuidDefaultMixRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i1.UuidValue uuidDefaultAndDefaultModel;
 
   _i1.UuidValue uuidDefaultAndDefaultPersist;
 
   _i1.UuidValue uuidDefaultModelAndDefaultPersist;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -11,8 +11,8 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class UuidDefaultMix extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UuidDefaultMix
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefaultMix._({
     int? id,
     _i1.UuidValue? uuidDefaultAndDefaultModel,
@@ -23,8 +23,9 @@ abstract class UuidDefaultMix extends _i1.TableRow
         uuidDefaultAndDefaultPersist = uuidDefaultAndDefaultPersist ??
             _i1.UuidValue.fromString('6fa459ea-ee8a-3ca4-894e-db77e160355e'),
         uuidDefaultModelAndDefaultPersist = uuidDefaultModelAndDefaultPersist ??
-            _i1.UuidValue.fromString('d9428888-122b-11e1-b85c-61cd3cbb3210'),
-        super(id);
+            _i1.UuidValue.fromString('d9428888-122b-11e1-b85c-61cd3cbb3210') {
+    _id = id;
+  }
 
   factory UuidDefaultMix({
     int? id,
@@ -49,11 +50,23 @@ abstract class UuidDefaultMix extends _i1.TableRow
 
   static const db = UuidDefaultMixRepository._();
 
+  int? _id;
+
   _i1.UuidValue uuidDefaultAndDefaultModel;
 
   _i1.UuidValue uuidDefaultAndDefaultPersist;
 
   _i1.UuidValue uuidDefaultModelAndDefaultPersist;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
 
-abstract class UuidDefaultModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UuidDefaultModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefaultModel._({
     int? id,
     _i1.UuidValue? uuidDefaultModelRandom,
@@ -26,8 +26,9 @@ abstract class UuidDefaultModel extends _i1.TableRow
         uuidDefaultModelStr = uuidDefaultModelStr ??
             _i1.UuidValue.fromString('550e8400-e29b-41d4-a716-446655440000'),
         uuidDefaultModelStrNull = uuidDefaultModelStrNull ??
-            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301'),
-        super(id);
+            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301') {
+    _id = id;
+  }
 
   factory UuidDefaultModel({
     int? id,
@@ -61,6 +62,8 @@ abstract class UuidDefaultModel extends _i1.TableRow
 
   static const db = UuidDefaultModelRepository._();
 
+  int? _id;
+
   _i1.UuidValue uuidDefaultModelRandom;
 
   _i1.UuidValue? uuidDefaultModelRandomNull;
@@ -68,6 +71,16 @@ abstract class UuidDefaultModel extends _i1.TableRow
   _i1.UuidValue uuidDefaultModelStr;
 
   _i1.UuidValue? uuidDefaultModelStrNull;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -15,7 +15,7 @@ import 'package:uuid/uuid.dart' as _i2;
 abstract class UuidDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefaultModel._({
-    int? id,
+    this.id,
     _i1.UuidValue? uuidDefaultModelRandom,
     _i1.UuidValue? uuidDefaultModelRandomNull,
     _i1.UuidValue? uuidDefaultModelStr,
@@ -26,9 +26,7 @@ abstract class UuidDefaultModel
         uuidDefaultModelStr = uuidDefaultModelStr ??
             _i1.UuidValue.fromString('550e8400-e29b-41d4-a716-446655440000'),
         uuidDefaultModelStrNull = uuidDefaultModelStrNull ??
-            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301') {
-    _id = id;
-  }
+            _i1.UuidValue.fromString('3f2504e0-4f89-11d3-9a0c-0305e82c3301');
 
   factory UuidDefaultModel({
     int? id,
@@ -62,7 +60,8 @@ abstract class UuidDefaultModel
 
   static const db = UuidDefaultModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i1.UuidValue uuidDefaultModelRandom;
 
@@ -71,16 +70,6 @@ abstract class UuidDefaultModel
   _i1.UuidValue uuidDefaultModelStr;
 
   _i1.UuidValue? uuidDefaultModelStrNull;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -11,13 +11,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class UuidDefaultPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UuidDefaultPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefaultPersist._({
     int? id,
     this.uuidDefaultPersistRandom,
     this.uuidDefaultPersistStr,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UuidDefaultPersist({
     int? id,
@@ -44,9 +46,21 @@ abstract class UuidDefaultPersist extends _i1.TableRow
 
   static const db = UuidDefaultPersistRepository._();
 
+  int? _id;
+
   _i1.UuidValue? uuidDefaultPersistRandom;
 
   _i1.UuidValue? uuidDefaultPersistStr;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class UuidDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefaultPersist._({
-    int? id,
+    this.id,
     this.uuidDefaultPersistRandom,
     this.uuidDefaultPersistStr,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UuidDefaultPersist({
     int? id,
@@ -46,21 +44,12 @@ abstract class UuidDefaultPersist
 
   static const db = UuidDefaultPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i1.UuidValue? uuidDefaultPersistRandom;
 
   _i1.UuidValue? uuidDefaultPersistStr;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class EmptyModelRelationItem extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class EmptyModelRelationItem
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   EmptyModelRelationItem._({
     int? id,
     required this.name,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory EmptyModelRelationItem({
     int? id,
@@ -35,9 +37,21 @@ abstract class EmptyModelRelationItem extends _i1.TableRow
 
   static const db = EmptyModelRelationItemRepository._();
 
+  int? _id;
+
   String name;
 
   int? _relationEmptyModelItemsRelationEmptyModelId;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class EmptyModelRelationItem
     implements _i1.TableRow, _i1.ProtocolSerialization {
   EmptyModelRelationItem._({
-    int? id,
+    this.id,
     required this.name,
-  }) {
-    _id = id;
-  }
+  });
 
   factory EmptyModelRelationItem({
     int? id,
@@ -37,21 +35,12 @@ abstract class EmptyModelRelationItem
 
   static const db = EmptyModelRelationItemRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   int? _relationEmptyModelItemsRelationEmptyModelId;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -11,9 +11,11 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class EmptyModelWithTable extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
-  EmptyModelWithTable._({int? id}) : super(id);
+abstract class EmptyModelWithTable
+    implements _i1.TableRow, _i1.ProtocolSerialization {
+  EmptyModelWithTable._({int? id}) {
+    _id = id;
+  }
 
   factory EmptyModelWithTable({int? id}) = _EmptyModelWithTableImpl;
 
@@ -24,6 +26,18 @@ abstract class EmptyModelWithTable extends _i1.TableRow
   static final t = EmptyModelWithTableTable();
 
   static const db = EmptyModelWithTableRepository._();
+
+  int? _id;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -13,9 +13,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class EmptyModelWithTable
     implements _i1.TableRow, _i1.ProtocolSerialization {
-  EmptyModelWithTable._({int? id}) {
-    _id = id;
-  }
+  EmptyModelWithTable._({this.id});
 
   factory EmptyModelWithTable({int? id}) = _EmptyModelWithTableImpl;
 
@@ -27,17 +25,8 @@ abstract class EmptyModelWithTable
 
   static const db = EmptyModelWithTableRepository._();
 
-  int? _id;
-
   @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
+  int? id;
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -15,11 +15,9 @@ import '../protocol.dart' as _i2;
 abstract class RelationEmptyModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
   RelationEmptyModel._({
-    int? id,
+    this.id,
     this.items,
-  }) {
-    _id = id;
-  }
+  });
 
   factory RelationEmptyModel({
     int? id,
@@ -40,19 +38,10 @@ abstract class RelationEmptyModel
 
   static const db = RelationEmptyModelRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   List<_i2.EmptyModelRelationItem>? items;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -12,12 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
 
-abstract class RelationEmptyModel extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class RelationEmptyModel
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   RelationEmptyModel._({
     int? id,
     this.items,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory RelationEmptyModel({
     int? id,
@@ -38,7 +40,19 @@ abstract class RelationEmptyModel extends _i1.TableRow
 
   static const db = RelationEmptyModelRepository._();
 
+  int? _id;
+
   List<_i2.EmptyModelRelationItem>? items;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -15,13 +15,11 @@ import '../../protocol.dart' as _i2;
 abstract class CityWithLongTableName
     implements _i1.TableRow, _i1.ProtocolSerialization {
   CityWithLongTableName._({
-    int? id,
+    this.id,
     required this.name,
     this.citizens,
     this.organizations,
-  }) {
-    _id = id;
-  }
+  });
 
   factory CityWithLongTableName({
     int? id,
@@ -50,23 +48,14 @@ abstract class CityWithLongTableName
 
   static const db = CityWithLongTableNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.PersonWithLongTableName>? citizens;
 
   List<_i2.OrganizationWithLongTableName>? organizations;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class CityWithLongTableName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class CityWithLongTableName
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   CityWithLongTableName._({
     int? id,
     required this.name,
     this.citizens,
     this.organizations,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory CityWithLongTableName({
     int? id,
@@ -48,11 +50,23 @@ abstract class CityWithLongTableName extends _i1.TableRow
 
   static const db = CityWithLongTableNameRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.PersonWithLongTableName>? citizens;
 
   List<_i2.OrganizationWithLongTableName>? organizations;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -15,14 +15,12 @@ import '../../protocol.dart' as _i2;
 abstract class OrganizationWithLongTableName
     implements _i1.TableRow, _i1.ProtocolSerialization {
   OrganizationWithLongTableName._({
-    int? id,
+    this.id,
     required this.name,
     this.people,
     this.cityId,
     this.city,
-  }) {
-    _id = id;
-  }
+  });
 
   factory OrganizationWithLongTableName({
     int? id,
@@ -53,7 +51,8 @@ abstract class OrganizationWithLongTableName
 
   static const db = OrganizationWithLongTableNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
@@ -62,16 +61,6 @@ abstract class OrganizationWithLongTableName
   int? cityId;
 
   _i2.CityWithLongTableName? city;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -12,15 +12,17 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class OrganizationWithLongTableName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class OrganizationWithLongTableName
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   OrganizationWithLongTableName._({
     int? id,
     required this.name,
     this.people,
     this.cityId,
     this.city,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory OrganizationWithLongTableName({
     int? id,
@@ -51,6 +53,8 @@ abstract class OrganizationWithLongTableName extends _i1.TableRow
 
   static const db = OrganizationWithLongTableNameRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.PersonWithLongTableName>? people;
@@ -58,6 +62,16 @@ abstract class OrganizationWithLongTableName extends _i1.TableRow
   int? cityId;
 
   _i2.CityWithLongTableName? city;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -15,13 +15,11 @@ import '../../protocol.dart' as _i2;
 abstract class PersonWithLongTableName
     implements _i1.TableRow, _i1.ProtocolSerialization {
   PersonWithLongTableName._({
-    int? id,
+    this.id,
     required this.name,
     this.organizationId,
     this.organization,
-  }) {
-    _id = id;
-  }
+  });
 
   factory PersonWithLongTableName({
     int? id,
@@ -47,7 +45,8 @@ abstract class PersonWithLongTableName
 
   static const db = PersonWithLongTableNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
@@ -56,16 +55,6 @@ abstract class PersonWithLongTableName
   _i2.OrganizationWithLongTableName? organization;
 
   int? _cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class PersonWithLongTableName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class PersonWithLongTableName
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   PersonWithLongTableName._({
     int? id,
     required this.name,
     this.organizationId,
     this.organization,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory PersonWithLongTableName({
     int? id,
@@ -45,6 +47,8 @@ abstract class PersonWithLongTableName extends _i1.TableRow
 
   static const db = PersonWithLongTableNameRepository._();
 
+  int? _id;
+
   String name;
 
   int? organizationId;
@@ -52,6 +56,16 @@ abstract class PersonWithLongTableName extends _i1.TableRow
   _i2.OrganizationWithLongTableName? organization;
 
   int? _cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -13,11 +13,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class MaxFieldName implements _i1.TableRow, _i1.ProtocolSerialization {
   MaxFieldName._({
-    int? id,
+    this.id,
     required this.thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo,
-  }) {
-    _id = id;
-  }
+  });
 
   factory MaxFieldName({
     int? id,
@@ -39,19 +37,10 @@ abstract class MaxFieldName implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = MaxFieldNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -11,12 +11,13 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class MaxFieldName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class MaxFieldName implements _i1.TableRow, _i1.ProtocolSerialization {
   MaxFieldName._({
     int? id,
     required this.thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory MaxFieldName({
     int? id,
@@ -38,7 +39,19 @@ abstract class MaxFieldName extends _i1.TableRow
 
   static const db = MaxFieldNameRepository._();
 
+  int? _id;
+
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class LongImplicitIdField
     implements _i1.TableRow, _i1.ProtocolSerialization {
   LongImplicitIdField._({
-    int? id,
+    this.id,
     required this.name,
-  }) {
-    _id = id;
-  }
+  });
 
   factory LongImplicitIdField({
     int? id,
@@ -36,21 +34,12 @@ abstract class LongImplicitIdField
 
   static const db = LongImplicitIdFieldRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   int? _longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class LongImplicitIdField extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class LongImplicitIdField
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   LongImplicitIdField._({
     int? id,
     required this.name,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory LongImplicitIdField({
     int? id,
@@ -34,9 +36,21 @@ abstract class LongImplicitIdField extends _i1.TableRow
 
   static const db = LongImplicitIdFieldRepository._();
 
+  int? _id;
+
   String name;
 
   int? _longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -15,12 +15,10 @@ import '../../protocol.dart' as _i2;
 abstract class LongImplicitIdFieldCollection
     implements _i1.TableRow, _i1.ProtocolSerialization {
   LongImplicitIdFieldCollection._({
-    int? id,
+    this.id,
     required this.name,
     this.thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa,
-  }) {
-    _id = id;
-  }
+  });
 
   factory LongImplicitIdFieldCollection({
     int? id,
@@ -48,22 +46,13 @@ abstract class LongImplicitIdFieldCollection
 
   static const db = LongImplicitIdFieldCollectionRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.LongImplicitIdField>?
       thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class LongImplicitIdFieldCollection extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class LongImplicitIdFieldCollection
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   LongImplicitIdFieldCollection._({
     int? id,
     required this.name,
     this.thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory LongImplicitIdFieldCollection({
     int? id,
@@ -46,10 +48,22 @@ abstract class LongImplicitIdFieldCollection extends _i1.TableRow
 
   static const db = LongImplicitIdFieldCollectionRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.LongImplicitIdField>?
       thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class RelationToMultipleMaxFieldName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class RelationToMultipleMaxFieldName
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   RelationToMultipleMaxFieldName._({
     int? id,
     required this.name,
     this.multipleMaxFieldNames,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory RelationToMultipleMaxFieldName({
     int? id,
@@ -43,9 +45,21 @@ abstract class RelationToMultipleMaxFieldName extends _i1.TableRow
 
   static const db = RelationToMultipleMaxFieldNameRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.MultipleMaxFieldName>? multipleMaxFieldNames;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -15,12 +15,10 @@ import '../../protocol.dart' as _i2;
 abstract class RelationToMultipleMaxFieldName
     implements _i1.TableRow, _i1.ProtocolSerialization {
   RelationToMultipleMaxFieldName._({
-    int? id,
+    this.id,
     required this.name,
     this.multipleMaxFieldNames,
-  }) {
-    _id = id;
-  }
+  });
 
   factory RelationToMultipleMaxFieldName({
     int? id,
@@ -45,21 +43,12 @@ abstract class RelationToMultipleMaxFieldName
 
   static const db = RelationToMultipleMaxFieldNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.MultipleMaxFieldName>? multipleMaxFieldNames;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -11,12 +11,13 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class UserNote extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UserNote implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNote._({
     int? id,
     required this.name,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UserNote({
     int? id,
@@ -34,9 +35,21 @@ abstract class UserNote extends _i1.TableRow
 
   static const db = UserNoteRepository._();
 
+  int? _id;
+
   String name;
 
   int? _userNoteCollectionsUsernotespropertynameUserNoteCollectionsId;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -13,11 +13,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class UserNote implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNote._({
-    int? id,
+    this.id,
     required this.name,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UserNote({
     int? id,
@@ -35,21 +33,12 @@ abstract class UserNote implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = UserNoteRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   int? _userNoteCollectionsUsernotespropertynameUserNoteCollectionsId;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -15,12 +15,10 @@ import '../../protocol.dart' as _i2;
 abstract class UserNoteCollection
     implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNoteCollection._({
-    int? id,
+    this.id,
     required this.name,
     this.userNotesPropertyName,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UserNoteCollection({
     int? id,
@@ -43,21 +41,12 @@ abstract class UserNoteCollection
 
   static const db = UserNoteCollectionRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.UserNote>? userNotesPropertyName;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class UserNoteCollection extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UserNoteCollection
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNoteCollection._({
     int? id,
     required this.name,
     this.userNotesPropertyName,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UserNoteCollection({
     int? id,
@@ -41,9 +43,21 @@ abstract class UserNoteCollection extends _i1.TableRow
 
   static const db = UserNoteCollectionRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.UserNote>? userNotesPropertyName;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class UserNoteCollectionWithALongName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UserNoteCollectionWithALongName
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNoteCollectionWithALongName._({
     int? id,
     required this.name,
     this.notes,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UserNoteCollectionWithALongName({
     int? id,
@@ -42,9 +44,21 @@ abstract class UserNoteCollectionWithALongName extends _i1.TableRow
 
   static const db = UserNoteCollectionWithALongNameRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.UserNoteWithALongName>? notes;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -15,12 +15,10 @@ import '../../protocol.dart' as _i2;
 abstract class UserNoteCollectionWithALongName
     implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNoteCollectionWithALongName._({
-    int? id,
+    this.id,
     required this.name,
     this.notes,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UserNoteCollectionWithALongName({
     int? id,
@@ -44,21 +42,12 @@ abstract class UserNoteCollectionWithALongName
 
   static const db = UserNoteCollectionWithALongNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.UserNoteWithALongName>? notes;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class UserNoteWithALongName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UserNoteWithALongName
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNoteWithALongName._({
     int? id,
     required this.name,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UserNoteWithALongName({
     int? id,
@@ -35,9 +37,21 @@ abstract class UserNoteWithALongName extends _i1.TableRow
 
   static const db = UserNoteWithALongNameRepository._();
 
+  int? _id;
+
   String name;
 
   int? _userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class UserNoteWithALongName
     implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNoteWithALongName._({
-    int? id,
+    this.id,
     required this.name,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UserNoteWithALongName({
     int? id,
@@ -37,21 +35,12 @@ abstract class UserNoteWithALongName
 
   static const db = UserNoteWithALongNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   int? _userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -11,13 +11,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class MultipleMaxFieldName extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class MultipleMaxFieldName
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   MultipleMaxFieldName._({
     int? id,
     required this.thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1,
     required this.thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory MultipleMaxFieldName({
     int? id,
@@ -46,11 +48,23 @@ abstract class MultipleMaxFieldName extends _i1.TableRow
 
   static const db = MultipleMaxFieldNameRepository._();
 
+  int? _id;
+
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1;
 
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2;
 
   int? _relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class MultipleMaxFieldName
     implements _i1.TableRow, _i1.ProtocolSerialization {
   MultipleMaxFieldName._({
-    int? id,
+    this.id,
     required this.thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1,
     required this.thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2,
-  }) {
-    _id = id;
-  }
+  });
 
   factory MultipleMaxFieldName({
     int? id,
@@ -48,23 +46,14 @@ abstract class MultipleMaxFieldName
 
   static const db = MultipleMaxFieldNameRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1;
 
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2;
 
   int? _relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
 
-abstract class City extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class City implements _i1.TableRow, _i1.ProtocolSerialization {
   City._({
     int? id,
     required this.name,
     this.citizens,
     this.organizations,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory City({
     int? id,
@@ -44,11 +46,23 @@ abstract class City extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = CityRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.Person>? citizens;
 
   List<_i2.Organization>? organizations;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -14,13 +14,11 @@ import '../protocol.dart' as _i2;
 
 abstract class City implements _i1.TableRow, _i1.ProtocolSerialization {
   City._({
-    int? id,
+    this.id,
     required this.name,
     this.citizens,
     this.organizations,
-  }) {
-    _id = id;
-  }
+  });
 
   factory City({
     int? id,
@@ -46,23 +44,14 @@ abstract class City implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = CityRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.Person>? citizens;
 
   List<_i2.Organization>? organizations;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -14,14 +14,12 @@ import '../protocol.dart' as _i2;
 
 abstract class Organization implements _i1.TableRow, _i1.ProtocolSerialization {
   Organization._({
-    int? id,
+    this.id,
     required this.name,
     this.people,
     this.cityId,
     this.city,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Organization({
     int? id,
@@ -50,7 +48,8 @@ abstract class Organization implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = OrganizationRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
@@ -59,16 +58,6 @@ abstract class Organization implements _i1.TableRow, _i1.ProtocolSerialization {
   int? cityId;
 
   _i2.City? city;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -12,15 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
 
-abstract class Organization extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Organization implements _i1.TableRow, _i1.ProtocolSerialization {
   Organization._({
     int? id,
     required this.name,
     this.people,
     this.cityId,
     this.city,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Organization({
     int? id,
@@ -49,6 +50,8 @@ abstract class Organization extends _i1.TableRow
 
   static const db = OrganizationRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.Person>? people;
@@ -56,6 +59,16 @@ abstract class Organization extends _i1.TableRow
   int? cityId;
 
   _i2.City? city;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
 
-abstract class Person extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Person implements _i1.TableRow, _i1.ProtocolSerialization {
   Person._({
     int? id,
     required this.name,
     this.organizationId,
     this.organization,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Person({
     int? id,
@@ -44,6 +45,8 @@ abstract class Person extends _i1.TableRow
 
   static const db = PersonRepository._();
 
+  int? _id;
+
   String name;
 
   int? organizationId;
@@ -51,6 +54,16 @@ abstract class Person extends _i1.TableRow
   _i2.Organization? organization;
 
   int? _cityCitizensCityId;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -14,13 +14,11 @@ import '../protocol.dart' as _i2;
 
 abstract class Person implements _i1.TableRow, _i1.ProtocolSerialization {
   Person._({
-    int? id,
+    this.id,
     required this.name,
     this.organizationId,
     this.organization,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Person({
     int? id,
@@ -45,7 +43,8 @@ abstract class Person implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = PersonRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
@@ -54,16 +53,6 @@ abstract class Person implements _i1.TableRow, _i1.ProtocolSerialization {
   _i2.Organization? organization;
 
   int? _cityCitizensCityId;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -14,12 +14,10 @@ import '../../protocol.dart' as _i2;
 
 abstract class Course implements _i1.TableRow, _i1.ProtocolSerialization {
   Course._({
-    int? id,
+    this.id,
     required this.name,
     this.enrollments,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Course({
     int? id,
@@ -41,21 +39,12 @@ abstract class Course implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = CourseRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.Enrollment>? enrollments;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -12,13 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Course extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Course implements _i1.TableRow, _i1.ProtocolSerialization {
   Course._({
     int? id,
     required this.name,
     this.enrollments,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Course({
     int? id,
@@ -40,9 +41,21 @@ abstract class Course extends _i1.TableRow
 
   static const db = CourseRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.Enrollment>? enrollments;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -14,14 +14,12 @@ import '../../protocol.dart' as _i2;
 
 abstract class Enrollment implements _i1.TableRow, _i1.ProtocolSerialization {
   Enrollment._({
-    int? id,
+    this.id,
     required this.studentId,
     this.student,
     required this.courseId,
     this.course,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Enrollment({
     int? id,
@@ -51,7 +49,8 @@ abstract class Enrollment implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = EnrollmentRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int studentId;
 
@@ -60,16 +59,6 @@ abstract class Enrollment implements _i1.TableRow, _i1.ProtocolSerialization {
   int courseId;
 
   _i2.Course? course;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -12,15 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Enrollment extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Enrollment implements _i1.TableRow, _i1.ProtocolSerialization {
   Enrollment._({
     int? id,
     required this.studentId,
     this.student,
     required this.courseId,
     this.course,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Enrollment({
     int? id,
@@ -50,6 +51,8 @@ abstract class Enrollment extends _i1.TableRow
 
   static const db = EnrollmentRepository._();
 
+  int? _id;
+
   int studentId;
 
   _i2.Student? student;
@@ -57,6 +60,16 @@ abstract class Enrollment extends _i1.TableRow
   int courseId;
 
   _i2.Course? course;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -14,12 +14,10 @@ import '../../protocol.dart' as _i2;
 
 abstract class Student implements _i1.TableRow, _i1.ProtocolSerialization {
   Student._({
-    int? id,
+    this.id,
     required this.name,
     this.enrollments,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Student({
     int? id,
@@ -41,21 +39,12 @@ abstract class Student implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = StudentRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.Enrollment>? enrollments;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -12,13 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Student extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Student implements _i1.TableRow, _i1.ProtocolSerialization {
   Student._({
     int? id,
     required this.name,
     this.enrollments,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Student({
     int? id,
@@ -40,9 +41,21 @@ abstract class Student extends _i1.TableRow
 
   static const db = StudentRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.Enrollment>? enrollments;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -14,13 +14,11 @@ import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
 
 abstract class ObjectUser implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectUser._({
-    int? id,
+    this.id,
     this.name,
     required this.userInfoId,
     this.userInfo,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectUser({
     int? id,
@@ -45,23 +43,14 @@ abstract class ObjectUser implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = ObjectUserRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String? name;
 
   int userInfoId;
 
   _i2.UserInfo? userInfo;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
 
-abstract class ObjectUser extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectUser implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectUser._({
     int? id,
     this.name,
     required this.userInfoId,
     this.userInfo,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectUser({
     int? id,
@@ -44,11 +45,23 @@ abstract class ObjectUser extends _i1.TableRow
 
   static const db = ObjectUserRepository._();
 
+  int? _id;
+
   String? name;
 
   int userInfoId;
 
   _i2.UserInfo? userInfo;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -13,12 +13,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class ParentUser implements _i1.TableRow, _i1.ProtocolSerialization {
   ParentUser._({
-    int? id,
+    this.id,
     this.name,
     this.userInfoId,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ParentUser({
     int? id,
@@ -38,21 +36,12 @@ abstract class ParentUser implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = ParentUserRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String? name;
 
   int? userInfoId;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -11,13 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ParentUser extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ParentUser implements _i1.TableRow, _i1.ProtocolSerialization {
   ParentUser._({
     int? id,
     this.name,
     this.userInfoId,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ParentUser({
     int? id,
@@ -37,9 +38,21 @@ abstract class ParentUser extends _i1.TableRow
 
   static const db = ParentUserRepository._();
 
+  int? _id;
+
   String? name;
 
   int? userInfoId;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -14,12 +14,10 @@ import '../../protocol.dart' as _i2;
 
 abstract class Arena implements _i1.TableRow, _i1.ProtocolSerialization {
   Arena._({
-    int? id,
+    this.id,
     required this.name,
     this.team,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Arena({
     int? id,
@@ -42,21 +40,12 @@ abstract class Arena implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = ArenaRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   _i2.Team? team;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -12,12 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Arena extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class Arena implements _i1.TableRow, _i1.ProtocolSerialization {
   Arena._({
     int? id,
     required this.name,
     this.team,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Arena({
     int? id,
@@ -40,9 +42,21 @@ abstract class Arena extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = ArenaRepository._();
 
+  int? _id;
+
   String name;
 
   _i2.Team? team;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -14,13 +14,11 @@ import '../../protocol.dart' as _i2;
 
 abstract class Player implements _i1.TableRow, _i1.ProtocolSerialization {
   Player._({
-    int? id,
+    this.id,
     required this.name,
     this.teamId,
     this.team,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Player({
     int? id,
@@ -45,23 +43,14 @@ abstract class Player implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = PlayerRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   int? teamId;
 
   _i2.Team? team;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Player extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Player implements _i1.TableRow, _i1.ProtocolSerialization {
   Player._({
     int? id,
     required this.name,
     this.teamId,
     this.team,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Player({
     int? id,
@@ -44,11 +45,23 @@ abstract class Player extends _i1.TableRow
 
   static const db = PlayerRepository._();
 
+  int? _id;
+
   String name;
 
   int? teamId;
 
   _i2.Team? team;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Team extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class Team implements _i1.TableRow, _i1.ProtocolSerialization {
   Team._({
     int? id,
     required this.name,
     this.arenaId,
     this.arena,
     this.players,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Team({
     int? id,
@@ -48,6 +50,8 @@ abstract class Team extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = TeamRepository._();
 
+  int? _id;
+
   String name;
 
   int? arenaId;
@@ -55,6 +59,16 @@ abstract class Team extends _i1.TableRow implements _i1.ProtocolSerialization {
   _i2.Arena? arena;
 
   List<_i2.Player>? players;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -14,14 +14,12 @@ import '../../protocol.dart' as _i2;
 
 abstract class Team implements _i1.TableRow, _i1.ProtocolSerialization {
   Team._({
-    int? id,
+    this.id,
     required this.name,
     this.arenaId,
     this.arena,
     this.players,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Team({
     int? id,
@@ -50,7 +48,8 @@ abstract class Team implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = TeamRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
@@ -59,16 +58,6 @@ abstract class Team implements _i1.TableRow, _i1.ProtocolSerialization {
   _i2.Arena? arena;
 
   List<_i2.Player>? players;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Comment extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Comment implements _i1.TableRow, _i1.ProtocolSerialization {
   Comment._({
     int? id,
     required this.description,
     required this.orderId,
     this.order,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Comment({
     int? id,
@@ -44,11 +45,23 @@ abstract class Comment extends _i1.TableRow
 
   static const db = CommentRepository._();
 
+  int? _id;
+
   String description;
 
   int orderId;
 
   _i2.Order? order;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -14,13 +14,11 @@ import '../../protocol.dart' as _i2;
 
 abstract class Comment implements _i1.TableRow, _i1.ProtocolSerialization {
   Comment._({
-    int? id,
+    this.id,
     required this.description,
     required this.orderId,
     this.order,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Comment({
     int? id,
@@ -45,23 +43,14 @@ abstract class Comment implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = CommentRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String description;
 
   int orderId;
 
   _i2.Order? order;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -12,13 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Customer extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Customer implements _i1.TableRow, _i1.ProtocolSerialization {
   Customer._({
     int? id,
     required this.name,
     this.orders,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Customer({
     int? id,
@@ -40,9 +41,21 @@ abstract class Customer extends _i1.TableRow
 
   static const db = CustomerRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.Order>? orders;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -14,12 +14,10 @@ import '../../protocol.dart' as _i2;
 
 abstract class Customer implements _i1.TableRow, _i1.ProtocolSerialization {
   Customer._({
-    int? id,
+    this.id,
     required this.name,
     this.orders,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Customer({
     int? id,
@@ -41,21 +39,12 @@ abstract class Customer implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = CustomerRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.Order>? orders;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -14,14 +14,12 @@ import '../../protocol.dart' as _i2;
 
 abstract class Order implements _i1.TableRow, _i1.ProtocolSerialization {
   Order._({
-    int? id,
+    this.id,
     required this.description,
     required this.customerId,
     this.customer,
     this.comments,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Order({
     int? id,
@@ -50,7 +48,8 @@ abstract class Order implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = OrderRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String description;
 
@@ -59,16 +58,6 @@ abstract class Order implements _i1.TableRow, _i1.ProtocolSerialization {
   _i2.Customer? customer;
 
   List<_i2.Comment>? comments;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Order extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class Order implements _i1.TableRow, _i1.ProtocolSerialization {
   Order._({
     int? id,
     required this.description,
     required this.customerId,
     this.customer,
     this.comments,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Order({
     int? id,
@@ -48,6 +50,8 @@ abstract class Order extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = OrderRepository._();
 
+  int? _id;
+
   String description;
 
   int customerId;
@@ -55,6 +59,16 @@ abstract class Order extends _i1.TableRow implements _i1.ProtocolSerialization {
   _i2.Customer? customer;
 
   List<_i2.Comment>? comments;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Address extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Address implements _i1.TableRow, _i1.ProtocolSerialization {
   Address._({
     int? id,
     required this.street,
     this.inhabitantId,
     this.inhabitant,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Address({
     int? id,
@@ -44,11 +45,23 @@ abstract class Address extends _i1.TableRow
 
   static const db = AddressRepository._();
 
+  int? _id;
+
   String street;
 
   int? inhabitantId;
 
   _i2.Citizen? inhabitant;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -14,13 +14,11 @@ import '../../protocol.dart' as _i2;
 
 abstract class Address implements _i1.TableRow, _i1.ProtocolSerialization {
   Address._({
-    int? id,
+    this.id,
     required this.street,
     this.inhabitantId,
     this.inhabitant,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Address({
     int? id,
@@ -45,23 +43,14 @@ abstract class Address implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = AddressRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String street;
 
   int? inhabitantId;
 
   _i2.Citizen? inhabitant;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -12,8 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Citizen extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Citizen implements _i1.TableRow, _i1.ProtocolSerialization {
   Citizen._({
     int? id,
     required this.name,
@@ -22,7 +21,9 @@ abstract class Citizen extends _i1.TableRow
     this.company,
     this.oldCompanyId,
     this.oldCompany,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Citizen({
     int? id,
@@ -59,6 +60,8 @@ abstract class Citizen extends _i1.TableRow
 
   static const db = CitizenRepository._();
 
+  int? _id;
+
   String name;
 
   _i2.Address? address;
@@ -70,6 +73,16 @@ abstract class Citizen extends _i1.TableRow
   int? oldCompanyId;
 
   _i2.Company? oldCompany;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -14,16 +14,14 @@ import '../../protocol.dart' as _i2;
 
 abstract class Citizen implements _i1.TableRow, _i1.ProtocolSerialization {
   Citizen._({
-    int? id,
+    this.id,
     required this.name,
     this.address,
     required this.companyId,
     this.company,
     this.oldCompanyId,
     this.oldCompany,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Citizen({
     int? id,
@@ -60,7 +58,8 @@ abstract class Citizen implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = CitizenRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
@@ -73,16 +72,6 @@ abstract class Citizen implements _i1.TableRow, _i1.ProtocolSerialization {
   int? oldCompanyId;
 
   _i2.Company? oldCompany;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -14,13 +14,11 @@ import '../../protocol.dart' as _i2;
 
 abstract class Company implements _i1.TableRow, _i1.ProtocolSerialization {
   Company._({
-    int? id,
+    this.id,
     required this.name,
     required this.townId,
     this.town,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Company({
     int? id,
@@ -45,23 +43,14 @@ abstract class Company implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = CompanyRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   int townId;
 
   _i2.Town? town;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Company extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Company implements _i1.TableRow, _i1.ProtocolSerialization {
   Company._({
     int? id,
     required this.name,
     required this.townId,
     this.town,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Company({
     int? id,
@@ -44,11 +45,23 @@ abstract class Company extends _i1.TableRow
 
   static const db = CompanyRepository._();
 
+  int? _id;
+
   String name;
 
   int townId;
 
   _i2.Town? town;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -12,13 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
 
-abstract class Town extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class Town implements _i1.TableRow, _i1.ProtocolSerialization {
   Town._({
     int? id,
     required this.name,
     this.mayorId,
     this.mayor,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Town({
     int? id,
@@ -43,11 +45,23 @@ abstract class Town extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = TownRepository._();
 
+  int? _id;
+
   String name;
 
   int? mayorId;
 
   _i2.Citizen? mayor;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -14,13 +14,11 @@ import '../../protocol.dart' as _i2;
 
 abstract class Town implements _i1.TableRow, _i1.ProtocolSerialization {
   Town._({
-    int? id,
+    this.id,
     required this.name,
     this.mayorId,
     this.mayor,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Town({
     int? id,
@@ -45,23 +43,14 @@ abstract class Town implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = TownRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   int? mayorId;
 
   _i2.Citizen? mayor;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -12,15 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
 
-abstract class Blocking extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Blocking implements _i1.TableRow, _i1.ProtocolSerialization {
   Blocking._({
     int? id,
     required this.blockedId,
     this.blocked,
     required this.blockedById,
     this.blockedBy,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Blocking({
     int? id,
@@ -50,6 +51,8 @@ abstract class Blocking extends _i1.TableRow
 
   static const db = BlockingRepository._();
 
+  int? _id;
+
   int blockedId;
 
   _i2.Member? blocked;
@@ -57,6 +60,16 @@ abstract class Blocking extends _i1.TableRow
   int blockedById;
 
   _i2.Member? blockedBy;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -14,14 +14,12 @@ import '../../../protocol.dart' as _i2;
 
 abstract class Blocking implements _i1.TableRow, _i1.ProtocolSerialization {
   Blocking._({
-    int? id,
+    this.id,
     required this.blockedId,
     this.blocked,
     required this.blockedById,
     this.blockedBy,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Blocking({
     int? id,
@@ -51,7 +49,8 @@ abstract class Blocking implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = BlockingRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int blockedId;
 
@@ -60,16 +59,6 @@ abstract class Blocking implements _i1.TableRow, _i1.ProtocolSerialization {
   int blockedById;
 
   _i2.Member? blockedBy;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -14,13 +14,11 @@ import '../../../protocol.dart' as _i2;
 
 abstract class Member implements _i1.TableRow, _i1.ProtocolSerialization {
   Member._({
-    int? id,
+    this.id,
     required this.name,
     this.blocking,
     this.blockedBy,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Member({
     int? id,
@@ -46,23 +44,14 @@ abstract class Member implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = MemberRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
   List<_i2.Blocking>? blocking;
 
   List<_i2.Blocking>? blockedBy;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -12,14 +12,15 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
 
-abstract class Member extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class Member implements _i1.TableRow, _i1.ProtocolSerialization {
   Member._({
     int? id,
     required this.name,
     this.blocking,
     this.blockedBy,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Member({
     int? id,
@@ -45,11 +46,23 @@ abstract class Member extends _i1.TableRow
 
   static const db = MemberRepository._();
 
+  int? _id;
+
   String name;
 
   List<_i2.Blocking>? blocking;
 
   List<_i2.Blocking>? blockedBy;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
 
-abstract class Cat extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class Cat implements _i1.TableRow, _i1.ProtocolSerialization {
   Cat._({
     int? id,
     required this.name,
     this.motherId,
     this.mother,
     this.kittens,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Cat({
     int? id,
@@ -48,6 +50,8 @@ abstract class Cat extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = CatRepository._();
 
+  int? _id;
+
   String name;
 
   int? motherId;
@@ -55,6 +59,16 @@ abstract class Cat extends _i1.TableRow implements _i1.ProtocolSerialization {
   _i2.Cat? mother;
 
   List<_i2.Cat>? kittens;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -14,14 +14,12 @@ import '../../../protocol.dart' as _i2;
 
 abstract class Cat implements _i1.TableRow, _i1.ProtocolSerialization {
   Cat._({
-    int? id,
+    this.id,
     required this.name,
     this.motherId,
     this.mother,
     this.kittens,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Cat({
     int? id,
@@ -50,7 +48,8 @@ abstract class Cat implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = CatRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String name;
 
@@ -59,16 +58,6 @@ abstract class Cat implements _i1.TableRow, _i1.ProtocolSerialization {
   _i2.Cat? mother;
 
   List<_i2.Cat>? kittens;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
 
-abstract class Post extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class Post implements _i1.TableRow, _i1.ProtocolSerialization {
   Post._({
     int? id,
     required this.content,
     this.previous,
     this.nextId,
     this.next,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Post({
     int? id,
@@ -49,6 +51,8 @@ abstract class Post extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = PostRepository._();
 
+  int? _id;
+
   String content;
 
   _i2.Post? previous;
@@ -56,6 +60,16 @@ abstract class Post extends _i1.TableRow implements _i1.ProtocolSerialization {
   int? nextId;
 
   _i2.Post? next;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -14,14 +14,12 @@ import '../../../protocol.dart' as _i2;
 
 abstract class Post implements _i1.TableRow, _i1.ProtocolSerialization {
   Post._({
-    int? id,
+    this.id,
     required this.content,
     this.previous,
     this.nextId,
     this.next,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Post({
     int? id,
@@ -51,7 +49,8 @@ abstract class Post implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = PostRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String content;
 
@@ -60,16 +59,6 @@ abstract class Post implements _i1.TableRow, _i1.ProtocolSerialization {
   int? nextId;
 
   _i2.Post? next;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
 
-abstract class ObjectFieldPersist extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectFieldPersist
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectFieldPersist._({
     int? id,
     required this.normal,
     this.api,
     this.data,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectFieldPersist({
     int? id,
@@ -44,11 +46,23 @@ abstract class ObjectFieldPersist extends _i1.TableRow
 
   static const db = ObjectFieldPersistRepository._();
 
+  int? _id;
+
   String normal;
 
   String? api;
 
   _i2.SimpleData? data;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
@@ -15,13 +15,11 @@ import 'protocol.dart' as _i2;
 abstract class ObjectFieldPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectFieldPersist._({
-    int? id,
+    this.id,
     required this.normal,
     this.api,
     this.data,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectFieldPersist({
     int? id,
@@ -46,23 +44,14 @@ abstract class ObjectFieldPersist
 
   static const db = ObjectFieldPersistRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String normal;
 
   String? api;
 
   _i2.SimpleData? data;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -14,13 +14,11 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ObjectFieldScopes
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectFieldScopes._({
-    int? id,
+    this.id,
     required this.normal,
     this.api,
     this.database,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectFieldScopes({
     int? id,
@@ -42,23 +40,14 @@ abstract class ObjectFieldScopes
 
   static const db = ObjectFieldScopesRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String normal;
 
   String? api;
 
   String? database;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -11,14 +11,16 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ObjectFieldScopes extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectFieldScopes
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectFieldScopes._({
     int? id,
     required this.normal,
     this.api,
     this.database,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectFieldScopes({
     int? id,
@@ -40,11 +42,23 @@ abstract class ObjectFieldScopes extends _i1.TableRow
 
   static const db = ObjectFieldScopesRepository._();
 
+  int? _id;
+
   String normal;
 
   String? api;
 
   String? database;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -15,11 +15,9 @@ import 'dart:typed_data' as _i2;
 abstract class ObjectWithByteData
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithByteData._({
-    int? id,
+    this.id,
     required this.byteData,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithByteData({
     int? id,
@@ -38,19 +36,10 @@ abstract class ObjectWithByteData
 
   static const db = ObjectWithByteDataRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i2.ByteData byteData;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -12,12 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
 
-abstract class ObjectWithByteData extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithByteData
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithByteData._({
     int? id,
     required this.byteData,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithByteData({
     int? id,
@@ -36,7 +38,19 @@ abstract class ObjectWithByteData extends _i1.TableRow
 
   static const db = ObjectWithByteDataRepository._();
 
+  int? _id;
+
   _i2.ByteData byteData;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ObjectWithDuration extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithDuration
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithDuration._({
     int? id,
     required this.duration,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithDuration({
     int? id,
@@ -35,7 +37,19 @@ abstract class ObjectWithDuration extends _i1.TableRow
 
   static const db = ObjectWithDurationRepository._();
 
+  int? _id;
+
   Duration duration;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ObjectWithDuration
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithDuration._({
-    int? id,
+    this.id,
     required this.duration,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithDuration({
     int? id,
@@ -37,19 +35,10 @@ abstract class ObjectWithDuration
 
   static const db = ObjectWithDurationRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   Duration duration;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
 
-abstract class ObjectWithEnum extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithEnum
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithEnum._({
     int? id,
     required this.testEnum,
@@ -21,7 +21,9 @@ abstract class ObjectWithEnum extends _i1.TableRow
     required this.enumList,
     required this.nullableEnumList,
     required this.enumListList,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithEnum({
     int? id,
@@ -57,6 +59,8 @@ abstract class ObjectWithEnum extends _i1.TableRow
 
   static const db = ObjectWithEnumRepository._();
 
+  int? _id;
+
   _i2.TestEnum testEnum;
 
   _i2.TestEnum? nullableEnum;
@@ -66,6 +70,16 @@ abstract class ObjectWithEnum extends _i1.TableRow
   List<_i2.TestEnum?> nullableEnumList;
 
   List<List<_i2.TestEnum>> enumListList;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -15,15 +15,13 @@ import 'protocol.dart' as _i2;
 abstract class ObjectWithEnum
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithEnum._({
-    int? id,
+    this.id,
     required this.testEnum,
     this.nullableEnum,
     required this.enumList,
     required this.nullableEnumList,
     required this.enumListList,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithEnum({
     int? id,
@@ -59,7 +57,8 @@ abstract class ObjectWithEnum
 
   static const db = ObjectWithEnumRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i2.TestEnum testEnum;
 
@@ -70,16 +69,6 @@ abstract class ObjectWithEnum
   List<_i2.TestEnum?> nullableEnumList;
 
   List<List<_i2.TestEnum>> enumListList;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ObjectWithIndex
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithIndex._({
-    int? id,
+    this.id,
     required this.indexed,
     required this.indexed2,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithIndex({
     int? id,
@@ -39,21 +37,12 @@ abstract class ObjectWithIndex
 
   static const db = ObjectWithIndexRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int indexed;
 
   int indexed2;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -11,13 +11,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ObjectWithIndex extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithIndex
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithIndex._({
     int? id,
     required this.indexed,
     required this.indexed2,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithIndex({
     int? id,
@@ -37,9 +39,21 @@ abstract class ObjectWithIndex extends _i1.TableRow
 
   static const db = ObjectWithIndexRepository._();
 
+  int? _id;
+
   int indexed;
 
   int indexed2;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -15,7 +15,7 @@ import 'protocol.dart' as _i2;
 abstract class ObjectWithObject
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithObject._({
-    int? id,
+    this.id,
     required this.data,
     this.nullableData,
     required this.dataList,
@@ -25,9 +25,7 @@ abstract class ObjectWithObject
     this.nestedDataList,
     this.nestedDataListInMap,
     this.nestedDataMap,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithObject({
     int? id,
@@ -106,7 +104,8 @@ abstract class ObjectWithObject
 
   static const db = ObjectWithObjectRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i2.SimpleData data;
 
@@ -125,16 +124,6 @@ abstract class ObjectWithObject
   Map<String, List<List<Map<int, _i2.SimpleData>>?>>? nestedDataListInMap;
 
   Map<String, Map<int, _i2.SimpleData>>? nestedDataMap;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -12,8 +12,8 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
 
-abstract class ObjectWithObject extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithObject
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithObject._({
     int? id,
     required this.data,
@@ -25,7 +25,9 @@ abstract class ObjectWithObject extends _i1.TableRow
     this.nestedDataList,
     this.nestedDataListInMap,
     this.nestedDataMap,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithObject({
     int? id,
@@ -104,6 +106,8 @@ abstract class ObjectWithObject extends _i1.TableRow
 
   static const db = ObjectWithObjectRepository._();
 
+  int? _id;
+
   _i2.SimpleData data;
 
   _i2.SimpleData? nullableData;
@@ -121,6 +125,16 @@ abstract class ObjectWithObject extends _i1.TableRow
   Map<String, List<List<Map<int, _i2.SimpleData>>?>>? nestedDataListInMap;
 
   Map<String, Map<int, _i2.SimpleData>>? nestedDataMap;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ObjectWithParent extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithParent
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithParent._({
     int? id,
     required this.other,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithParent({
     int? id,
@@ -34,7 +36,19 @@ abstract class ObjectWithParent extends _i1.TableRow
 
   static const db = ObjectWithParentRepository._();
 
+  int? _id;
+
   int other;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ObjectWithParent
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithParent._({
-    int? id,
+    this.id,
     required this.other,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithParent({
     int? id,
@@ -36,19 +34,10 @@ abstract class ObjectWithParent
 
   static const db = ObjectWithParentRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int other;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ObjectWithSelfParent
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithSelfParent._({
-    int? id,
+    this.id,
     this.other,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithSelfParent({
     int? id,
@@ -37,19 +35,10 @@ abstract class ObjectWithSelfParent
 
   static const db = ObjectWithSelfParentRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int? other;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -11,12 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ObjectWithSelfParent extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithSelfParent
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithSelfParent._({
     int? id,
     this.other,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithSelfParent({
     int? id,
@@ -35,7 +37,19 @@ abstract class ObjectWithSelfParent extends _i1.TableRow
 
   static const db = ObjectWithSelfParentRepository._();
 
+  int? _id;
+
   int? other;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -11,13 +11,15 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ObjectWithUuid extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class ObjectWithUuid
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithUuid._({
     int? id,
     required this.uuid,
     this.uuidNullable,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory ObjectWithUuid({
     int? id,
@@ -40,9 +42,21 @@ abstract class ObjectWithUuid extends _i1.TableRow
 
   static const db = ObjectWithUuidRepository._();
 
+  int? _id;
+
   _i1.UuidValue uuid;
 
   _i1.UuidValue? uuidNullable;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -14,12 +14,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class ObjectWithUuid
     implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectWithUuid._({
-    int? id,
+    this.id,
     required this.uuid,
     this.uuidNullable,
-  }) {
-    _id = id;
-  }
+  });
 
   factory ObjectWithUuid({
     int? id,
@@ -42,21 +40,12 @@ abstract class ObjectWithUuid
 
   static const db = ObjectWithUuidRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   _i1.UuidValue uuid;
 
   _i1.UuidValue? uuidNullable;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -15,13 +15,11 @@ import 'protocol.dart' as _i2;
 abstract class RelatedUniqueData
     implements _i1.TableRow, _i1.ProtocolSerialization {
   RelatedUniqueData._({
-    int? id,
+    this.id,
     required this.uniqueDataId,
     this.uniqueData,
     required this.number,
-  }) {
-    _id = id;
-  }
+  });
 
   factory RelatedUniqueData({
     int? id,
@@ -46,23 +44,14 @@ abstract class RelatedUniqueData
 
   static const db = RelatedUniqueDataRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int uniqueDataId;
 
   _i2.UniqueData? uniqueData;
 
   int number;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -12,14 +12,16 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
 
-abstract class RelatedUniqueData extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class RelatedUniqueData
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   RelatedUniqueData._({
     int? id,
     required this.uniqueDataId,
     this.uniqueData,
     required this.number,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory RelatedUniqueData({
     int? id,
@@ -44,11 +46,23 @@ abstract class RelatedUniqueData extends _i1.TableRow
 
   static const db = RelatedUniqueDataRepository._();
 
+  int? _id;
+
   int uniqueDataId;
 
   _i2.UniqueData? uniqueData;
 
   int number;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -13,9 +13,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class ScopeNoneFields
     implements _i1.TableRow, _i1.ProtocolSerialization {
-  ScopeNoneFields._({int? id}) {
-    _id = id;
-  }
+  ScopeNoneFields._({this.id});
 
   factory ScopeNoneFields({int? id}) = _ScopeNoneFieldsImpl;
 
@@ -27,19 +25,10 @@ abstract class ScopeNoneFields
 
   static const db = ScopeNoneFieldsRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   String? _name;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -11,9 +11,11 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class ScopeNoneFields extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
-  ScopeNoneFields._({int? id}) : super(id);
+abstract class ScopeNoneFields
+    implements _i1.TableRow, _i1.ProtocolSerialization {
+  ScopeNoneFields._({int? id}) {
+    _id = id;
+  }
 
   factory ScopeNoneFields({int? id}) = _ScopeNoneFieldsImpl;
 
@@ -25,7 +27,19 @@ abstract class ScopeNoneFields extends _i1.TableRow
 
   static const db = ScopeNoneFieldsRepository._();
 
+  int? _id;
+
   String? _name;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -12,12 +12,13 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Just some simple data.
-abstract class SimpleData extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class SimpleData implements _i1.TableRow, _i1.ProtocolSerialization {
   SimpleData._({
     int? id,
     required this.num,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory SimpleData({
     int? id,
@@ -35,10 +36,22 @@ abstract class SimpleData extends _i1.TableRow
 
   static const db = SimpleDataRepository._();
 
+  int? _id;
+
   /// The only field of [SimpleData]
   ///
   /// Second Value Extra Text
   int num;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -14,11 +14,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 /// Just some simple data.
 abstract class SimpleData implements _i1.TableRow, _i1.ProtocolSerialization {
   SimpleData._({
-    int? id,
+    this.id,
     required this.num,
-  }) {
-    _id = id;
-  }
+  });
 
   factory SimpleData({
     int? id,
@@ -36,22 +34,13 @@ abstract class SimpleData implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = SimpleDataRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The only field of [SimpleData]
   ///
   /// Second Value Extra Text
   int num;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -12,12 +12,14 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 
 /// Just some simple data.
-abstract class SimpleDateTime extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class SimpleDateTime
+    implements _i1.TableRow, _i1.ProtocolSerialization {
   SimpleDateTime._({
     int? id,
     required this.dateTime,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory SimpleDateTime({
     int? id,
@@ -36,8 +38,20 @@ abstract class SimpleDateTime extends _i1.TableRow
 
   static const db = SimpleDateTimeRepository._();
 
+  int? _id;
+
   /// The only field of [SimpleDateTime]
   DateTime dateTime;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -15,11 +15,9 @@ import 'package:serverpod/serverpod.dart' as _i1;
 abstract class SimpleDateTime
     implements _i1.TableRow, _i1.ProtocolSerialization {
   SimpleDateTime._({
-    int? id,
+    this.id,
     required this.dateTime,
-  }) {
-    _id = id;
-  }
+  });
 
   factory SimpleDateTime({
     int? id,
@@ -38,20 +36,11 @@ abstract class SimpleDateTime
 
   static const db = SimpleDateTimeRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   /// The only field of [SimpleDateTime]
   DateTime dateTime;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -13,7 +13,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'protocol.dart' as _i3;
 
-abstract class Types extends _i1.TableRow implements _i1.ProtocolSerialization {
+abstract class Types implements _i1.TableRow, _i1.ProtocolSerialization {
   Types._({
     int? id,
     this.anInt,
@@ -26,7 +26,9 @@ abstract class Types extends _i1.TableRow implements _i1.ProtocolSerialization {
     this.aUuid,
     this.anEnum,
     this.aStringifiedEnum,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory Types({
     int? id,
@@ -75,6 +77,8 @@ abstract class Types extends _i1.TableRow implements _i1.ProtocolSerialization {
 
   static const db = TypesRepository._();
 
+  int? _id;
+
   int? anInt;
 
   bool? aBool;
@@ -94,6 +98,16 @@ abstract class Types extends _i1.TableRow implements _i1.ProtocolSerialization {
   _i3.TestEnum? anEnum;
 
   _i3.TestEnumStringified? aStringifiedEnum;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -15,7 +15,7 @@ import 'protocol.dart' as _i3;
 
 abstract class Types implements _i1.TableRow, _i1.ProtocolSerialization {
   Types._({
-    int? id,
+    this.id,
     this.anInt,
     this.aBool,
     this.aDouble,
@@ -26,9 +26,7 @@ abstract class Types implements _i1.TableRow, _i1.ProtocolSerialization {
     this.aUuid,
     this.anEnum,
     this.aStringifiedEnum,
-  }) {
-    _id = id;
-  }
+  });
 
   factory Types({
     int? id,
@@ -77,7 +75,8 @@ abstract class Types implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = TypesRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int? anInt;
 
@@ -98,16 +97,6 @@ abstract class Types implements _i1.TableRow, _i1.ProtocolSerialization {
   _i3.TestEnum? anEnum;
 
   _i3.TestEnumStringified? aStringifiedEnum;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -11,13 +11,14 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
-abstract class UniqueData extends _i1.TableRow
-    implements _i1.ProtocolSerialization {
+abstract class UniqueData implements _i1.TableRow, _i1.ProtocolSerialization {
   UniqueData._({
     int? id,
     required this.number,
     required this.email,
-  }) : super(id);
+  }) {
+    _id = id;
+  }
 
   factory UniqueData({
     int? id,
@@ -37,9 +38,21 @@ abstract class UniqueData extends _i1.TableRow
 
   static const db = UniqueDataRepository._();
 
+  int? _id;
+
   int number;
 
   String email;
+
+  @override
+  int? get id {
+    return _id;
+  }
+
+  @override
+  set id(int? value) {
+    _id = value;
+  }
 
   @override
   _i1.Table get table => t;

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -13,12 +13,10 @@ import 'package:serverpod/serverpod.dart' as _i1;
 
 abstract class UniqueData implements _i1.TableRow, _i1.ProtocolSerialization {
   UniqueData._({
-    int? id,
+    this.id,
     required this.number,
     required this.email,
-  }) {
-    _id = id;
-  }
+  });
 
   factory UniqueData({
     int? id,
@@ -38,21 +36,12 @@ abstract class UniqueData implements _i1.TableRow, _i1.ProtocolSerialization {
 
   static const db = UniqueDataRepository._();
 
-  int? _id;
+  @override
+  int? id;
 
   int number;
 
   String email;
-
-  @override
-  int? get id {
-    return _id;
-  }
-
-  @override
-  set id(int? value) {
-    _id = value;
-  }
 
   @override
   _i1.Table get table => t;

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -160,14 +160,25 @@ class SerializableModelLibraryGenerator {
       }
 
       if (serverCode && tableName != null) {
-        classBuilder.extend =
-            refer('TableRow', 'package:serverpod/serverpod.dart');
+        classBuilder.implements.add(
+          refer('TableRow', 'package:serverpod/serverpod.dart'),
+        );
 
         classBuilder.fields.addAll([
           _buildModelClassTableField(className),
         ]);
 
         classBuilder.fields.add(_buildModelClassDBField(className));
+
+        classBuilder.fields.add(Field(
+          (f) => f
+            ..name = '_id'
+            ..type = refer('int?'),
+        ));
+
+        classBuilder.methods.add(_buildIdGetter());
+
+        classBuilder.methods.add(_buildIdSetter());
 
         classBuilder.methods.add(_buildModelClassTableGetter());
       } else {
@@ -619,6 +630,30 @@ class SerializableModelLibraryGenerator {
     );
   }
 
+  Method _buildIdGetter() {
+    return Method(
+      (m) => m
+        ..name = 'id'
+        ..annotations.add(refer('override'))
+        ..type = MethodType.getter
+        ..returns = refer('int?')
+        ..body = const Code('return _id;'),
+    );
+  }
+
+  Method _buildIdSetter() {
+    return Method(
+      (m) => m
+        ..name = 'id'
+        ..annotations.add(refer('override'))
+        ..type = MethodType.setter
+        ..requiredParameters.add(Parameter((p) => p
+          ..name = 'value'
+          ..type = refer('int?')))
+        ..body = const Code('_id = value;'),
+    );
+  }
+
   Field _buildModelClassTableField(String className) {
     return Field((f) => f
       ..static = true
@@ -978,7 +1013,7 @@ class SerializableModelLibraryGenerator {
       }
 
       if (serverCode && tableName != null) {
-        c.initializers.add(refer('super').call([refer('id')]).code);
+        c.body = Block.of([const Code('_id = id;')]);
       }
     });
   }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1047,15 +1047,9 @@ class SerializableModelLibraryGenerator {
     return [...classDefinition.parentFields, ...fields]
         .where((field) => field.shouldIncludeField(serverCode))
         .map((field) {
-      bool hasPrimaryKey =
-          field.name == 'id' && tableName != null && serverCode;
-
-      bool shouldIncludeType =
-          hasPrimaryKey || !setAsToThis || field.defaultModelValue != null;
+      bool shouldIncludeType = !setAsToThis || field.defaultModelValue != null;
 
       bool hasDefaults = field.hasDefauls;
-
-      bool isIdFieldInMainConstructor = field.name == 'id' && setAsToThis;
 
       var type = field.type.reference(
         serverCode,
@@ -1068,10 +1062,8 @@ class SerializableModelLibraryGenerator {
         (p) => p
           ..named = true
           ..required = !(field.type.nullable || hasDefaults)
-          ..type =
-              shouldIncludeType && !isIdFieldInMainConstructor ? type : null
-          ..toThis = !shouldIncludeType && fields.contains(field) ||
-              isIdFieldInMainConstructor
+          ..type = shouldIncludeType ? type : null
+          ..toThis = !shouldIncludeType && fields.contains(field)
           ..toSuper = !shouldIncludeType && inheritedFields.contains(field)
           ..name = field.name,
       );

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/entity_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/entity_class_test.dart
@@ -166,12 +166,8 @@ void main() {
           expect(constructor, isNotNull, reason: 'No private constructor');
         });
 
-        test('with id param', () {
-          expect(constructor?.parameters.toSource(), '({int? id})');
-        });
-
-        test('initializing id in constructor body', () {
-          expect(constructor?.body.toSource(), '{_id = id;}');
+        test('initializing id in initializer list', () {
+          expect(constructor?.parameters.toSource(), '({this.id})');
         });
       });
 
@@ -198,14 +194,14 @@ void main() {
             reason: 'Missing declaration for table method.');
       });
 
-      test('is NOT generated with id field.', () {
+      test('is generated with id field.', () {
         expect(
             CompilationUnitHelpers.hasFieldDeclaration(
               maybeClassNamedExample!,
               name: 'id',
             ),
-            isFalse,
-            reason: 'Declaration for id field should not be generated.');
+            isTrue,
+            reason: 'Declaration for id field should be generated.');
       });
 
       test('has a static include method.', () {

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/entity_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/entity_class_test.dart
@@ -137,9 +137,9 @@ void main() {
     });
 
     group('then the class named $testClassName', () {
-      test('inherits from TableRow.', () {
+      test('implements TableRow.', () {
         expect(
-            CompilationUnitHelpers.hasExtendsClause(
+            CompilationUnitHelpers.hasImplementsClause(
               maybeClassNamedExample!,
               name: 'TableRow',
             ),
@@ -170,8 +170,8 @@ void main() {
           expect(constructor?.parameters.toSource(), '({int? id})');
         });
 
-        test('passing id to super', () {
-          expect(constructor?.initializers.first.toSource(), 'super(id)');
+        test('initializing id in constructor body', () {
+          expect(constructor?.body.toSource(), '{_id = id;}');
         });
       });
 


### PR DESCRIPTION
This PR refactors the implementation of `TableRow` from:
an `abstract class` that was `extended`
to
an `abstract interface class` that is `implemented` 

with the following steps:
TableRow
1. `TableRow` was changed to be an interface
2.  Instead of the `constructor` a `getter` and a `setter` was added for `id`

ModelLibraryGenerator
1. The generated class now `implements` TableRow instead of extending it
2. The class now has a private field `_id` that is initialized in the constructor body instead of calling `super(id)`
3. Additionally it `overrides` the `getter` and `setter` from TableRow 

`entity_class_test.dart` 
1. Test no longer expects TableRow to be `extended` but `implemented`
2. Test no longer expects `id` to be passed to `super` but to be initialized in the constructor body

`insert_sql_query_test`
- Test util classes were changed in the same fashion

closes #2711 
connected to #1873 

I would recommend reviewing it commit by commit, as the PR includes the output of `generate_all` but note, I forgot to update the test in the database package at first. This is done in the last commit 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
I don't think there are breaking changes as explained by @SandPod in #2711 