### PR TITLE
fix: Guard against duplicated fieldNames within hierarchy

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -512,7 +512,7 @@ class Restrictions {
             parentClassWithDuplicatedFieldName != null) {
           return [
             SourceSpanSeverityException(
-              'Duplicated field definition. Field with name "$fieldName" already exists in inherited class "${parentClassWithDuplicatedFieldName.className}".',
+              'The field name "$fieldName" is already defined in an inherited class ("${parentClassWithDuplicatedFieldName.className}").',
               span,
             )
           ];
@@ -1431,8 +1431,8 @@ class Restrictions {
         .classDefinition;
   }
 
-  /// Traverses up the class hierarchy from [currentModel], applying [findFunction] to each parent.
-  /// Returns the first non-null result from [findFunction], or `null` if no match is found.
+  /// Traverses up the class hierarchy from [currentModel], applying [predicate] to each parent.
+  /// Returns the first non-null result from [predicate], or `null` if no match is found.
   ///
   /// ```dart
   /// var serverOnlyAncestor = _findInHierarchy(
@@ -1440,14 +1440,14 @@ class Restrictions {
   ///  (ClassDefinition ancestor) => ancestor.serverOnly ? ancestor : null,
   /// );
   /// ```
-  T? _findInHierarchy<T>(
+  T? _findInParentHierarchy<T>(
     ClassDefinition currentModel,
-    T? Function(ClassDefinition) findFunction,
+    T? Function(ClassDefinition) predicate,
   ) {
     var parentModel = _getParentClass(currentModel);
 
     while (parentModel != null) {
-      var result = findFunction(parentModel);
+      var result = predicate(parentModel);
       if (result != null) return result;
 
       parentModel = _getParentClass(parentModel);
@@ -1459,7 +1459,7 @@ class Restrictions {
   ClassDefinition? _findTableClassInParentClasses(
     ClassDefinition currentModel,
   ) {
-    return _findInHierarchy(
+    return _findInParentHierarchy(
       currentModel,
       (ClassDefinition ancestor) =>
           ancestor.tableName != null ? ancestor : null,
@@ -1469,7 +1469,7 @@ class Restrictions {
   ClassDefinition? _findServerOnlyClassInParentClasses(
     ClassDefinition currentModel,
   ) {
-    return _findInHierarchy(
+    return _findInParentHierarchy(
       currentModel,
       (ClassDefinition ancestor) => ancestor.serverOnly ? ancestor : null,
     );
@@ -1479,7 +1479,7 @@ class Restrictions {
     ClassDefinition currentModel,
     String fieldName,
   ) {
-    return _findInHierarchy(
+    return _findInParentHierarchy(
       currentModel,
       (ClassDefinition ancestor) {
         var parentFieldNames = ancestor.fields.map((field) => field.name);
@@ -1497,7 +1497,7 @@ class Restrictions {
     ClassDefinition currentModel,
     String fieldName,
   ) {
-    return _findInHierarchy(
+    return _findInParentHierarchy(
       currentModel,
       (ClassDefinition ancestor) {
         return ancestor.fields

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
@@ -247,7 +247,7 @@ void main() {
       var error = collector.errors.first;
       expect(
         error.message,
-        'You cannot declare "ExampleChildClass" with field: "name" as it is already declared in "Example".',
+        'Duplicated field definition. Field with name "name" already exists in inherited class "Example".',
       );
     });
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
@@ -247,7 +247,7 @@ void main() {
       var error = collector.errors.first;
       expect(
         error.message,
-        'Duplicated field definition. Field with name "name" already exists in inherited class "Example".',
+        'The field name "name" is already defined in an inherited class ("Example").',
       );
     });
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
@@ -212,91 +212,129 @@ void main() {
         'The "table" property is not allowed because another class, "Example", in the class hierarchy already has one defined. Only one table definition is allowed when using inheritance.',
       );
     });
-  });
 
-  test(
-      'Given a child-class, When the parent-class is serverOnly but the child-class is not, then error is collected that a client class cannot extend a serverOnly class',
-      () {
-    var modelSources = [
-      ModelSourceBuilder().withYaml(
-        '''
+    test(
+        'Given a child-class, when a field name already exists within the hierarchy, then an error is collected that child-class cannot be declared with this field.',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('example2').withYaml(
+          '''
+          class: ExampleChildClass
+          extends: Example
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'You cannot declare "ExampleChildClass" with field: "name" as it is already declared in "Example".',
+      );
+    });
+
+    test(
+        'Given a child-class, When the parent-class is serverOnly but the child-class is not, then error is collected that a client class cannot extend a serverOnly class',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
           class: Example
           serverOnly: true
           fields:
             name: String
           ''',
-      ).build(),
-      ModelSourceBuilder().withFileName('example2').withYaml(
-        '''
+        ).build(),
+        ModelSourceBuilder().withFileName('example2').withYaml(
+          '''
           class: ExampleChildClass
           extends: Example
           fields:
             age: int
           ''',
-      ).build(),
-    ];
+        ).build(),
+      ];
 
-    var collector = CodeGenerationCollector();
-    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
-        .validateAll();
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
 
-    expect(
-      collector.errors,
-      isNotEmpty,
-      reason: 'Expected an error but none was generated.',
-    );
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
 
-    var error = collector.errors.first;
-    expect(
-      error.message,
-      'Cannot extend a "serverOnly" class in the inheritance chain ("Example") unless class is marked as "serverOnly".',
-    );
-  });
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'Cannot extend a "serverOnly" class in the inheritance chain ("Example") unless class is marked as "serverOnly".',
+      );
+    });
 
-  test(
-      'Given a serverOnly child-class, When the parent-class is not serverOnly but the grandparent-class is, then error is collected that a client class cannot extend a serverOnly class',
-      () {
-    var modelSources = [
-      ModelSourceBuilder().withYaml(
-        '''
+    test(
+        'Given a serverOnly child-class, When the parent-class is not serverOnly but the grandparent-class is, then error is collected that a client class cannot extend a serverOnly class',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
           class: ExampleGrandparentClass
           serverOnly: true
           fields:
             name: String
           ''',
-      ).build(),
-      ModelSourceBuilder().withFileName('example1').withYaml(
-        '''
+        ).build(),
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
           class: Example
           extends: ExampleGrandparentClass
           fields:
             name: String
           ''',
-      ).build(),
-      ModelSourceBuilder().withFileName('example2').withYaml(
-        '''
+        ).build(),
+        ModelSourceBuilder().withFileName('example2').withYaml(
+          '''
           class: ExampleChildClass
           extends: Example
           fields:
             age: int
           ''',
-      ).build(),
-    ];
+        ).build(),
+      ];
 
-    var collector = CodeGenerationCollector();
-    StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
-        .validateAll();
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
 
-    expect(
-      collector.errors,
-      isNotEmpty,
-      reason: 'Expected an error but none was generated.',
-    );
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
 
-    var error = collector.errors.first;
-    expect(
-      error.message,
-      'Cannot extend a "serverOnly" class in the inheritance chain ("ExampleGrandparentClass") unless class is marked as "serverOnly".',
-    );
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'Cannot extend a "serverOnly" class in the inheritance chain ("ExampleGrandparentClass") unless class is marked as "serverOnly".',
+      );
+    });
   });
 }


### PR DESCRIPTION
This PR adds a restriction to `validateFieldName` making sure that field names are not duplicated across the hierarchy.

![Selection_007](https://github.com/user-attachments/assets/6a0ec452-bd3c-40fd-a037-f3783eb1538e)


Furthermore a test was added to `inheritance_test.dart` testing the above mentioned restriction.

Lastly I did a little cleanup, by extracting the logic traversing up the hierarchy into a separate method `_findInParentHierarchy` that is used in the individual methods to search the hierarchy
- `_findTableClassInParentClasses`
- `_findServerOnlyClassInParentClasses`
- `_findAncestorWithDuplicatedFieldName`
-  `_findFieldWithDuplicatedName`

linked to: #1873  and #1618 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

no breaking changes