### PR TITLE
fix: Load passwords from env even if the passwords file does not exist.

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -301,7 +301,7 @@ class Serverpod {
 
     // Load passwords
     _passwordManager = PasswordManager(runMode: runMode);
-    _passwords = _passwordManager.loadPasswords() ?? {};
+    _passwords = _passwordManager.loadPasswords();
 
     // Load config
     this.config = config ??

--- a/packages/serverpod_shared/lib/src/password_manager.dart
+++ b/packages/serverpod_shared/lib/src/password_manager.dart
@@ -61,15 +61,18 @@ class PasswordManager {
 
   /// Load all passwords for the current run mode, or null if passwords fail
   /// to load.
-  Map<String, String>? loadPasswords() {
+  Map<String, String> loadPasswords([
+    String passwordsFilePath = 'config/passwords.yaml',
+  ]) {
+    Map<String, Map> data;
     try {
-      var passwordYaml = File('config/passwords.yaml').readAsStringSync();
-      var data = (loadYaml(passwordYaml) as Map).cast<String, Map>();
-
-      return loadPasswordsFromMap(data, environment: Platform.environment);
+      var passwordYaml = File(passwordsFilePath).readAsStringSync();
+      data = (loadYaml(passwordYaml) as Map).cast<String, Map>();
     } catch (e) {
-      return null;
+      data = {};
     }
+
+    return loadPasswordsFromMap(data, environment: Platform.environment);
   }
 
   /// Merge custom passwords with the existing password collection.

--- a/packages/serverpod_shared/test_integration/assets/load_passwords/runner_empty_passwords.dart
+++ b/packages/serverpod_shared/test_integration/assets/load_passwords/runner_empty_passwords.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+void main() {
+  var passwords = PasswordManager(runMode: 'development').loadPasswords(
+    './config/empty_passwords.yaml',
+  );
+
+  stdout.write(passwords.toString());
+}

--- a/packages/serverpod_shared/test_integration/assets/load_passwords/runner_missing_passwords.dart
+++ b/packages/serverpod_shared/test_integration/assets/load_passwords/runner_missing_passwords.dart
@@ -1,9 +1,12 @@
 import 'dart:io';
 import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:uuid/uuid.dart';
 
 void main() {
+  var missingFileName = const Uuid().v4();
+
   var passwords = PasswordManager(runMode: 'development').loadPasswords(
-    './config/missing_passwords.yaml',
+    './config/$missingFileName.yaml',
   );
 
   stdout.write(passwords.toString());

--- a/packages/serverpod_shared/test_integration/assets/load_passwords/runner_missing_passwords.dart
+++ b/packages/serverpod_shared/test_integration/assets/load_passwords/runner_missing_passwords.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+void main() {
+  var passwords = PasswordManager(runMode: 'development').loadPasswords(
+    './config/missing_passwords.yaml',
+  );
+
+  stdout.write(passwords.toString());
+}

--- a/packages/serverpod_shared/test_integration/load_passwords_test.dart
+++ b/packages/serverpod_shared/test_integration/load_passwords_test.dart
@@ -100,4 +100,37 @@ void main() {
       );
     });
   });
+
+  group(
+      'Given an empty serverpod passwords file and the env variable SERVERPOD_DATABASE_PASSWORD is set when loading the passwords',
+      () {
+    var dbPassword = const Uuid().v4();
+
+    setUpAll(() async {
+      result = await Process.run(
+        'dart',
+        ['run', 'runner_empty_passwords.dart'],
+        environment: {
+          'SERVERPOD_DATABASE_PASSWORD': dbPassword,
+        },
+        workingDirectory: 'test_integration/assets/load_passwords',
+      );
+      stderr.writeln(result.stderr);
+    });
+
+    test('then the loading of the config was successful', () {
+      expect(result.exitCode, 0);
+    });
+
+    test('then the database password is set', () {
+      expect(result.stdout, contains('database: $dbPassword'));
+    });
+
+    test('then the service secret is not set', () {
+      expect(
+        result.stdout,
+        isNot(contains('serviceSecret')),
+      );
+    });
+  });
 }

--- a/packages/serverpod_shared/test_integration/load_passwords_test.dart
+++ b/packages/serverpod_shared/test_integration/load_passwords_test.dart
@@ -67,4 +67,37 @@ void main() {
       );
     });
   });
+
+  group(
+      'Given no serverpod passwords file exists but the env variable SERVERPOD_DATABASE_PASSWORD is set when loading the passwords',
+      () {
+    var dbPassword = const Uuid().v4();
+
+    setUpAll(() async {
+      result = await Process.run(
+        'dart',
+        ['run', 'runner_missing_passwords.dart'],
+        environment: {
+          'SERVERPOD_DATABASE_PASSWORD': dbPassword,
+        },
+        workingDirectory: 'test_integration/assets/load_passwords',
+      );
+      stderr.writeln(result.stderr);
+    });
+
+    test('then the loading of the config was successful', () {
+      expect(result.exitCode, 0);
+    });
+
+    test('then the database password is set', () {
+      expect(result.stdout, contains('database: $dbPassword'));
+    });
+
+    test('then the service secret is not set', () {
+      expect(
+        result.stdout,
+        isNot(contains('serviceSecret')),
+      );
+    });
+  });
 }

--- a/tools/serverpod_cli/lib/src/config_info/config_info.dart
+++ b/tools/serverpod_cli/lib/src/config_info/config_info.dart
@@ -5,7 +5,7 @@ class ConfigInfo {
   String? serverId;
   late ServerpodConfig config;
   ConfigInfo(String runMode, {this.serverId}) {
-    var passwords = PasswordManager(runMode: runMode).loadPasswords() ?? {};
+    var passwords = PasswordManager(runMode: runMode).loadPasswords();
     config = ServerpodConfig.load(runMode, serverId ?? 'undefined', passwords);
   }
 


### PR DESCRIPTION
# Changes

Ignore the passwords.yaml file if it does not exist but still load the passwords from env if possible.

Closes: https://github.com/serverpod/serverpod/issues/2800

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

none