### PR TITLE
fix: Catch database exceptions at the end of transactions.

### DIFF
--- a/packages/serverpod_test/lib/src/transaction_manager.dart
+++ b/packages/serverpod_test/lib/src/transaction_manager.dart
@@ -44,7 +44,13 @@ class TransactionManager {
           await _endTransactionScopeCompleter.future;
         },
         isUserCall: false,
-      ),
+      ).catchError((error, stackTrace) {
+        // no-op:
+        // If a database exception occurred during the transaction,
+        // but the exception was caught and the transactions was allowed to complete,
+        // then the transaction will rethrow it when it completes.
+        // This has to be caught, otherwise the dart test runner will fail the test suite.
+      }),
     );
 
     await transactionStartedCompleter.future;

--- a/tests/serverpod_test_server/config/passwords.yaml
+++ b/tests/serverpod_test_server/config/passwords.yaml
@@ -14,3 +14,7 @@ production:
   database: 'password'
   redis: 'password'
   serviceSecret: 'super_SECRET_password'
+test:
+  database: 'password'
+  redis: 'password'
+  serviceSecret: 'super_SECRET_password'

--- a/tests/serverpod_test_server/config/test.yaml
+++ b/tests/serverpod_test_server/config/test.yaml
@@ -1,0 +1,30 @@
+# Duplicate of production.yaml
+# The test tools use test by default, but the other integration tests use production as run mode
+apiServer:
+  port: 8080
+  publicHost: serverpod_test_server
+  publicPort: 8080
+  publicScheme: http
+
+insightsServer:
+  port: 8081
+  publicHost: serverpod_test_server
+  publicPort: 8081
+  publicScheme: http
+
+webServer:
+  port: 8082
+  publicHost: serverpod_test_server
+  publicPort: 8082
+  publicScheme: http
+
+database:
+  host: postgres
+  port: 5432
+  name: serverpod_test
+  user: postgres
+
+redis:
+  enabled: true
+  host: redis
+  port: 6379

--- a/tests/serverpod_test_server/test_integration/method_streaming_cancel_test.dart
+++ b/tests/serverpod_test_server/test_integration/method_streaming_cancel_test.dart
@@ -1,4 +1,3 @@
-import 'package:serverpod/serverpod.dart';
 import 'package:test/test.dart';
 
 import 'test_tools/serverpod_test_tools.dart';

--- a/tests/serverpod_test_server/test_integration/method_streaming_cancel_test.dart
+++ b/tests/serverpod_test_server/test_integration/method_streaming_cancel_test.dart
@@ -58,6 +58,5 @@ void main() {
         );
       });
     },
-    runMode: ServerpodRunMode.production,
   );
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/authentication_validation_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/authentication_validation_test.dart
@@ -305,6 +305,5 @@ void main() {
         });
       });
     },
-    runMode: ServerpodRunMode.production,
   );
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/database_operations_in_endpoint_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_operations_in_endpoint_test.dart
@@ -88,7 +88,6 @@ void main() {
         });
       });
     },
-    runMode: ServerpodRunMode.production,
   );
 
   withServerpod(
@@ -168,7 +167,6 @@ void main() {
         });
       });
     },
-    runMode: ServerpodRunMode.production,
     rollbackDatabase: RollbackDatabase.afterEach,
   );
 
@@ -200,7 +198,6 @@ void main() {
             expect(simpleDatas[1].num, 123);
           });
         },
-        runMode: ServerpodRunMode.production,
         rollbackDatabase: RollbackDatabase.afterAll,
       );
 
@@ -214,7 +211,6 @@ void main() {
             expect(simpleDatas, hasLength(0));
           });
         },
-        runMode: ServerpodRunMode.production,
       );
     });
 
@@ -240,7 +236,6 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.afterAll,
-        runMode: ServerpodRunMode.production,
       );
 
       withServerpod(
@@ -253,7 +248,6 @@ void main() {
             expect(simpleDatas, hasLength(0));
           });
         },
-        runMode: ServerpodRunMode.production,
       );
     });
 
@@ -280,7 +274,6 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.afterAll,
-        runMode: ServerpodRunMode.production,
       );
 
       withServerpod(
@@ -294,7 +287,6 @@ void main() {
             expect(simpleDatas, hasLength(0));
           });
         },
-        runMode: ServerpodRunMode.production,
       );
     });
   });
@@ -326,7 +318,6 @@ void main() {
             expect(simpleDatas[1].num, 123);
           });
         },
-        runMode: ServerpodRunMode.production,
         rollbackDatabase: RollbackDatabase.disabled,
       );
 
@@ -351,7 +342,6 @@ void main() {
             expect(simpleDatas[1].num, 123);
           });
         },
-        runMode: ServerpodRunMode.production,
         rollbackDatabase: RollbackDatabase.disabled,
       );
     });
@@ -377,7 +367,6 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.disabled,
-        runMode: ServerpodRunMode.production,
       );
 
       withServerpod(
@@ -399,7 +388,6 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.disabled,
-        runMode: ServerpodRunMode.production,
       );
     });
 
@@ -426,7 +414,6 @@ void main() {
         });
       },
       rollbackDatabase: RollbackDatabase.disabled,
-      runMode: ServerpodRunMode.production,
     );
   });
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/protocol_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/protocol_test.dart
@@ -3,156 +3,162 @@ import 'package:test/test.dart';
 import 'serverpod_test_tools.dart';
 
 void main() {
-  withServerpod('Given TestToolsEndpoint', (sessionBuilder, endpoints) {
-    test('when calling method with positional arg then echoes the value',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalArg(sessionBuilder, 'PositionalArg');
-      expect(result, 'PositionalArg');
-    });
+  withServerpod(
+    'Given TestToolsEndpoint',
+    (sessionBuilder, endpoints) {
+      test('when calling method with positional arg then echoes the value',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalArg(sessionBuilder, 'PositionalArg');
+        expect(result, 'PositionalArg');
+      });
 
-    test('when calling method with named arg then echoes the value', () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoNamedArg(sessionBuilder, string: 'NamedArg');
-      expect(result, 'NamedArg');
-    });
+      test('when calling method with named arg then echoes the value',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoNamedArg(sessionBuilder, string: 'NamedArg');
+        expect(result, 'NamedArg');
+      });
 
-    test(
-        'when calling method with a nullable named arg with value then echoes value',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoNullableNamedArg(sessionBuilder, string: 'NamedArg');
-      expect(result, 'NamedArg');
-    });
+      test(
+          'when calling method with a nullable named arg with value then echoes value',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoNullableNamedArg(sessionBuilder, string: 'NamedArg');
+        expect(result, 'NamedArg');
+      });
 
-    test(
-        'when calling method with a nullable named arg without passing value then echoes null',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoNullableNamedArg(sessionBuilder);
-      expect(result, isNull);
-    });
+      test(
+          'when calling method with a nullable named arg without passing value then echoes null',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoNullableNamedArg(sessionBuilder);
+        expect(result, isNull);
+      });
 
-    test('when calling method with optional arg then echoes the value',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoOptionalArg(sessionBuilder, 'OptionalArg');
-      expect(result, 'OptionalArg');
-    });
+      test('when calling method with optional arg then echoes the value',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoOptionalArg(sessionBuilder, 'OptionalArg');
+        expect(result, 'OptionalArg');
+      });
 
-    test('when calling method with optional arg without value then echoes null',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoOptionalArg(sessionBuilder);
-      expect(result, isNull);
-    });
+      test(
+          'when calling method with optional arg without value then echoes null',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoOptionalArg(sessionBuilder);
+        expect(result, isNull);
+      });
 
-    test('when calling method with positional and named args then echoes args',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalAndNamedArgs(
-        sessionBuilder,
-        'PositionalArg',
-        string2: 'NamedArg',
-      );
+      test(
+          'when calling method with positional and named args then echoes args',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalAndNamedArgs(
+          sessionBuilder,
+          'PositionalArg',
+          string2: 'NamedArg',
+        );
 
-      expect(result, ['PositionalArg', 'NamedArg']);
-    });
+        expect(result, ['PositionalArg', 'NamedArg']);
+      });
 
-    test(
-        'when calling method with positional and nullable named args with named arg then echoes args',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalAndNullableNamedArgs(
-        sessionBuilder,
-        'PositionalArg',
-        string2: 'NamedArg',
-      );
+      test(
+          'when calling method with positional and nullable named args with named arg then echoes args',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalAndNullableNamedArgs(
+          sessionBuilder,
+          'PositionalArg',
+          string2: 'NamedArg',
+        );
 
-      expect(result, ['PositionalArg', 'NamedArg']);
-    });
+        expect(result, ['PositionalArg', 'NamedArg']);
+      });
 
-    test(
-        'when calling method with positional and named args without passing named arg then echoes null',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalAndNullableNamedArgs(
-        sessionBuilder,
-        'PositionalArg',
-      );
+      test(
+          'when calling method with positional and named args without passing named arg then echoes null',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalAndNullableNamedArgs(
+          sessionBuilder,
+          'PositionalArg',
+        );
 
-      expect(result, ['PositionalArg', null]);
-    });
+        expect(result, ['PositionalArg', null]);
+      });
 
-    test(
-        'when calling method with positional and optional args then echoes both args',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalAndOptionalArgs(
-        sessionBuilder,
-        'PositionalArg',
-        'OptionalArg',
-      );
+      test(
+          'when calling method with positional and optional args then echoes both args',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalAndOptionalArgs(
+          sessionBuilder,
+          'PositionalArg',
+          'OptionalArg',
+        );
 
-      expect(result, ['PositionalArg', 'OptionalArg']);
-    });
+        expect(result, ['PositionalArg', 'OptionalArg']);
+      });
 
-    test(
-        'when calling method with positional and optional args without passing value then echoes null',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalAndOptionalArgs(
-        sessionBuilder,
-        'PositionalArg',
-      );
+      test(
+          'when calling method with positional and optional args without passing value then echoes null',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalAndOptionalArgs(
+          sessionBuilder,
+          'PositionalArg',
+        );
 
-      expect(result, ['PositionalArg', null]);
-    });
+        expect(result, ['PositionalArg', null]);
+      });
 
-    test('when calling method with named stream arg then echoes stream',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoNamedArgStream(
-            sessionBuilder,
-            strings: Stream.fromIterable(['NamedArg']),
-          )
-          .toList();
+      test('when calling method with named stream arg then echoes stream',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoNamedArgStream(
+              sessionBuilder,
+              strings: Stream.fromIterable(['NamedArg']),
+            )
+            .toList();
 
-      expect(result, ['NamedArg']);
-    });
+        expect(result, ['NamedArg']);
+      });
 
-    test('when calling method with named stream arg then echoes list future',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoNamedArgStreamAsFuture(
-        sessionBuilder,
-        strings: Stream.fromIterable(['NamedArg']),
-      );
+      test('when calling method with named stream arg then echoes list future',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoNamedArgStreamAsFuture(
+          sessionBuilder,
+          strings: Stream.fromIterable(['NamedArg']),
+        );
 
-      expect(result, 'NamedArg');
-    });
+        expect(result, 'NamedArg');
+      });
 
-    test('when calling method with positional stream arg then echoes stream',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalArgStream(
-            sessionBuilder,
-            Stream.fromIterable(['PositionalArg']),
-          )
-          .toList();
+      test('when calling method with positional stream arg then echoes stream',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalArgStream(
+              sessionBuilder,
+              Stream.fromIterable(['PositionalArg']),
+            )
+            .toList();
 
-      expect(result, ['PositionalArg']);
-    });
+        expect(result, ['PositionalArg']);
+      });
 
-    test('when calling method with named stream arg then echoes list future',
-        () async {
-      final result = await endpoints.methodSignaturePermutations
-          .echoPositionalArgStreamAsFuture(
-        sessionBuilder,
-        Stream.fromIterable(['NamedArg']),
-      );
+      test('when calling method with named stream arg then echoes list future',
+          () async {
+        final result = await endpoints.methodSignaturePermutations
+            .echoPositionalArgStreamAsFuture(
+          sessionBuilder,
+          Stream.fromIterable(['NamedArg']),
+        );
 
-      expect(result, 'NamedArg');
-    });
-  }, runMode: ServerpodRunMode.production);
+        expect(result, 'NamedArg');
+      });
+    },
+  );
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/protocol_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/protocol_test.dart
@@ -1,4 +1,3 @@
-import 'package:serverpod/serverpod.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';

--- a/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
@@ -74,6 +74,5 @@ void main() {
         await expectLater(stream.take(1), emitsInOrder([111]));
       });
     },
-    runMode: ServerpodRunMode.production,
   );
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
@@ -1,4 +1,3 @@
-import 'package:serverpod/serverpod.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';

--- a/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/rollback_database_test.dart
@@ -35,7 +35,6 @@ void main() {
         expect(result.length, 0);
       });
     },
-    runMode: ServerpodRunMode.production,
   );
 
   group('Given rollbackDatabase set to afterEach', () {
@@ -70,7 +69,6 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.afterEach,
-        runMode: ServerpodRunMode.production,
       );
 
       withServerpod(
@@ -85,7 +83,6 @@ void main() {
             expect(result.length, 0);
           });
         },
-        runMode: ServerpodRunMode.production,
       );
     });
 
@@ -122,19 +119,21 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.afterEach,
-        runMode: ServerpodRunMode.production,
       );
 
-      withServerpod('', (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+      withServerpod(
+        '',
+        (sessionBuilder, endpoints) {
+          var session = sessionBuilder.build();
 
-        test('then the database is rolled back after the first withServerpod',
-            () async {
-          final result = await SimpleData.db.find(session);
+          test('then the database is rolled back after the first withServerpod',
+              () async {
+            final result = await SimpleData.db.find(session);
 
-          expect(result.length, 0);
-        });
-      }, runMode: ServerpodRunMode.production);
+            expect(result.length, 0);
+          });
+        },
+      );
     });
 
     withServerpod(
@@ -176,7 +175,6 @@ void main() {
         });
       },
       rollbackDatabase: RollbackDatabase.afterEach,
-      runMode: ServerpodRunMode.production,
     );
   });
 
@@ -213,7 +211,6 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.afterAll,
-        runMode: ServerpodRunMode.production,
       );
 
       withServerpod(
@@ -227,7 +224,6 @@ void main() {
             expect(result.length, 0);
           });
         },
-        runMode: ServerpodRunMode.production,
       );
     });
 
@@ -265,19 +261,21 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.afterAll,
-        runMode: ServerpodRunMode.production,
       );
 
-      withServerpod('', (sessionBuilder, endpoints) {
-        var session = sessionBuilder.build();
+      withServerpod(
+        '',
+        (sessionBuilder, endpoints) {
+          var session = sessionBuilder.build();
 
-        test('then the database is rolled back after the first withServerpod',
-            () async {
-          final result = await SimpleData.db.find(session);
+          test('then the database is rolled back after the first withServerpod',
+              () async {
+            final result = await SimpleData.db.find(session);
 
-          expect(result.length, 0);
-        });
-      }, runMode: ServerpodRunMode.production);
+            expect(result.length, 0);
+          });
+        },
+      );
     });
 
     group(
@@ -303,7 +301,6 @@ void main() {
           });
         },
         rollbackDatabase: RollbackDatabase.afterAll,
-        runMode: ServerpodRunMode.production,
       );
 
       withServerpod(
@@ -318,7 +315,6 @@ void main() {
             expect(result.length, 0);
           });
         },
-        runMode: ServerpodRunMode.production,
       );
     });
   });
@@ -344,7 +340,6 @@ void main() {
         });
       },
       rollbackDatabase: RollbackDatabase.disabled,
-      runMode: ServerpodRunMode.production,
     );
 
     withServerpod(
@@ -368,7 +363,6 @@ void main() {
         });
       },
       rollbackDatabase: RollbackDatabase.disabled,
-      runMode: ServerpodRunMode.production,
     );
   });
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
@@ -63,6 +63,5 @@ void main() {
         });
       });
     },
-    runMode: ServerpodRunMode.production,
   );
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_copy_with_test.dart
@@ -1,4 +1,3 @@
-import 'package:serverpod/serverpod.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';

--- a/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
@@ -4,62 +4,68 @@ import 'package:test/test.dart';
 import 'serverpod_test_tools.dart';
 
 void main() {
-  withServerpod('Given calling endpoint returning Future',
-      (sessionBuilder, endpoints) {
-    group('when using the same session between two calls', () {
-      late UuidValue sessionId1;
-      late UuidValue sessionId2;
+  withServerpod(
+    'Given calling endpoint returning Future',
+    (sessionBuilder, endpoints) {
+      group('when using the same session between two calls', () {
+        late UuidValue sessionId1;
+        late UuidValue sessionId2;
 
-      setUp(() async {
-        sessionId1 = await endpoints.testTools.returnsSessionId(sessionBuilder);
-        sessionId2 = await endpoints.testTools.returnsSessionId(sessionBuilder);
+        setUp(() async {
+          sessionId1 =
+              await endpoints.testTools.returnsSessionId(sessionBuilder);
+          sessionId2 =
+              await endpoints.testTools.returnsSessionId(sessionBuilder);
+        });
+
+        test('then session id is unique in each endpoint call', () async {
+          expect(sessionId1, isNot(sessionId2));
+        });
       });
 
-      test('then session id is unique in each endpoint call', () async {
-        expect(sessionId1, isNot(sessionId2));
+      test(
+          "when method is returning the session's `endpoint` and `method` properties then the correct name and method is returned",
+          () async {
+        var [endpoint, method] = await endpoints.testTools
+            .returnsSessionEndpointAndMethod(sessionBuilder);
+        expect(endpoint, 'testTools');
+        expect(method, 'returnsSessionEndpointAndMethod');
       });
-    });
+    },
+  );
 
-    test(
-        "when method is returning the session's `endpoint` and `method` properties then the correct name and method is returned",
-        () async {
-      var [endpoint, method] = await endpoints.testTools
-          .returnsSessionEndpointAndMethod(sessionBuilder);
-      expect(endpoint, 'testTools');
-      expect(method, 'returnsSessionEndpointAndMethod');
-    });
-  }, runMode: ServerpodRunMode.production);
+  withServerpod(
+    'Given calling endpoint returning Stream',
+    (sessionBuilder, endpoints) {
+      group('when using the same session between two calls', () {
+        late Stream<UuidValue> sessionId1Stream;
+        late Stream<UuidValue> sessionId2Stream;
 
-  withServerpod('Given calling endpoint returning Stream',
-      (sessionBuilder, endpoints) {
-    group('when using the same session between two calls', () {
-      late Stream<UuidValue> sessionId1Stream;
-      late Stream<UuidValue> sessionId2Stream;
+        setUp(() async {
+          sessionId1Stream = await endpoints.testTools
+              .returnsSessionIdFromStream(sessionBuilder);
+          sessionId2Stream = await endpoints.testTools
+              .returnsSessionIdFromStream(sessionBuilder);
+        });
 
-      setUp(() async {
-        sessionId1Stream = await endpoints.testTools
-            .returnsSessionIdFromStream(sessionBuilder);
-        sessionId2Stream = await endpoints.testTools
-            .returnsSessionIdFromStream(sessionBuilder);
+        test('then session id is unique in each endpoint call', () async {
+          var sessionId1 = await sessionId1Stream.first;
+          var sessionId2 = await sessionId2Stream.first;
+          expect(sessionId1, isNot(sessionId2));
+        });
       });
 
-      test('then session id is unique in each endpoint call', () async {
-        var sessionId1 = await sessionId1Stream.first;
-        var sessionId2 = await sessionId2Stream.first;
-        expect(sessionId1, isNot(sessionId2));
+      test(
+          "when method is returning the session's `endpoint` and `method` properties then the correct name and method is returned",
+          () async {
+        var [endpoint, method] = await endpoints.testTools
+            .returnsSessionEndpointAndMethodFromStream(sessionBuilder)
+            .take(2)
+            .toList();
+
+        expect(endpoint, 'testTools');
+        expect(method, 'returnsSessionEndpointAndMethodFromStream');
       });
-    });
-
-    test(
-        "when method is returning the session's `endpoint` and `method` properties then the correct name and method is returned",
-        () async {
-      var [endpoint, method] = await endpoints.testTools
-          .returnsSessionEndpointAndMethodFromStream(sessionBuilder)
-          .take(2)
-          .toList();
-
-      expect(endpoint, 'testTools');
-      expect(method, 'returnsSessionEndpointAndMethodFromStream');
-    });
-  }, runMode: ServerpodRunMode.production);
+    },
+  );
 }

--- a/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       test(
           'when next test is run '
-          'then should still work', () async {
+          'then database operations should still work', () async {
         await SimpleData.db.insertRow(session, SimpleData(num: 1));
 
         expect(await SimpleData.db.find(session), hasLength(1));

--- a/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -19,6 +19,11 @@ void main() {
           await UniqueData.db.insertRow(session, data);
         });
 
+        // Even though this exception is caught in this test, due to how transactions work
+        // the exception will be re-thrown when the top level test transaction is canceled.
+        // If the top level transaction error is not caught this test will fail.
+        // Therefore, this test validates that the exception is caught on the top level
+        // and does not fail the dart test runner.
         await expectLater(future, throwsA(isA<DatabaseException>()));
       });
 

--- a/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -1,0 +1,35 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+import 'serverpod_test_tools.dart';
+
+void main() {
+  withServerpod(
+    'Given transaction call in test',
+    (sessionBuilder, endpoints) {
+      var session = sessionBuilder.build();
+
+      test(
+          'when database exception occurs '
+          'then should close transaction after test suite and should not fail `dart test` by leaking exceptions',
+          () async {
+        var future = session.db.transaction((tx) async {
+          var data = UniqueData(number: 1, email: 'test@test.com');
+          await UniqueData.db.insertRow(session, data);
+          await UniqueData.db.insertRow(session, data);
+        });
+
+        await expectLater(future, throwsA(isA<DatabaseException>()));
+      });
+
+      test(
+          'when next test is run '
+          'then should still work', () async {
+        await SimpleData.db.insertRow(session, SimpleData(num: 1));
+
+        expect(await SimpleData.db.find(session), hasLength(1));
+      });
+    },
+  );
+}

--- a/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/transaction_correctness_test.dart
@@ -12,8 +12,7 @@ void main() {
 
       test(
           'when database exception occurs '
-          'then should close transaction after test suite and should not fail `dart test` by leaking exceptions',
-          () async {
+          'then should not fail `dart test` by leaking exceptions', () async {
         var future = session.db.transaction((tx) async {
           var data = UniqueData(number: 1, email: 'test@test.com');
           await UniqueData.db.insertRow(session, data);
@@ -32,4 +31,54 @@ void main() {
       });
     },
   );
+
+  group('Demontrate transaction difference between prod and test tools', () {
+    withServerpod(
+      'Given transaction call in test with database rollbacks enabled (default)',
+      (sessionBuilder, endpoints) {
+        var session = sessionBuilder.build();
+        test(
+            'when database exception occurs '
+            'then transaction WILL NOT throw exception if it was caught in the transaction',
+            () async {
+          var future = session.db.transaction((tx) async {
+            var data = UniqueData(number: 1, email: 'test@test.com');
+            try {
+              await UniqueData.db.insertRow(session, data);
+              await UniqueData.db.insertRow(session, data);
+            } catch (_) {}
+          });
+
+          // ATTENTION: This does not throw in test tools when rollbacks are enabled,
+          // but does throw in production environment where rollbacks are disabled!
+          await expectLater(future, completes);
+        });
+      },
+    );
+
+    withServerpod(
+      'Given transaction call in test with database rollbacks disabled',
+      (sessionBuilder, endpoints) {
+        var session = sessionBuilder.build();
+
+        test(
+            'when database exception occurs '
+            'then transaction WILL throw exception even if it was caught in the transaction',
+            () async {
+          var future = session.db.transaction((tx) async {
+            var data = UniqueData(number: 1, email: 'test@test.com');
+            try {
+              await UniqueData.db.insertRow(session, data, transaction: tx);
+              await UniqueData.db.insertRow(session, data, transaction: tx);
+            } catch (_) {}
+          });
+
+          // ATTENTION: This does not throw in test tools when rollbacks are enabled,
+          // but does throw in production environment where rollbacks are disabled!
+          await expectLater(future, throwsA(isA<Exception>()));
+        });
+      },
+      rollbackDatabase: RollbackDatabase.disabled,
+    );
+  });
 }


### PR DESCRIPTION
## Description
As explained in detail in this issue: #2850 , database exceptions are re-thrown if a transaction is allowed to complete when a database exception has occurred. This PR ensures those errors are caught when the top level test transaction completes.

We should also create a small caveat in the test docs about this. Currently the following code will throw in production code, but will complete successfully in test code:
```dart
session.db.transaction((tx) async {
  var data = UniqueData(number: 1, email: 'test@test.com');
  try {
    await UniqueData.db.insertRow(session, data);
    await UniqueData.db.insertRow(session, data);
  } catch (_) {
    // Ignore duplicate key exception from DB
  }
});
```
While this is a theoretical inconsistency, it should very rarely (if ever) be a problem because this type of code does not make sense and should be considered an anti-pattern. The transaction is aborted when errors happen, so no more operations can be performed anyway.

## Changes
- Adds `catchError` to the top level test transaction [4abee2ac7531924c80acaf6df151a674c646a4ae]
- Adds a test config for `serverpod_test_server` to avoid having to pass a production run mode to the `withServerpod` helper [a05fe24]

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.