### PR TITLE
fix: take current transaction into account for `include`/`includeList` queries

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -358,7 +358,7 @@ class DatabaseConnection {
     Session session,
     String query, {
     int? timeoutInSeconds,
-    Transaction? transaction,
+    required Transaction? transaction,
     bool ignoreRows = false,
     bool simpleQueryMode = false,
     QueryParameters? parameters,
@@ -473,7 +473,7 @@ class DatabaseConnection {
     Session session,
     String query, {
     int? timeoutInSeconds,
-    Transaction? transaction,
+    required Transaction? transaction,
   }) async {
     var result = await _query(
       session,
@@ -505,6 +505,7 @@ class DatabaseConnection {
       table,
       include,
       result,
+      transaction,
     );
 
     return result
@@ -555,6 +556,7 @@ class DatabaseConnection {
     Table table,
     Include? include,
     Iterable<Map<String, dynamic>> previousResultSet,
+    Transaction? transaction,
   ) async {
     if (include == null) return {};
 
@@ -597,13 +599,18 @@ class DatabaseConnection {
             .withInclude(nestedInclude.include)
             .build();
 
-        var includeListResult = await _mappedResultsQuery(session, query);
+        var includeListResult = await _mappedResultsQuery(
+          session,
+          query,
+          transaction: transaction,
+        );
 
         var resolvedLists = await _queryIncludedLists(
           session,
           nestedInclude.table,
           nestedInclude,
           includeListResult,
+          transaction,
         );
 
         var resolvedList = includeListResult
@@ -627,6 +634,7 @@ class DatabaseConnection {
           relativeRelationTable,
           nestedInclude,
           previousResultSet,
+          transaction,
         );
 
         resolvedListRelations.addAll(resolvedNestedListRelations);


### PR DESCRIPTION
## Description 

Fixes #2802 

See issue for details.

## Changes
- Passes transaction to `_queryIncludedLists` to ensure include calls take the current transaction into account 

## Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.