### PR TITLE
fix: Fixes #2826, HTTP code 500 instead of 400 upon param errors

### DIFF
--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -449,9 +449,24 @@ class ResultInvalidParams extends Result {
   }
 }
 
+/// The result of a failed [Endpoint] method call where the
+/// endpoint was not found.
+class ResultNoSuchEndpoint extends Result {
+  /// Description of the error.
+  final String errorDescription;
+
+  /// Creates a new [ResultNoSuchEndpoint] object.
+  ResultNoSuchEndpoint(this.errorDescription);
+
+  @override
+  String toString() {
+    return errorDescription;
+  }
+}
+
 /// The result of a failed [EndpointDispatch.getMethodStreamCallContext],
 /// [EndpointDispatch.getMethodCallContext] or [EndpointDispatch.getEndpointConnector] call.
-abstract class GetEndpointMethodException implements Exception {
+abstract class EndpointDispatchException implements Exception {
   /// Description of the error.
   String get message;
 
@@ -462,7 +477,7 @@ abstract class GetEndpointMethodException implements Exception {
 }
 
 /// The user is not authorized to access the endpoint.
-class NotAuthorizedException extends GetEndpointMethodException {
+class NotAuthorizedException extends EndpointDispatchException {
   @override
   String message;
 
@@ -475,7 +490,7 @@ class NotAuthorizedException extends GetEndpointMethodException {
 }
 
 /// The endpoint was not found.
-class EndpointNotFoundException extends GetEndpointMethodException {
+class EndpointNotFoundException extends EndpointDispatchException {
   @override
   String message = 'Endpoint not found';
 
@@ -484,7 +499,7 @@ class EndpointNotFoundException extends GetEndpointMethodException {
 }
 
 /// The endpoint method was not found.
-class MethodNotFoundException extends GetEndpointMethodException {
+class MethodNotFoundException extends EndpointDispatchException {
   @override
   String message = 'Method not found';
 
@@ -493,7 +508,7 @@ class MethodNotFoundException extends GetEndpointMethodException {
 }
 
 /// The found endpoint method was not of the expected type.
-class InvalidEndpointMethodTypeException extends GetEndpointMethodException {
+class InvalidEndpointMethodTypeException extends EndpointDispatchException {
   @override
   String get message =>
       'Endpoint method $_methodName in $_endpointPath is not of the expected type.';
@@ -507,7 +522,7 @@ class InvalidEndpointMethodTypeException extends GetEndpointMethodException {
 }
 
 /// The input parameters were invalid.
-class InvalidParametersException extends GetEndpointMethodException {
+class InvalidParametersException extends EndpointDispatchException {
   @override
   String message = 'Invalid parameters';
 

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -449,14 +449,20 @@ class ResultInvalidParams extends Result {
   }
 }
 
-/// The result of a failed [EndpointDispatch.getMethodStreamCallContext], [EndpointDispatch.getMethodCallContext] or [EndpointDispatch.getEndpointConnector] call.
-abstract class GetAuthorizedEndpointMethodException implements Exception {
+/// The result of a failed [EndpointDispatch.getMethodStreamCallContext],
+/// [EndpointDispatch.getMethodCallContext] or [EndpointDispatch.getEndpointConnector] call.
+abstract class GetEndpointMethodException implements Exception {
   /// Description of the error.
   String get message;
+
+  @override
+  String toString() {
+    return 'Endpoint dispatch error: $message';
+  }
 }
 
 /// The user is not authorized to access the endpoint.
-class NotAuthorizedException implements GetAuthorizedEndpointMethodException {
+class NotAuthorizedException extends GetEndpointMethodException {
   @override
   String message;
 
@@ -469,8 +475,7 @@ class NotAuthorizedException implements GetAuthorizedEndpointMethodException {
 }
 
 /// The endpoint was not found.
-class EndpointNotFoundException
-    implements GetAuthorizedEndpointMethodException {
+class EndpointNotFoundException extends GetEndpointMethodException {
   @override
   String message = 'Endpoint not found';
 
@@ -479,7 +484,7 @@ class EndpointNotFoundException
 }
 
 /// The endpoint method was not found.
-class MethodNotFoundException implements GetAuthorizedEndpointMethodException {
+class MethodNotFoundException extends GetEndpointMethodException {
   @override
   String message = 'Method not found';
 
@@ -488,8 +493,7 @@ class MethodNotFoundException implements GetAuthorizedEndpointMethodException {
 }
 
 /// The found endpoint method was not of the expected type.
-class InvalidEndpointMethodTypeException
-    implements GetAuthorizedEndpointMethodException {
+class InvalidEndpointMethodTypeException extends GetEndpointMethodException {
   @override
   String get message =>
       'Endpoint method $_methodName in $_endpointPath is not of the expected type.';
@@ -503,8 +507,7 @@ class InvalidEndpointMethodTypeException
 }
 
 /// The input parameters were invalid.
-class InvalidParametersException
-    implements GetAuthorizedEndpointMethodException {
+class InvalidParametersException extends GetEndpointMethodException {
   @override
   String message = 'Invalid parameters';
 

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -317,6 +317,7 @@ class Server {
       }
 
       request.response.statusCode = HttpStatus.badRequest;
+      request.response.writeln(result.errorDescription);
       await request.response.close();
       return;
     } else if (result is ResultAuthenticationFailed) {
@@ -526,11 +527,8 @@ class Server {
       return ResultInvalidParams(e.message);
     } on NotAuthorizedException catch (e) {
       return e.authenticationFailedResult;
-    } on InvalidParametersException catch (e, stackTrace) {
-      var sessionLogId =
-          await maybeSession?.close(error: e, stackTrace: stackTrace);
-      return ResultInternalServerError(
-          e.toString(), stackTrace, sessionLogId ?? 0);
+    } on InvalidParametersException catch (e) {
+      return ResultInvalidParams(e.message);
     } on SerializableException catch (exception) {
       return ExceptionResult(model: exception);
     } on Exception catch (e, stackTrace) {

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -436,8 +436,7 @@ class Server {
     var path = uri.pathSegments.join('/');
     var endpointComponents = path.split('.');
     if (endpointComponents.isEmpty || endpointComponents.length > 2) {
-      return ResultNoSuchEndpoint(
-          'Endpoint $path is not a valid endpoint name');
+      return ResultInvalidParams('Endpoint $path is not a valid endpoint name');
     }
 
     // Read query parameters

--- a/tests/serverpod_test_server/test_e2e/cloud_storage_test.dart
+++ b/tests/serverpod_test_server/test_e2e/cloud_storage_test.dart
@@ -106,8 +106,7 @@ void main() {
       var url = Uri.parse(
           '${serverUrl}serverpod_cloud_storage?method=file&foo=testdir/myfile2.bin');
       var response = await http.get(url);
-      // TODO: Actual response should probably be 400 (see server todo with verification of parameters).
-      expect(response.statusCode, equals(500));
+      expect(response.statusCode, equals(400));
     });
 
     test('Attempt retrieve file through URL with invalid method', () async {

--- a/tests/serverpod_test_server/test_e2e/http_codes_test.dart
+++ b/tests/serverpod_test_server/test_e2e/http_codes_test.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('Given an HTTP client invoking a serverpod endpoint method', () {
+    setUpAll(() async {});
+
+    tearDownAll(() async {});
+
+    test(
+        'when calling an endpoint method with correct parameters '
+        'then it should respond with 200 ok', () async {
+      var response = await http.post(
+        Uri.parse('${serverUrl}simple'),
+        body: jsonEncode({
+          'method': 'hello',
+          'name': 'Starbase Alpha',
+        }),
+      );
+
+      expect(response.statusCode, 200);
+      expect(response.body, contains('Hello Starbase Alpha'));
+    });
+
+    test(
+        'when calling an endpoint method with missing parameters '
+        'then it should respond with 400 bad request', () async {
+      var response = await http.post(
+        Uri.parse('${serverUrl}simple'),
+        body: jsonEncode({
+          'method': 'hello',
+        }),
+      );
+
+      expect(response.statusCode, 400);
+      expect(response.body, contains('Missing required query parameter: name'));
+    });
+
+    test(
+        'when calling an endpoint method with too many parameters '
+        'then it should respond with 400 bad request', () async {
+      var response = await http.post(
+        Uri.parse('${serverUrl}simple'),
+        body: jsonEncode({
+          'method': 'hello',
+          'name': 'Starbase Alpha',
+          'extra': 'spurious value',
+        }),
+      );
+
+      expect(response.statusCode, 400);
+    }, skip: 'desired behavior unclear');
+
+    test(
+        'when calling an endpoint method with misspelled method name '
+        'then it should respond with 400 bad request', () async {
+      var response = await http.post(
+        Uri.parse('${serverUrl}simpleMistake'),
+        body: jsonEncode({
+          'method': 'hello',
+          'name': 'Starbase Alpha',
+        }),
+      );
+
+      expect(response.statusCode, 400);
+      expect(response.body, contains('Endpoint simpleMistake not found'));
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_e2e/http_codes_test.dart
+++ b/tests/serverpod_test_server/test_e2e/http_codes_test.dart
@@ -42,7 +42,7 @@ void main() {
     });
 
     test(
-        'when calling an endpoint method with misspelled endpoint path '
+        'when calling an endpoint method with non-existing endpoint path '
         'then it should respond with 404 not found', () async {
       final nonExistingPath =
           'path_${Uuid().v4().replaceAll('-', '_').toLowerCase()}';
@@ -59,7 +59,7 @@ void main() {
     });
 
     test(
-        'when calling an endpoint method with misspelled method name '
+        'when calling an endpoint method with non-existing method name '
         'then it should respond with 400 bad request', () async {
       final nonExistingName =
           'path_${Uuid().v4().replaceAll('-', '_').toLowerCase()}';


### PR DESCRIPTION
Fixes the issue where Serverpod server responds with HTTP code 500 instead of 400 upon wrong endpoint parameters.

Closes #2826 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
Breaks previous error response behavior, but that behavior was wrong and upon discussion in team this was deemed ok.