### PR TITLE
fix: Add integration test to module

### DIFF
--- a/templates/pubspecs/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 
 dev_dependencies:
   lints: '>=3.0.0 <6.0.0'
+  test: ^1.24.2
+  serverpod_test: SERVERPOD_VERSION
 
 dependency_overrides:
   serverpod:
@@ -23,3 +25,5 @@ dependency_overrides:
     path: ../../../packages/serverpod_serialization
   serverpod_shared:
     path: ../../../packages/serverpod_shared
+  serverpod_test:
+    path: ../../../packages/serverpod_test

--- a/tests/docker/tests_integration/Dockerfile
+++ b/tests/docker/tests_integration/Dockerfile
@@ -10,9 +10,13 @@ WORKDIR /app
 # Copy the whole serverpod repo into the container.
 COPY . .
 
-# Install dependencies for test server.
-WORKDIR tests/serverpod_test_server
+# Install dependencies.
+WORKDIR /app/tests/serverpod_test_module/serverpod_test_module_server/
 RUN dart pub get
+
+WORKDIR /app/tests/serverpod_test_server
+RUN dart pub get
+
 
 # Setup database tables.
 CMD ["../docker/tests_integration/run_tests.sh"]

--- a/tests/docker/tests_integration/run_tests.sh
+++ b/tests/docker/tests_integration/run_tests.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+checkLastExitCode() {
+  local last_exit_code=$?
+  if [ $last_exit_code -ne 0 ]; then
+    exit $last_exit_code
+  fi
+}
+
 # Wait for database to be up (timeout after 60 seconds)
 echo "### Wait for Postgres"
 /app/tests/docker/tests_integration/wait-for-it.sh postgres:5432 -t 60 -- echo "### Postgres is UP"
@@ -16,4 +23,10 @@ pwd
 dart bin/main.dart -m production -r maintenance --apply-migrations
 
 # Run tests
+echo "### Running tests"
 dart test test_integration --concurrency=1
+checkLastExitCode
+
+cd ../serverpod_test_module/serverpod_test_module_server/
+echo $(pwd)
+dart test ./test/integration

--- a/tests/serverpod_test_module/serverpod_test_module_server/config/generator.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/config/generator.yaml
@@ -2,3 +2,4 @@ type: module
 nickname: server_test_module
 
 client_package_path: ../serverpod_test_module_client
+server_test_tools_path: test/integration/test_tools

--- a/tests/serverpod_test_module/serverpod_test_module_server/config/passwords.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/config/passwords.yaml
@@ -1,7 +1,3 @@
-shared:
-  authKeySalt: 'salty'
-  AWSAccessKeyId: 'AKIAXR2IQI6JRDCVBT3A'
-  AWSSecretKey: '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'
 test:
   database: 'password'
   redis: 'password'

--- a/tests/serverpod_test_module/serverpod_test_module_server/config/passwords.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/config/passwords.yaml
@@ -1,0 +1,8 @@
+shared:
+  authKeySalt: 'salty'
+  AWSAccessKeyId: 'AKIAXR2IQI6JRDCVBT3A'
+  AWSSecretKey: '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'
+test:
+  database: 'password'
+  redis: 'password'
+  serviceSecret: 'super_SECRET_password'

--- a/tests/serverpod_test_module/serverpod_test_module_server/config/test.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/config/test.yaml
@@ -1,0 +1,28 @@
+apiServer:
+  port: 8080
+  publicHost: serverpod_test_server
+  publicPort: 8080
+  publicScheme: http
+
+insightsServer:
+  port: 8081
+  publicHost: serverpod_test_server
+  publicPort: 8081
+  publicScheme: http
+
+webServer:
+  port: 8082
+  publicHost: serverpod_test_server
+  publicPort: 8082
+  publicScheme: http
+
+database:
+  host: postgres
+  port: 5432
+  name: serverpod_test
+  user: postgres
+
+redis:
+  enabled: true
+  host: redis
+  port: 6379

--- a/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
 
 dev_dependencies:
   lints: '>=3.0.0 <6.0.0'
+  test: ^1.24.2
+  serverpod_test: 2.1.4
 
 dependency_overrides:
   serverpod:
@@ -24,3 +26,5 @@ dependency_overrides:
     path: ../../../packages/serverpod_serialization
   serverpod_shared:
     path: ../../../packages/serverpod_shared
+  serverpod_test:
+    path: ../../../packages/serverpod_test

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/module_endpoint_test.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/module_endpoint_test.dart
@@ -1,0 +1,21 @@
+import 'package:serverpod_test_module_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+import 'test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod('Given ModuleEndpoint', (sessionBuilder, endpoints) {
+    test('when calling hello with name then returns greeting', () async {
+      final result = await endpoints.module.hello(sessionBuilder, 'name');
+      expect(result, 'Hello name');
+    });
+
+    test('when calling modifyModuleObject with object then modifies object',
+        () async {
+      final object = ModuleClass(name: 'name', data: 1);
+      final result =
+          await endpoints.module.modifyModuleObject(sessionBuilder, object);
+      expect(result.data, 42);
+    });
+  });
+}

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -133,7 +133,91 @@ class _ModuleEndpoint {
 
 class _StreamingEndpoint {
   _StreamingEndpoint(
-    _endpointDispatch,
-    _serializationManager,
+    this._endpointDispatch,
+    this._serializationManager,
   );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<bool> wasStreamOpenCalled(
+      _i1.TestSessionBuilder sessionBuilder) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'streaming',
+        method: 'wasStreamOpenCalled',
+      );
+      var _localCallContext = await _endpointDispatch.getMethodCallContext(
+        createSessionCallback: (_) => _localUniqueSession,
+        endpointPath: 'streaming',
+        methodName: 'wasStreamOpenCalled',
+        parameters: _i1.testObjectToJson({}),
+        serializationManager: _serializationManager,
+      );
+      var _localReturnValue = await (_localCallContext.method.call(
+        _localUniqueSession,
+        _localCallContext.arguments,
+      ) as _i3.Future<bool>);
+      await _localUniqueSession.close();
+      return _localReturnValue;
+    });
+  }
+
+  _i3.Future<bool> wasStreamClosedCalled(
+      _i1.TestSessionBuilder sessionBuilder) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'streaming',
+        method: 'wasStreamClosedCalled',
+      );
+      var _localCallContext = await _endpointDispatch.getMethodCallContext(
+        createSessionCallback: (_) => _localUniqueSession,
+        endpointPath: 'streaming',
+        methodName: 'wasStreamClosedCalled',
+        parameters: _i1.testObjectToJson({}),
+        serializationManager: _serializationManager,
+      );
+      var _localReturnValue = await (_localCallContext.method.call(
+        _localUniqueSession,
+        _localCallContext.arguments,
+      ) as _i3.Future<bool>);
+      await _localUniqueSession.close();
+      return _localReturnValue;
+    });
+  }
+
+  _i3.Stream<int> intEchoStream(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i3.Stream<int> stream,
+  ) {
+    var _localTestStreamManager = _i1.TestStreamManager<int>();
+    _i1.callStreamFunctionAndHandleExceptions(
+      () async {
+        var _localUniqueSession =
+            (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+          endpoint: 'streaming',
+          method: 'intEchoStream',
+        );
+        var _localCallContext =
+            await _endpointDispatch.getMethodStreamCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'streaming',
+          methodName: 'intEchoStream',
+          arguments: {},
+          requestedInputStreams: ['stream'],
+          serializationManager: _serializationManager,
+        );
+        await _localTestStreamManager.callStreamMethod(
+          _localCallContext,
+          _localUniqueSession,
+          {'stream': stream},
+        );
+      },
+      _localTestStreamManager.outputStreamController,
+    );
+    return _localTestStreamManager.outputStreamController.stream;
+  }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -92,7 +92,7 @@ class _ModuleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'module',
         methodName: 'hello',
-        parameters: {'name': _i1.testObjectToJson(name)},
+        parameters: _i1.testObjectToJson({'name': name}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -118,7 +118,7 @@ class _ModuleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'module',
         methodName: 'modifyModuleObject',
-        parameters: {'object': _i1.testObjectToJson(object)},
+        parameters: _i1.testObjectToJson({'object': object}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -1,0 +1,139 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_local_identifiers
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_test/serverpod_test.dart' as _i1;
+import 'package:serverpod/serverpod.dart' as _i2;
+import 'dart:async' as _i3;
+import 'package:serverpod_test_module_server/src/generated/module_class.dart'
+    as _i4;
+import 'package:serverpod_test_module_server/src/generated/protocol.dart';
+import 'package:serverpod_test_module_server/src/generated/endpoints.dart';
+export 'package:serverpod_test/serverpod_test_public_exports.dart';
+
+@_i1.isTestGroup
+withServerpod(
+  String testGroupName,
+  _i1.TestClosure<TestEndpoints> testClosure, {
+  String? runMode,
+  bool? enableSessionLogging,
+  _i1.RollbackDatabase? rollbackDatabase,
+  bool? applyMigrations,
+}) {
+  _i1.buildWithServerpod<_InternalTestEndpoints>(
+    testGroupName,
+    _i1.TestServerpod(
+      testEndpoints: _InternalTestEndpoints(),
+      endpoints: Endpoints(),
+      serializationManager: Protocol(),
+      runMode: runMode,
+      applyMigrations: applyMigrations,
+      isDatabaseEnabled: true,
+    ),
+    maybeRollbackDatabase: rollbackDatabase,
+    maybeEnableSessionLogging: enableSessionLogging,
+  )(testClosure);
+}
+
+class TestEndpoints {
+  late final _ModuleEndpoint module;
+
+  late final _StreamingEndpoint streaming;
+}
+
+class _InternalTestEndpoints extends TestEndpoints
+    implements _i1.InternalTestEndpoints {
+  @override
+  initialize(
+    _i2.SerializationManager serializationManager,
+    _i2.EndpointDispatch endpoints,
+  ) {
+    module = _ModuleEndpoint(
+      endpoints,
+      serializationManager,
+    );
+    streaming = _StreamingEndpoint(
+      endpoints,
+      serializationManager,
+    );
+  }
+}
+
+class _ModuleEndpoint {
+  _ModuleEndpoint(
+    this._endpointDispatch,
+    this._serializationManager,
+  );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<String> hello(
+    _i1.TestSessionBuilder sessionBuilder,
+    String name,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'module',
+        method: 'hello',
+      );
+      var _localCallContext = await _endpointDispatch.getMethodCallContext(
+        createSessionCallback: (_) => _localUniqueSession,
+        endpointPath: 'module',
+        methodName: 'hello',
+        parameters: {'name': _i1.testObjectToJson(name)},
+        serializationManager: _serializationManager,
+      );
+      var _localReturnValue = await (_localCallContext.method.call(
+        _localUniqueSession,
+        _localCallContext.arguments,
+      ) as _i3.Future<String>);
+      await _localUniqueSession.close();
+      return _localReturnValue;
+    });
+  }
+
+  _i3.Future<_i4.ModuleClass> modifyModuleObject(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i4.ModuleClass object,
+  ) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'module',
+        method: 'modifyModuleObject',
+      );
+      var _localCallContext = await _endpointDispatch.getMethodCallContext(
+        createSessionCallback: (_) => _localUniqueSession,
+        endpointPath: 'module',
+        methodName: 'modifyModuleObject',
+        parameters: {'object': _i1.testObjectToJson(object)},
+        serializationManager: _serializationManager,
+      );
+      var _localReturnValue = await (_localCallContext.method.call(
+        _localUniqueSession,
+        _localCallContext.arguments,
+      ) as _i3.Future<_i4.ModuleClass>);
+      await _localUniqueSession.close();
+      return _localReturnValue;
+    });
+  }
+}
+
+class _StreamingEndpoint {
+  _StreamingEndpoint(
+    _endpointDispatch,
+    _serializationManager,
+  );
+}

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -346,10 +346,10 @@ class _AsyncTasksEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'asyncTasks',
         methodName: 'insertRowToSimpleDataAfterDelay',
-        parameters: {
-          'num': _i1.testObjectToJson(num),
-          'seconds': _i1.testObjectToJson(seconds),
-        },
+        parameters: _i1.testObjectToJson({
+          'num': num,
+          'seconds': seconds,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -375,7 +375,7 @@ class _AsyncTasksEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'asyncTasks',
         methodName: 'throwExceptionAfterDelay',
-        parameters: {'seconds': _i1.testObjectToJson(seconds)},
+        parameters: _i1.testObjectToJson({'seconds': seconds}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -409,7 +409,7 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'removeAllUsers',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -432,7 +432,7 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'countUsers',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -459,10 +459,10 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'createUser',
-        parameters: {
-          'email': _i1.testObjectToJson(email),
-          'password': _i1.testObjectToJson(password),
-        },
+        parameters: _i1.testObjectToJson({
+          'email': email,
+          'password': password,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -490,11 +490,11 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'authenticate',
-        parameters: {
-          'email': _i1.testObjectToJson(email),
-          'password': _i1.testObjectToJson(password),
-          'scopes': _i1.testObjectToJson(scopes),
-        },
+        parameters: _i1.testObjectToJson({
+          'email': email,
+          'password': password,
+          'scopes': scopes,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -517,7 +517,7 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'signOut',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -544,10 +544,10 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'updateScopes',
-        parameters: {
-          'userId': _i1.testObjectToJson(userId),
-          'scopes': _i1.testObjectToJson(scopes),
-        },
+        parameters: _i1.testObjectToJson({
+          'userId': userId,
+          'scopes': scopes,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -584,7 +584,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testInt',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -610,7 +610,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testDouble',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -636,7 +636,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testBool',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -662,7 +662,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testDateTime',
-        parameters: {'dateTime': _i1.testObjectToJson(dateTime)},
+        parameters: _i1.testObjectToJson({'dateTime': dateTime}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -688,7 +688,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testString',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -714,7 +714,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testByteData',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -740,7 +740,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testDuration',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -766,7 +766,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testUuid',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -800,7 +800,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'reset',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -827,10 +827,10 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'storePublicFile',
-        parameters: {
-          'path': _i1.testObjectToJson(path),
-          'byteData': _i1.testObjectToJson(byteData),
-        },
+        parameters: _i1.testObjectToJson({
+          'path': path,
+          'byteData': byteData,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -856,7 +856,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'retrievePublicFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -882,7 +882,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'existsPublicFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -908,7 +908,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'deletePublicFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -934,7 +934,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'getPublicUrlForFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -960,7 +960,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'getDirectFilePostUrl',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -986,7 +986,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'verifyDirectFileUpload',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1024,10 +1024,10 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'storePublicFile',
-        parameters: {
-          'path': _i1.testObjectToJson(path),
-          'byteData': _i1.testObjectToJson(byteData),
-        },
+        parameters: _i1.testObjectToJson({
+          'path': path,
+          'byteData': byteData,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1053,7 +1053,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'retrievePublicFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1079,7 +1079,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'existsPublicFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1105,7 +1105,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'deletePublicFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1131,7 +1131,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'getPublicUrlForFile',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1157,7 +1157,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'getDirectFilePostUrl',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1183,7 +1183,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'verifyDirectFileUpload',
-        parameters: {'path': _i1.testObjectToJson(path)},
+        parameters: _i1.testObjectToJson({'path': path}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1218,7 +1218,7 @@ class _CustomClassProtocolEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customClassProtocol',
         methodName: 'getProtocolField',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1255,7 +1255,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClass',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1281,7 +1281,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClassNullable',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1307,7 +1307,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClass2',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1333,7 +1333,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClass2Nullable',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1359,7 +1359,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnExternalCustomClass',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1385,7 +1385,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnExternalCustomClassNullable',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1411,7 +1411,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnFreezedCustomClass',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1437,7 +1437,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnFreezedCustomClassNullable',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1472,7 +1472,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteAllSimpleTestData',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1498,7 +1498,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteSimpleTestDataLessThan',
-        parameters: {'num': _i1.testObjectToJson(num)},
+        parameters: _i1.testObjectToJson({'num': num}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1524,7 +1524,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findAndDeleteSimpleTestData',
-        parameters: {'num': _i1.testObjectToJson(num)},
+        parameters: _i1.testObjectToJson({'num': num}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1550,7 +1550,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'createSimpleTestData',
-        parameters: {'numRows': _i1.testObjectToJson(numRows)},
+        parameters: _i1.testObjectToJson({'numRows': numRows}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1577,10 +1577,10 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findSimpleData',
-        parameters: {
-          'limit': _i1.testObjectToJson(limit),
-          'offset': _i1.testObjectToJson(offset),
-        },
+        parameters: _i1.testObjectToJson({
+          'limit': limit,
+          'offset': offset,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1606,7 +1606,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findFirstRowSimpleData',
-        parameters: {'num': _i1.testObjectToJson(num)},
+        parameters: _i1.testObjectToJson({'num': num}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1632,7 +1632,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findByIdSimpleData',
-        parameters: {'id': _i1.testObjectToJson(id)},
+        parameters: _i1.testObjectToJson({'id': id}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1661,12 +1661,12 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findSimpleDataRowsLessThan',
-        parameters: {
-          'num': _i1.testObjectToJson(num),
-          'offset': _i1.testObjectToJson(offset),
-          'limit': _i1.testObjectToJson(limit),
-          'descending': _i1.testObjectToJson(descending),
-        },
+        parameters: _i1.testObjectToJson({
+          'num': num,
+          'offset': offset,
+          'limit': limit,
+          'descending': descending,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1692,7 +1692,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'insertRowSimpleData',
-        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
+        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1718,7 +1718,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'updateRowSimpleData',
-        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
+        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1744,7 +1744,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteRowSimpleData',
-        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
+        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1768,7 +1768,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteWhereSimpleData',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1791,7 +1791,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'countSimpleData',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1817,7 +1817,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'insertTypes',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1843,7 +1843,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'updateTypes',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1866,7 +1866,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'countTypesRows',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1890,7 +1890,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteAllInTypes',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1916,7 +1916,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getTypes',
-        parameters: {'id': _i1.testObjectToJson(id)},
+        parameters: _i1.testObjectToJson({'id': id}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1942,7 +1942,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getTypesRawQuery',
-        parameters: {'id': _i1.testObjectToJson(id)},
+        parameters: _i1.testObjectToJson({'id': id}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1968,7 +1968,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'storeObjectWithEnum',
-        parameters: {'object': _i1.testObjectToJson(object)},
+        parameters: _i1.testObjectToJson({'object': object}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1994,7 +1994,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getObjectWithEnum',
-        parameters: {'id': _i1.testObjectToJson(id)},
+        parameters: _i1.testObjectToJson({'id': id}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2020,7 +2020,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'storeObjectWithObject',
-        parameters: {'object': _i1.testObjectToJson(object)},
+        parameters: _i1.testObjectToJson({'object': object}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2046,7 +2046,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getObjectWithObject',
-        parameters: {'id': _i1.testObjectToJson(id)},
+        parameters: _i1.testObjectToJson({'id': id}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2069,7 +2069,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteAll',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2093,7 +2093,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'testByteDataStore',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2130,7 +2130,7 @@ class _TransactionsDatabaseEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'transactionsDatabase',
         methodName: 'removeRow',
-        parameters: {'num': _i1.testObjectToJson(num)},
+        parameters: _i1.testObjectToJson({'num': num}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2158,11 +2158,11 @@ class _TransactionsDatabaseEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'transactionsDatabase',
         methodName: 'updateInsertDelete',
-        parameters: {
-          'numUpdate': _i1.testObjectToJson(numUpdate),
-          'numInsert': _i1.testObjectToJson(numInsert),
-          'numDelete': _i1.testObjectToJson(numDelete),
-        },
+        parameters: _i1.testObjectToJson({
+          'numUpdate': numUpdate,
+          'numInsert': numInsert,
+          'numDelete': numDelete,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2199,7 +2199,7 @@ class _DeprecationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'deprecation',
         methodName: 'setGlobalDouble',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2223,7 +2223,7 @@ class _DeprecationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'deprecation',
         methodName: 'getGlobalDouble',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2258,7 +2258,7 @@ class _EchoRequestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'echoRequest',
         methodName: 'echoAuthenticationKey',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2284,7 +2284,7 @@ class _EchoRequestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'echoRequest',
         methodName: 'echoHttpHeader',
-        parameters: {'headerName': _i1.testObjectToJson(headerName)},
+        parameters: _i1.testObjectToJson({'headerName': headerName}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2322,10 +2322,10 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'findVerificationCode',
-        parameters: {
-          'userName': _i1.testObjectToJson(userName),
-          'email': _i1.testObjectToJson(email),
-        },
+        parameters: _i1.testObjectToJson({
+          'userName': userName,
+          'email': email,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2351,7 +2351,7 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'findResetCode',
-        parameters: {'email': _i1.testObjectToJson(email)},
+        parameters: _i1.testObjectToJson({'email': email}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2374,7 +2374,7 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'tearDown',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2402,11 +2402,11 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'createUser',
-        parameters: {
-          'userName': _i1.testObjectToJson(userName),
-          'email': _i1.testObjectToJson(email),
-          'password': _i1.testObjectToJson(password),
-        },
+        parameters: _i1.testObjectToJson({
+          'userName': userName,
+          'email': email,
+          'password': password,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2441,7 +2441,7 @@ class _ExceptionTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'exceptionTest',
         methodName: 'throwNormalException',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2465,7 +2465,7 @@ class _ExceptionTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'exceptionTest',
         methodName: 'throwExceptionWithData',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2489,7 +2489,7 @@ class _ExceptionTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'exceptionTest',
         methodName: 'workingWithoutException',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2523,7 +2523,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'failedCall',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2547,7 +2547,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'failedDatabaseQuery',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2571,7 +2571,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'failedDatabaseQueryCaughtException',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2594,7 +2594,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'slowCall',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2618,7 +2618,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'caughtException',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2655,7 +2655,7 @@ class _FieldScopesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'fieldScopes',
         methodName: 'storeObject',
-        parameters: {'object': _i1.testObjectToJson(object)},
+        parameters: _i1.testObjectToJson({'object': object}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2679,7 +2679,7 @@ class _FieldScopesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'fieldScopes',
         methodName: 'retrieveObject',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2716,7 +2716,7 @@ class _FutureCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'futureCalls',
         methodName: 'makeFutureCall',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2753,7 +2753,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2779,7 +2779,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2805,7 +2805,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListNullable',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2831,7 +2831,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListNullableList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2857,7 +2857,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListListNullable',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2883,7 +2883,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListNullableInts',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2909,7 +2909,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnNullableIntListNullableInts',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2935,7 +2935,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDoubleList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2961,7 +2961,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDoubleListNullableDoubles',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2987,7 +2987,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnBoolList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3013,7 +3013,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnBoolListNullableBools',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3039,7 +3039,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnStringList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3065,7 +3065,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnStringListNullableStrings',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3091,7 +3091,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDateTimeList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3117,7 +3117,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDateTimeListNullableDateTimes',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3143,7 +3143,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnByteDataList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3169,7 +3169,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnByteDataListNullableByteDatas',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3195,7 +3195,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnSimpleDataList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3221,7 +3221,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnSimpleDataListNullableSimpleData',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3247,7 +3247,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnSimpleDataListNullable',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3274,7 +3274,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnNullableSimpleDataListNullableSimpleData',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3300,7 +3300,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDurationList',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3326,7 +3326,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDurationListNullableDurations',
-        parameters: {'list': _i1.testObjectToJson(list)},
+        parameters: _i1.testObjectToJson({'list': list}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3363,7 +3363,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'slowQueryMethod',
-        parameters: {'seconds': _i1.testObjectToJson(seconds)},
+        parameters: _i1.testObjectToJson({'seconds': seconds}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3389,7 +3389,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'queryMethod',
-        parameters: {'queries': _i1.testObjectToJson(queries)},
+        parameters: _i1.testObjectToJson({'queries': queries}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3413,7 +3413,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'failedQueryMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3439,7 +3439,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'slowMethod',
-        parameters: {'delayMillis': _i1.testObjectToJson(delayMillis)},
+        parameters: _i1.testObjectToJson({'delayMillis': delayMillis}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3462,7 +3462,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'failingMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3485,7 +3485,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'emptyMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3512,10 +3512,10 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'log',
-        parameters: {
-          'message': _i1.testObjectToJson(message),
-          'logLevels': _i1.testObjectToJson(logLevels),
-        },
+        parameters: _i1.testObjectToJson({
+          'message': message,
+          'logLevels': logLevels,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3541,7 +3541,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'logInfo',
-        parameters: {'message': _i1.testObjectToJson(message)},
+        parameters: _i1.testObjectToJson({'message': message}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3569,11 +3569,11 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'logDebugAndInfoAndError',
-        parameters: {
-          'debug': _i1.testObjectToJson(debug),
-          'info': _i1.testObjectToJson(info),
-          'error': _i1.testObjectToJson(error),
-        },
+        parameters: _i1.testObjectToJson({
+          'debug': debug,
+          'info': info,
+          'error': error,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3596,7 +3596,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'twoQueries',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3743,7 +3743,7 @@ class _LoggingDisabledEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'loggingDisabled',
         methodName: 'logInfo',
-        parameters: {'message': _i1.testObjectToJson(message)},
+        parameters: _i1.testObjectToJson({'message': message}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3780,7 +3780,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3806,7 +3806,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntMapNullable',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3832,7 +3832,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnNestedIntMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3858,7 +3858,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntMapNullableInts',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3884,7 +3884,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnNullableIntMapNullableInts',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3910,7 +3910,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntIntMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3936,7 +3936,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnEnumIntMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3962,7 +3962,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnEnumMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3988,7 +3988,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDoubleMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4014,7 +4014,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDoubleMapNullableDoubles',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4040,7 +4040,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnBoolMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4066,7 +4066,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnBoolMapNullableBools',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4092,7 +4092,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnStringMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4118,7 +4118,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnStringMapNullableStrings',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4144,7 +4144,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDateTimeMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4170,7 +4170,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDateTimeMapNullableDateTimes',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4196,7 +4196,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnByteDataMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4222,7 +4222,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnByteDataMapNullableByteDatas',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4248,7 +4248,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnSimpleDataMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4275,7 +4275,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnSimpleDataMapNullableSimpleData',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4301,7 +4301,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnSimpleDataMapNullable',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4328,7 +4328,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnNullableSimpleDataMapNullableSimpleData',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4354,7 +4354,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDurationMap',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4380,7 +4380,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDurationMapNullableDurations',
-        parameters: {'map': _i1.testObjectToJson(map)},
+        parameters: _i1.testObjectToJson({'map': map}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4417,7 +4417,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalArg',
-        parameters: {'string': _i1.testObjectToJson(string)},
+        parameters: _i1.testObjectToJson({'string': string}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4443,7 +4443,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoNamedArg',
-        parameters: {'string': _i1.testObjectToJson(string)},
+        parameters: _i1.testObjectToJson({'string': string}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4469,7 +4469,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoNullableNamedArg',
-        parameters: {'string': _i1.testObjectToJson(string)},
+        parameters: _i1.testObjectToJson({'string': string}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4495,7 +4495,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoOptionalArg',
-        parameters: {'string': _i1.testObjectToJson(string)},
+        parameters: _i1.testObjectToJson({'string': string}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4522,10 +4522,10 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalAndNamedArgs',
-        parameters: {
-          'string1': _i1.testObjectToJson(string1),
-          'string2': _i1.testObjectToJson(string2),
-        },
+        parameters: _i1.testObjectToJson({
+          'string1': string1,
+          'string2': string2,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4552,10 +4552,10 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalAndNullableNamedArgs',
-        parameters: {
-          'string1': _i1.testObjectToJson(string1),
-          'string2': _i1.testObjectToJson(string2),
-        },
+        parameters: _i1.testObjectToJson({
+          'string1': string1,
+          'string2': string2,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4582,10 +4582,10 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalAndOptionalArgs',
-        parameters: {
-          'string1': _i1.testObjectToJson(string1),
-          'string2': _i1.testObjectToJson(string2),
-        },
+        parameters: _i1.testObjectToJson({
+          'string1': string1,
+          'string2': string2,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4805,7 +4805,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'methodCallEndpoint',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4918,7 +4918,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'wasBroadcastStreamCanceled',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4942,7 +4942,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'wasSessionWillCloseListenerCalled',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5348,7 +5348,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'simpleEndpoint',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5374,7 +5374,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'intParameter',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5400,7 +5400,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'doubleInputValue',
-        parameters: {'value': _i1.testObjectToJson(value)},
+        parameters: _i1.testObjectToJson({'value': value}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5426,7 +5426,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'delayedResponse',
-        parameters: {'delay': _i1.testObjectToJson(delay)},
+        parameters: _i1.testObjectToJson({'delay': delay}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5544,7 +5544,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'completeAllDelayedResponses',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6010,7 +6010,7 @@ class _ModuleSerializationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'moduleSerialization',
         methodName: 'serializeModuleObject',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6036,7 +6036,7 @@ class _ModuleSerializationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'moduleSerialization',
         methodName: 'modifyModuleObject',
-        parameters: {'object': _i1.testObjectToJson(object)},
+        parameters: _i1.testObjectToJson({'object': object}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6060,7 +6060,7 @@ class _ModuleSerializationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'moduleSerialization',
         methodName: 'serializeNestedModuleObject',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6100,13 +6100,12 @@ class _NamedParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'namedParameters',
         methodName: 'namedParametersMethod',
-        parameters: {
-          'namedInt': _i1.testObjectToJson(namedInt),
-          'intWithDefaultValue': _i1.testObjectToJson(intWithDefaultValue),
-          'nullableInt': _i1.testObjectToJson(nullableInt),
-          'nullableIntWithDefaultValue':
-              _i1.testObjectToJson(nullableIntWithDefaultValue),
-        },
+        parameters: _i1.testObjectToJson({
+          'namedInt': namedInt,
+          'intWithDefaultValue': intWithDefaultValue,
+          'nullableInt': nullableInt,
+          'nullableIntWithDefaultValue': nullableIntWithDefaultValue,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6133,10 +6132,10 @@ class _NamedParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'namedParameters',
         methodName: 'namedParametersMethodEqualInts',
-        parameters: {
-          'namedInt': _i1.testObjectToJson(namedInt),
-          'nullableInt': _i1.testObjectToJson(nullableInt),
-        },
+        parameters: _i1.testObjectToJson({
+          'namedInt': namedInt,
+          'nullableInt': nullableInt,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6173,7 +6172,7 @@ class _OptionalParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'optionalParameters',
         methodName: 'returnOptionalInt',
-        parameters: {'optionalInt': _i1.testObjectToJson(optionalInt)},
+        parameters: _i1.testObjectToJson({'optionalInt': optionalInt}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6211,10 +6210,10 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'setSimpleData',
-        parameters: {
-          'key': _i1.testObjectToJson(key),
-          'data': _i1.testObjectToJson(data),
-        },
+        parameters: _i1.testObjectToJson({
+          'key': key,
+          'data': data,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6241,10 +6240,10 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'setSimpleDataWithLifetime',
-        parameters: {
-          'key': _i1.testObjectToJson(key),
-          'data': _i1.testObjectToJson(data),
-        },
+        parameters: _i1.testObjectToJson({
+          'key': key,
+          'data': data,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6270,7 +6269,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'getSimpleData',
-        parameters: {'key': _i1.testObjectToJson(key)},
+        parameters: _i1.testObjectToJson({'key': key}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6296,7 +6295,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'deleteSimpleData',
-        parameters: {'key': _i1.testObjectToJson(key)},
+        parameters: _i1.testObjectToJson({'key': key}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6320,7 +6319,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'resetMessageCentralTest',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6346,7 +6345,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'listenToChannel',
-        parameters: {'channel': _i1.testObjectToJson(channel)},
+        parameters: _i1.testObjectToJson({'channel': channel}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6373,10 +6372,10 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'postToChannel',
-        parameters: {
-          'channel': _i1.testObjectToJson(channel),
-          'data': _i1.testObjectToJson(data),
-        },
+        parameters: _i1.testObjectToJson({
+          'channel': channel,
+          'data': data,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6400,7 +6399,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'countSubscribedChannels',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6435,7 +6434,7 @@ class _ServerOnlyScopedFieldModelEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'serverOnlyScopedFieldModel',
         methodName: 'getScopeServerOnlyField',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6470,7 +6469,7 @@ class _ServerOnlyScopedFieldChildModelEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'serverOnlyScopedFieldChildModel',
         methodName: 'getProtocolField',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6504,7 +6503,7 @@ class _SignInRequiredEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'signInRequired',
         methodName: 'testMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6538,7 +6537,7 @@ class _AdminScopeRequiredEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'adminScopeRequired',
         methodName: 'testMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6576,10 +6575,10 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'setGlobalInt',
-        parameters: {
-          'value': _i1.testObjectToJson(value),
-          'secondValue': _i1.testObjectToJson(secondValue),
-        },
+        parameters: _i1.testObjectToJson({
+          'value': value,
+          'secondValue': secondValue,
+        }),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6602,7 +6601,7 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'addToGlobalInt',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6625,7 +6624,7 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'getGlobalInt',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6651,7 +6650,7 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'hello',
-        parameters: {'name': _i1.testObjectToJson(name)},
+        parameters: _i1.testObjectToJson({'name': name}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6699,7 +6698,7 @@ class _SubSubDirTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'subSubDirTest',
         methodName: 'testMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6733,7 +6732,7 @@ class _SubDirTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'subDirTest',
         methodName: 'testMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6768,7 +6767,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'returnsSessionId',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6792,7 +6791,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'returnsSessionEndpointAndMethod',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6878,7 +6877,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'returnsString',
-        parameters: {'string': _i1.testObjectToJson(string)},
+        parameters: _i1.testObjectToJson({'string': string}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7029,7 +7028,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'postNumberToSharedStream',
-        parameters: {'number': _i1.testObjectToJson(number)},
+        parameters: _i1.testObjectToJson({'number': number}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7117,7 +7116,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleData',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7141,7 +7140,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'getAllSimpleData',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7167,7 +7166,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleDatasInsideTransactions',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7193,7 +7192,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleDataAndThrowInsideTransaction',
-        parameters: {'data': _i1.testObjectToJson(data)},
+        parameters: _i1.testObjectToJson({'data': data}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7217,7 +7216,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleDatasInParallelTransactionCalls',
-        parameters: {},
+        parameters: _i1.testObjectToJson({}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7243,7 +7242,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'echoSimpleData',
-        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
+        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7269,7 +7268,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'echoSimpleDatas',
-        parameters: {'simpleDatas': _i1.testObjectToJson(simpleDatas)},
+        parameters: _i1.testObjectToJson({'simpleDatas': simpleDatas}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7306,7 +7305,7 @@ class _AuthenticatedTestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authenticatedTestTools',
         methodName: 'returnsString',
-        parameters: {'string': _i1.testObjectToJson(string)},
+        parameters: _i1.testObjectToJson({'string': string}),
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -346,10 +346,10 @@ class _AsyncTasksEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'asyncTasks',
         methodName: 'insertRowToSimpleDataAfterDelay',
-        parameters: _i1.testObjectToJson({
-          'num': num,
-          'seconds': seconds,
-        }),
+        parameters: {
+          'num': _i1.testObjectToJson(num),
+          'seconds': _i1.testObjectToJson(seconds),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -375,7 +375,7 @@ class _AsyncTasksEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'asyncTasks',
         methodName: 'throwExceptionAfterDelay',
-        parameters: _i1.testObjectToJson({'seconds': seconds}),
+        parameters: {'seconds': _i1.testObjectToJson(seconds)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -409,7 +409,7 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'removeAllUsers',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -432,7 +432,7 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'countUsers',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -459,10 +459,10 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'createUser',
-        parameters: _i1.testObjectToJson({
-          'email': email,
-          'password': password,
-        }),
+        parameters: {
+          'email': _i1.testObjectToJson(email),
+          'password': _i1.testObjectToJson(password),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -490,11 +490,11 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'authenticate',
-        parameters: _i1.testObjectToJson({
-          'email': email,
-          'password': password,
-          'scopes': scopes,
-        }),
+        parameters: {
+          'email': _i1.testObjectToJson(email),
+          'password': _i1.testObjectToJson(password),
+          'scopes': _i1.testObjectToJson(scopes),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -517,7 +517,7 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'signOut',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -544,10 +544,10 @@ class _AuthenticationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authentication',
         methodName: 'updateScopes',
-        parameters: _i1.testObjectToJson({
-          'userId': userId,
-          'scopes': scopes,
-        }),
+        parameters: {
+          'userId': _i1.testObjectToJson(userId),
+          'scopes': _i1.testObjectToJson(scopes),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -584,7 +584,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testInt',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -610,7 +610,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testDouble',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -636,7 +636,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testBool',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -662,7 +662,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testDateTime',
-        parameters: _i1.testObjectToJson({'dateTime': dateTime}),
+        parameters: {'dateTime': _i1.testObjectToJson(dateTime)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -688,7 +688,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testString',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -714,7 +714,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testByteData',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -740,7 +740,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testDuration',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -766,7 +766,7 @@ class _BasicTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicTypes',
         methodName: 'testUuid',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -800,7 +800,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'reset',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -827,10 +827,10 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'storePublicFile',
-        parameters: _i1.testObjectToJson({
-          'path': path,
-          'byteData': byteData,
-        }),
+        parameters: {
+          'path': _i1.testObjectToJson(path),
+          'byteData': _i1.testObjectToJson(byteData),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -856,7 +856,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'retrievePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -882,7 +882,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'existsPublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -908,7 +908,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'deletePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -934,7 +934,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'getPublicUrlForFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -960,7 +960,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'getDirectFilePostUrl',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -986,7 +986,7 @@ class _CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'cloudStorage',
         methodName: 'verifyDirectFileUpload',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1024,10 +1024,10 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'storePublicFile',
-        parameters: _i1.testObjectToJson({
-          'path': path,
-          'byteData': byteData,
-        }),
+        parameters: {
+          'path': _i1.testObjectToJson(path),
+          'byteData': _i1.testObjectToJson(byteData),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1053,7 +1053,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'retrievePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1079,7 +1079,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'existsPublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1105,7 +1105,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'deletePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1131,7 +1131,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'getPublicUrlForFile',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1157,7 +1157,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'getDirectFilePostUrl',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1183,7 +1183,7 @@ class _S3CloudStorageEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 's3CloudStorage',
         methodName: 'verifyDirectFileUpload',
-        parameters: _i1.testObjectToJson({'path': path}),
+        parameters: {'path': _i1.testObjectToJson(path)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1218,7 +1218,7 @@ class _CustomClassProtocolEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customClassProtocol',
         methodName: 'getProtocolField',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1255,7 +1255,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClass',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1281,7 +1281,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClassNullable',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1307,7 +1307,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClass2',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1333,7 +1333,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnCustomClass2Nullable',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1359,7 +1359,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnExternalCustomClass',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1385,7 +1385,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnExternalCustomClassNullable',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1411,7 +1411,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnFreezedCustomClass',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1437,7 +1437,7 @@ class _CustomTypesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'customTypes',
         methodName: 'returnFreezedCustomClassNullable',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1472,7 +1472,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteAllSimpleTestData',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1498,7 +1498,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteSimpleTestDataLessThan',
-        parameters: _i1.testObjectToJson({'num': num}),
+        parameters: {'num': _i1.testObjectToJson(num)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1524,7 +1524,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findAndDeleteSimpleTestData',
-        parameters: _i1.testObjectToJson({'num': num}),
+        parameters: {'num': _i1.testObjectToJson(num)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1550,7 +1550,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'createSimpleTestData',
-        parameters: _i1.testObjectToJson({'numRows': numRows}),
+        parameters: {'numRows': _i1.testObjectToJson(numRows)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1577,10 +1577,10 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findSimpleData',
-        parameters: _i1.testObjectToJson({
-          'limit': limit,
-          'offset': offset,
-        }),
+        parameters: {
+          'limit': _i1.testObjectToJson(limit),
+          'offset': _i1.testObjectToJson(offset),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1606,7 +1606,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findFirstRowSimpleData',
-        parameters: _i1.testObjectToJson({'num': num}),
+        parameters: {'num': _i1.testObjectToJson(num)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1632,7 +1632,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findByIdSimpleData',
-        parameters: _i1.testObjectToJson({'id': id}),
+        parameters: {'id': _i1.testObjectToJson(id)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1661,12 +1661,12 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'findSimpleDataRowsLessThan',
-        parameters: _i1.testObjectToJson({
-          'num': num,
-          'offset': offset,
-          'limit': limit,
-          'descending': descending,
-        }),
+        parameters: {
+          'num': _i1.testObjectToJson(num),
+          'offset': _i1.testObjectToJson(offset),
+          'limit': _i1.testObjectToJson(limit),
+          'descending': _i1.testObjectToJson(descending),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1692,7 +1692,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'insertRowSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1718,7 +1718,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'updateRowSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1744,7 +1744,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteRowSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1768,7 +1768,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteWhereSimpleData',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1791,7 +1791,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'countSimpleData',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1817,7 +1817,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'insertTypes',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1843,7 +1843,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'updateTypes',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1866,7 +1866,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'countTypesRows',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1890,7 +1890,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteAllInTypes',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1916,7 +1916,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getTypes',
-        parameters: _i1.testObjectToJson({'id': id}),
+        parameters: {'id': _i1.testObjectToJson(id)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1942,7 +1942,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getTypesRawQuery',
-        parameters: _i1.testObjectToJson({'id': id}),
+        parameters: {'id': _i1.testObjectToJson(id)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1968,7 +1968,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'storeObjectWithEnum',
-        parameters: _i1.testObjectToJson({'object': object}),
+        parameters: {'object': _i1.testObjectToJson(object)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -1994,7 +1994,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getObjectWithEnum',
-        parameters: _i1.testObjectToJson({'id': id}),
+        parameters: {'id': _i1.testObjectToJson(id)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2020,7 +2020,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'storeObjectWithObject',
-        parameters: _i1.testObjectToJson({'object': object}),
+        parameters: {'object': _i1.testObjectToJson(object)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2046,7 +2046,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'getObjectWithObject',
-        parameters: _i1.testObjectToJson({'id': id}),
+        parameters: {'id': _i1.testObjectToJson(id)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2069,7 +2069,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'deleteAll',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2093,7 +2093,7 @@ class _BasicDatabase {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'basicDatabase',
         methodName: 'testByteDataStore',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2130,7 +2130,7 @@ class _TransactionsDatabaseEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'transactionsDatabase',
         methodName: 'removeRow',
-        parameters: _i1.testObjectToJson({'num': num}),
+        parameters: {'num': _i1.testObjectToJson(num)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2158,11 +2158,11 @@ class _TransactionsDatabaseEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'transactionsDatabase',
         methodName: 'updateInsertDelete',
-        parameters: _i1.testObjectToJson({
-          'numUpdate': numUpdate,
-          'numInsert': numInsert,
-          'numDelete': numDelete,
-        }),
+        parameters: {
+          'numUpdate': _i1.testObjectToJson(numUpdate),
+          'numInsert': _i1.testObjectToJson(numInsert),
+          'numDelete': _i1.testObjectToJson(numDelete),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2199,7 +2199,7 @@ class _DeprecationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'deprecation',
         methodName: 'setGlobalDouble',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2223,7 +2223,7 @@ class _DeprecationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'deprecation',
         methodName: 'getGlobalDouble',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2258,7 +2258,7 @@ class _EchoRequestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'echoRequest',
         methodName: 'echoAuthenticationKey',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2284,7 +2284,7 @@ class _EchoRequestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'echoRequest',
         methodName: 'echoHttpHeader',
-        parameters: _i1.testObjectToJson({'headerName': headerName}),
+        parameters: {'headerName': _i1.testObjectToJson(headerName)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2322,10 +2322,10 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'findVerificationCode',
-        parameters: _i1.testObjectToJson({
-          'userName': userName,
-          'email': email,
-        }),
+        parameters: {
+          'userName': _i1.testObjectToJson(userName),
+          'email': _i1.testObjectToJson(email),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2351,7 +2351,7 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'findResetCode',
-        parameters: _i1.testObjectToJson({'email': email}),
+        parameters: {'email': _i1.testObjectToJson(email)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2374,7 +2374,7 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'tearDown',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2402,11 +2402,11 @@ class _EmailAuthTestMethods {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'emailAuthTestMethods',
         methodName: 'createUser',
-        parameters: _i1.testObjectToJson({
-          'userName': userName,
-          'email': email,
-          'password': password,
-        }),
+        parameters: {
+          'userName': _i1.testObjectToJson(userName),
+          'email': _i1.testObjectToJson(email),
+          'password': _i1.testObjectToJson(password),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2441,7 +2441,7 @@ class _ExceptionTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'exceptionTest',
         methodName: 'throwNormalException',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2465,7 +2465,7 @@ class _ExceptionTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'exceptionTest',
         methodName: 'throwExceptionWithData',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2489,7 +2489,7 @@ class _ExceptionTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'exceptionTest',
         methodName: 'workingWithoutException',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2523,7 +2523,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'failedCall',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2547,7 +2547,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'failedDatabaseQuery',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2571,7 +2571,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'failedDatabaseQueryCaughtException',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2594,7 +2594,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'slowCall',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2618,7 +2618,7 @@ class _FailedCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'failedCalls',
         methodName: 'caughtException',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2655,7 +2655,7 @@ class _FieldScopesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'fieldScopes',
         methodName: 'storeObject',
-        parameters: _i1.testObjectToJson({'object': object}),
+        parameters: {'object': _i1.testObjectToJson(object)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2679,7 +2679,7 @@ class _FieldScopesEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'fieldScopes',
         methodName: 'retrieveObject',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2716,7 +2716,7 @@ class _FutureCallsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'futureCalls',
         methodName: 'makeFutureCall',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2753,7 +2753,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2779,7 +2779,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2805,7 +2805,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListNullable',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2831,7 +2831,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListNullableList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2857,7 +2857,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListListNullable',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2883,7 +2883,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnIntListNullableInts',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2909,7 +2909,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnNullableIntListNullableInts',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2935,7 +2935,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDoubleList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2961,7 +2961,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDoubleListNullableDoubles',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -2987,7 +2987,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnBoolList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3013,7 +3013,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnBoolListNullableBools',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3039,7 +3039,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnStringList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3065,7 +3065,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnStringListNullableStrings',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3091,7 +3091,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDateTimeList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3117,7 +3117,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDateTimeListNullableDateTimes',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3143,7 +3143,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnByteDataList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3169,7 +3169,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnByteDataListNullableByteDatas',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3195,7 +3195,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnSimpleDataList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3221,7 +3221,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnSimpleDataListNullableSimpleData',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3247,7 +3247,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnSimpleDataListNullable',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3274,7 +3274,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnNullableSimpleDataListNullableSimpleData',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3300,7 +3300,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDurationList',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3326,7 +3326,7 @@ class _ListParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'listParameters',
         methodName: 'returnDurationListNullableDurations',
-        parameters: _i1.testObjectToJson({'list': list}),
+        parameters: {'list': _i1.testObjectToJson(list)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3363,7 +3363,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'slowQueryMethod',
-        parameters: _i1.testObjectToJson({'seconds': seconds}),
+        parameters: {'seconds': _i1.testObjectToJson(seconds)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3389,7 +3389,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'queryMethod',
-        parameters: _i1.testObjectToJson({'queries': queries}),
+        parameters: {'queries': _i1.testObjectToJson(queries)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3413,7 +3413,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'failedQueryMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3439,7 +3439,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'slowMethod',
-        parameters: _i1.testObjectToJson({'delayMillis': delayMillis}),
+        parameters: {'delayMillis': _i1.testObjectToJson(delayMillis)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3462,7 +3462,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'failingMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3485,7 +3485,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'emptyMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3512,10 +3512,10 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'log',
-        parameters: _i1.testObjectToJson({
-          'message': message,
-          'logLevels': logLevels,
-        }),
+        parameters: {
+          'message': _i1.testObjectToJson(message),
+          'logLevels': _i1.testObjectToJson(logLevels),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3541,7 +3541,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'logInfo',
-        parameters: _i1.testObjectToJson({'message': message}),
+        parameters: {'message': _i1.testObjectToJson(message)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3569,11 +3569,11 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'logDebugAndInfoAndError',
-        parameters: _i1.testObjectToJson({
-          'debug': debug,
-          'info': info,
-          'error': error,
-        }),
+        parameters: {
+          'debug': _i1.testObjectToJson(debug),
+          'info': _i1.testObjectToJson(info),
+          'error': _i1.testObjectToJson(error),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3596,7 +3596,7 @@ class _LoggingEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'logging',
         methodName: 'twoQueries',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3743,7 +3743,7 @@ class _LoggingDisabledEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'loggingDisabled',
         methodName: 'logInfo',
-        parameters: _i1.testObjectToJson({'message': message}),
+        parameters: {'message': _i1.testObjectToJson(message)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3780,7 +3780,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3806,7 +3806,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntMapNullable',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3832,7 +3832,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnNestedIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3858,7 +3858,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntMapNullableInts',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3884,7 +3884,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnNullableIntMapNullableInts',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3910,7 +3910,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnIntIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3936,7 +3936,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnEnumIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3962,7 +3962,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnEnumMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -3988,7 +3988,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDoubleMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4014,7 +4014,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDoubleMapNullableDoubles',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4040,7 +4040,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnBoolMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4066,7 +4066,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnBoolMapNullableBools',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4092,7 +4092,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnStringMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4118,7 +4118,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnStringMapNullableStrings',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4144,7 +4144,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDateTimeMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4170,7 +4170,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDateTimeMapNullableDateTimes',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4196,7 +4196,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnByteDataMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4222,7 +4222,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnByteDataMapNullableByteDatas',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4248,7 +4248,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnSimpleDataMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4275,7 +4275,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnSimpleDataMapNullableSimpleData',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4301,7 +4301,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnSimpleDataMapNullable',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4328,7 +4328,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnNullableSimpleDataMapNullableSimpleData',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4354,7 +4354,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDurationMap',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4380,7 +4380,7 @@ class _MapParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'mapParameters',
         methodName: 'returnDurationMapNullableDurations',
-        parameters: _i1.testObjectToJson({'map': map}),
+        parameters: {'map': _i1.testObjectToJson(map)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4417,7 +4417,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalArg',
-        parameters: _i1.testObjectToJson({'string': string}),
+        parameters: {'string': _i1.testObjectToJson(string)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4443,7 +4443,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoNamedArg',
-        parameters: _i1.testObjectToJson({'string': string}),
+        parameters: {'string': _i1.testObjectToJson(string)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4469,7 +4469,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoNullableNamedArg',
-        parameters: _i1.testObjectToJson({'string': string}),
+        parameters: {'string': _i1.testObjectToJson(string)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4495,7 +4495,7 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoOptionalArg',
-        parameters: _i1.testObjectToJson({'string': string}),
+        parameters: {'string': _i1.testObjectToJson(string)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4522,10 +4522,10 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalAndNamedArgs',
-        parameters: _i1.testObjectToJson({
-          'string1': string1,
-          'string2': string2,
-        }),
+        parameters: {
+          'string1': _i1.testObjectToJson(string1),
+          'string2': _i1.testObjectToJson(string2),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4552,10 +4552,10 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalAndNullableNamedArgs',
-        parameters: _i1.testObjectToJson({
-          'string1': string1,
-          'string2': string2,
-        }),
+        parameters: {
+          'string1': _i1.testObjectToJson(string1),
+          'string2': _i1.testObjectToJson(string2),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4582,10 +4582,10 @@ class _MethodSignaturePermutationsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodSignaturePermutations',
         methodName: 'echoPositionalAndOptionalArgs',
-        parameters: _i1.testObjectToJson({
-          'string1': string1,
-          'string2': string2,
-        }),
+        parameters: {
+          'string1': _i1.testObjectToJson(string1),
+          'string2': _i1.testObjectToJson(string2),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4805,7 +4805,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'methodCallEndpoint',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4918,7 +4918,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'wasBroadcastStreamCanceled',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -4942,7 +4942,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'wasSessionWillCloseListenerCalled',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5348,7 +5348,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'simpleEndpoint',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5374,7 +5374,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'intParameter',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5400,7 +5400,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'doubleInputValue',
-        parameters: _i1.testObjectToJson({'value': value}),
+        parameters: {'value': _i1.testObjectToJson(value)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5426,7 +5426,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'delayedResponse',
-        parameters: _i1.testObjectToJson({'delay': delay}),
+        parameters: {'delay': _i1.testObjectToJson(delay)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -5544,7 +5544,7 @@ class _MethodStreaming {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'methodStreaming',
         methodName: 'completeAllDelayedResponses',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6010,7 +6010,7 @@ class _ModuleSerializationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'moduleSerialization',
         methodName: 'serializeModuleObject',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6036,7 +6036,7 @@ class _ModuleSerializationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'moduleSerialization',
         methodName: 'modifyModuleObject',
-        parameters: _i1.testObjectToJson({'object': object}),
+        parameters: {'object': _i1.testObjectToJson(object)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6060,7 +6060,7 @@ class _ModuleSerializationEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'moduleSerialization',
         methodName: 'serializeNestedModuleObject',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6100,12 +6100,13 @@ class _NamedParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'namedParameters',
         methodName: 'namedParametersMethod',
-        parameters: _i1.testObjectToJson({
-          'namedInt': namedInt,
-          'intWithDefaultValue': intWithDefaultValue,
-          'nullableInt': nullableInt,
-          'nullableIntWithDefaultValue': nullableIntWithDefaultValue,
-        }),
+        parameters: {
+          'namedInt': _i1.testObjectToJson(namedInt),
+          'intWithDefaultValue': _i1.testObjectToJson(intWithDefaultValue),
+          'nullableInt': _i1.testObjectToJson(nullableInt),
+          'nullableIntWithDefaultValue':
+              _i1.testObjectToJson(nullableIntWithDefaultValue),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6132,10 +6133,10 @@ class _NamedParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'namedParameters',
         methodName: 'namedParametersMethodEqualInts',
-        parameters: _i1.testObjectToJson({
-          'namedInt': namedInt,
-          'nullableInt': nullableInt,
-        }),
+        parameters: {
+          'namedInt': _i1.testObjectToJson(namedInt),
+          'nullableInt': _i1.testObjectToJson(nullableInt),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6172,7 +6173,7 @@ class _OptionalParametersEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'optionalParameters',
         methodName: 'returnOptionalInt',
-        parameters: _i1.testObjectToJson({'optionalInt': optionalInt}),
+        parameters: {'optionalInt': _i1.testObjectToJson(optionalInt)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6210,10 +6211,10 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'setSimpleData',
-        parameters: _i1.testObjectToJson({
-          'key': key,
-          'data': data,
-        }),
+        parameters: {
+          'key': _i1.testObjectToJson(key),
+          'data': _i1.testObjectToJson(data),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6240,10 +6241,10 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'setSimpleDataWithLifetime',
-        parameters: _i1.testObjectToJson({
-          'key': key,
-          'data': data,
-        }),
+        parameters: {
+          'key': _i1.testObjectToJson(key),
+          'data': _i1.testObjectToJson(data),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6269,7 +6270,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'getSimpleData',
-        parameters: _i1.testObjectToJson({'key': key}),
+        parameters: {'key': _i1.testObjectToJson(key)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6295,7 +6296,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'deleteSimpleData',
-        parameters: _i1.testObjectToJson({'key': key}),
+        parameters: {'key': _i1.testObjectToJson(key)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6319,7 +6320,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'resetMessageCentralTest',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6345,7 +6346,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'listenToChannel',
-        parameters: _i1.testObjectToJson({'channel': channel}),
+        parameters: {'channel': _i1.testObjectToJson(channel)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6372,10 +6373,10 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'postToChannel',
-        parameters: _i1.testObjectToJson({
-          'channel': channel,
-          'data': data,
-        }),
+        parameters: {
+          'channel': _i1.testObjectToJson(channel),
+          'data': _i1.testObjectToJson(data),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6399,7 +6400,7 @@ class _RedisEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'redis',
         methodName: 'countSubscribedChannels',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6434,7 +6435,7 @@ class _ServerOnlyScopedFieldModelEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'serverOnlyScopedFieldModel',
         methodName: 'getScopeServerOnlyField',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6469,7 +6470,7 @@ class _ServerOnlyScopedFieldChildModelEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'serverOnlyScopedFieldChildModel',
         methodName: 'getProtocolField',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6503,7 +6504,7 @@ class _SignInRequiredEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'signInRequired',
         methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6537,7 +6538,7 @@ class _AdminScopeRequiredEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'adminScopeRequired',
         methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6575,10 +6576,10 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'setGlobalInt',
-        parameters: _i1.testObjectToJson({
-          'value': value,
-          'secondValue': secondValue,
-        }),
+        parameters: {
+          'value': _i1.testObjectToJson(value),
+          'secondValue': _i1.testObjectToJson(secondValue),
+        },
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6601,7 +6602,7 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'addToGlobalInt',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6624,7 +6625,7 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'getGlobalInt',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6650,7 +6651,7 @@ class _SimpleEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'simple',
         methodName: 'hello',
-        parameters: _i1.testObjectToJson({'name': name}),
+        parameters: {'name': _i1.testObjectToJson(name)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6698,7 +6699,7 @@ class _SubSubDirTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'subSubDirTest',
         methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6732,7 +6733,7 @@ class _SubDirTestEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'subDirTest',
         methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6767,7 +6768,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'returnsSessionId',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6791,7 +6792,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'returnsSessionEndpointAndMethod',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -6877,7 +6878,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'returnsString',
-        parameters: _i1.testObjectToJson({'string': string}),
+        parameters: {'string': _i1.testObjectToJson(string)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7028,7 +7029,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'postNumberToSharedStream',
-        parameters: _i1.testObjectToJson({'number': number}),
+        parameters: {'number': _i1.testObjectToJson(number)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7116,7 +7117,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleData',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7140,7 +7141,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'getAllSimpleData',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7166,7 +7167,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleDatasInsideTransactions',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7192,7 +7193,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleDataAndThrowInsideTransaction',
-        parameters: _i1.testObjectToJson({'data': data}),
+        parameters: {'data': _i1.testObjectToJson(data)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7216,7 +7217,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'createSimpleDatasInParallelTransactionCalls',
-        parameters: _i1.testObjectToJson({}),
+        parameters: {},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7242,7 +7243,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'echoSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+        parameters: {'simpleData': _i1.testObjectToJson(simpleData)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7268,7 +7269,7 @@ class _TestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'testTools',
         methodName: 'echoSimpleDatas',
-        parameters: _i1.testObjectToJson({'simpleDatas': simpleDatas}),
+        parameters: {'simpleDatas': _i1.testObjectToJson(simpleDatas)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(
@@ -7305,7 +7306,7 @@ class _AuthenticatedTestToolsEndpoint {
         createSessionCallback: (_) => _localUniqueSession,
         endpointPath: 'authenticatedTestTools',
         methodName: 'returnsString',
-        parameters: _i1.testObjectToJson({'string': string}),
+        parameters: {'string': _i1.testObjectToJson(string)},
         serializationManager: _serializationManager,
       );
       var _localReturnValue = await (_localCallContext.method.call(

--- a/util/generate_all
+++ b/util/generate_all
@@ -60,4 +60,4 @@ dart $CLI generate --no-analytics --experimental-features=all
 
 echo "\ntests/serverpod_test_module/serverpod_test_module_server"
 cd $BASE/tests/serverpod_test_module/serverpod_test_module_server
-dart $CLI generate --no-analytics
+dart $CLI generate --no-analytics --experimental-features=all


### PR DESCRIPTION

## Description
This started out as a PR to support testing imported modules from a main Serverpod project. This turned out to be a bit tricky and is tracked in this issue: https://github.com/serverpod/serverpod/issues/2848

Testing modules in isolation is supported out of the box, so I simply added a test to our test module that verifies that this works.

## Changes
- Adds integration test to `serverpod_test_module/serverpod_test_module_server`
- Modifies the integration test scripts to run the module tests as well

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.