### PR TITLE
fix: inheritance for serverOnly scoped classes and fields

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2012,6 +2012,22 @@ class EndpointServerOnlyScopedFieldModel extends _i1.EndpointRef {
 }
 
 /// {@category Endpoint}
+class EndpointServerOnlyScopedFieldChildModel extends _i1.EndpointRef {
+  EndpointServerOnlyScopedFieldChildModel(_i1.EndpointCaller caller)
+      : super(caller);
+
+  @override
+  String get name => 'serverOnlyScopedFieldChildModel';
+
+  _i2.Future<_i19.ScopeServerOnlyField> getProtocolField() =>
+      caller.callServerEndpoint<_i19.ScopeServerOnlyField>(
+        'serverOnlyScopedFieldChildModel',
+        'getProtocolField',
+        {},
+      );
+}
+
+/// {@category Endpoint}
 class EndpointSignInRequired extends _i1.EndpointRef {
   EndpointSignInRequired(_i1.EndpointCaller caller) : super(caller);
 
@@ -2361,6 +2377,8 @@ class Client extends _i1.ServerpodClientShared {
     optionalParameters = EndpointOptionalParameters(this);
     redis = EndpointRedis(this);
     serverOnlyScopedFieldModel = EndpointServerOnlyScopedFieldModel(this);
+    serverOnlyScopedFieldChildModel =
+        EndpointServerOnlyScopedFieldChildModel(this);
     signInRequired = EndpointSignInRequired(this);
     adminScopeRequired = EndpointAdminScopeRequired(this);
     simple = EndpointSimple(this);
@@ -2433,6 +2451,9 @@ class Client extends _i1.ServerpodClientShared {
 
   late final EndpointServerOnlyScopedFieldModel serverOnlyScopedFieldModel;
 
+  late final EndpointServerOnlyScopedFieldChildModel
+      serverOnlyScopedFieldChildModel;
+
   late final EndpointSignInRequired signInRequired;
 
   late final EndpointAdminScopeRequired adminScopeRequired;
@@ -2485,6 +2506,7 @@ class Client extends _i1.ServerpodClientShared {
         'optionalParameters': optionalParameters,
         'redis': redis,
         'serverOnlyScopedFieldModel': serverOnlyScopedFieldModel,
+        'serverOnlyScopedFieldChildModel': serverOnlyScopedFieldChildModel,
         'signInRequired': signInRequired,
         'adminScopeRequired': adminScopeRequired,
         'simple': simple,

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -35,7 +35,9 @@ import 'package:serverpod_test_client/src/protocol/module_datatype.dart'
     as _i18;
 import 'package:serverpod_test_client/src/protocol/scopes/scope_server_only_field.dart'
     as _i19;
-import 'protocol.dart' as _i20;
+import 'package:serverpod_test_client/src/protocol/scopes/scope_server_only_field_child.dart'
+    as _i20;
+import 'protocol.dart' as _i21;
 
 /// {@category Endpoint}
 class EndpointAsyncTasks extends _i1.EndpointRef {
@@ -2019,8 +2021,8 @@ class EndpointServerOnlyScopedFieldChildModel extends _i1.EndpointRef {
   @override
   String get name => 'serverOnlyScopedFieldChildModel';
 
-  _i2.Future<_i19.ScopeServerOnlyField> getProtocolField() =>
-      caller.callServerEndpoint<_i19.ScopeServerOnlyField>(
+  _i2.Future<_i20.ScopeServerOnlyFieldChild> getProtocolField() =>
+      caller.callServerEndpoint<_i20.ScopeServerOnlyFieldChild>(
         'serverOnlyScopedFieldChildModel',
         'getProtocolField',
         {},
@@ -2337,7 +2339,7 @@ class Client extends _i1.ServerpodClientShared {
     bool? disconnectStreamsOnLostInternetConnection,
   }) : super(
           host,
-          _i20.Protocol(),
+          _i21.Protocol(),
           securityContext: securityContext,
           authenticationKeyManager: authenticationKeyManager,
           streamingConnectionTimeout: streamingConnectionTimeout,

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -113,33 +113,34 @@ import 'object_with_uuid.dart' as _i92;
 import 'related_unique_data.dart' as _i93;
 import 'scopes/scope_none_fields.dart' as _i94;
 import 'scopes/scope_server_only_field.dart' as _i95;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i96;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i97;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i98;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i99;
-import 'scopes/server_only_class_field.dart' as _i100;
-import 'simple_data.dart' as _i101;
-import 'simple_data_list.dart' as _i102;
-import 'simple_data_map.dart' as _i103;
-import 'simple_data_object.dart' as _i104;
-import 'simple_date_time.dart' as _i105;
-import 'test_enum.dart' as _i106;
-import 'test_enum_stringified.dart' as _i107;
-import 'types.dart' as _i108;
-import 'types_list.dart' as _i109;
-import 'types_map.dart' as _i110;
-import 'unique_data.dart' as _i111;
-import 'protocol.dart' as _i112;
+import 'scopes/scope_server_only_field_child.dart' as _i96;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i97;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i98;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i99;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i100;
+import 'scopes/server_only_class_field.dart' as _i101;
+import 'simple_data.dart' as _i102;
+import 'simple_data_list.dart' as _i103;
+import 'simple_data_map.dart' as _i104;
+import 'simple_data_object.dart' as _i105;
+import 'simple_date_time.dart' as _i106;
+import 'test_enum.dart' as _i107;
+import 'test_enum_stringified.dart' as _i108;
+import 'types.dart' as _i109;
+import 'types_list.dart' as _i110;
+import 'types_map.dart' as _i111;
+import 'unique_data.dart' as _i112;
+import 'protocol.dart' as _i113;
 import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
-    as _i113;
-import 'dart:typed_data' as _i114;
-import 'package:serverpod_test_client/src/custom_classes.dart' as _i115;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i116;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i117;
+    as _i114;
+import 'dart:typed_data' as _i115;
+import 'package:serverpod_test_client/src/custom_classes.dart' as _i116;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i117;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i118;
 import 'package:serverpod_test_client/src/protocol_custom_classes.dart'
-    as _i118;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i119;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i120;
+    as _i119;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i120;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i121;
 export 'defaults/boolean/bool_default.dart';
 export 'defaults/boolean/bool_default_mix.dart';
 export 'defaults/boolean/bool_default_model.dart';
@@ -234,6 +235,7 @@ export 'object_with_uuid.dart';
 export 'related_unique_data.dart';
 export 'scopes/scope_none_fields.dart';
 export 'scopes/scope_server_only_field.dart';
+export 'scopes/scope_server_only_field_child.dart';
 export 'scopes/serverOnly/default_server_only_class.dart';
 export 'scopes/serverOnly/default_server_only_enum.dart';
 export 'scopes/serverOnly/not_server_only_class.dart';
@@ -547,53 +549,56 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i95.ScopeServerOnlyField) {
       return _i95.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i96.DefaultServerOnlyClass) {
-      return _i96.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i96.ScopeServerOnlyFieldChild) {
+      return _i96.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i97.DefaultServerOnlyEnum) {
-      return _i97.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i97.DefaultServerOnlyClass) {
+      return _i97.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i98.NotServerOnlyClass) {
-      return _i98.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i98.DefaultServerOnlyEnum) {
+      return _i98.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i99.NotServerOnlyEnum) {
-      return _i99.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i99.NotServerOnlyClass) {
+      return _i99.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i100.ServerOnlyClassField) {
-      return _i100.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i100.NotServerOnlyEnum) {
+      return _i100.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i101.SimpleData) {
-      return _i101.SimpleData.fromJson(data) as T;
+    if (t == _i101.ServerOnlyClassField) {
+      return _i101.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i102.SimpleDataList) {
-      return _i102.SimpleDataList.fromJson(data) as T;
+    if (t == _i102.SimpleData) {
+      return _i102.SimpleData.fromJson(data) as T;
     }
-    if (t == _i103.SimpleDataMap) {
-      return _i103.SimpleDataMap.fromJson(data) as T;
+    if (t == _i103.SimpleDataList) {
+      return _i103.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i104.SimpleDataObject) {
-      return _i104.SimpleDataObject.fromJson(data) as T;
+    if (t == _i104.SimpleDataMap) {
+      return _i104.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i105.SimpleDateTime) {
-      return _i105.SimpleDateTime.fromJson(data) as T;
+    if (t == _i105.SimpleDataObject) {
+      return _i105.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i106.TestEnum) {
-      return _i106.TestEnum.fromJson(data) as T;
+    if (t == _i106.SimpleDateTime) {
+      return _i106.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i107.TestEnumStringified) {
-      return _i107.TestEnumStringified.fromJson(data) as T;
+    if (t == _i107.TestEnum) {
+      return _i107.TestEnum.fromJson(data) as T;
     }
-    if (t == _i108.Types) {
-      return _i108.Types.fromJson(data) as T;
+    if (t == _i108.TestEnumStringified) {
+      return _i108.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i109.TypesList) {
-      return _i109.TypesList.fromJson(data) as T;
+    if (t == _i109.Types) {
+      return _i109.Types.fromJson(data) as T;
     }
-    if (t == _i110.TypesMap) {
-      return _i110.TypesMap.fromJson(data) as T;
+    if (t == _i110.TypesList) {
+      return _i110.TypesList.fromJson(data) as T;
     }
-    if (t == _i111.UniqueData) {
-      return _i111.UniqueData.fromJson(data) as T;
+    if (t == _i111.TypesMap) {
+      return _i111.TypesMap.fromJson(data) as T;
+    }
+    if (t == _i112.UniqueData) {
+      return _i112.UniqueData.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.BoolDefault?>()) {
       return (data != null ? _i2.BoolDefault.fromJson(data) : null) as T;
@@ -911,63 +916,69 @@ class Protocol extends _i1.SerializationManager {
       return (data != null ? _i95.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i96.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i96.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i96.ScopeServerOnlyFieldChild?>()) {
+      return (data != null
+          ? _i96.ScopeServerOnlyFieldChild.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i97.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i97.DefaultServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i97.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i97.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i98.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i98.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i98.NotServerOnlyClass?>()) {
-      return (data != null ? _i98.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i99.NotServerOnlyClass?>()) {
+      return (data != null ? _i99.NotServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i99.NotServerOnlyEnum?>()) {
-      return (data != null ? _i99.NotServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i100.ServerOnlyClassField?>()) {
-      return (data != null ? _i100.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i100.NotServerOnlyEnum?>()) {
+      return (data != null ? _i100.NotServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i101.SimpleData?>()) {
-      return (data != null ? _i101.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i102.SimpleDataList?>()) {
-      return (data != null ? _i102.SimpleDataList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i103.SimpleDataMap?>()) {
-      return (data != null ? _i103.SimpleDataMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i104.SimpleDataObject?>()) {
-      return (data != null ? _i104.SimpleDataObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i105.SimpleDateTime?>()) {
-      return (data != null ? _i105.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.TestEnum?>()) {
-      return (data != null ? _i106.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i107.TestEnumStringified?>()) {
-      return (data != null ? _i107.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i101.ServerOnlyClassField?>()) {
+      return (data != null ? _i101.ServerOnlyClassField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i108.Types?>()) {
-      return (data != null ? _i108.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i102.SimpleData?>()) {
+      return (data != null ? _i102.SimpleData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i109.TypesList?>()) {
-      return (data != null ? _i109.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i103.SimpleDataList?>()) {
+      return (data != null ? _i103.SimpleDataList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i110.TypesMap?>()) {
-      return (data != null ? _i110.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i104.SimpleDataMap?>()) {
+      return (data != null ? _i104.SimpleDataMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i111.UniqueData?>()) {
-      return (data != null ? _i111.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i105.SimpleDataObject?>()) {
+      return (data != null ? _i105.SimpleDataObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<List<_i112.EmptyModelRelationItem>?>()) {
+    if (t == _i1.getType<_i106.SimpleDateTime?>()) {
+      return (data != null ? _i106.SimpleDateTime.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i107.TestEnum?>()) {
+      return (data != null ? _i107.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i108.TestEnumStringified?>()) {
+      return (data != null ? _i108.TestEnumStringified.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i109.Types?>()) {
+      return (data != null ? _i109.Types.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i110.TypesList?>()) {
+      return (data != null ? _i110.TypesList.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i111.TypesMap?>()) {
+      return (data != null ? _i111.TypesMap.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i112.UniqueData?>()) {
+      return (data != null ? _i112.UniqueData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<List<_i113.EmptyModelRelationItem>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.EmptyModelRelationItem>(e))
+              .map((e) => deserialize<_i113.EmptyModelRelationItem>(e))
               .toList()
           : null) as dynamic;
     }
@@ -975,118 +986,118 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i112.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i113.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i113.PersonWithLongTableName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.OrganizationWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i113.OrganizationWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.OrganizationWithLongTableName>(e))
+              .map((e) => deserialize<_i113.OrganizationWithLongTableName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i113.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i113.PersonWithLongTableName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i113.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i113.LongImplicitIdField>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i113.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i113.MultipleMaxFieldName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.UserNote>?>()) {
+    if (t == _i1.getType<List<_i113.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.UserNote>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i113.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i113.UserNoteWithALongName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Person>?>()) {
+    if (t == _i1.getType<List<_i113.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Organization>?>()) {
+    if (t == _i1.getType<List<_i113.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.Organization>(e))
+              .map((e) => deserialize<_i113.Organization>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Person>?>()) {
+    if (t == _i1.getType<List<_i113.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i113.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i113.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Player>?>()) {
+    if (t == _i1.getType<List<_i113.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Player>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Order>?>()) {
+    if (t == _i1.getType<List<_i113.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Order>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Comment>?>()) {
+    if (t == _i1.getType<List<_i113.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Comment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Blocking>?>()) {
+    if (t == _i1.getType<List<_i113.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Blocking>?>()) {
+    if (t == _i1.getType<List<_i113.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Cat>?>()) {
+    if (t == _i1.getType<List<_i113.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Cat>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i113.ModuleClass>) {
+    if (t == List<_i114.ModuleClass>) {
       return (data as List)
-          .map((e) => deserialize<_i113.ModuleClass>(e))
+          .map((e) => deserialize<_i114.ModuleClass>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i113.ModuleClass>) {
+    if (t == Map<String, _i114.ModuleClass>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i113.ModuleClass>(v)))
+              deserialize<String>(k), deserialize<_i114.ModuleClass>(v)))
           as dynamic;
     }
     if (t == List<int>) {
@@ -1106,25 +1117,25 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i112.SimpleData>) {
+    if (t == List<_i113.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i112.SimpleData>(e))
+          .map((e) => deserialize<_i113.SimpleData>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i112.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i113.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i112.SimpleData?>) {
+    if (t == List<_i113.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i112.SimpleData?>(e))
+          .map((e) => deserialize<_i113.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i112.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i113.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.SimpleData?>(e))
+              .map((e) => deserialize<_i113.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
@@ -1146,22 +1157,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i114.ByteData>) {
-      return (data as List).map((e) => deserialize<_i114.ByteData>(e)).toList()
+    if (t == List<_i115.ByteData>) {
+      return (data as List).map((e) => deserialize<_i115.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i114.ByteData>?>()) {
+    if (t == _i1.getType<List<_i115.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i114.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i115.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i114.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i114.ByteData?>(e)).toList()
+    if (t == List<_i115.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i115.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i114.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i115.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i114.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i115.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -1222,25 +1233,25 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == _i115.CustomClass3) {
-      return _i115.CustomClass3.fromJson(data) as T;
+    if (t == _i116.CustomClass3) {
+      return _i116.CustomClass3.fromJson(data) as T;
     }
-    if (t == List<_i112.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i112.TestEnum>(e)).toList()
+    if (t == List<_i113.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i113.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i112.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i112.TestEnum?>(e)).toList()
+    if (t == List<_i113.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i113.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i112.TestEnum>>) {
+    if (t == List<List<_i113.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i112.TestEnum>>(e))
+          .map((e) => deserialize<List<_i113.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i112.SimpleData>) {
+    if (t == Map<String, _i113.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i112.SimpleData>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i113.SimpleData>(v))) as dynamic;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -1251,9 +1262,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i114.ByteData>) {
+    if (t == Map<String, _i115.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i114.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i115.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -1266,9 +1277,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i112.SimpleData?>) {
+    if (t == Map<String, _i113.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i112.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i113.SimpleData?>(v)))
           as dynamic;
     }
     if (t == Map<String, String?>) {
@@ -1280,9 +1291,9 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i114.ByteData?>) {
+    if (t == Map<String, _i115.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i114.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i115.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -1300,53 +1311,53 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i112.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i113.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i113.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.SimpleData?>(e))
+              .map((e) => deserialize<_i113.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<List<_i112.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i113.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i112.SimpleData>>(e))
+              .map((e) => deserialize<List<_i113.SimpleData>>(e))
               .toList()
           : null) as dynamic;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i112.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i113.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i112.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i113.SimpleData>>?>>(v)))
           : null) as dynamic;
     }
-    if (t == List<List<Map<int, _i112.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i113.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i112.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i113.SimpleData>>?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<Map<int, _i112.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i113.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i112.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i113.SimpleData>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == Map<int, _i112.SimpleData>) {
+    if (t == Map<int, _i113.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i112.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i113.SimpleData>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i112.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i113.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i112.SimpleData>>(v)))
+              deserialize<Map<int, _i113.SimpleData>>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -1374,9 +1385,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i114.ByteData>?>()) {
+    if (t == _i1.getType<List<_i115.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i114.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i115.ByteData>(e)).toList()
           : null) as dynamic;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -1389,44 +1400,44 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i113.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.TestEnum>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i113.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i112.TestEnumStringified>(e))
+              .map((e) => deserialize<_i113.TestEnumStringified>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i112.Types>?>()) {
+    if (t == _i1.getType<List<_i113.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i112.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i113.Types>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<Map<String, _i112.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i113.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i112.Types>>(e))
+              .map((e) => deserialize<Map<String, _i113.Types>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == Map<String, _i112.Types>) {
+    if (t == Map<String, _i113.Types>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i112.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i113.Types>(v)))
           as dynamic;
     }
-    if (t == _i1.getType<List<List<_i112.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i113.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i112.Types>>(e))
+              .map((e) => deserialize<List<_i113.Types>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == List<_i112.Types>) {
-      return (data as List).map((e) => deserialize<_i112.Types>(e)).toList()
+    if (t == List<_i113.Types>) {
+      return (data as List).map((e) => deserialize<_i113.Types>(e)).toList()
           as dynamic;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -1459,10 +1470,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i114.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i115.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i114.ByteData>(e['k']),
+              deserialize<_i115.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
@@ -1478,42 +1489,42 @@ class Protocol extends _i1.SerializationManager {
               deserialize<_i1.UuidValue>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i112.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i113.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i112.TestEnum>(e['k']),
+              deserialize<_i113.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i112.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i113.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i112.TestEnumStringified>(e['k']),
+              deserialize<_i113.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i112.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i113.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i112.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i113.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<Map<_i112.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i113.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i112.Types, String>>(e['k']),
+              deserialize<Map<_i113.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == Map<_i112.Types, String>) {
+    if (t == Map<_i113.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i112.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i113.Types>(e['k']), deserialize<String>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<Map<List<_i112.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i113.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i112.Types>>(e['k']),
+              deserialize<List<_i113.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
@@ -1547,10 +1558,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i114.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i115.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i114.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i115.ByteData>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -1565,34 +1576,34 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i112.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i113.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i112.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i113.TestEnum>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i112.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i113.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i112.TestEnumStringified>(v)))
+              deserialize<_i113.TestEnumStringified>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i112.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i113.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i112.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i113.Types>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i112.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i113.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i112.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i113.Types>>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, List<_i112.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i113.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i112.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i113.Types>>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<List<String>?>()) {
@@ -1604,9 +1615,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i116.SimpleData>) {
+    if (t == List<_i117.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i116.SimpleData>(e))
+          .map((e) => deserialize<_i117.SimpleData>(e))
           .toList() as dynamic;
     }
     if (t == List<int>) {
@@ -1697,40 +1708,40 @@ class Protocol extends _i1.SerializationManager {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i114.ByteData>) {
-      return (data as List).map((e) => deserialize<_i114.ByteData>(e)).toList()
+    if (t == List<_i115.ByteData>) {
+      return (data as List).map((e) => deserialize<_i115.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i114.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i114.ByteData?>(e)).toList()
+    if (t == List<_i115.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i115.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i116.SimpleData?>) {
+    if (t == List<_i117.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i116.SimpleData?>(e))
+          .map((e) => deserialize<_i117.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i116.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i117.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i116.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i117.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i116.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i117.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i116.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i117.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i116.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i117.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i116.SimpleData?>(e))
+              .map((e) => deserialize<_i117.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i116.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i117.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i116.SimpleData?>(e))
+              .map((e) => deserialize<_i117.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
@@ -1785,14 +1796,14 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i117.TestEnum, int>) {
+    if (t == Map<_i118.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i117.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i118.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i117.TestEnum>) {
+    if (t == Map<String, _i118.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i117.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i118.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -1831,47 +1842,47 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i114.ByteData>) {
+    if (t == Map<String, _i115.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i114.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i115.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i114.ByteData?>) {
+    if (t == Map<String, _i115.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i114.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i115.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i116.SimpleData>) {
+    if (t == Map<String, _i117.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i116.SimpleData>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i117.SimpleData>(v))) as dynamic;
     }
-    if (t == Map<String, _i116.SimpleData?>) {
+    if (t == Map<String, _i117.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i116.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i117.SimpleData?>(v)))
           as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i116.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i117.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i116.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i117.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i116.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i117.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i116.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i117.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i116.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i117.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i116.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i117.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i116.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i117.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i116.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i117.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -1884,47 +1895,47 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == _i115.CustomClass) {
-      return _i115.CustomClass.fromJson(data) as T;
+    if (t == _i116.CustomClass) {
+      return _i116.CustomClass.fromJson(data) as T;
     }
-    if (t == _i115.CustomClass2) {
-      return _i115.CustomClass2.fromJson(data) as T;
+    if (t == _i116.CustomClass2) {
+      return _i116.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i118.ProtocolCustomClass) {
-      return _i118.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i119.ProtocolCustomClass) {
+      return _i119.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i119.ExternalCustomClass) {
-      return _i119.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i120.ExternalCustomClass) {
+      return _i120.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i119.FreezedCustomClass) {
-      return _i119.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i120.FreezedCustomClass) {
+      return _i120.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i115.CustomClass?>()) {
-      return (data != null ? _i115.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i116.CustomClass?>()) {
+      return (data != null ? _i116.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i115.CustomClass2?>()) {
-      return (data != null ? _i115.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i116.CustomClass2?>()) {
+      return (data != null ? _i116.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i115.CustomClass3?>()) {
-      return (data != null ? _i115.CustomClass3.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i116.CustomClass3?>()) {
+      return (data != null ? _i116.CustomClass3.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i118.ProtocolCustomClass?>()) {
-      return (data != null ? _i118.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i119.ProtocolCustomClass?>()) {
+      return (data != null ? _i119.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i119.ExternalCustomClass?>()) {
-      return (data != null ? _i119.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i120.ExternalCustomClass?>()) {
+      return (data != null ? _i120.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i119.FreezedCustomClass?>()) {
-      return (data != null ? _i119.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i120.FreezedCustomClass?>()) {
+      return (data != null ? _i120.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
     try {
-      return _i120.Protocol().deserialize<T>(data, t);
+      return _i121.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i113.Protocol().deserialize<T>(data, t);
+      return _i114.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -1933,22 +1944,22 @@ class Protocol extends _i1.SerializationManager {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i115.CustomClass) {
+    if (data is _i116.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i115.CustomClass2) {
+    if (data is _i116.CustomClass2) {
       return 'CustomClass2';
     }
-    if (data is _i115.CustomClass3) {
+    if (data is _i116.CustomClass3) {
       return 'CustomClass3';
     }
-    if (data is _i118.ProtocolCustomClass) {
+    if (data is _i119.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
     }
-    if (data is _i119.ExternalCustomClass) {
+    if (data is _i120.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i119.FreezedCustomClass) {
+    if (data is _i120.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.BoolDefault) {
@@ -2233,59 +2244,62 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i95.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i96.DefaultServerOnlyClass) {
+    if (data is _i96.ScopeServerOnlyFieldChild) {
+      return 'ScopeServerOnlyFieldChild';
+    }
+    if (data is _i97.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i97.DefaultServerOnlyEnum) {
+    if (data is _i98.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i98.NotServerOnlyClass) {
+    if (data is _i99.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i99.NotServerOnlyEnum) {
+    if (data is _i100.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i100.ServerOnlyClassField) {
+    if (data is _i101.ServerOnlyClassField) {
       return 'ServerOnlyClassField';
     }
-    if (data is _i101.SimpleData) {
+    if (data is _i102.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i102.SimpleDataList) {
+    if (data is _i103.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i103.SimpleDataMap) {
+    if (data is _i104.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i104.SimpleDataObject) {
+    if (data is _i105.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i105.SimpleDateTime) {
+    if (data is _i106.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i106.TestEnum) {
+    if (data is _i107.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i107.TestEnumStringified) {
+    if (data is _i108.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i108.Types) {
+    if (data is _i109.Types) {
       return 'Types';
     }
-    if (data is _i109.TypesList) {
+    if (data is _i110.TypesList) {
       return 'TypesList';
     }
-    if (data is _i110.TypesMap) {
+    if (data is _i111.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i111.UniqueData) {
+    if (data is _i112.UniqueData) {
       return 'UniqueData';
     }
-    className = _i120.Protocol().getClassNameForObject(data);
+    className = _i121.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    className = _i113.Protocol().getClassNameForObject(data);
+    className = _i114.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
@@ -2295,22 +2309,22 @@ class Protocol extends _i1.SerializationManager {
   @override
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i115.CustomClass>(data['data']);
+      return deserialize<_i116.CustomClass>(data['data']);
     }
     if (data['className'] == 'CustomClass2') {
-      return deserialize<_i115.CustomClass2>(data['data']);
+      return deserialize<_i116.CustomClass2>(data['data']);
     }
     if (data['className'] == 'CustomClass3') {
-      return deserialize<_i115.CustomClass3>(data['data']);
+      return deserialize<_i116.CustomClass3>(data['data']);
     }
     if (data['className'] == 'ProtocolCustomClass') {
-      return deserialize<_i118.ProtocolCustomClass>(data['data']);
+      return deserialize<_i119.ProtocolCustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i119.ExternalCustomClass>(data['data']);
+      return deserialize<_i120.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i119.FreezedCustomClass>(data['data']);
+      return deserialize<_i120.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'BoolDefault') {
       return deserialize<_i2.BoolDefault>(data['data']);
@@ -2594,61 +2608,64 @@ class Protocol extends _i1.SerializationManager {
     if (data['className'] == 'ScopeServerOnlyField') {
       return deserialize<_i95.ScopeServerOnlyField>(data['data']);
     }
+    if (data['className'] == 'ScopeServerOnlyFieldChild') {
+      return deserialize<_i96.ScopeServerOnlyFieldChild>(data['data']);
+    }
     if (data['className'] == 'DefaultServerOnlyClass') {
-      return deserialize<_i96.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i97.DefaultServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyEnum') {
-      return deserialize<_i97.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i98.DefaultServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyClass') {
-      return deserialize<_i98.NotServerOnlyClass>(data['data']);
+      return deserialize<_i99.NotServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyEnum') {
-      return deserialize<_i99.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i100.NotServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'ServerOnlyClassField') {
-      return deserialize<_i100.ServerOnlyClassField>(data['data']);
+      return deserialize<_i101.ServerOnlyClassField>(data['data']);
     }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i101.SimpleData>(data['data']);
+      return deserialize<_i102.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i102.SimpleDataList>(data['data']);
+      return deserialize<_i103.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'SimpleDataMap') {
-      return deserialize<_i103.SimpleDataMap>(data['data']);
+      return deserialize<_i104.SimpleDataMap>(data['data']);
     }
     if (data['className'] == 'SimpleDataObject') {
-      return deserialize<_i104.SimpleDataObject>(data['data']);
+      return deserialize<_i105.SimpleDataObject>(data['data']);
     }
     if (data['className'] == 'SimpleDateTime') {
-      return deserialize<_i105.SimpleDateTime>(data['data']);
+      return deserialize<_i106.SimpleDateTime>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i106.TestEnum>(data['data']);
+      return deserialize<_i107.TestEnum>(data['data']);
     }
     if (data['className'] == 'TestEnumStringified') {
-      return deserialize<_i107.TestEnumStringified>(data['data']);
+      return deserialize<_i108.TestEnumStringified>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i108.Types>(data['data']);
+      return deserialize<_i109.Types>(data['data']);
     }
     if (data['className'] == 'TypesList') {
-      return deserialize<_i109.TypesList>(data['data']);
+      return deserialize<_i110.TypesList>(data['data']);
     }
     if (data['className'] == 'TypesMap') {
-      return deserialize<_i110.TypesMap>(data['data']);
+      return deserialize<_i111.TypesMap>(data['data']);
     }
     if (data['className'] == 'UniqueData') {
-      return deserialize<_i111.UniqueData>(data['data']);
+      return deserialize<_i112.UniqueData>(data['data']);
     }
     if (data['className'].startsWith('serverpod_auth.')) {
       data['className'] = data['className'].substring(15);
-      return _i120.Protocol().deserializeByClassName(data);
+      return _i121.Protocol().deserializeByClassName(data);
     }
     if (data['className'].startsWith('serverpod_test_module.')) {
       data['className'] = data['className'].substring(22);
-      return _i113.Protocol().deserializeByClassName(data);
+      return _i114.Protocol().deserializeByClassName(data);
     }
     return super.deserializeByClassName(data);
   }

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field.dart
@@ -12,16 +12,11 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../protocol.dart' as _i2;
 
-abstract class ScopeServerOnlyField implements _i1.SerializableModel {
-  ScopeServerOnlyField._({
+class ScopeServerOnlyField implements _i1.SerializableModel {
+  ScopeServerOnlyField({
     this.allScope,
     this.nested,
   });
-
-  factory ScopeServerOnlyField({
-    _i2.Types? allScope,
-    _i2.ScopeServerOnlyField? nested,
-  }) = _ScopeServerOnlyFieldImpl;
 
   factory ScopeServerOnlyField.fromJson(
       Map<String, dynamic> jsonSerialization) {
@@ -42,9 +37,17 @@ abstract class ScopeServerOnlyField implements _i1.SerializableModel {
   _i2.ScopeServerOnlyField? nested;
 
   ScopeServerOnlyField copyWith({
-    _i2.Types? allScope,
-    _i2.ScopeServerOnlyField? nested,
-  });
+    Object? allScope = _Undefined,
+    Object? nested = _Undefined,
+  }) {
+    return ScopeServerOnlyField(
+      allScope: allScope is _i2.Types? ? allScope : this.allScope?.copyWith(),
+      nested: nested is _i2.ScopeServerOnlyField?
+          ? nested
+          : this.nested?.copyWith(),
+    );
+  }
+
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -60,26 +63,3 @@ abstract class ScopeServerOnlyField implements _i1.SerializableModel {
 }
 
 class _Undefined {}
-
-class _ScopeServerOnlyFieldImpl extends ScopeServerOnlyField {
-  _ScopeServerOnlyFieldImpl({
-    _i2.Types? allScope,
-    _i2.ScopeServerOnlyField? nested,
-  }) : super._(
-          allScope: allScope,
-          nested: nested,
-        );
-
-  @override
-  ScopeServerOnlyField copyWith({
-    Object? allScope = _Undefined,
-    Object? nested = _Undefined,
-  }) {
-    return ScopeServerOnlyField(
-      allScope: allScope is _i2.Types? ? allScope : this.allScope?.copyWith(),
-      nested: nested is _i2.ScopeServerOnlyField?
-          ? nested
-          : this.nested?.copyWith(),
-    );
-  }
-}

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field_child.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field_child.dart
@@ -1,0 +1,94 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import '../protocol.dart' as _i1;
+import 'package:serverpod_client/serverpod_client.dart' as _i2;
+
+abstract class ScopeServerOnlyFieldChild extends _i1.ScopeServerOnlyField
+    implements _i2.SerializableModel {
+  ScopeServerOnlyFieldChild._({
+    super.allScope,
+    super.nested,
+    required this.childFoo,
+  });
+
+  factory ScopeServerOnlyFieldChild({
+    _i1.Types? allScope,
+    _i1.ScopeServerOnlyField? nested,
+    required String childFoo,
+  }) = _ScopeServerOnlyFieldChildImpl;
+
+  factory ScopeServerOnlyFieldChild.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ScopeServerOnlyFieldChild(
+      allScope: jsonSerialization['allScope'] == null
+          ? null
+          : _i1.Types.fromJson(
+              (jsonSerialization['allScope'] as Map<String, dynamic>)),
+      nested: jsonSerialization['nested'] == null
+          ? null
+          : _i1.ScopeServerOnlyField.fromJson(
+              (jsonSerialization['nested'] as Map<String, dynamic>)),
+      childFoo: jsonSerialization['childFoo'] as String,
+    );
+  }
+
+  String childFoo;
+
+  @override
+  ScopeServerOnlyFieldChild copyWith({
+    Object? allScope,
+    Object? nested,
+    String? childFoo,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (allScope != null) 'allScope': allScope?.toJson(),
+      if (nested != null) 'nested': nested?.toJson(),
+      'childFoo': childFoo,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i2.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _ScopeServerOnlyFieldChildImpl extends ScopeServerOnlyFieldChild {
+  _ScopeServerOnlyFieldChildImpl({
+    _i1.Types? allScope,
+    _i1.ScopeServerOnlyField? nested,
+    required String childFoo,
+  }) : super._(
+          allScope: allScope,
+          nested: nested,
+          childFoo: childFoo,
+        );
+
+  @override
+  ScopeServerOnlyFieldChild copyWith({
+    Object? allScope = _Undefined,
+    Object? nested = _Undefined,
+    String? childFoo,
+  }) {
+    return ScopeServerOnlyFieldChild(
+      allScope: allScope is _i1.Types? ? allScope : this.allScope?.copyWith(),
+      nested: nested is _i1.ScopeServerOnlyField?
+          ? nested
+          : this.nested?.copyWith(),
+      childFoo: childFoo ?? this.childFoo,
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/endpoints/server_only_scoped_field_model_child.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/server_only_scoped_field_model_child.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+
+class ServerOnlyScopedFieldChildModelEndpoint extends Endpoint {
+  Future<ScopeServerOnlyField> getProtocolField(
+    Session session,
+  ) async {
+    return ScopeServerOnlyFieldChild(
+        serverOnlyScope: Types(anInt: 2),
+        nested: ScopeServerOnlyField(
+          allScope: Types(anInt: 1),
+          serverOnlyScope: Types(anInt: 2),
+        ),
+        childFoo: 'childFoo');
+  }
+}

--- a/tests/serverpod_test_server/lib/src/endpoints/server_only_scoped_field_model_child.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/server_only_scoped_field_model_child.dart
@@ -8,11 +8,12 @@ class ServerOnlyScopedFieldChildModelEndpoint extends Endpoint {
     Session session,
   ) async {
     return ScopeServerOnlyFieldChild(
+      serverOnlyScope: Types(anInt: 2),
+      nested: ScopeServerOnlyField(
+        allScope: Types(anInt: 1),
         serverOnlyScope: Types(anInt: 2),
-        nested: ScopeServerOnlyField(
-          allScope: Types(anInt: 1),
-          serverOnlyScope: Types(anInt: 2),
-        ),
-        childFoo: 'childFoo');
+      ),
+      childFoo: 'childFoo',
+    );
   }
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/server_only_scoped_field_model_child.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/server_only_scoped_field_model_child.dart
@@ -4,7 +4,7 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 
 class ServerOnlyScopedFieldChildModelEndpoint extends Endpoint {
-  Future<ScopeServerOnlyField> getProtocolField(
+  Future<ScopeServerOnlyFieldChild> getProtocolField(
     Session session,
   ) async {
     return ScopeServerOnlyFieldChild(

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -37,30 +37,31 @@ import '../endpoints/named_parameters.dart' as _i25;
 import '../endpoints/optional_parameters.dart' as _i26;
 import '../endpoints/redis.dart' as _i27;
 import '../endpoints/server_only_scoped_field_model.dart' as _i28;
-import '../endpoints/signin_required.dart' as _i29;
-import '../endpoints/simple.dart' as _i30;
-import '../endpoints/streaming.dart' as _i31;
-import '../endpoints/streaming_logging.dart' as _i32;
-import '../endpoints/subDir/subSubDir/subsubdir_test_endpoint.dart' as _i33;
-import '../endpoints/subDir/subdir_test_endpoint.dart' as _i34;
-import '../endpoints/test_tools.dart' as _i35;
-import 'dart:typed_data' as _i36;
-import 'package:uuid/uuid_value.dart' as _i37;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i38;
-import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i39;
-import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i40;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i41;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i42;
+import '../endpoints/server_only_scoped_field_model_child.dart' as _i29;
+import '../endpoints/signin_required.dart' as _i30;
+import '../endpoints/simple.dart' as _i31;
+import '../endpoints/streaming.dart' as _i32;
+import '../endpoints/streaming_logging.dart' as _i33;
+import '../endpoints/subDir/subSubDir/subsubdir_test_endpoint.dart' as _i34;
+import '../endpoints/subDir/subdir_test_endpoint.dart' as _i35;
+import '../endpoints/test_tools.dart' as _i36;
+import 'dart:typed_data' as _i37;
+import 'package:uuid/uuid_value.dart' as _i38;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i39;
+import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i40;
+import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i41;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i42;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i43;
 import 'package:serverpod_test_server/src/generated/object_with_enum.dart'
-    as _i43;
-import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i44;
-import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i45;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i46;
+import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+    as _i46;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i47;
 import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
-    as _i47;
-import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i48;
+    as _i48;
+import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i49;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -246,55 +247,62 @@ class Endpoints extends _i1.EndpointDispatch {
           'serverOnlyScopedFieldModel',
           null,
         ),
-      'signInRequired': _i29.SignInRequiredEndpoint()
+      'serverOnlyScopedFieldChildModel':
+          _i29.ServerOnlyScopedFieldChildModelEndpoint()
+            ..initialize(
+              server,
+              'serverOnlyScopedFieldChildModel',
+              null,
+            ),
+      'signInRequired': _i30.SignInRequiredEndpoint()
         ..initialize(
           server,
           'signInRequired',
           null,
         ),
-      'adminScopeRequired': _i29.AdminScopeRequiredEndpoint()
+      'adminScopeRequired': _i30.AdminScopeRequiredEndpoint()
         ..initialize(
           server,
           'adminScopeRequired',
           null,
         ),
-      'simple': _i30.SimpleEndpoint()
+      'simple': _i31.SimpleEndpoint()
         ..initialize(
           server,
           'simple',
           null,
         ),
-      'streaming': _i31.StreamingEndpoint()
+      'streaming': _i32.StreamingEndpoint()
         ..initialize(
           server,
           'streaming',
           null,
         ),
-      'streamingLogging': _i32.StreamingLoggingEndpoint()
+      'streamingLogging': _i33.StreamingLoggingEndpoint()
         ..initialize(
           server,
           'streamingLogging',
           null,
         ),
-      'subSubDirTest': _i33.SubSubDirTestEndpoint()
+      'subSubDirTest': _i34.SubSubDirTestEndpoint()
         ..initialize(
           server,
           'subSubDirTest',
           null,
         ),
-      'subDirTest': _i34.SubDirTestEndpoint()
+      'subDirTest': _i35.SubDirTestEndpoint()
         ..initialize(
           server,
           'subDirTest',
           null,
         ),
-      'testTools': _i35.TestToolsEndpoint()
+      'testTools': _i36.TestToolsEndpoint()
         ..initialize(
           server,
           'testTools',
           null,
         ),
-      'authenticatedTestTools': _i35.AuthenticatedTestToolsEndpoint()
+      'authenticatedTestTools': _i36.AuthenticatedTestToolsEndpoint()
         ..initialize(
           server,
           'authenticatedTestTools',
@@ -567,7 +575,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i36.ByteData?>(),
+              type: _i1.getType<_i37.ByteData?>(),
               nullable: true,
             )
           },
@@ -603,7 +611,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i37.UuidValue?>(),
+              type: _i1.getType<_i38.UuidValue?>(),
               nullable: true,
             )
           },
@@ -642,7 +650,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'byteData': _i1.ParameterDescription(
               name: 'byteData',
-              type: _i1.getType<_i36.ByteData>(),
+              type: _i1.getType<_i37.ByteData>(),
               nullable: false,
             ),
           },
@@ -787,7 +795,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'byteData': _i1.ParameterDescription(
               name: 'byteData',
-              type: _i1.getType<_i36.ByteData>(),
+              type: _i1.getType<_i37.ByteData>(),
               nullable: false,
             ),
           },
@@ -944,7 +952,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i38.CustomClass>(),
+              type: _i1.getType<_i39.CustomClass>(),
               nullable: false,
             )
           },
@@ -963,7 +971,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i38.CustomClass?>(),
+              type: _i1.getType<_i39.CustomClass?>(),
               nullable: true,
             )
           },
@@ -982,7 +990,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i38.CustomClass2>(),
+              type: _i1.getType<_i39.CustomClass2>(),
               nullable: false,
             )
           },
@@ -1001,7 +1009,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i38.CustomClass2?>(),
+              type: _i1.getType<_i39.CustomClass2?>(),
               nullable: true,
             )
           },
@@ -1020,7 +1028,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i39.ExternalCustomClass>(),
+              type: _i1.getType<_i40.ExternalCustomClass>(),
               nullable: false,
             )
           },
@@ -1039,7 +1047,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i39.ExternalCustomClass?>(),
+              type: _i1.getType<_i40.ExternalCustomClass?>(),
               nullable: true,
             )
           },
@@ -1058,7 +1066,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i40.FreezedCustomClass>(),
+              type: _i1.getType<_i41.FreezedCustomClass>(),
               nullable: false,
             )
           },
@@ -1077,7 +1085,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i40.FreezedCustomClass?>(),
+              type: _i1.getType<_i41.FreezedCustomClass?>(),
               nullable: true,
             )
           },
@@ -1268,7 +1276,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i41.SimpleData>(),
+              type: _i1.getType<_i42.SimpleData>(),
               nullable: false,
             )
           },
@@ -1287,7 +1295,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i41.SimpleData>(),
+              type: _i1.getType<_i42.SimpleData>(),
               nullable: false,
             )
           },
@@ -1306,7 +1314,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i41.SimpleData>(),
+              type: _i1.getType<_i42.SimpleData>(),
               nullable: false,
             )
           },
@@ -1345,7 +1353,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i42.Types>(),
+              type: _i1.getType<_i43.Types>(),
               nullable: false,
             )
           },
@@ -1363,7 +1371,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i42.Types>(),
+              type: _i1.getType<_i43.Types>(),
               nullable: false,
             )
           },
@@ -1438,7 +1446,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i43.ObjectWithEnum>(),
+              type: _i1.getType<_i44.ObjectWithEnum>(),
               nullable: false,
             )
           },
@@ -1476,7 +1484,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i44.ObjectWithObject>(),
+              type: _i1.getType<_i45.ObjectWithObject>(),
               nullable: false,
             )
           },
@@ -1855,7 +1863,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i45.ObjectFieldScopes>(),
+              type: _i1.getType<_i46.ObjectFieldScopes>(),
               nullable: false,
             )
           },
@@ -1890,7 +1898,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i41.SimpleData?>(),
+              type: _i1.getType<_i42.SimpleData?>(),
               nullable: true,
             )
           },
@@ -2200,7 +2208,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i36.ByteData>>(),
+              type: _i1.getType<List<_i37.ByteData>>(),
               nullable: false,
             )
           },
@@ -2219,7 +2227,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i36.ByteData?>>(),
+              type: _i1.getType<List<_i37.ByteData?>>(),
               nullable: false,
             )
           },
@@ -2238,7 +2246,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i41.SimpleData>>(),
+              type: _i1.getType<List<_i42.SimpleData>>(),
               nullable: false,
             )
           },
@@ -2257,7 +2265,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i41.SimpleData?>>(),
+              type: _i1.getType<List<_i42.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -2276,7 +2284,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i41.SimpleData>?>(),
+              type: _i1.getType<List<_i42.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -2295,7 +2303,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i41.SimpleData?>?>(),
+              type: _i1.getType<List<_i42.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -2740,7 +2748,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<_i46.TestEnum, int>>(),
+              type: _i1.getType<Map<_i47.TestEnum, int>>(),
               nullable: false,
             )
           },
@@ -2759,7 +2767,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i46.TestEnum>>(),
+              type: _i1.getType<Map<String, _i47.TestEnum>>(),
               nullable: false,
             )
           },
@@ -2930,7 +2938,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i36.ByteData>>(),
+              type: _i1.getType<Map<String, _i37.ByteData>>(),
               nullable: false,
             )
           },
@@ -2949,7 +2957,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i36.ByteData?>>(),
+              type: _i1.getType<Map<String, _i37.ByteData?>>(),
               nullable: false,
             )
           },
@@ -2968,7 +2976,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i41.SimpleData>>(),
+              type: _i1.getType<Map<String, _i42.SimpleData>>(),
               nullable: false,
             )
           },
@@ -2987,7 +2995,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i41.SimpleData?>>(),
+              type: _i1.getType<Map<String, _i42.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -3006,7 +3014,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i41.SimpleData>?>(),
+              type: _i1.getType<Map<String, _i42.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -3025,7 +3033,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i41.SimpleData?>?>(),
+              type: _i1.getType<Map<String, _i42.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -3775,7 +3783,7 @@ class Endpoints extends _i1.EndpointDispatch {
           name: 'simpleInOutDataStream',
           params: {},
           streamParams: {
-            'simpleDataStream': _i1.StreamParameterDescription<_i41.SimpleData>(
+            'simpleDataStream': _i1.StreamParameterDescription<_i42.SimpleData>(
               name: 'simpleDataStream',
               nullable: false,
             )
@@ -3789,7 +3797,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['methodStreaming'] as _i23.MethodStreaming)
                   .simpleInOutDataStream(
             session,
-            streamParams['simpleDataStream']!.cast<_i41.SimpleData>(),
+            streamParams['simpleDataStream']!.cast<_i42.SimpleData>(),
           ),
         ),
         'delayedStreamResponse': _i1.MethodStreamConnector(
@@ -4155,7 +4163,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i47.ModuleClass>(),
+              type: _i1.getType<_i48.ModuleClass>(),
               nullable: false,
             )
           },
@@ -4291,7 +4299,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i41.SimpleData>(),
+              type: _i1.getType<_i42.SimpleData>(),
               nullable: false,
             ),
           },
@@ -4315,7 +4323,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i41.SimpleData>(),
+              type: _i1.getType<_i42.SimpleData>(),
               nullable: false,
             ),
           },
@@ -4404,7 +4412,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i41.SimpleData>(),
+              type: _i1.getType<_i42.SimpleData>(),
               nullable: false,
             ),
           },
@@ -4447,6 +4455,23 @@ class Endpoints extends _i1.EndpointDispatch {
         )
       },
     );
+    connectors['serverOnlyScopedFieldChildModel'] = _i1.EndpointConnector(
+      name: 'serverOnlyScopedFieldChildModel',
+      endpoint: endpoints['serverOnlyScopedFieldChildModel']!,
+      methodConnectors: {
+        'getProtocolField': _i1.MethodConnector(
+          name: 'getProtocolField',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['serverOnlyScopedFieldChildModel']
+                      as _i29.ServerOnlyScopedFieldChildModelEndpoint)
+                  .getProtocolField(session),
+        )
+      },
+    );
     connectors['signInRequired'] = _i1.EndpointConnector(
       name: 'signInRequired',
       endpoint: endpoints['signInRequired']!,
@@ -4458,7 +4483,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['signInRequired'] as _i29.SignInRequiredEndpoint)
+              (endpoints['signInRequired'] as _i30.SignInRequiredEndpoint)
                   .testMethod(session),
         )
       },
@@ -4475,7 +4500,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['adminScopeRequired']
-                      as _i29.AdminScopeRequiredEndpoint)
+                      as _i30.AdminScopeRequiredEndpoint)
                   .testMethod(session),
         )
       },
@@ -4502,7 +4527,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i30.SimpleEndpoint).setGlobalInt(
+              (endpoints['simple'] as _i31.SimpleEndpoint).setGlobalInt(
             session,
             params['value'],
             params['secondValue'],
@@ -4515,7 +4540,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i30.SimpleEndpoint)
+              (endpoints['simple'] as _i31.SimpleEndpoint)
                   .addToGlobalInt(session),
         ),
         'getGlobalInt': _i1.MethodConnector(
@@ -4525,7 +4550,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i30.SimpleEndpoint)
+              (endpoints['simple'] as _i31.SimpleEndpoint)
                   .getGlobalInt(session),
         ),
         'hello': _i1.MethodConnector(
@@ -4541,7 +4566,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['simple'] as _i30.SimpleEndpoint).hello(
+              (endpoints['simple'] as _i31.SimpleEndpoint).hello(
             session,
             params['name'],
           ),
@@ -4569,7 +4594,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['subSubDirTest'] as _i33.SubSubDirTestEndpoint)
+              (endpoints['subSubDirTest'] as _i34.SubSubDirTestEndpoint)
                   .testMethod(session),
         )
       },
@@ -4585,7 +4610,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['subDirTest'] as _i34.SubDirTestEndpoint)
+              (endpoints['subDirTest'] as _i35.SubDirTestEndpoint)
                   .testMethod(session),
         )
       },
@@ -4601,7 +4626,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsSessionId(session),
         ),
         'returnsSessionEndpointAndMethod': _i1.MethodConnector(
@@ -4611,7 +4636,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsSessionEndpointAndMethod(session),
         ),
         'returnsString': _i1.MethodConnector(
@@ -4627,7 +4652,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint).returnsString(
+              (endpoints['testTools'] as _i36.TestToolsEndpoint).returnsString(
             session,
             params['string'],
           ),
@@ -4645,7 +4670,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .postNumberToSharedStream(
             session,
             params['number'],
@@ -4664,7 +4689,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .createSimpleData(
             session,
             params['data'],
@@ -4677,7 +4702,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .getAllSimpleData(session),
         ),
         'createSimpleDatasInsideTransactions': _i1.MethodConnector(
@@ -4693,7 +4718,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .createSimpleDatasInsideTransactions(
             session,
             params['data'],
@@ -4712,7 +4737,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .createSimpleDataAndThrowInsideTransaction(
             session,
             params['data'],
@@ -4725,7 +4750,7 @@ class Endpoints extends _i1.EndpointDispatch {
             _i1.Session session,
             Map<String, dynamic> params,
           ) async =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .createSimpleDatasInParallelTransactionCalls(session),
         ),
         'returnsSessionIdFromStream': _i1.MethodStreamConnector(
@@ -4738,7 +4763,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
             Map<String, Stream> streamParams,
           ) =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsSessionIdFromStream(session),
         ),
         'returnsSessionEndpointAndMethodFromStream': _i1.MethodStreamConnector(
@@ -4751,7 +4776,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
             Map<String, Stream> streamParams,
           ) =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsSessionEndpointAndMethodFromStream(session),
         ),
         'returnsStream': _i1.MethodStreamConnector(
@@ -4770,7 +4795,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
             Map<String, Stream> streamParams,
           ) =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint).returnsStream(
+              (endpoints['testTools'] as _i36.TestToolsEndpoint).returnsStream(
             session,
             params['n'],
           ),
@@ -4790,7 +4815,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
             Map<String, Stream> streamParams,
           ) =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsListFromInputStream(
             session,
             streamParams['numbers']!.cast<int>(),
@@ -4811,7 +4836,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
             Map<String, Stream> streamParams,
           ) =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsStreamFromInputStream(
             session,
             streamParams['numbers']!.cast<int>(),
@@ -4833,7 +4858,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
             Map<String, Stream> streamParams,
           ) =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .postNumberToSharedStreamAndReturnStream(
             session,
             params['number'],
@@ -4849,7 +4874,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
             Map<String, Stream> streamParams,
           ) =>
-              (endpoints['testTools'] as _i35.TestToolsEndpoint)
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .listenForNumbersOnSharedStream(session),
         ),
       },
@@ -4872,7 +4897,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, dynamic> params,
           ) async =>
               (endpoints['authenticatedTestTools']
-                      as _i35.AuthenticatedTestToolsEndpoint)
+                      as _i36.AuthenticatedTestToolsEndpoint)
                   .returnsString(
             session,
             params['string'],
@@ -4895,7 +4920,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, Stream> streamParams,
           ) =>
               (endpoints['authenticatedTestTools']
-                      as _i35.AuthenticatedTestToolsEndpoint)
+                      as _i36.AuthenticatedTestToolsEndpoint)
                   .returnsStream(
             session,
             params['n'],
@@ -4917,7 +4942,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, Stream> streamParams,
           ) =>
               (endpoints['authenticatedTestTools']
-                      as _i35.AuthenticatedTestToolsEndpoint)
+                      as _i36.AuthenticatedTestToolsEndpoint)
                   .returnsListFromInputStream(
             session,
             streamParams['numbers']!.cast<int>(),
@@ -4939,7 +4964,7 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, Stream> streamParams,
           ) =>
               (endpoints['authenticatedTestTools']
-                      as _i35.AuthenticatedTestToolsEndpoint)
+                      as _i36.AuthenticatedTestToolsEndpoint)
                   .intEchoStream(
             session,
             streamParams['stream']!.cast<int>(),
@@ -4947,8 +4972,8 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
-    modules['serverpod_auth'] = _i48.Endpoints()..initializeEndpoints(server);
-    modules['serverpod_test_module'] = _i47.Endpoints()
+    modules['serverpod_auth'] = _i49.Endpoints()..initializeEndpoints(server);
+    modules['serverpod_test_module'] = _i48.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -117,32 +117,33 @@ import 'object_with_uuid.dart' as _i95;
 import 'related_unique_data.dart' as _i96;
 import 'scopes/scope_none_fields.dart' as _i97;
 import 'scopes/scope_server_only_field.dart' as _i98;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i99;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i100;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i101;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i102;
-import 'scopes/serverOnly/server_only_class.dart' as _i103;
-import 'scopes/serverOnly/server_only_enum.dart' as _i104;
-import 'scopes/server_only_class_field.dart' as _i105;
-import 'simple_data.dart' as _i106;
-import 'simple_data_list.dart' as _i107;
-import 'simple_data_map.dart' as _i108;
-import 'simple_data_object.dart' as _i109;
-import 'simple_date_time.dart' as _i110;
-import 'test_enum.dart' as _i111;
-import 'test_enum_stringified.dart' as _i112;
-import 'types.dart' as _i113;
-import 'types_list.dart' as _i114;
-import 'types_map.dart' as _i115;
-import 'unique_data.dart' as _i116;
-import 'protocol.dart' as _i117;
-import 'dart:typed_data' as _i118;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i119;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i120;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i121;
+import 'scopes/scope_server_only_field_child.dart' as _i99;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i100;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i101;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i102;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i103;
+import 'scopes/serverOnly/server_only_class.dart' as _i104;
+import 'scopes/serverOnly/server_only_enum.dart' as _i105;
+import 'scopes/server_only_class_field.dart' as _i106;
+import 'simple_data.dart' as _i107;
+import 'simple_data_list.dart' as _i108;
+import 'simple_data_map.dart' as _i109;
+import 'simple_data_object.dart' as _i110;
+import 'simple_date_time.dart' as _i111;
+import 'test_enum.dart' as _i112;
+import 'test_enum_stringified.dart' as _i113;
+import 'types.dart' as _i114;
+import 'types_list.dart' as _i115;
+import 'types_map.dart' as _i116;
+import 'unique_data.dart' as _i117;
+import 'protocol.dart' as _i118;
+import 'dart:typed_data' as _i119;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i120;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i121;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i122;
 import 'package:serverpod_test_server/src/protocol_custom_classes.dart'
-    as _i122;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i123;
+    as _i123;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i124;
 export 'defaults/boolean/bool_default.dart';
 export 'defaults/boolean/bool_default_mix.dart';
 export 'defaults/boolean/bool_default_model.dart';
@@ -237,6 +238,7 @@ export 'object_with_uuid.dart';
 export 'related_unique_data.dart';
 export 'scopes/scope_none_fields.dart';
 export 'scopes/scope_server_only_field.dart';
+export 'scopes/scope_server_only_field_child.dart';
 export 'scopes/serverOnly/default_server_only_class.dart';
 export 'scopes/serverOnly/default_server_only_enum.dart';
 export 'scopes/serverOnly/not_server_only_class.dart';
@@ -5010,59 +5012,62 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i98.ScopeServerOnlyField) {
       return _i98.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i99.DefaultServerOnlyClass) {
-      return _i99.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i99.ScopeServerOnlyFieldChild) {
+      return _i99.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i100.DefaultServerOnlyEnum) {
-      return _i100.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i100.DefaultServerOnlyClass) {
+      return _i100.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i101.NotServerOnlyClass) {
-      return _i101.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i101.DefaultServerOnlyEnum) {
+      return _i101.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i102.NotServerOnlyEnum) {
-      return _i102.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i102.NotServerOnlyClass) {
+      return _i102.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i103.ServerOnlyClass) {
-      return _i103.ServerOnlyClass.fromJson(data) as T;
+    if (t == _i103.NotServerOnlyEnum) {
+      return _i103.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i104.ServerOnlyEnum) {
-      return _i104.ServerOnlyEnum.fromJson(data) as T;
+    if (t == _i104.ServerOnlyClass) {
+      return _i104.ServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i105.ServerOnlyClassField) {
-      return _i105.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i105.ServerOnlyEnum) {
+      return _i105.ServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i106.SimpleData) {
-      return _i106.SimpleData.fromJson(data) as T;
+    if (t == _i106.ServerOnlyClassField) {
+      return _i106.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i107.SimpleDataList) {
-      return _i107.SimpleDataList.fromJson(data) as T;
+    if (t == _i107.SimpleData) {
+      return _i107.SimpleData.fromJson(data) as T;
     }
-    if (t == _i108.SimpleDataMap) {
-      return _i108.SimpleDataMap.fromJson(data) as T;
+    if (t == _i108.SimpleDataList) {
+      return _i108.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i109.SimpleDataObject) {
-      return _i109.SimpleDataObject.fromJson(data) as T;
+    if (t == _i109.SimpleDataMap) {
+      return _i109.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i110.SimpleDateTime) {
-      return _i110.SimpleDateTime.fromJson(data) as T;
+    if (t == _i110.SimpleDataObject) {
+      return _i110.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i111.TestEnum) {
-      return _i111.TestEnum.fromJson(data) as T;
+    if (t == _i111.SimpleDateTime) {
+      return _i111.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i112.TestEnumStringified) {
-      return _i112.TestEnumStringified.fromJson(data) as T;
+    if (t == _i112.TestEnum) {
+      return _i112.TestEnum.fromJson(data) as T;
     }
-    if (t == _i113.Types) {
-      return _i113.Types.fromJson(data) as T;
+    if (t == _i113.TestEnumStringified) {
+      return _i113.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i114.TypesList) {
-      return _i114.TypesList.fromJson(data) as T;
+    if (t == _i114.Types) {
+      return _i114.Types.fromJson(data) as T;
     }
-    if (t == _i115.TypesMap) {
-      return _i115.TypesMap.fromJson(data) as T;
+    if (t == _i115.TypesList) {
+      return _i115.TypesList.fromJson(data) as T;
     }
-    if (t == _i116.UniqueData) {
-      return _i116.UniqueData.fromJson(data) as T;
+    if (t == _i116.TypesMap) {
+      return _i116.TypesMap.fromJson(data) as T;
+    }
+    if (t == _i117.UniqueData) {
+      return _i117.UniqueData.fromJson(data) as T;
     }
     if (t == _i1.getType<_i5.BoolDefault?>()) {
       return (data != null ? _i5.BoolDefault.fromJson(data) : null) as T;
@@ -5381,70 +5386,75 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data != null ? _i98.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i99.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i99.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i99.ScopeServerOnlyFieldChild?>()) {
+      return (data != null
+          ? _i99.ScopeServerOnlyFieldChild.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i100.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i100.DefaultServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i100.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i100.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i101.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i101.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i101.NotServerOnlyClass?>()) {
-      return (data != null ? _i101.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i102.NotServerOnlyClass?>()) {
+      return (data != null ? _i102.NotServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i102.NotServerOnlyEnum?>()) {
-      return (data != null ? _i102.NotServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i103.NotServerOnlyEnum?>()) {
+      return (data != null ? _i103.NotServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i103.ServerOnlyClass?>()) {
-      return (data != null ? _i103.ServerOnlyClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i104.ServerOnlyClass?>()) {
+      return (data != null ? _i104.ServerOnlyClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i104.ServerOnlyEnum?>()) {
-      return (data != null ? _i104.ServerOnlyEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i105.ServerOnlyEnum?>()) {
+      return (data != null ? _i105.ServerOnlyEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i105.ServerOnlyClassField?>()) {
-      return (data != null ? _i105.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i106.ServerOnlyClassField?>()) {
+      return (data != null ? _i106.ServerOnlyClassField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i106.SimpleData?>()) {
-      return (data != null ? _i106.SimpleData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i107.SimpleData?>()) {
+      return (data != null ? _i107.SimpleData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i107.SimpleDataList?>()) {
-      return (data != null ? _i107.SimpleDataList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i108.SimpleDataList?>()) {
+      return (data != null ? _i108.SimpleDataList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i108.SimpleDataMap?>()) {
-      return (data != null ? _i108.SimpleDataMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i109.SimpleDataMap?>()) {
+      return (data != null ? _i109.SimpleDataMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i109.SimpleDataObject?>()) {
-      return (data != null ? _i109.SimpleDataObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i110.SimpleDataObject?>()) {
+      return (data != null ? _i110.SimpleDataObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i110.SimpleDateTime?>()) {
-      return (data != null ? _i110.SimpleDateTime.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i111.SimpleDateTime?>()) {
+      return (data != null ? _i111.SimpleDateTime.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i111.TestEnum?>()) {
-      return (data != null ? _i111.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i112.TestEnum?>()) {
+      return (data != null ? _i112.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i112.TestEnumStringified?>()) {
-      return (data != null ? _i112.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i113.TestEnumStringified?>()) {
+      return (data != null ? _i113.TestEnumStringified.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i113.Types?>()) {
-      return (data != null ? _i113.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i114.Types?>()) {
+      return (data != null ? _i114.Types.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i114.TypesList?>()) {
-      return (data != null ? _i114.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i115.TypesList?>()) {
+      return (data != null ? _i115.TypesList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i115.TypesMap?>()) {
-      return (data != null ? _i115.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i116.TypesMap?>()) {
+      return (data != null ? _i116.TypesMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i116.UniqueData?>()) {
-      return (data != null ? _i116.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i117.UniqueData?>()) {
+      return (data != null ? _i117.UniqueData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<List<_i117.EmptyModelRelationItem>?>()) {
+    if (t == _i1.getType<List<_i118.EmptyModelRelationItem>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.EmptyModelRelationItem>(e))
+              .map((e) => deserialize<_i118.EmptyModelRelationItem>(e))
               .toList()
           : null) as dynamic;
     }
@@ -5452,108 +5462,108 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i117.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i118.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i118.PersonWithLongTableName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.OrganizationWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i118.OrganizationWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.OrganizationWithLongTableName>(e))
+              .map((e) => deserialize<_i118.OrganizationWithLongTableName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i118.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i118.PersonWithLongTableName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i118.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i118.LongImplicitIdField>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i118.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i118.MultipleMaxFieldName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.UserNote>?>()) {
+    if (t == _i1.getType<List<_i118.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.UserNote>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i118.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i118.UserNoteWithALongName>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Person>?>()) {
+    if (t == _i1.getType<List<_i118.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Organization>?>()) {
+    if (t == _i1.getType<List<_i118.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.Organization>(e))
+              .map((e) => deserialize<_i118.Organization>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Person>?>()) {
+    if (t == _i1.getType<List<_i118.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Person>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i118.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i118.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Enrollment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Player>?>()) {
+    if (t == _i1.getType<List<_i118.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Player>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Order>?>()) {
+    if (t == _i1.getType<List<_i118.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Order>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Comment>?>()) {
+    if (t == _i1.getType<List<_i118.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Comment>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Blocking>?>()) {
+    if (t == _i1.getType<List<_i118.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Blocking>?>()) {
+    if (t == _i1.getType<List<_i118.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Blocking>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Cat>?>()) {
+    if (t == _i1.getType<List<_i118.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Cat>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<_i4.ModuleClass>) {
@@ -5582,25 +5592,25 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i117.SimpleData>) {
+    if (t == List<_i118.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i117.SimpleData>(e))
+          .map((e) => deserialize<_i118.SimpleData>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i117.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i117.SimpleData?>) {
+    if (t == List<_i118.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i117.SimpleData?>(e))
+          .map((e) => deserialize<_i118.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i117.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.SimpleData?>(e))
+              .map((e) => deserialize<_i118.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
@@ -5622,22 +5632,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i118.ByteData>) {
-      return (data as List).map((e) => deserialize<_i118.ByteData>(e)).toList()
+    if (t == List<_i119.ByteData>) {
+      return (data as List).map((e) => deserialize<_i119.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i118.ByteData>?>()) {
+    if (t == _i1.getType<List<_i119.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i118.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i119.ByteData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == List<_i118.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i118.ByteData?>(e)).toList()
+    if (t == List<_i119.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i119.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == _i1.getType<List<_i118.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i119.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i118.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i119.ByteData?>(e)).toList()
           : null) as dynamic;
     }
     if (t == List<Duration>) {
@@ -5698,25 +5708,25 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as dynamic;
     }
-    if (t == _i119.CustomClass3) {
-      return _i119.CustomClass3.fromJson(data) as T;
+    if (t == _i120.CustomClass3) {
+      return _i120.CustomClass3.fromJson(data) as T;
     }
-    if (t == List<_i117.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i117.TestEnum>(e)).toList()
+    if (t == List<_i118.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i118.TestEnum>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i117.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i117.TestEnum?>(e)).toList()
+    if (t == List<_i118.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i118.TestEnum?>(e)).toList()
           as dynamic;
     }
-    if (t == List<List<_i117.TestEnum>>) {
+    if (t == List<List<_i118.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i117.TestEnum>>(e))
+          .map((e) => deserialize<List<_i118.TestEnum>>(e))
           .toList() as dynamic;
     }
-    if (t == Map<String, _i117.SimpleData>) {
+    if (t == Map<String, _i118.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i117.SimpleData>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i118.SimpleData>(v))) as dynamic;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -5727,9 +5737,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i118.ByteData>) {
+    if (t == Map<String, _i119.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i118.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i119.ByteData>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -5742,9 +5752,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i117.SimpleData?>) {
+    if (t == Map<String, _i118.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i117.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i118.SimpleData?>(v)))
           as dynamic;
     }
     if (t == Map<String, String?>) {
@@ -5756,9 +5766,9 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i118.ByteData?>) {
+    if (t == Map<String, _i119.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i118.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i119.ByteData?>(v)))
           as dynamic;
     }
     if (t == Map<String, Duration?>) {
@@ -5776,66 +5786,66 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<List<_i117.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.SimpleData?>(e))
+              .map((e) => deserialize<_i118.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<List<_i117.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i118.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i117.SimpleData>>(e))
+              .map((e) => deserialize<List<_i118.SimpleData>>(e))
               .toList()
           : null) as dynamic;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i117.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i118.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i117.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i118.SimpleData>>?>>(v)))
           : null) as dynamic;
     }
-    if (t == List<List<Map<int, _i117.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i118.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i117.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i118.SimpleData>>?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<Map<int, _i117.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i118.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i117.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i118.SimpleData>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == Map<int, _i117.SimpleData>) {
+    if (t == Map<int, _i118.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i117.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i118.SimpleData>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i117.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i118.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i117.SimpleData>>(v)))
+              deserialize<Map<int, _i118.SimpleData>>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<List<_i118.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.ServerOnlyClass>(e))
+              .map((e) => deserialize<_i118.ServerOnlyClass>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i117.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<Map<String, _i118.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i117.ServerOnlyClass>(v)))
+              deserialize<String>(k), deserialize<_i118.ServerOnlyClass>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -5863,9 +5873,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i118.ByteData>?>()) {
+    if (t == _i1.getType<List<_i119.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i118.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i119.ByteData>(e)).toList()
           : null) as dynamic;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -5878,44 +5888,44 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<_i1.UuidValue>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i118.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.TestEnum>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i118.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.TestEnumStringified>(e))
+              .map((e) => deserialize<_i118.TestEnumStringified>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i117.Types>?>()) {
+    if (t == _i1.getType<List<_i118.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i117.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.Types>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<Map<String, _i117.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i118.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i117.Types>>(e))
+              .map((e) => deserialize<Map<String, _i118.Types>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == Map<String, _i117.Types>) {
+    if (t == Map<String, _i118.Types>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i117.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i118.Types>(v)))
           as dynamic;
     }
-    if (t == _i1.getType<List<List<_i117.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i118.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i117.Types>>(e))
+              .map((e) => deserialize<List<_i118.Types>>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == List<_i117.Types>) {
-      return (data as List).map((e) => deserialize<_i117.Types>(e)).toList()
+    if (t == List<_i118.Types>) {
+      return (data as List).map((e) => deserialize<_i118.Types>(e)).toList()
           as dynamic;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -5948,10 +5958,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i118.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i119.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i118.ByteData>(e['k']),
+              deserialize<_i119.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
@@ -5967,42 +5977,42 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<_i1.UuidValue>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i117.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i118.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i117.TestEnum>(e['k']),
+              deserialize<_i118.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i117.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i118.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i117.TestEnumStringified>(e['k']),
+              deserialize<_i118.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<_i117.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i118.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i117.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i118.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<Map<_i117.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i118.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i117.Types, String>>(e['k']),
+              deserialize<Map<_i118.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
-    if (t == Map<_i117.Types, String>) {
+    if (t == Map<_i118.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i117.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i118.Types>(e['k']), deserialize<String>(e['v']))))
           as dynamic;
     }
-    if (t == _i1.getType<Map<List<_i117.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i118.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i117.Types>>(e['k']),
+              deserialize<List<_i118.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as dynamic;
     }
@@ -6036,10 +6046,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i118.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i119.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i118.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i119.ByteData>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -6054,34 +6064,34 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i117.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i118.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i117.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i118.TestEnum>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i117.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i118.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i117.TestEnumStringified>(v)))
+              deserialize<_i118.TestEnumStringified>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i117.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i118.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i117.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i118.Types>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i117.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i118.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i117.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i118.Types>>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, List<_i117.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i118.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i117.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i118.Types>>(v)))
           : null) as dynamic;
     }
     if (t == _i1.getType<List<String>?>()) {
@@ -6093,9 +6103,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<String>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i120.SimpleData>) {
+    if (t == List<_i121.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i120.SimpleData>(e))
+          .map((e) => deserialize<_i121.SimpleData>(e))
           .toList() as dynamic;
     }
     if (t == List<int>) {
@@ -6186,40 +6196,40 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i118.ByteData>) {
-      return (data as List).map((e) => deserialize<_i118.ByteData>(e)).toList()
+    if (t == List<_i119.ByteData>) {
+      return (data as List).map((e) => deserialize<_i119.ByteData>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i118.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i118.ByteData?>(e)).toList()
+    if (t == List<_i119.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i119.ByteData?>(e)).toList()
           as dynamic;
     }
-    if (t == List<_i120.SimpleData?>) {
+    if (t == List<_i121.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i120.SimpleData?>(e))
+          .map((e) => deserialize<_i121.SimpleData?>(e))
           .toList() as dynamic;
     }
-    if (t == _i1.getType<List<_i120.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i121.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i120.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i121.SimpleData>(e)).toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i120.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i120.SimpleData?>(e))
+              .map((e) => deserialize<_i121.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
-    if (t == _i1.getType<List<_i120.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i120.SimpleData?>(e))
+              .map((e) => deserialize<_i121.SimpleData?>(e))
               .toList()
           : null) as dynamic;
     }
@@ -6274,14 +6284,14 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<_i121.TestEnum, int>) {
+    if (t == Map<_i122.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i121.TestEnum>(e['k']), deserialize<int>(e['v']))))
+              deserialize<_i122.TestEnum>(e['k']), deserialize<int>(e['v']))))
           as dynamic;
     }
-    if (t == Map<String, _i121.TestEnum>) {
+    if (t == Map<String, _i122.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i121.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i122.TestEnum>(v)))
           as dynamic;
     }
     if (t == Map<String, double>) {
@@ -6320,47 +6330,47 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<DateTime?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i118.ByteData>) {
+    if (t == Map<String, _i119.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i118.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i119.ByteData>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i118.ByteData?>) {
+    if (t == Map<String, _i119.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i118.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i119.ByteData?>(v)))
           as dynamic;
     }
-    if (t == Map<String, _i120.SimpleData>) {
+    if (t == Map<String, _i121.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i120.SimpleData>(v))) as dynamic;
+          deserialize<String>(k), deserialize<_i121.SimpleData>(v))) as dynamic;
     }
-    if (t == Map<String, _i120.SimpleData?>) {
+    if (t == Map<String, _i121.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i120.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i121.SimpleData?>(v)))
           as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i120.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i121.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i120.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i121.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i120.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i121.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i120.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i121.SimpleData>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i120.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i121.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i120.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i121.SimpleData?>(v)))
           : null) as dynamic;
     }
-    if (t == _i1.getType<Map<String, _i120.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i121.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i120.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i121.SimpleData?>(v)))
           : null) as dynamic;
     }
     if (t == Map<String, Duration>) {
@@ -6373,40 +6383,40 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<Duration?>(v)))
           as dynamic;
     }
-    if (t == _i119.CustomClass) {
-      return _i119.CustomClass.fromJson(data) as T;
+    if (t == _i120.CustomClass) {
+      return _i120.CustomClass.fromJson(data) as T;
     }
-    if (t == _i119.CustomClass2) {
-      return _i119.CustomClass2.fromJson(data) as T;
+    if (t == _i120.CustomClass2) {
+      return _i120.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i122.ProtocolCustomClass) {
-      return _i122.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i123.ProtocolCustomClass) {
+      return _i123.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i123.ExternalCustomClass) {
-      return _i123.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i124.ExternalCustomClass) {
+      return _i124.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i123.FreezedCustomClass) {
-      return _i123.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i124.FreezedCustomClass) {
+      return _i124.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i119.CustomClass?>()) {
-      return (data != null ? _i119.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i120.CustomClass?>()) {
+      return (data != null ? _i120.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i119.CustomClass2?>()) {
-      return (data != null ? _i119.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i120.CustomClass2?>()) {
+      return (data != null ? _i120.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i119.CustomClass3?>()) {
-      return (data != null ? _i119.CustomClass3.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i120.CustomClass3?>()) {
+      return (data != null ? _i120.CustomClass3.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i122.ProtocolCustomClass?>()) {
-      return (data != null ? _i122.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i123.ProtocolCustomClass?>()) {
+      return (data != null ? _i123.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i123.ExternalCustomClass?>()) {
-      return (data != null ? _i123.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i124.ExternalCustomClass?>()) {
+      return (data != null ? _i124.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i123.FreezedCustomClass?>()) {
-      return (data != null ? _i123.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i124.FreezedCustomClass?>()) {
+      return (data != null ? _i124.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
     try {
@@ -6425,22 +6435,22 @@ class Protocol extends _i1.SerializationManagerServer {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i119.CustomClass) {
+    if (data is _i120.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i119.CustomClass2) {
+    if (data is _i120.CustomClass2) {
       return 'CustomClass2';
     }
-    if (data is _i119.CustomClass3) {
+    if (data is _i120.CustomClass3) {
       return 'CustomClass3';
     }
-    if (data is _i122.ProtocolCustomClass) {
+    if (data is _i123.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
     }
-    if (data is _i123.ExternalCustomClass) {
+    if (data is _i124.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i123.FreezedCustomClass) {
+    if (data is _i124.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i5.BoolDefault) {
@@ -6725,58 +6735,61 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i98.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i99.DefaultServerOnlyClass) {
+    if (data is _i99.ScopeServerOnlyFieldChild) {
+      return 'ScopeServerOnlyFieldChild';
+    }
+    if (data is _i100.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i100.DefaultServerOnlyEnum) {
+    if (data is _i101.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i101.NotServerOnlyClass) {
+    if (data is _i102.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i102.NotServerOnlyEnum) {
+    if (data is _i103.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i103.ServerOnlyClass) {
+    if (data is _i104.ServerOnlyClass) {
       return 'ServerOnlyClass';
     }
-    if (data is _i104.ServerOnlyEnum) {
+    if (data is _i105.ServerOnlyEnum) {
       return 'ServerOnlyEnum';
     }
-    if (data is _i105.ServerOnlyClassField) {
+    if (data is _i106.ServerOnlyClassField) {
       return 'ServerOnlyClassField';
     }
-    if (data is _i106.SimpleData) {
+    if (data is _i107.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i107.SimpleDataList) {
+    if (data is _i108.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i108.SimpleDataMap) {
+    if (data is _i109.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i109.SimpleDataObject) {
+    if (data is _i110.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i110.SimpleDateTime) {
+    if (data is _i111.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i111.TestEnum) {
+    if (data is _i112.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i112.TestEnumStringified) {
+    if (data is _i113.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i113.Types) {
+    if (data is _i114.Types) {
       return 'Types';
     }
-    if (data is _i114.TypesList) {
+    if (data is _i115.TypesList) {
       return 'TypesList';
     }
-    if (data is _i115.TypesMap) {
+    if (data is _i116.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i116.UniqueData) {
+    if (data is _i117.UniqueData) {
       return 'UniqueData';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -6797,22 +6810,22 @@ class Protocol extends _i1.SerializationManagerServer {
   @override
   dynamic deserializeByClassName(Map<String, dynamic> data) {
     if (data['className'] == 'CustomClass') {
-      return deserialize<_i119.CustomClass>(data['data']);
+      return deserialize<_i120.CustomClass>(data['data']);
     }
     if (data['className'] == 'CustomClass2') {
-      return deserialize<_i119.CustomClass2>(data['data']);
+      return deserialize<_i120.CustomClass2>(data['data']);
     }
     if (data['className'] == 'CustomClass3') {
-      return deserialize<_i119.CustomClass3>(data['data']);
+      return deserialize<_i120.CustomClass3>(data['data']);
     }
     if (data['className'] == 'ProtocolCustomClass') {
-      return deserialize<_i122.ProtocolCustomClass>(data['data']);
+      return deserialize<_i123.ProtocolCustomClass>(data['data']);
     }
     if (data['className'] == 'ExternalCustomClass') {
-      return deserialize<_i123.ExternalCustomClass>(data['data']);
+      return deserialize<_i124.ExternalCustomClass>(data['data']);
     }
     if (data['className'] == 'FreezedCustomClass') {
-      return deserialize<_i123.FreezedCustomClass>(data['data']);
+      return deserialize<_i124.FreezedCustomClass>(data['data']);
     }
     if (data['className'] == 'BoolDefault') {
       return deserialize<_i5.BoolDefault>(data['data']);
@@ -7096,59 +7109,62 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data['className'] == 'ScopeServerOnlyField') {
       return deserialize<_i98.ScopeServerOnlyField>(data['data']);
     }
+    if (data['className'] == 'ScopeServerOnlyFieldChild') {
+      return deserialize<_i99.ScopeServerOnlyFieldChild>(data['data']);
+    }
     if (data['className'] == 'DefaultServerOnlyClass') {
-      return deserialize<_i99.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i100.DefaultServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'DefaultServerOnlyEnum') {
-      return deserialize<_i100.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i101.DefaultServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyClass') {
-      return deserialize<_i101.NotServerOnlyClass>(data['data']);
+      return deserialize<_i102.NotServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'NotServerOnlyEnum') {
-      return deserialize<_i102.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i103.NotServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'ServerOnlyClass') {
-      return deserialize<_i103.ServerOnlyClass>(data['data']);
+      return deserialize<_i104.ServerOnlyClass>(data['data']);
     }
     if (data['className'] == 'ServerOnlyEnum') {
-      return deserialize<_i104.ServerOnlyEnum>(data['data']);
+      return deserialize<_i105.ServerOnlyEnum>(data['data']);
     }
     if (data['className'] == 'ServerOnlyClassField') {
-      return deserialize<_i105.ServerOnlyClassField>(data['data']);
+      return deserialize<_i106.ServerOnlyClassField>(data['data']);
     }
     if (data['className'] == 'SimpleData') {
-      return deserialize<_i106.SimpleData>(data['data']);
+      return deserialize<_i107.SimpleData>(data['data']);
     }
     if (data['className'] == 'SimpleDataList') {
-      return deserialize<_i107.SimpleDataList>(data['data']);
+      return deserialize<_i108.SimpleDataList>(data['data']);
     }
     if (data['className'] == 'SimpleDataMap') {
-      return deserialize<_i108.SimpleDataMap>(data['data']);
+      return deserialize<_i109.SimpleDataMap>(data['data']);
     }
     if (data['className'] == 'SimpleDataObject') {
-      return deserialize<_i109.SimpleDataObject>(data['data']);
+      return deserialize<_i110.SimpleDataObject>(data['data']);
     }
     if (data['className'] == 'SimpleDateTime') {
-      return deserialize<_i110.SimpleDateTime>(data['data']);
+      return deserialize<_i111.SimpleDateTime>(data['data']);
     }
     if (data['className'] == 'TestEnum') {
-      return deserialize<_i111.TestEnum>(data['data']);
+      return deserialize<_i112.TestEnum>(data['data']);
     }
     if (data['className'] == 'TestEnumStringified') {
-      return deserialize<_i112.TestEnumStringified>(data['data']);
+      return deserialize<_i113.TestEnumStringified>(data['data']);
     }
     if (data['className'] == 'Types') {
-      return deserialize<_i113.Types>(data['data']);
+      return deserialize<_i114.Types>(data['data']);
     }
     if (data['className'] == 'TypesList') {
-      return deserialize<_i114.TypesList>(data['data']);
+      return deserialize<_i115.TypesList>(data['data']);
     }
     if (data['className'] == 'TypesMap') {
-      return deserialize<_i115.TypesMap>(data['data']);
+      return deserialize<_i116.TypesMap>(data['data']);
     }
     if (data['className'] == 'UniqueData') {
-      return deserialize<_i116.UniqueData>(data['data']);
+      return deserialize<_i117.UniqueData>(data['data']);
     }
     if (data['className'].startsWith('serverpod.')) {
       data['className'] = data['className'].substring(10);
@@ -7350,14 +7366,14 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i96.RelatedUniqueData.t;
       case _i97.ScopeNoneFields:
         return _i97.ScopeNoneFields.t;
-      case _i106.SimpleData:
-        return _i106.SimpleData.t;
-      case _i110.SimpleDateTime:
-        return _i110.SimpleDateTime.t;
-      case _i113.Types:
-        return _i113.Types.t;
-      case _i116.UniqueData:
-        return _i116.UniqueData.t;
+      case _i107.SimpleData:
+        return _i107.SimpleData.t;
+      case _i111.SimpleDateTime:
+        return _i111.SimpleDateTime.t;
+      case _i114.Types:
+        return _i114.Types.t;
+      case _i117.UniqueData:
+        return _i117.UniqueData.t;
     }
     return null;
   }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -243,6 +243,8 @@ redis:
   - countSubscribedChannels:
 serverOnlyScopedFieldModel:
   - getScopeServerOnlyField:
+serverOnlyScopedFieldChildModel:
+  - getProtocolField:
 signInRequired:
   - testMethod:
 adminScopeRequired:

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field.dart
@@ -12,19 +12,13 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
 
-abstract class ScopeServerOnlyField
+class ScopeServerOnlyField
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
-  ScopeServerOnlyField._({
+  ScopeServerOnlyField({
     this.allScope,
     this.serverOnlyScope,
     this.nested,
   });
-
-  factory ScopeServerOnlyField({
-    _i2.Types? allScope,
-    _i2.Types? serverOnlyScope,
-    _i2.ScopeServerOnlyField? nested,
-  }) = _ScopeServerOnlyFieldImpl;
 
   factory ScopeServerOnlyField.fromJson(
       Map<String, dynamic> jsonSerialization) {
@@ -51,10 +45,21 @@ abstract class ScopeServerOnlyField
   _i2.ScopeServerOnlyField? nested;
 
   ScopeServerOnlyField copyWith({
-    _i2.Types? allScope,
-    _i2.Types? serverOnlyScope,
-    _i2.ScopeServerOnlyField? nested,
-  });
+    Object? allScope = _Undefined,
+    Object? serverOnlyScope = _Undefined,
+    Object? nested = _Undefined,
+  }) {
+    return ScopeServerOnlyField(
+      allScope: allScope is _i2.Types? ? allScope : this.allScope?.copyWith(),
+      serverOnlyScope: serverOnlyScope is _i2.Types?
+          ? serverOnlyScope
+          : this.serverOnlyScope?.copyWith(),
+      nested: nested is _i2.ScopeServerOnlyField?
+          ? nested
+          : this.nested?.copyWith(),
+    );
+  }
+
   @override
   Map<String, dynamic> toJson() {
     return {
@@ -79,32 +84,3 @@ abstract class ScopeServerOnlyField
 }
 
 class _Undefined {}
-
-class _ScopeServerOnlyFieldImpl extends ScopeServerOnlyField {
-  _ScopeServerOnlyFieldImpl({
-    _i2.Types? allScope,
-    _i2.Types? serverOnlyScope,
-    _i2.ScopeServerOnlyField? nested,
-  }) : super._(
-          allScope: allScope,
-          serverOnlyScope: serverOnlyScope,
-          nested: nested,
-        );
-
-  @override
-  ScopeServerOnlyField copyWith({
-    Object? allScope = _Undefined,
-    Object? serverOnlyScope = _Undefined,
-    Object? nested = _Undefined,
-  }) {
-    return ScopeServerOnlyField(
-      allScope: allScope is _i2.Types? ? allScope : this.allScope?.copyWith(),
-      serverOnlyScope: serverOnlyScope is _i2.Types?
-          ? serverOnlyScope
-          : this.serverOnlyScope?.copyWith(),
-      nested: nested is _i2.ScopeServerOnlyField?
-          ? nested
-          : this.nested?.copyWith(),
-    );
-  }
-}

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field_child.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field_child.dart
@@ -1,0 +1,117 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import '../protocol.dart' as _i1;
+import 'package:serverpod/serverpod.dart' as _i2;
+
+abstract class ScopeServerOnlyFieldChild extends _i1.ScopeServerOnlyField
+    implements _i2.SerializableModel, _i2.ProtocolSerialization {
+  ScopeServerOnlyFieldChild._({
+    super.allScope,
+    super.serverOnlyScope,
+    super.nested,
+    required this.childFoo,
+  });
+
+  factory ScopeServerOnlyFieldChild({
+    _i1.Types? allScope,
+    _i1.Types? serverOnlyScope,
+    _i1.ScopeServerOnlyField? nested,
+    required String childFoo,
+  }) = _ScopeServerOnlyFieldChildImpl;
+
+  factory ScopeServerOnlyFieldChild.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ScopeServerOnlyFieldChild(
+      allScope: jsonSerialization['allScope'] == null
+          ? null
+          : _i1.Types.fromJson(
+              (jsonSerialization['allScope'] as Map<String, dynamic>)),
+      serverOnlyScope: jsonSerialization['serverOnlyScope'] == null
+          ? null
+          : _i1.Types.fromJson(
+              (jsonSerialization['serverOnlyScope'] as Map<String, dynamic>)),
+      nested: jsonSerialization['nested'] == null
+          ? null
+          : _i1.ScopeServerOnlyField.fromJson(
+              (jsonSerialization['nested'] as Map<String, dynamic>)),
+      childFoo: jsonSerialization['childFoo'] as String,
+    );
+  }
+
+  String childFoo;
+
+  @override
+  ScopeServerOnlyFieldChild copyWith({
+    Object? allScope,
+    Object? serverOnlyScope,
+    Object? nested,
+    String? childFoo,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      if (allScope != null) 'allScope': allScope?.toJson(),
+      if (serverOnlyScope != null) 'serverOnlyScope': serverOnlyScope?.toJson(),
+      if (nested != null) 'nested': nested?.toJson(),
+      'childFoo': childFoo,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      if (allScope != null) 'allScope': allScope?.toJsonForProtocol(),
+      if (nested != null) 'nested': nested?.toJsonForProtocol(),
+      'childFoo': childFoo,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i2.SerializationManager.encode(this);
+  }
+}
+
+class _Undefined {}
+
+class _ScopeServerOnlyFieldChildImpl extends ScopeServerOnlyFieldChild {
+  _ScopeServerOnlyFieldChildImpl({
+    _i1.Types? allScope,
+    _i1.Types? serverOnlyScope,
+    _i1.ScopeServerOnlyField? nested,
+    required String childFoo,
+  }) : super._(
+          allScope: allScope,
+          serverOnlyScope: serverOnlyScope,
+          nested: nested,
+          childFoo: childFoo,
+        );
+
+  @override
+  ScopeServerOnlyFieldChild copyWith({
+    Object? allScope = _Undefined,
+    Object? serverOnlyScope = _Undefined,
+    Object? nested = _Undefined,
+    String? childFoo,
+  }) {
+    return ScopeServerOnlyFieldChild(
+      allScope: allScope is _i1.Types? ? allScope : this.allScope?.copyWith(),
+      serverOnlyScope: serverOnlyScope is _i1.Types?
+          ? serverOnlyScope
+          : this.serverOnlyScope?.copyWith(),
+      nested: nested is _i1.ScopeServerOnlyField?
+          ? nested
+          : this.nested?.copyWith(),
+      childFoo: childFoo ?? this.childFoo,
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/models/scopes/scope_server_only_field_child.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/scopes/scope_server_only_field_child.spy.yaml
@@ -1,0 +1,4 @@
+class: ScopeServerOnlyFieldChild
+extends: ScopeServerOnlyField
+fields:
+    childFoo: String

--- a/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/json_protocol_test.dart
@@ -208,6 +208,24 @@ void main() {
   );
 
   group(
+      "Given a Serverpod server when fetching an custom class object that extends another custom class object and inherits a server only field",
+      () {
+    late http.Response response;
+
+    setUpAll(() async {
+      response = await http.post(
+        Uri.parse("${serverUrl}serverOnlyScopedFieldChildModel"),
+        body: jsonEncode({"method": "getProtocolField"}),
+      );
+    });
+
+    test('then the response body should not contain server-only field', () {
+      Map jsonMap = jsonDecode(response.body);
+      expect(jsonMap, isNot(contains('serverOnlyScope')));
+    });
+  });
+
+  group(
       "Given a Serverpod server when calling an endpoint which throws a normal exception, ",
       () {
     late http.Response response;

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -38,6 +38,8 @@ import 'package:serverpod_test_server/src/generated/module_datatype.dart'
     as _i19;
 import 'package:serverpod_test_server/src/generated/scopes/scope_server_only_field.dart'
     as _i20;
+import 'package:serverpod_test_server/src/generated/scopes/scope_server_only_field_child.dart'
+    as _i21;
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 import 'package:serverpod_test_server/src/generated/endpoints.dart';
 export 'package:serverpod_test/serverpod_test_public_exports.dart';
@@ -6454,7 +6456,7 @@ class _ServerOnlyScopedFieldChildModelEndpoint {
 
   final _i2.SerializationManager _serializationManager;
 
-  _i3.Future<_i20.ScopeServerOnlyField> getProtocolField(
+  _i3.Future<_i21.ScopeServerOnlyFieldChild> getProtocolField(
       _i1.TestSessionBuilder sessionBuilder) async {
     return _i1.callAwaitableFunctionAndHandleExceptions(() async {
       var _localUniqueSession =
@@ -6472,7 +6474,7 @@ class _ServerOnlyScopedFieldChildModelEndpoint {
       var _localReturnValue = await (_localCallContext.method.call(
         _localUniqueSession,
         _localCallContext.arguments,
-      ) as _i3.Future<_i20.ScopeServerOnlyField>);
+      ) as _i3.Future<_i21.ScopeServerOnlyFieldChild>);
       await _localUniqueSession.close();
       return _localReturnValue;
     });

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -126,6 +126,9 @@ class TestEndpoints {
 
   late final _ServerOnlyScopedFieldModelEndpoint serverOnlyScopedFieldModel;
 
+  late final _ServerOnlyScopedFieldChildModelEndpoint
+      serverOnlyScopedFieldChildModel;
+
   late final _SignInRequiredEndpoint signInRequired;
 
   late final _AdminScopeRequiredEndpoint adminScopeRequired;
@@ -269,6 +272,10 @@ class _InternalTestEndpoints extends TestEndpoints
       serializationManager,
     );
     serverOnlyScopedFieldModel = _ServerOnlyScopedFieldModelEndpoint(
+      endpoints,
+      serializationManager,
+    );
+    serverOnlyScopedFieldChildModel = _ServerOnlyScopedFieldChildModelEndpoint(
       endpoints,
       serializationManager,
     );
@@ -6424,6 +6431,41 @@ class _ServerOnlyScopedFieldModelEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'serverOnlyScopedFieldModel',
         methodName: 'getScopeServerOnlyField',
+        parameters: {},
+        serializationManager: _serializationManager,
+      );
+      var _localReturnValue = await (_localCallContext.method.call(
+        _localUniqueSession,
+        _localCallContext.arguments,
+      ) as _i3.Future<_i20.ScopeServerOnlyField>);
+      await _localUniqueSession.close();
+      return _localReturnValue;
+    });
+  }
+}
+
+class _ServerOnlyScopedFieldChildModelEndpoint {
+  _ServerOnlyScopedFieldChildModelEndpoint(
+    this._endpointDispatch,
+    this._serializationManager,
+  );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<_i20.ScopeServerOnlyField> getProtocolField(
+      _i1.TestSessionBuilder sessionBuilder) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'serverOnlyScopedFieldChildModel',
+        method: 'getProtocolField',
+      );
+      var _localCallContext = await _endpointDispatch.getMethodCallContext(
+        createSessionCallback: (_) => _localUniqueSession,
+        endpointPath: 'serverOnlyScopedFieldChildModel',
+        methodName: 'getProtocolField',
         parameters: {},
         serializationManager: _serializationManager,
       );

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -308,6 +308,15 @@ class Restrictions {
       ];
     }
 
+    if (parentClass.serverOnly && !documentDefinition!.serverOnly) {
+      return [
+        SourceSpanSeverityException(
+          'You cannot extend a server only class from a client class.',
+          span,
+        )
+      ];
+    }
+
     return [];
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -317,7 +317,7 @@ class Restrictions {
     if (!documentDefinition!.serverOnly && ancestorServerOnlyClass != null) {
       return [
         SourceSpanSeverityException(
-          'The class "${documentDefinition!.className}" cannot inherit from the server-only class "${ancestorServerOnlyClass.className}" unless it is also marked as "serverOnly".',
+          'Cannot extend a "serverOnly" class in the inheritance chain ("${ancestorServerOnlyClass.className}") unless class is marked as "serverOnly".',
           span,
         )
       ];

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -308,10 +308,16 @@ class Restrictions {
       ];
     }
 
-    if (parentClass.serverOnly && !documentDefinition!.serverOnly) {
+    var currentModel =
+        parsedModels.findByClassName(documentDefinition!.className);
+
+    var ancestorServerOnlyClass =
+        _findServerOnlyClassInParentClasses(currentModel);
+
+    if (!documentDefinition!.serverOnly && ancestorServerOnlyClass != null) {
       return [
         SourceSpanSeverityException(
-          'You cannot extend a server only class from a client class.',
+          'The class "${documentDefinition!.className}" cannot inherit from the server-only class "${ancestorServerOnlyClass.className}" unless it is also marked as "serverOnly".',
           span,
         )
       ];
@@ -1415,6 +1421,20 @@ class Restrictions {
       parentModel = _getParentClass(parentModel);
     }
 
+    return null;
+  }
+
+  ClassDefinition? _findServerOnlyClassInParentClasses(
+    SerializableModelDefinition? currentModel,
+  ) {
+    if (currentModel is! ClassDefinition) return null;
+    var parentModel = _getParentClass(currentModel);
+
+    while (parentModel != null) {
+      if (parentModel.serverOnly) return parentModel;
+
+      parentModel = _getParentClass(parentModel);
+    }
     return null;
   }
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -59,8 +59,7 @@ class SerializableModelLibraryGenerator {
           // We need to generate the implementation class for the copyWith method
           // to support differentiating between null and undefined values.
           // https://stackoverflow.com/questions/68009392/dart-custom-copywith-method-with-nullable-properties
-          if (_shouldCreateUndefinedClass(classDefinition, fields))
-            _buildUndefinedClass(),
+          if (_shouldCreateUndefinedClass(fields)) _buildUndefinedClass(),
           if (!classDefinition.isParentClass)
             _buildModelImplClass(
               className,
@@ -253,14 +252,8 @@ class SerializableModelLibraryGenerator {
   }
 
   bool _shouldCreateUndefinedClass(
-    ClassDefinition classDefinition,
     List<SerializableModelFieldDefinition> fields,
   ) {
-    if (classDefinition.parentClass != null &&
-        classDefinition.parentClass!.serverOnly) {
-      return true;
-    }
-
     return fields
         .where((field) => field.shouldIncludeField(serverCode))
         .any((field) => field.type.nullable);
@@ -445,19 +438,9 @@ class SerializableModelLibraryGenerator {
                 config: config,
               );
 
-              var isInheritedField =
-                  classDefinition.inheritedFields.contains(field);
-              var isServerOnlyField =
-                  field.scope == ModelFieldScopeDefinition.serverOnly;
-
-              var type =
-                  field.type.nullable || isInheritedField && isServerOnlyField
-                      ? refer('Object?')
-                      : fieldType;
+              var type = field.type.nullable ? refer('Object?') : fieldType;
               var defaultValue =
-                  field.type.nullable || isInheritedField && isServerOnlyField
-                      ? const Code('_Undefined')
-                      : null;
+                  field.type.nullable ? const Code('_Undefined') : null;
 
               return Parameter((p) {
                 p
@@ -495,9 +478,7 @@ class SerializableModelLibraryGenerator {
       );
 
       Expression valueDefinition;
-      if (field.type.nullable ||
-          classDefinition.inheritedFields.contains(field) &&
-              field.scope == ModelFieldScopeDefinition.serverOnly) {
+      if (field.type.nullable) {
         valueDefinition = refer(field.name)
             .isA(field.type.reference(
               serverCode,
@@ -1166,11 +1147,8 @@ class SerializableModelLibraryGenerator {
       );
 
       var isInheritedField = classDefinition.inheritedFields.contains(field);
-      var isServerOnlyField =
-          field.scope == ModelFieldScopeDefinition.serverOnly;
 
-      var type = isServerOnlyField && isInheritedField ||
-              field.type.nullable && isInheritedField
+      var type = field.type.nullable && isInheritedField
           ? refer('Object?')
           : fieldType;
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
@@ -213,4 +213,43 @@ void main() {
       );
     });
   });
+
+  test(
+      'Given a child-class, When the parent-class is serverOnly but the child-class is not, then error is collected that a client class cannot extend a serverOnly class',
+      () {
+    var modelSources = [
+      ModelSourceBuilder().withYaml(
+        '''
+          class: Example
+          serverOnly: true
+          fields:
+            name: String
+          ''',
+      ).build(),
+      ModelSourceBuilder().withFileName('example2').withYaml(
+        '''
+          class: ExampleChildClass
+          extends: Example
+          fields:
+            age: int
+          ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+        .validateAll();
+
+    expect(
+      collector.errors,
+      isNotEmpty,
+      reason: 'Expected an error but none was generated.',
+    );
+
+    var error = collector.errors.first;
+    expect(
+      error.message,
+      'You cannot extend a server only class from a client class.',
+    );
+  });
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
@@ -249,12 +249,12 @@ void main() {
     var error = collector.errors.first;
     expect(
       error.message,
-      'The class "ExampleChildClass" cannot inherit from the server-only class "Example" unless it is also marked as "serverOnly".',
+      'Cannot extend a "serverOnly" class in the inheritance chain ("Example") unless class is marked as "serverOnly".',
     );
   });
 
   test(
-      'Given a serverOnly child-class, When the parent-class not serverOnly but the grandparent-class is, then error is collected that a client class cannot extend a serverOnly class',
+      'Given a serverOnly child-class, When the parent-class is not serverOnly but the grandparent-class is, then error is collected that a client class cannot extend a serverOnly class',
       () {
     var modelSources = [
       ModelSourceBuilder().withYaml(
@@ -296,7 +296,7 @@ void main() {
     var error = collector.errors.first;
     expect(
       error.message,
-      'The class "Example" cannot inherit from the server-only class "ExampleGrandparentClass" unless it is also marked as "serverOnly".',
+      'Cannot extend a "serverOnly" class in the inheritance chain ("ExampleGrandparentClass") unless class is marked as "serverOnly".',
     );
   });
 }

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/inheritance_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/inheritance_class_test.dart
@@ -389,25 +389,32 @@ void main() {
     var compilationUnit =
         parseString(content: codeMap[childExpectedFilePath]!).unit;
 
-    group('Then the $childClassName', () {
+    group('then the $childClassName', () {
       var childClass = CompilationUnitHelpers.tryFindClassDeclaration(
         compilationUnit,
         name: childClassName,
       );
 
-      group('has a copyWith method', () {
+      group('has a copyWith method with named params', () {
         var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
           childClass!,
           name: 'copyWith',
         );
 
-        test(
-            'with named params where nullable-inherited fields are "Object?" and nullable-local fields are typed',
-            () {
-          expect(
-            copyWithMethod?.parameters?.toSource(),
-            '({int? id, Object? name, int? age})',
+        test('where nullable-inherited fields are "Object?"', () {
+          var nameParam = copyWithMethod?.parameters?.parameters.firstWhere(
+            (param) => param.name.toString() == 'name',
           );
+
+          expect(nameParam?.toSource(), 'Object? name');
+        }, skip: copyWithMethod == null);
+
+        test('where nullable-local fields are typed', () {
+          var ageParam = copyWithMethod?.parameters?.parameters.firstWhere(
+            (param) => param.name.toString() == 'age',
+          );
+
+          expect(ageParam?.toSource(), 'int? age');
         }, skip: copyWithMethod == null);
       });
     });


### PR DESCRIPTION
This PR tries to adjust the `SerializableModelLibraryGenerator` to handle inherited serverOnly fields correctly. As the parentClass declares them as `Object?` but the child-class parses their real type (`int`, `String` etc.) we now check in the methods building `_buildCopyWithMethod` and `_buildAbstractCopyWithMethod` and pass them to the childs copyWith method as expected

Furthermore a test case was added to `json_protocol_test.dart` making sure `serverOnly` fields are not leaked when inherited. 

Another test was added to `server_code_generator/inheritance_class_test.dart` checking if nullable fields are typed as expected in the `copyWith` method. 

And a `restriction` and `test` was added to only allow extending a `serverOnly` class if the child is marked as `serverOnly` aswell. 

![Selection_003](https://github.com/user-attachments/assets/7baf5726-bd8d-46b3-b21e-2d79d607f9c7)




linked to: #1873 and #1618 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

no breaking changes