### PR TITLE
fix: Support test tools for mini projects

### DIFF
--- a/packages/serverpod_test/lib/src/function_call_wrappers.dart
+++ b/packages/serverpod_test/lib/src/function_call_wrappers.dart
@@ -73,7 +73,7 @@ class ServerpodInsufficientAccessException implements Exception {
 
 /// Thrown if a stream connection is closed with an error.
 /// For example, if the user authentication was revoked.
-class ConnectionClosedException {
+class ConnectionClosedException implements Exception {
   /// Creates a new [ConnectionClosedException].
   const ConnectionClosedException();
 }

--- a/packages/serverpod_test/lib/src/test_database_proxy.dart
+++ b/packages/serverpod_test/lib/src/test_database_proxy.dart
@@ -153,7 +153,7 @@ class TestDatabaseProxy implements Database {
       await _transactionManager.removePreviousSavePoint(unlock: true);
       return result;
     } catch (e) {
-      await _transactionManager.rollbacktoPreviousSavePoint(unlock: true);
+      await _transactionManager.rollbackToPreviousSavePoint(unlock: true);
       rethrow;
     }
   }

--- a/packages/serverpod_test/lib/src/test_session_builder.dart
+++ b/packages/serverpod_test/lib/src/test_session_builder.dart
@@ -6,8 +6,10 @@ import 'test_serverpod.dart';
 abstract class AuthenticationOverride {
   /// Sets the session to be authenticated with the provided userId and scope.
   static AuthenticationOverride authenticationInfo(
-          int userId, Set<Scope> scopes,
-          {String? authId}) =>
+    int userId,
+    Set<Scope> scopes, {
+    String? authId,
+  }) =>
       _AuthenticationInfoOverride(userId, scopes, authId: authId);
 
   /// Sets the session to be unauthenticated. This is the default.

--- a/packages/serverpod_test/lib/src/transaction_manager.dart
+++ b/packages/serverpod_test/lib/src/transaction_manager.dart
@@ -97,7 +97,7 @@ class TransactionManager {
   }
 
   /// Rolls back the database to the previous save point in the current transaction.
-  Future<void> rollbacktoPreviousSavePoint({bool unlock = false}) async {
+  Future<void> rollbackToPreviousSavePoint({bool unlock = false}) async {
     var savePointId = await removePreviousSavePoint(unlock: unlock);
 
     await serverpodSession.db.unsafeExecute(

--- a/packages/serverpod_test/lib/src/with_serverpod.dart
+++ b/packages/serverpod_test/lib/src/with_serverpod.dart
@@ -116,7 +116,7 @@ void Function(TestClosure<T>)
               'The transaction manager is null.',
             );
           }
-          await localTransactionManager.rollbacktoPreviousSavePoint();
+          await localTransactionManager.rollbackToPreviousSavePoint();
           await localTransactionManager.addSavePoint();
         }
 

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -46,9 +46,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 withServerpod(
   String testGroupName,
   _i1.TestClosure<TestEndpoints> testClosure, {
-  _i1.RollbackDatabase? rollbackDatabase,
   String? runMode,
   bool? enableSessionLogging,
+  _i1.RollbackDatabase? rollbackDatabase,
   bool? applyMigrations,
 }) {
   _i1.buildWithServerpod<_InternalTestEndpoints>(
@@ -59,6 +59,7 @@ withServerpod(
       serializationManager: Protocol(),
       runMode: runMode,
       applyMigrations: applyMigrations,
+      isDatabaseEnabled: true,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -135,15 +135,29 @@ class GeneratorConfig {
       ];
 
   final List<String>? _relativeServerTestToolsPathParts;
+  static const _defaultRelativeServerTestToolsPathParts = [
+    'integration_test',
+    'test_tools'
+  ];
+
   List<String>? get generatedServerTestToolsPathParts {
     var localRelativeServerTestToolsPathParts =
         _relativeServerTestToolsPathParts;
-    if (localRelativeServerTestToolsPathParts == null) return null;
+    if (localRelativeServerTestToolsPathParts != null) {
+      return [
+        ...serverPackageDirectoryPathParts,
+        ...localRelativeServerTestToolsPathParts
+      ];
+    }
 
-    return [
-      ...serverPackageDirectoryPathParts,
-      ...localRelativeServerTestToolsPathParts
-    ];
+    if (isExperimentalFeatureEnabled(ExperimentalFeature.testToolsForMini)) {
+      return [
+        ...serverPackageDirectoryPathParts,
+        ..._defaultRelativeServerTestToolsPathParts
+      ];
+    }
+
+    return null;
   }
 
   /// The path parts to the protocol directory in the dart client package.

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/config/serverpod_feature.dart';
@@ -10,7 +11,6 @@ import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
-import 'package:path/path.dart' as p;
 
 import '../generator/types.dart';
 
@@ -141,6 +141,10 @@ class GeneratorConfig {
   ];
 
   List<String>? get generatedServerTestToolsPathParts {
+    if (!isExperimentalFeatureEnabled(ExperimentalFeature.testTools)) {
+      return null;
+    }
+
     var localRelativeServerTestToolsPathParts =
         _relativeServerTestToolsPathParts;
     if (localRelativeServerTestToolsPathParts != null) {
@@ -150,7 +154,8 @@ class GeneratorConfig {
       ];
     }
 
-    if (isExperimentalFeatureEnabled(ExperimentalFeature.testToolsForMini)) {
+    var isServerpodMini = !isFeatureEnabled(ServerpodFeature.database);
+    if (isServerpodMini) {
       return [
         ...serverPackageDirectoryPathParts,
         ..._defaultRelativeServerTestToolsPathParts

--- a/tools/serverpod_cli/lib/src/config/experimental_feature.dart
+++ b/tools/serverpod_cli/lib/src/config/experimental_feature.dart
@@ -12,9 +12,12 @@ class CommandLineExperimentalFeatures {
 
 enum ExperimentalFeature {
   all,
-// TODO: Remove when inheritance is enabled by default.
-// Tracked by issue: https://github.com/serverpod/serverpod/issues/2711
-  inheritance;
+  // TODO: Remove when inheritance is enabled by default.
+  // Tracked by issue: https://github.com/serverpod/serverpod/issues/2711
+  inheritance,
+  // TODO: Remove when test templates are generated and the feature is public
+  // Tracked by issue: https://github.com/serverpod/serverpod/issues/2734
+  testToolsForMini;
 
   static ExperimentalFeature fromString(String value) {
     for (var feature in ExperimentalFeature.values) {

--- a/tools/serverpod_cli/lib/src/config/experimental_feature.dart
+++ b/tools/serverpod_cli/lib/src/config/experimental_feature.dart
@@ -17,7 +17,7 @@ enum ExperimentalFeature {
   inheritance,
   // TODO: Remove when test templates are generated and the feature is public
   // Tracked by issue: https://github.com/serverpod/serverpod/issues/2734
-  testToolsForMini;
+  testTools;
 
   static ExperimentalFeature fromString(String value) {
     for (var feature in ExperimentalFeature.values) {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -393,10 +393,6 @@ class ServerTestToolsGenerator {
         ])
         ..optionalParameters.addAll([
           Parameter((p) => p
-            ..name = 'rollbackDatabase'
-            ..named = true
-            ..type = refer('RollbackDatabase?', serverpodTestUrl)),
-          Parameter((p) => p
             ..name = 'runMode'
             ..named = true
             ..type = refer('String?')),
@@ -404,11 +400,16 @@ class ServerTestToolsGenerator {
             ..name = 'enableSessionLogging'
             ..named = true
             ..type = refer('bool?')),
-          if (config.isFeatureEnabled(ServerpodFeature.database))
+          if (config.isFeatureEnabled(ServerpodFeature.database)) ...[
+            Parameter((p) => p
+              ..name = 'rollbackDatabase'
+              ..named = true
+              ..type = refer('RollbackDatabase?', serverpodTestUrl)),
             Parameter((p) => p
               ..name = 'applyMigrations'
               ..named = true
-              ..type = refer('bool?')),
+              ..type = refer('bool?'))
+          ],
         ])
         ..body = refer(
                 'buildWithServerpod<_InternalTestEndpoints>', serverpodTestUrl)
@@ -427,11 +428,17 @@ class ServerTestToolsGenerator {
                     config.isFeatureEnabled(ServerpodFeature.database)
                         ? refer('applyMigrations')
                         : literalBool(false),
+                'isDatabaseEnabled': literalBool(
+                  config.isFeatureEnabled(ServerpodFeature.database),
+                ),
               },
             ),
           ],
           {
-            'maybeRollbackDatabase': refer('rollbackDatabase'),
+            'maybeRollbackDatabase':
+                config.isFeatureEnabled(ServerpodFeature.database)
+                    ? refer('rollbackDatabase')
+                    : literalNull,
             'maybeEnableSessionLogging': refer('enableSessionLogging'),
           },
         ).call([

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/expected_files_created_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/expected_files_created_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
 import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
 import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
@@ -159,7 +160,11 @@ void main() {
       () {
     var configWithTestToolsPath = GeneratorConfigBuilder()
         .withName(projectName)
-        .withRelativeServerTestToolsPathParts(
+        .withEnabledExperimentalFeatures(
+      [
+        ExperimentalFeature.testTools,
+      ],
+    ).withRelativeServerTestToolsPathParts(
       [
         'integration_test',
         'serverpod_test_tools',

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
@@ -2,6 +2,7 @@ import 'package:path/path.dart' as path;
 import 'package:recase/recase.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
 import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
@@ -12,7 +13,11 @@ import 'package:test/test.dart';
 const projectName = 'example_project';
 final config = GeneratorConfigBuilder()
     .withName(projectName)
-    .withRelativeServerTestToolsPathParts(
+    .withEnabledExperimentalFeatures(
+  [
+    ExperimentalFeature.testTools,
+  ],
+).withRelativeServerTestToolsPathParts(
   [
     'integration_test',
     'test_tools',
@@ -99,7 +104,11 @@ void main() {
       () {
     var serverpodMiniConfig = GeneratorConfigBuilder()
         .withName(projectName)
-        .withRelativeServerTestToolsPathParts(
+        .withEnabledExperimentalFeatures(
+      [
+        ExperimentalFeature.testTools,
+      ],
+    ).withRelativeServerTestToolsPathParts(
       [
         'integration_test',
         'test_tools',

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
@@ -64,9 +64,9 @@ void main() {
               r'withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
-              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  String\? runMode,\n'
               r'  bool\? enableSessionLogging,\n'
+              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  bool\? applyMigrations,\n'
               r'\}\)',
             ));
@@ -122,7 +122,7 @@ void main() {
     var testToolsFile = codeMap[expectedFileName];
 
     test(
-      'then test tools file has `withServerpod` function without `applyMigrations` parameter',
+      'then test tools file has `withServerpod` function without `rollbackDatabase` and `applyMigrations` parameters',
       () {
         expect(
             testToolsFile,
@@ -131,7 +131,6 @@ void main() {
               r'withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
-              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  String\? runMode,\n'
               r'  bool\? enableSessionLogging,\n'
               r'\}\)',
@@ -176,9 +175,9 @@ void main() {
               r'withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
-              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  String\? runMode,\n'
               r'  bool\? enableSessionLogging,\n'
+              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  bool\? applyMigrations,\n'
               r'\}\)',
             ));
@@ -255,9 +254,9 @@ void main() {
               r'withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
-              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  String\? runMode,\n'
               r'  bool\? enableSessionLogging,\n'
+              r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
               r'  bool\? applyMigrations,\n'
               r'\}\)',
             ));


### PR DESCRIPTION
## Description.
Small changes to make the test tools work for Serverpod mini projects.

Closes #2740.  

## Changes
- Adds `isDatabaseEnabled` argument to `buildWithServerpod`

## Testing ❗ 
- Tested and verified that it works with a Serverpod Mini project
- I didn't add an integration test here, only updated the unit test. 
- The plan is to add bootstrap tests that actually runs the example tests to ensure they pass when fixing issue #2734. I think such a test is a pragmatic way to validate this behavior for the moment.
  - (The alternative would be to create a `serverpod_test_mini` project in which we can generate the test tools and write a an integration test in an authentic Serverpod mini environment, but that felt overkill right now.)


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.