### PR TITLE
Add Configuration for Controlling `session.log` Output to DB and Console

### DIFF
--- a/packages/serverpod/lib/src/server/features.dart
+++ b/packages/serverpod/lib/src/server/features.dart
@@ -38,5 +38,10 @@ class Features {
   static bool get enableScheduledHealthChecks => enableDatabase;
 
   /// Returns true if the web server is enabled.
-  static bool get enablePersistentLogging => enableDatabase;
+  static bool get enablePersistentLogging =>
+      _instance._config.sessionLogs?.persistentEnabled == true;
+
+  /// Returns true if the web server is enabled.
+  static bool get enableConsoleLogging =>
+      _instance._config.sessionLogs?.consoleEnabled == true;
 }

--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -229,3 +229,45 @@ class StdOutLogWriter extends LogWriter {
     return _logId;
   }
 }
+
+@internal
+class MultipleLogWriter extends LogWriter {
+  final List<LogWriter> _logWriters;
+
+  MultipleLogWriter(this._logWriters);
+
+  @override
+  Future<int> closeLog(SessionLogEntry entry) async {
+    var response =
+        await Future.wait(_logWriters.map((writer) => writer.closeLog(entry)));
+    return response.firstOrNull ?? 0;
+  }
+
+  @override
+  Future<void> logEntry(LogEntry entry) async {
+    await Future.wait(
+      _logWriters.map((writer) => writer.logEntry(entry)),
+    );
+  }
+
+  @override
+  Future<void> logMessage(MessageLogEntry entry) async {
+    await Future.wait(
+      _logWriters.map((writer) => writer.logMessage(entry)),
+    );
+  }
+
+  @override
+  Future<void> logQuery(QueryLogEntry entry) async {
+    await Future.wait(
+      _logWriters.map((writer) => writer.logQuery(entry)),
+    );
+  }
+
+  @override
+  Future<void> openLog(SessionLogEntry entry) async {
+    await Future.wait(
+      _logWriters.map((writer) => writer.openLog(entry)),
+    );
+  }
+}

--- a/packages/serverpod/lib/src/server/log_manager/log_writers.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_writers.dart
@@ -247,22 +247,16 @@ class MultipleLogWriter extends LogWriter {
   Future<int> closeLog(SessionLogEntry entry) async {
     int? databaseLogId;
 
-    // Close logs for all writers and collect their log IDs
     var responses = await Future.wait(_logWriters.map((writer) async {
-      // Each writer closes the log and returns a logId
       var logId = await writer.closeLog(entry);
 
-      // If this writer is a DatabaseLogWriter, prioritize its logId
       if (writer is DatabaseLogWriter) {
         databaseLogId = logId;
       }
 
-      // Return the logId for this writer to include in the results
       return logId;
     }));
 
-    // Return the DatabaseLogWriter's logId if available,
-    // otherwise use the first logId from any writer
     return databaseLogId ?? responses.firstOrNull ?? 0;
   }
 

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -52,8 +52,12 @@ class ServerpodConfig {
     this.database,
     this.redis,
     this.serviceSecret,
-    this.sessionLogs,
-  }) {
+    SessionLogConfig? sessionLogs,
+  }) : sessionLogs = sessionLogs ??
+            SessionLogConfig(
+              persistentEnabled: database != null,
+              consoleEnabled: database == null,
+            ) {
     apiServer._name = 'api';
     insightsServer?._name = 'insights';
     webServer?._name = 'web';

--- a/packages/serverpod_shared/lib/src/config.dart
+++ b/packages/serverpod_shared/lib/src/config.dart
@@ -57,6 +57,9 @@ class ServerpodConfig {
     apiServer._name = 'api';
     insightsServer?._name = 'insights';
     webServer?._name = 'web';
+    sessionLogs?._validate(
+      databaseEnabled: database != null,
+    );
   }
 
   /// Creates a default bare bone configuration.
@@ -430,24 +433,25 @@ class SessionLogConfig {
       name,
     );
 
-    var isSessionPersistentLogEnabled = sessionLogConfigJson[
-            ServerpodEnv.sessionPersistentLogEnabled.configKey] ??
-        false;
-
-    if (isSessionPersistentLogEnabled && !databaseEnabled) {
-      stdout.writeln(
-        'Warning: The `persistentEnabled` setting was enabled in the configuration, but this project was created without database support. '
-        'Persistent logging is only available when the database is enabled, so the value will be overridden and disabled.',
-      );
-      isSessionPersistentLogEnabled = false;
-    }
-
     return SessionLogConfig(
-      persistentEnabled: isSessionPersistentLogEnabled,
+      persistentEnabled: sessionLogConfigJson[
+              ServerpodEnv.sessionPersistentLogEnabled.configKey] ??
+          false,
       consoleEnabled: sessionLogConfigJson[
               ServerpodEnv.sessionConsoleLogEnabled.configKey] ??
           false,
     );
+  }
+
+  void _validate({
+    required bool databaseEnabled,
+  }) {
+    if (persistentEnabled && !databaseEnabled) {
+      throw StateError(
+        'The `persistentEnabled` setting was enabled in the configuration, but this project was created without database support. '
+        'Persistent logging is only available when the database is enabled.',
+      );
+    }
   }
 
   @override

--- a/packages/serverpod_shared/lib/src/environment_variables.dart
+++ b/packages/serverpod_shared/lib/src/environment_variables.dart
@@ -14,6 +14,9 @@ class ServerpodConfigMap {
 
   /// The redis configuration.
   static const String redis = 'redis';
+
+  /// The logs configuration.
+  static const String sessionLogs = 'sessionLogs';
 }
 
 /// The configuration sections for the serverpod server configuration file.
@@ -100,7 +103,13 @@ enum ServerpodEnv {
   webPublicScheme,
 
   /// The maximum request size for the server.
-  maxRequestSize;
+  maxRequestSize,
+
+  /// True if session persistent logging is enabled.
+  sessionPersistentLogEnabled,
+
+  /// True if session console logging is enabled.
+  sessionConsoleLogEnabled;
 
   /// The key used in the environment configuration file.
   String get configKey {
@@ -129,6 +138,8 @@ enum ServerpodEnv {
       (ServerpodEnv.webPublicPort) => ServerpodServerConfigMap.publicPort,
       (ServerpodEnv.webPublicScheme) => ServerpodServerConfigMap.publicScheme,
       (ServerpodEnv.maxRequestSize) => 'maxRequestSize',
+      (ServerpodEnv.sessionPersistentLogEnabled) => 'persistentEnabled',
+      (ServerpodEnv.sessionConsoleLogEnabled) => 'consoleEnabled',
     };
   }
 
@@ -162,6 +173,10 @@ enum ServerpodEnv {
       (ServerpodEnv.webPublicPort) => 'SERVERPOD_WEB_SERVER_PUBLIC_PORT',
       (ServerpodEnv.webPublicScheme) => 'SERVERPOD_WEB_SERVER_PUBLIC_SCHEME',
       (ServerpodEnv.maxRequestSize) => 'SERVERPOD_MAX_REQUEST_SIZE',
+      (ServerpodEnv.sessionPersistentLogEnabled) =>
+        'SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED',
+      (ServerpodEnv.sessionConsoleLogEnabled) =>
+        'SERVERPOD_SESSION_CONSOLE_LOG_ENABLED',
     };
   }
 }

--- a/packages/serverpod_shared/test/session_logs_config_test.dart
+++ b/packages/serverpod_shared/test/session_logs_config_test.dart
@@ -11,7 +11,7 @@ void main() {
   };
 
   test(
-    'Given a Serverpod config missing sessionLogs configuration when loading from Map then sessionLogs is null.',
+    'Given a Serverpod config missing sessionLogs configuration when loading from Map then sessionLogs is null',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -33,7 +33,7 @@ apiServer:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is true then it is overridden to false.',
+    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is true then a StateError is thrown',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -46,21 +46,28 @@ sessionLogs:
   consoleEnabled: false
 ''';
 
-      var config = ServerpodConfig.loadFromMap(
-        runMode,
-        serverId,
-        passwords,
-        loadYaml(serverpodConfig),
-        environment: {},
+      expect(
+        () => ServerpodConfig.loadFromMap(
+          runMode,
+          serverId,
+          passwords,
+          loadYaml(serverpodConfig),
+          environment: {},
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains(
+                'The `persistentEnabled` setting was enabled in the configuration, but this project was created without database support.'),
+          ),
+        ),
       );
-
-      expect(config.sessionLogs?.persistentEnabled, isFalse);
-      expect(config.sessionLogs?.consoleEnabled, isFalse);
     },
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is false then it remains false.',
+    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is false then it remains false',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -87,7 +94,7 @@ sessionLogs:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and database when persistentEnabled is true then persistentEnabled remains true.',
+    'Given a Serverpod config with sessionLogs and database when persistentEnabled is true then persistentEnabled remains true',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -118,7 +125,7 @@ sessionLogs:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and database when persistentEnabled is false then persistentEnabled remains false.',
+    'Given a Serverpod config with sessionLogs and database when persistentEnabled is false then persistentEnabled remains false',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -149,7 +156,7 @@ sessionLogs:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and database when environment variables override them then sessionLogs config reflects the environment overrides.',
+    'Given a Serverpod config with sessionLogs and database when environment variables override them then sessionLogs config reflects the environment overrides',
     () {
       var config = ServerpodConfig.loadFromMap(
         runMode,

--- a/packages/serverpod_shared/test/session_logs_config_test.dart
+++ b/packages/serverpod_shared/test/session_logs_config_test.dart
@@ -1,0 +1,186 @@
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  var runMode = 'development';
+  var serverId = 'default';
+  var passwords = {
+    'serviceSecret': 'longpasswordthatisrequired',
+    'database': 'dbpassword'
+  };
+
+  test(
+    'Given a Serverpod config missing sessionLogs configuration when loading from Map then sessionLogs is null.',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+      );
+
+      expect(config.sessionLogs, isNull);
+    },
+  );
+
+  test(
+    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is true, it is overridden to false.',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: false
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+        environment: {},
+      );
+
+      expect(config.sessionLogs?.persistentEnabled, isFalse);
+      expect(config.sessionLogs?.consoleEnabled, isFalse);
+    },
+  );
+
+  test(
+    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is false, it remains false.',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+sessionLogs:
+  persistentEnabled: false
+  consoleEnabled: true
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+        environment: {},
+      );
+
+      expect(config.sessionLogs?.persistentEnabled, isFalse);
+      expect(config.sessionLogs?.consoleEnabled, isTrue);
+    },
+  );
+
+  test(
+    'Given a Serverpod config with sessionLogs and database when persistentEnabled is true, persistentEnabled remains true.',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: testUser
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: false
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+      );
+
+      expect(config.sessionLogs?.persistentEnabled, isTrue);
+      expect(config.sessionLogs?.consoleEnabled, isFalse);
+    },
+  );
+
+  test(
+    'Given a Serverpod config with sessionLogs and database when persistentEnabled is false, persistentEnabled remains false.',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: testUser
+sessionLogs:
+  persistentEnabled: false
+  consoleEnabled: true
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+      );
+
+      expect(config.sessionLogs?.persistentEnabled, isFalse);
+      expect(config.sessionLogs?.consoleEnabled, isTrue);
+    },
+  );
+
+  test(
+    'Given a Serverpod config with sessionLogs and database when environment variables override them, sessionLogs config reflects the environment overrides.',
+    () {
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        {
+          'apiServer': {
+            'port': 8080,
+            'publicHost': 'localhost',
+            'publicPort': 8080,
+            'publicScheme': 'http',
+          },
+          'database': {
+            'host': 'localhost',
+            'port': 5432,
+            'name': 'testDb',
+            'user': 'testUser',
+          },
+          'sessionLogs': {
+            'persistentEnabled': false,
+            'consoleEnabled': true,
+          },
+        },
+        environment: {
+          'SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED': 'true',
+          'SERVERPOD_SESSION_CONSOLE_LOG_ENABLED': 'false',
+        },
+      );
+
+      expect(config.sessionLogs?.persistentEnabled, isTrue);
+      expect(config.sessionLogs?.consoleEnabled, isFalse);
+    },
+  );
+}

--- a/packages/serverpod_shared/test/session_logs_config_test.dart
+++ b/packages/serverpod_shared/test/session_logs_config_test.dart
@@ -33,7 +33,7 @@ apiServer:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is true, it is overridden to false.',
+    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is true then it is overridden to false.',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -60,7 +60,7 @@ sessionLogs:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is false, it remains false.',
+    'Given a Serverpod config with sessionLogs and no database when persistentEnabled is false then it remains false.',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -87,7 +87,7 @@ sessionLogs:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and database when persistentEnabled is true, persistentEnabled remains true.',
+    'Given a Serverpod config with sessionLogs and database when persistentEnabled is true then persistentEnabled remains true.',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -118,7 +118,7 @@ sessionLogs:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and database when persistentEnabled is false, persistentEnabled remains false.',
+    'Given a Serverpod config with sessionLogs and database when persistentEnabled is false then persistentEnabled remains false.',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -149,7 +149,7 @@ sessionLogs:
   );
 
   test(
-    'Given a Serverpod config with sessionLogs and database when environment variables override them, sessionLogs config reflects the environment overrides.',
+    'Given a Serverpod config with sessionLogs and database when environment variables override them then sessionLogs config reflects the environment overrides.',
     () {
       var config = ServerpodConfig.loadFromMap(
         runMode,

--- a/packages/serverpod_shared/test/session_logs_config_test.dart
+++ b/packages/serverpod_shared/test/session_logs_config_test.dart
@@ -11,7 +11,7 @@ void main() {
   };
 
   test(
-    'Given a Serverpod config missing sessionLogs configuration when loading from Map then sessionLogs is null',
+    'Given a Serverpod config missing sessionLogs configuration and no database when loading from Map then sessionLogs defaults to console logging enabled and persistent logging disabled',
     () {
       var serverpodConfig = '''
 apiServer:
@@ -28,7 +28,36 @@ apiServer:
         loadYaml(serverpodConfig),
       );
 
-      expect(config.sessionLogs, isNull);
+      expect(config.sessionLogs?.persistentEnabled, isFalse);
+      expect(config.sessionLogs?.consoleEnabled, isTrue);
+    },
+  );
+
+  test(
+    'Given a Serverpod config missing sessionLogs configuration and a database when loading from Map then sessionLogs defaults to persistent logging enabled and console logging disabled',
+    () {
+      var serverpodConfig = '''
+apiServer:
+  port: 8080
+  publicHost: localhost
+  publicPort: 8080
+  publicScheme: http
+database:
+  host: localhost
+  port: 5432
+  name: testDb
+  user: testUser
+''';
+
+      var config = ServerpodConfig.loadFromMap(
+        runMode,
+        serverId,
+        passwords,
+        loadYaml(serverpodConfig),
+      );
+
+      expect(config.sessionLogs?.persistentEnabled, isTrue);
+      expect(config.sessionLogs?.consoleEnabled, isFalse);
     },
   );
 

--- a/packages/serverpod_shared/test_integration/assets/load_config/config/session_logs_db_development.yaml
+++ b/packages/serverpod_shared/test_integration/assets/load_config/config/session_logs_db_development.yaml
@@ -1,0 +1,15 @@
+apiServer:
+  port: 8080
+  publicHost: "localhost"
+  publicPort: 8080
+  publicScheme: "http"
+
+database:
+  host: localhost
+  port: 8090
+  name: serverpod_test
+  user: postgres
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/packages/serverpod_shared/test_integration/assets/load_config/config/session_logs_no_db_development.yaml
+++ b/packages/serverpod_shared/test_integration/assets/load_config/config/session_logs_no_db_development.yaml
@@ -1,0 +1,9 @@
+apiServer:
+  port: 8080
+  publicHost: "localhost"
+  publicPort: 8080
+  publicScheme: "http"
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/packages/serverpod_shared/test_integration/assets/load_config/session_logs_db_runner.dart
+++ b/packages/serverpod_shared/test_integration/assets/load_config/session_logs_db_runner.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+void main() {
+  var passwords = {
+    'database': 'databasePassword',
+  };
+
+  var config = ServerpodConfig.load(
+    'session_logs_db_development',
+    'default',
+    passwords,
+  );
+  stdout.write(config.toString());
+}

--- a/packages/serverpod_shared/test_integration/assets/load_config/session_logs_no_db_runner.dart
+++ b/packages/serverpod_shared/test_integration/assets/load_config/session_logs_no_db_runner.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+void main() {
+  var config = ServerpodConfig.load(
+    'session_logs_no_db_development',
+    'default',
+    {},
+  );
+  stdout.write(config.toString());
+}

--- a/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
+++ b/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
@@ -47,7 +47,7 @@ void main() {
     });
 
     test(
-        'when persistent logging is enabled but no database is supported, a Bad state error should be thrown and the process should terminate',
+        'when persistent logging is enabled but no database is supported, a StateError should be thrown and the process should terminate',
         () async {
       expect(result.exitCode, isNot(0),
           reason: 'The process should fail with a non-zero exit code');
@@ -55,7 +55,7 @@ void main() {
           result.stderr,
           contains(
               'Bad state: The `persistentEnabled` setting was enabled in the configuration'),
-          reason: 'The stderr should contain the Bad state exception message');
+          reason: 'The stderr should contain the StateError exception message');
     });
   });
 
@@ -113,15 +113,15 @@ void main() {
     });
 
     test(
-        'when the config is loaded, then the session persistent logging is not present by default',
+        'when the config is loaded, then the session persistent logging defaults to disabled',
         () async {
-      expect(result.stdout, isNot(contains('session persistent log enabled')));
+      expect(result.stdout, contains('session persistent log enabled: false'));
     });
 
     test(
-        'when the config is loaded, then the session console logging is not present by default',
+        'when the config is loaded, then the session console logging defaults to enabled',
         () async {
-      expect(result.stdout, isNot(contains('session console log enabled')));
+      expect(result.stdout, contains('session console log enabled: true'));
     });
   });
 }

--- a/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
+++ b/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
@@ -47,28 +47,15 @@ void main() {
     });
 
     test(
-        'when the loading of the config was successful then the exit code should be zero',
-        () {
-      expect(result.exitCode, 0, reason: 'The exit code should be zero');
-    });
-
-    test(
-        'when the config is loaded, then the session persistent logging is disabled due to missing database support',
+        'when persistent logging is enabled but no database is supported, a Bad state error should be thrown and the process should terminate',
         () async {
+      expect(result.exitCode, isNot(0),
+          reason: 'The process should fail with a non-zero exit code');
       expect(
-        result.stdout,
-        contains(
-          'Warning: The `persistentEnabled` setting was enabled in the configuration, but this project was created without database support. '
-          'Persistent logging is only available when the database is enabled, so the value will be overridden and disabled.',
-        ),
-      );
-      expect(result.stdout, contains('session persistent log enabled: false'));
-    });
-
-    test(
-        'when the config is loaded, then the session console logging is enabled as per configuration',
-        () async {
-      expect(result.stdout, contains('session console log enabled: true'));
+          result.stderr,
+          contains(
+              'Bad state: The `persistentEnabled` setting was enabled in the configuration'),
+          reason: 'The stderr should contain the Bad state exception message');
     });
   });
 

--- a/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
+++ b/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
@@ -15,16 +15,20 @@ void main() {
       stderr.writeln(result.stderr);
     });
 
-    test('then the loading of the config was successful', () {
-      expect(result.exitCode, 0);
+    test(
+        'when the loading of the config was successful then the exit code should be zero',
+        () {
+      expect(result.exitCode, 0, reason: 'The exit code should be zero');
     });
 
-    test('then the session persistent logging is enabled as per configuration',
+    test(
+        'when the config is loaded, then the session persistent logging is enabled as per configuration',
         () async {
       expect(result.stdout, contains('session persistent log enabled: true'));
     });
 
-    test('then the session console logging is enabled as per configuration',
+    test(
+        'when the config is loaded, then the session console logging is enabled as per configuration',
         () async {
       expect(result.stdout, contains('session console log enabled: true'));
     });
@@ -42,24 +46,27 @@ void main() {
       stderr.writeln(result.stderr);
     });
 
-    test('then the loading of the config was successful', () {
-      expect(result.exitCode, 0);
+    test(
+        'when the loading of the config was successful then the exit code should be zero',
+        () {
+      expect(result.exitCode, 0, reason: 'The exit code should be zero');
     });
 
     test(
-        'then the session persistent logging is disabled due to missing database support',
+        'when the config is loaded, then the session persistent logging is disabled due to missing database support',
         () async {
       expect(
         result.stdout,
         contains(
-          'Warning: Persistent session logging is enabled in the configuration, but this project was created without database support. '
+          'Warning: The `persistentEnabled` setting was enabled in the configuration, but this project was created without database support. '
           'Persistent logging is only available when the database is enabled, so the value will be overridden and disabled.',
         ),
       );
       expect(result.stdout, contains('session persistent log enabled: false'));
     });
 
-    test('then the session console logging is enabled as per configuration',
+    test(
+        'when the config is loaded, then the session console logging is enabled as per configuration',
         () async {
       expect(result.stdout, contains('session console log enabled: true'));
     });
@@ -81,17 +88,20 @@ void main() {
       stderr.writeln(result.stderr);
     });
 
-    test('then the loading of the config was successful', () {
-      expect(result.exitCode, 0);
+    test(
+        'when the loading of the config was successful then the exit code should be zero',
+        () {
+      expect(result.exitCode, 0, reason: 'The exit code should be zero');
     });
 
     test(
-        'then the session persistent logging is disabled by environment variable',
+        'when the config is loaded, then the session persistent logging is disabled by environment variable',
         () async {
       expect(result.stdout, contains('session persistent log enabled: false'));
     });
 
-    test('then the session console logging is disabled by environment variable',
+    test(
+        'when the config is loaded, then the session console logging is disabled by environment variable',
         () async {
       expect(result.stdout, contains('session console log enabled: false'));
     });
@@ -109,16 +119,20 @@ void main() {
       );
     });
 
-    test('then the loading of the config was successful', () {
-      expect(result.exitCode, 0);
+    test(
+        'when the loading of the config was successful then the exit code should be zero',
+        () {
+      expect(result.exitCode, 0, reason: 'The exit code should be zero');
     });
 
-    test('then the session persistent logging is not present by default',
+    test(
+        'when the config is loaded, then the session persistent logging is not present by default',
         () async {
       expect(result.stdout, isNot(contains('session persistent log enabled')));
     });
 
-    test('then the session console logging is not present by default',
+    test(
+        'when the config is loaded, then the session console logging is not present by default',
         () async {
       expect(result.stdout, isNot(contains('session console log enabled')));
     });

--- a/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
+++ b/packages/serverpod_shared/test_integration/load_session_logs_config_test.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  late ProcessResult result;
+
+  group('Given a serverpod config with session logs and database support', () {
+    setUpAll(() async {
+      result = await Process.run(
+        'dart',
+        ['run', 'session_logs_db_runner.dart'],
+        environment: {},
+        workingDirectory: 'test_integration/assets/load_config',
+      );
+      stderr.writeln(result.stderr);
+    });
+
+    test('then the loading of the config was successful', () {
+      expect(result.exitCode, 0);
+    });
+
+    test('then the session persistent logging is enabled as per configuration',
+        () async {
+      expect(result.stdout, contains('session persistent log enabled: true'));
+    });
+
+    test('then the session console logging is enabled as per configuration',
+        () async {
+      expect(result.stdout, contains('session console log enabled: true'));
+    });
+  });
+
+  group('Given a serverpod config with session logs but no database support',
+      () {
+    setUpAll(() async {
+      result = await Process.run(
+        'dart',
+        ['run', 'session_logs_no_db_runner.dart'],
+        environment: {},
+        workingDirectory: 'test_integration/assets/load_config',
+      );
+      stderr.writeln(result.stderr);
+    });
+
+    test('then the loading of the config was successful', () {
+      expect(result.exitCode, 0);
+    });
+
+    test(
+        'then the session persistent logging is disabled due to missing database support',
+        () async {
+      expect(
+        result.stdout,
+        contains(
+          'Warning: Persistent session logging is enabled in the configuration, but this project was created without database support. '
+          'Persistent logging is only available when the database is enabled, so the value will be overridden and disabled.',
+        ),
+      );
+      expect(result.stdout, contains('session persistent log enabled: false'));
+    });
+
+    test('then the session console logging is enabled as per configuration',
+        () async {
+      expect(result.stdout, contains('session console log enabled: true'));
+    });
+  });
+
+  group(
+      'Given a serverpod config with environment variables overriding session logs',
+      () {
+    setUpAll(() async {
+      result = await Process.run(
+        'dart',
+        ['run', 'session_logs_no_db_runner.dart'],
+        environment: {
+          'SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED': 'false',
+          'SERVERPOD_SESSION_CONSOLE_LOG_ENABLED': 'false',
+        },
+        workingDirectory: 'test_integration/assets/load_config',
+      );
+      stderr.writeln(result.stderr);
+    });
+
+    test('then the loading of the config was successful', () {
+      expect(result.exitCode, 0);
+    });
+
+    test(
+        'then the session persistent logging is disabled by environment variable',
+        () async {
+      expect(result.stdout, contains('session persistent log enabled: false'));
+    });
+
+    test('then the session console logging is disabled by environment variable',
+        () async {
+      expect(result.stdout, contains('session console log enabled: false'));
+    });
+  });
+
+  group(
+      'Given a serverpod config without session logs configured and no environment variables',
+      () {
+    setUpAll(() async {
+      result = await Process.run(
+        'dart',
+        ['run', 'runner.dart'],
+        environment: {},
+        workingDirectory: 'test_integration/assets/load_config',
+      );
+    });
+
+    test('then the loading of the config was successful', () {
+      expect(result.exitCode, 0);
+    });
+
+    test('then the session persistent logging is not present by default',
+        () async {
+      expect(result.stdout, isNot(contains('session persistent log enabled')));
+    });
+
+    test('then the session console logging is not present by default',
+        () async {
+      expect(result.stdout, isNot(contains('session console log enabled')));
+    });
+  });
+}

--- a/tests/serverpod_test_server/config/development.yaml
+++ b/tests/serverpod_test_server/config/development.yaml
@@ -26,3 +26,7 @@ redis:
   enabled: true
   host: localhost
   port: 8091
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/tests/serverpod_test_server/config/production.yaml
+++ b/tests/serverpod_test_server/config/production.yaml
@@ -26,3 +26,7 @@ redis:
   enabled: true
   host: redis
   port: 6379
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_method_call_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_method_call_logging_test.dart
@@ -28,7 +28,7 @@ void main() async {
     });
 
     tearDown(() async {
-      await await session.close();
+      await session.close();
       await server.shutdown(exitProcess: false);
     });
 
@@ -407,13 +407,19 @@ void main() async {
       record = MockStdout();
 
       server = IntegrationTestServer.create(
-          config: ServerpodConfig(
-              apiServer: ServerConfig(
-        port: 8080,
-        publicHost: 'localhost',
-        publicPort: 8080,
-        publicScheme: 'http',
-      )));
+        config: ServerpodConfig(
+          apiServer: ServerConfig(
+            port: 8080,
+            publicHost: 'localhost',
+            publicPort: 8080,
+            publicScheme: 'http',
+          ),
+          sessionLogs: SessionLogConfig(
+            persistentEnabled: false,
+            consoleEnabled: true,
+          ),
+        ),
+      );
 
       await IOOverrides.runZoned(() async {
         await server.start();

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_method_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_method_stream_logging_test.dart
@@ -32,7 +32,7 @@ void main() async {
   tearDown(() async {
     await client.closeStreamingMethodConnections(exception: null);
     client.close();
-    await await session.close();
+    await session.close();
     await server.shutdown(exitProcess: false);
   });
 

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_stream_logging_test.dart
@@ -23,7 +23,7 @@ void main() async {
     tearDown(() async {
       await client.closeStreamingConnection();
       client.close();
-      await await session.close();
+      await session.close();
       await server.shutdown(exitProcess: false);
     });
 

--- a/tests/serverpod_test_server/test_integration/logging/internal_session_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/internal_session_logging_test.dart
@@ -18,7 +18,7 @@ void main() async {
     });
 
     tearDown(() async {
-      await await session.close();
+      await session.close();
       await server.shutdown(exitProcess: false);
     });
 

--- a/tests/serverpod_test_server/test_integration/logging/override_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/override_logging_test.dart
@@ -20,7 +20,7 @@ void main() {
   });
 
   tearDown(() async {
-    await await session.close();
+    await session.close();
     await server.shutdown(exitProcess: false);
   });
 

--- a/tests/serverpod_test_server/test_integration/logging/session_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/session_logging_test.dart
@@ -1,0 +1,280 @@
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/builders/runtime_settings_builder.dart';
+import 'package:serverpod_test_server/test_util/logging_utils.dart';
+import 'package:serverpod_test_server/test_util/mock_stdout.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  var runMode = 'production';
+
+  group('Given persistent logging is enabled and console logging is disabled',
+      () {
+    late Serverpod server;
+    late Session session;
+    late MockStdout record;
+    setUp(() async {
+      record = MockStdout();
+
+      server = IntegrationTestServer.create(
+        config: ServerpodConfig(
+          runMode: runMode,
+          apiServer: ServerConfig(
+            port: 8080,
+            publicHost: 'localhost',
+            publicPort: 8080,
+            publicScheme: 'http',
+          ),
+          database: DatabaseConfig(
+            host: 'postgres',
+            port: 5432,
+            user: 'postgres',
+            password: 'password',
+            name: 'serverpod_test',
+          ),
+          sessionLogs: SessionLogConfig(
+            persistentEnabled: true,
+            consoleEnabled: false,
+          ),
+        ),
+      );
+      await server.start();
+      session = await server.createSession(enableLogging: false);
+      await LoggingUtil.clearAllLogs(session);
+    });
+
+    tearDown(() async {
+      await session.close();
+      await server.shutdown(exitProcess: false);
+    });
+
+    test(
+        'when a log is written then it should be stored in the database and not in stdout.',
+        () async {
+      var settings = RuntimeSettingsBuilder().build();
+      await server.updateRuntimeSettings(settings);
+
+      await IOOverrides.runZoned(
+        () async {
+          var testSession = await server.createSession(enableLogging: true);
+          testSession.log('Test message');
+          await testSession.close();
+        },
+        stdout: () => record,
+      );
+
+      var logs = await LoggingUtil.findAllLogs(session);
+      expect(logs, hasLength(1));
+      expect(logs.first.logs.first.message, 'Test message');
+
+      expect(record.output.contains('Test message'), isFalse);
+    });
+
+    test('when logging is disabled at runtime, then no log should be written.',
+        () async {
+      var settings = RuntimeSettingsBuilder().build();
+      await server.updateRuntimeSettings(settings);
+
+      await IOOverrides.runZoned(
+        () async {
+          var testSession = await server.createSession(enableLogging: false);
+          testSession.log('Test message');
+          await testSession.close();
+        },
+        stdout: () => record,
+      );
+
+      var logs = await LoggingUtil.findAllLogs(session);
+      expect(logs, isEmpty);
+
+      expect(record.output.contains('Test message'), isFalse);
+    });
+  }, timeout: Timeout(const Duration(seconds: 5)), retry: 1);
+
+  group('Given persistent logging is disabled and console logging is enabled',
+      () {
+    late Serverpod server;
+    late Session session;
+    late MockStdout record;
+    setUp(() async {
+      record = MockStdout();
+
+      server = IntegrationTestServer.create(
+        config: ServerpodConfig(
+          runMode: runMode,
+          apiServer: ServerConfig(
+            port: 8080,
+            publicHost: 'localhost',
+            publicPort: 8080,
+            publicScheme: 'http',
+          ),
+          database: DatabaseConfig(
+            host: 'postgres',
+            port: 5432,
+            user: 'postgres',
+            password: 'password',
+            name: 'serverpod_test',
+          ),
+          sessionLogs: SessionLogConfig(
+            persistentEnabled: false,
+            consoleEnabled: true,
+          ),
+        ),
+      );
+      await server.start();
+      session = await server.createSession(enableLogging: false);
+      await LoggingUtil.clearAllLogs(session);
+    });
+
+    tearDown(() async {
+      await session.close();
+      await server.shutdown(exitProcess: false);
+    });
+
+    test(
+        'when a log is written then it should not be stored in the database but should appear in stdout.',
+        () async {
+      var settings = RuntimeSettingsBuilder().build();
+      await server.updateRuntimeSettings(settings);
+
+      await IOOverrides.runZoned(
+        () async {
+          var testSession = await server.createSession(enableLogging: true);
+          testSession.log('Test message for console');
+          await testSession.close();
+        },
+        stdout: () => record,
+      );
+
+      var logs = await LoggingUtil.findAllLogs(session);
+      expect(logs, isEmpty);
+
+      expect(record.output.contains('Test message for console'), isTrue);
+    });
+  }, timeout: Timeout(const Duration(seconds: 5)), retry: 1);
+
+  group('Given both persistent and console logging are disabled', () {
+    late Serverpod server;
+    late Session session;
+    late MockStdout record;
+    setUp(() async {
+      record = MockStdout();
+
+      server = IntegrationTestServer.create(
+        config: ServerpodConfig(
+          runMode: runMode,
+          apiServer: ServerConfig(
+            port: 8080,
+            publicHost: 'localhost',
+            publicPort: 8080,
+            publicScheme: 'http',
+          ),
+          database: DatabaseConfig(
+            host: 'postgres',
+            port: 5432,
+            user: 'postgres',
+            password: 'password',
+            name: 'serverpod_test',
+          ),
+          sessionLogs: SessionLogConfig(
+            persistentEnabled: false,
+            consoleEnabled: false,
+          ),
+        ),
+      );
+      await server.start();
+      session = await server.createSession(enableLogging: false);
+      await LoggingUtil.clearAllLogs(session);
+    });
+
+    tearDown(() async {
+      await session.close();
+      await server.shutdown(exitProcess: false);
+    });
+
+    test(
+        'when a log is written then no log should be written to the database or stdout.',
+        () async {
+      var settings = RuntimeSettingsBuilder().build();
+      await server.updateRuntimeSettings(settings);
+
+      await IOOverrides.runZoned(
+        () async {
+          var testSession = await server.createSession(enableLogging: true);
+          testSession.log('Test message');
+          await testSession.close();
+        },
+        stdout: () => record,
+      );
+
+      var logs = await LoggingUtil.findAllLogs(session);
+      expect(logs, isEmpty);
+
+      expect(record.output.contains('Test message'), isFalse);
+    });
+  }, timeout: Timeout(const Duration(seconds: 5)), retry: 1);
+
+  group('Given persistent logging is enabled and console logging is disabled',
+      () {
+    late Serverpod server;
+    late Session session;
+    late MockStdout record;
+    setUp(() async {
+      record = MockStdout();
+
+      server = IntegrationTestServer.create(
+        config: ServerpodConfig(
+          runMode: runMode,
+          apiServer: ServerConfig(
+            port: 8080,
+            publicHost: 'localhost',
+            publicPort: 8080,
+            publicScheme: 'http',
+          ),
+          database: DatabaseConfig(
+            host: 'postgres',
+            port: 5432,
+            user: 'postgres',
+            password: 'password',
+            name: 'serverpod_test',
+          ),
+          sessionLogs: SessionLogConfig(
+            persistentEnabled: true,
+            consoleEnabled: false,
+          ),
+        ),
+      );
+      await server.start();
+      session = await server.createSession(enableLogging: false);
+      await LoggingUtil.clearAllLogs(session);
+    });
+
+    tearDown(() async {
+      await session.close();
+      await server.shutdown(exitProcess: false);
+    });
+
+    test(
+        'when a log is written then it should be stored in the database and not in stdout.',
+        () async {
+      var settings = RuntimeSettingsBuilder().build();
+      await server.updateRuntimeSettings(settings);
+
+      await IOOverrides.runZoned(
+        () async {
+          var testSession = await server.createSession(enableLogging: true);
+          testSession.log('Persistent log message');
+          await testSession.close();
+        },
+        stdout: () => record,
+      );
+
+      var logs = await LoggingUtil.findAllLogs(session);
+      expect(logs, hasLength(1));
+
+      expect(record.output.contains('Persistent log message'), isFalse);
+    });
+  }, timeout: Timeout(const Duration(seconds: 5)), retry: 1);
+}

--- a/tests/serverpod_test_server/test_integration/logging/session_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/session_logging_test.dart
@@ -212,11 +212,9 @@ void main() async {
     });
   });
 
-  group(
-      'Given persistent logging is enabled but the database support is not available',
-      () {
-    test('a StateError should be thrown due to lack of database support',
-        () async {
+  test(
+    'Given persistent logging is enabled and database support is not available when the server is created then a StateError should be thrown due to lack of database support',
+    () async {
       expect(
         () => IntegrationTestServer.create(
           config: ServerpodConfig(
@@ -242,8 +240,8 @@ void main() async {
           ),
         ),
       );
-    });
-  });
+    },
+  );
 
   group('Given no explicit sessionLogs configuration with a database', () {
     late Serverpod server;


### PR DESCRIPTION
### **Description**

This PR introduces the ability to control `session.log` output through both environment variables and configuration files. Logs can now be written to the database, the console, both, or neither, depending on configuration.

### **Key Changes:**
- Added support for two new environment variables:
  - `SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED`
  - `SERVERPOD_SESSION_CONSOLE_LOG_ENABLED`
  
- The `sessionLogs` section in the configuration file now supports:
  - `persistentEnabled`: Enable logging to the database.
  - `consoleEnabled`: Enable logging to the console.

### **Important Note:**
- If `persistentEnabled` is set to `true` but **no database configuration** is provided, a `StateError` will be thrown, as persistent logging requires database support. This ensures that invalid configurations are caught during initialization, preventing silent overrides.

### **How to Configure:**
- **Environment Variables**:
  - Control session logging with:
    - `SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED=true/false`
    - `SERVERPOD_SESSION_CONSOLE_LOG_ENABLED=true/false`
  
- **Configuration File**:
  - Modify the `sessionLogs` section:
    ```yaml
    sessionLogs:
      persistentEnabled: true
      consoleEnabled: true
    ```

Closes: #2393

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
