### PR TITLE
fix: Handle method and endpoint streams for modules

### DIFF
--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -89,6 +89,7 @@ abstract class EndpointDispatch {
       arguments: parsedArguments,
       inputStreams: inputStreams,
       endpoint: endpoint,
+      fullEndpointPath: endpointPath,
     );
   }
 
@@ -333,6 +334,9 @@ class MethodStreamCallContext {
   /// The endpoint the method is called on.
   final Endpoint endpoint;
 
+  /// The full path to the endpoint, including module.
+  final String fullEndpointPath;
+
   /// The input streams to pass to the method.
   final List<StreamParameterDescription> inputStreams;
 
@@ -342,6 +346,7 @@ class MethodStreamCallContext {
     required this.arguments,
     required this.inputStreams,
     required this.endpoint,
+    required this.fullEndpointPath,
   });
 }
 

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/endpoint_websocket_request_handler.dart
@@ -35,7 +35,7 @@ abstract class EndpointWebsocketRequestHandler {
       for (var module in endpointDispatch.modules.values) {
         for (var endpointConnector in module.connectors.values) {
           await _callStreamOpened(
-              session, endpointConnector.endpoint.name, endpointDispatch);
+              session, endpointConnector.endpoint.name, module);
         }
       }
 
@@ -126,7 +126,7 @@ abstract class EndpointWebsocketRequestHandler {
       for (var module in server.endpoints.modules.values) {
         for (var endpointConnector in module.connectors.values) {
           await _callStreamClosed(
-              session, endpointConnector.endpoint.name, endpointDispatch);
+              session, endpointConnector.endpoint.name, module);
         }
       }
       await session.close(error: error, stackTrace: stackTrace);

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
@@ -322,7 +322,7 @@ class MethodStreamManager {
       methodStreamCallContext.endpoint,
       session,
       onRevokedAuthentication: () => closeStream(
-        endpoint: methodStreamCallContext.endpoint.name,
+        endpoint: methodStreamCallContext.fullEndpointPath,
         method: methodStreamCallContext.method.name,
         methodStreamId: methodStreamId,
         reason: CloseReason.error,
@@ -352,7 +352,7 @@ class MethodStreamManager {
             methodStreamId, e, s, methodStreamCallContext);
 
         var streamKey = _buildStreamKey(
-          endpoint: methodStreamCallContext.endpoint.name,
+          endpoint: methodStreamCallContext.fullEndpointPath,
           method: methodStreamCallContext.method.name,
           methodStreamId: methodStreamId,
         );
@@ -371,7 +371,7 @@ class MethodStreamManager {
     var outputStreamContext =
         _OutputStreamContext(outputController, subscription);
     _outputStreamContexts[_buildStreamKey(
-      endpoint: methodStreamCallContext.endpoint.name,
+      endpoint: methodStreamCallContext.fullEndpointPath,
       method: methodStreamCallContext.method.name,
       methodStreamId: methodStreamId,
     )] = outputStreamContext;
@@ -430,7 +430,7 @@ class MethodStreamManager {
       var parameterName = streamParam.name;
       var controller = StreamController(onCancel: () async {
         var context = _inputStreamContexts.remove(_buildStreamKey(
-          endpoint: callContext.endpoint.name,
+          endpoint: callContext.fullEndpointPath,
           method: callContext.method.name,
           parameter: parameterName,
           methodStreamId: methodStreamId,
@@ -450,7 +450,7 @@ class MethodStreamManager {
 
       inputStreams[parameterName] = controller;
       _inputStreamContexts[_buildStreamKey(
-        endpoint: callContext.endpoint.name,
+        endpoint: callContext.fullEndpointPath,
         method: callContext.method.name,
         parameter: parameterName,
         methodStreamId: methodStreamId,
@@ -468,7 +468,7 @@ class MethodStreamManager {
     required UuidValue methodStreamId,
   }) async {
     var streamKey = _buildStreamKey(
-      endpoint: methodStreamCallContext.endpoint.name,
+      endpoint: methodStreamCallContext.fullEndpointPath,
       method: methodStreamCallContext.method.name,
       methodStreamId: methodStreamId,
     );
@@ -493,7 +493,7 @@ class MethodStreamManager {
       MethodStreamCallContext callContext, UuidValue methodStreamId) async {
     var context = _outputStreamContexts.remove(
       _buildStreamKey(
-        endpoint: callContext.endpoint.name,
+        endpoint: callContext.fullEndpointPath,
         method: callContext.method.name,
         methodStreamId: methodStreamId,
       ),
@@ -507,7 +507,7 @@ class MethodStreamManager {
     var inputStreamControllers = <StreamController>[];
     for (var streamParam in callContext.inputStreams) {
       var paramStreamContext = _inputStreamContexts.remove(_buildStreamKey(
-        endpoint: callContext.endpoint.name,
+        endpoint: callContext.fullEndpointPath,
         method: callContext.method.name,
         parameter: streamParam.name,
         methodStreamId: methodStreamId,
@@ -550,7 +550,7 @@ class MethodStreamManager {
         .whenComplete(
       () async {
         var streamKey = _buildStreamKey(
-          endpoint: methodStreamCallContext.endpoint.name,
+          endpoint: methodStreamCallContext.fullEndpointPath,
           method: methodStreamCallContext.method.name,
           methodStreamId: methodStreamId,
         );

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -39,14 +39,22 @@ class MethodWebsocketRequestHandler {
           case OpenMethodStreamCommand():
             webSocket.tryAdd(
               await _handleOpenMethodStreamCommand(
-                  server, webSocket, message, methodStreamManager),
+                server,
+                webSocket,
+                message,
+                methodStreamManager,
+              ),
             );
             break;
           case OpenMethodStreamResponse():
             break;
           case MethodStreamMessage():
             _dispatchMethodStreamMessage(
-                message, webSocket, server, methodStreamManager);
+              message,
+              webSocket,
+              server,
+              methodStreamManager,
+            );
             break;
           case CloseMethodStreamCommand():
             await methodStreamManager.closeStream(
@@ -106,7 +114,7 @@ class MethodWebsocketRequestHandler {
       ) {
         webSocket.tryAdd(
           CloseMethodStreamCommand.buildMessage(
-            endpoint: callContext.endpoint.name,
+            endpoint: callContext.fullEndpointPath,
             method: callContext.method.name,
             parameter: parameterName,
             connectionId: methodStreamId,
@@ -121,7 +129,7 @@ class MethodWebsocketRequestHandler {
       ) {
         webSocket.tryAdd(
           CloseMethodStreamCommand.buildMessage(
-            endpoint: callContext.endpoint.name,
+            endpoint: callContext.fullEndpointPath,
             method: callContext.method.name,
             connectionId: methodStreamId,
             reason: closeReason ?? CloseReason.done,
@@ -137,7 +145,7 @@ class MethodWebsocketRequestHandler {
         if (error is SerializableException) {
           webSocket.tryAdd(
             MethodStreamSerializableException.buildMessage(
-              endpoint: callContext.endpoint.name,
+              endpoint: callContext.fullEndpointPath,
               method: callContext.method.name,
               connectionId: methodStreamId,
               object: error,
@@ -152,7 +160,7 @@ class MethodWebsocketRequestHandler {
         MethodStreamCallContext callContext,
       ) {
         webSocket.tryAdd(MethodStreamMessage.buildMessage(
-          endpoint: callContext.endpoint.name,
+          endpoint: callContext.fullEndpointPath,
           method: callContext.method.name,
           connectionId: methodStreamId,
           object: value,

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/client.dart
@@ -41,6 +41,26 @@ class EndpointStreaming extends _i1.EndpointRef {
 
   @override
   String get name => 'serverpod_test_module.streaming';
+
+  _i2.Future<bool> wasStreamOpenCalled() => caller.callServerEndpoint<bool>(
+        'serverpod_test_module.streaming',
+        'wasStreamOpenCalled',
+        {},
+      );
+
+  _i2.Future<bool> wasStreamClosedCalled() => caller.callServerEndpoint<bool>(
+        'serverpod_test_module.streaming',
+        'wasStreamClosedCalled',
+        {},
+      );
+
+  _i2.Stream<int> intEchoStream(_i2.Stream<int> stream) =>
+      caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
+        'serverpod_test_module.streaming',
+        'intEchoStream',
+        {},
+        {'stream': stream},
+      );
 }
 
 class Caller extends _i1.ModuleEndpointCaller {

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
@@ -43,4 +43,10 @@ class StreamingEndpoint extends Endpoint {
       await sendStreamMessage(session, message);
     }));
   }
+
+  Stream<int> intEchoStream(Session session, Stream<int> stream) async* {
+    await for (var value in stream) {
+      yield value;
+    }
+  }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
@@ -7,16 +7,40 @@ import '../generated/protocol.dart';
 int globalInt = 0;
 
 class StreamingEndpoint extends Endpoint {
+  bool streamOpenedWasCalled = false;
+  bool streamClosedWasCalled = false;
+
   @override
-  Future<void> streamOpened(StreamingSession session) async {}
+  Future<void> streamOpened(StreamingSession session) async {
+    streamClosedWasCalled = false;
+    streamOpenedWasCalled = true;
+  }
+
+  Future<bool> wasStreamOpenCalled(Session session) async {
+    return streamOpenedWasCalled;
+  }
+
+  @override
+  Future<void> streamClosed(StreamingSession session) async {
+    streamOpenedWasCalled = false;
+    streamClosedWasCalled = true;
+  }
+
+  Future<bool> wasStreamClosedCalled(Session session) async {
+    return streamClosedWasCalled;
+  }
 
   @override
   Future<void> handleStreamMessage(
-      StreamingSession session, SerializableModel message) async {
-    if (message is ModuleClass) {
-      unawaited(Future.delayed(const Duration(seconds: 1)).then((value) async {
-        await sendStreamMessage(session, message);
-      }));
+    StreamingSession session,
+    SerializableModel message,
+  ) async {
+    if (message is! ModuleClass) {
+      return;
     }
+
+    unawaited(Future.delayed(const Duration(seconds: 1)).then((value) async {
+      await sendStreamMessage(session, message);
+    }));
   }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
@@ -12,7 +12,6 @@ class StreamingEndpoint extends Endpoint {
 
   @override
   Future<void> streamOpened(StreamingSession session) async {
-    streamClosedWasCalled = false;
     streamOpenedWasCalled = true;
   }
 
@@ -22,7 +21,6 @@ class StreamingEndpoint extends Endpoint {
 
   @override
   Future<void> streamClosed(StreamingSession session) async {
-    streamOpenedWasCalled = false;
     streamClosedWasCalled = true;
   }
 

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
@@ -77,7 +77,48 @@ class Endpoints extends _i1.EndpointDispatch {
     connectors['streaming'] = _i1.EndpointConnector(
       name: 'streaming',
       endpoint: endpoints['streaming']!,
-      methodConnectors: {},
+      methodConnectors: {
+        'wasStreamOpenCalled': _i1.MethodConnector(
+          name: 'wasStreamOpenCalled',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['streaming'] as _i3.StreamingEndpoint)
+                  .wasStreamOpenCalled(session),
+        ),
+        'wasStreamClosedCalled': _i1.MethodConnector(
+          name: 'wasStreamClosedCalled',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['streaming'] as _i3.StreamingEndpoint)
+                  .wasStreamClosedCalled(session),
+        ),
+        'intEchoStream': _i1.MethodStreamConnector(
+          name: 'intEchoStream',
+          params: {},
+          streamParams: {
+            'stream': _i1.StreamParameterDescription<int>(
+              name: 'stream',
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['streaming'] as _i3.StreamingEndpoint).intEchoStream(
+            session,
+            streamParams['stream']!.cast<int>(),
+          ),
+        ),
+      },
     );
   }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.yaml
@@ -2,3 +2,6 @@ module:
   - hello:
   - modifyModuleObject:
 streaming:
+  - wasStreamOpenCalled:
+  - wasStreamClosedCalled:
+  - intEchoStream:

--- a/tests/serverpod_test_server/test_e2e/module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/module_test.dart
@@ -9,18 +9,24 @@ import 'package:test/test.dart';
 void main() {
   var client = Client(serverUrl);
 
-  group('Modules', () {
-    test('Serialization', () async {
+  group('Given a module', () {
+    test(
+        'when calling a non-module endpoint that uses a module object '
+        'then should return true to indicate nothing went wrong', () async {
       var success = await client.moduleSerialization.serializeModuleObject();
       expect(success, equals(true));
     });
 
-    test('Module call', () async {
+    test(
+        'when calling endpoint method hello'
+        'then returns greeting', () async {
       var result = await client.modules.module.module.hello('World');
       expect(result, equals('Hello World'));
     });
 
-    test('Passing module object', () async {
+    test(
+        'when calling a non-module endpoint that modifies a module object '
+        'then should return modified object', () async {
       var moduleClass = module.ModuleClass(
         name: 'foo',
         data: 0,
@@ -30,7 +36,9 @@ void main() {
       expect(result.data, equals(42));
     });
 
-    test('Passing module object to module', () async {
+    test(
+        'when calling endpoint method that modifies object '
+        'then returns modified object', () async {
       var moduleClass = module.ModuleClass(
         name: 'foo',
         data: 0,
@@ -82,6 +90,25 @@ void main() {
             client.modules.module.streaming.wasStreamClosedCalled(),
             completion(isTrue));
       });
+    });
+
+    test(
+        'when calling stream-returning method that takes stream as a parameter '
+        'then should return a stream', () async {
+      var streamComplete = Completer();
+      var numberGenerator = List.generate(10, (index) => index++);
+      var inputStream = Stream<int>.fromIterable(numberGenerator);
+      var stream = client.modules.module.streaming.intEchoStream(inputStream);
+
+      var received = <int>[];
+      stream.listen((event) {
+        received.add(event);
+      }, onDone: () {
+        streamComplete.complete();
+      }, cancelOnError: true);
+
+      await streamComplete.future;
+      expect(received, numberGenerator);
     });
   });
 


### PR DESCRIPTION
## Description
Closes #2856.

This PR fixes two bugs 👇 
- Endpoint methods (as reported in the issue): Introduced in `2.1.1`, a typo slipped into [this refactor](https://github.com/serverpod/serverpod/commit/dd1258ca2bd91b534295f92e09de09b68b5800c7#diff-f2dab80fac9835e43d45b78a8fe2a5289e765c1f592ad611304d34ef27742f04L262) and module were not correctly scanned to do the `streamOpened` call
- Streaming methods: Introduced in `2.1.1` by [this PR](https://github.com/serverpod/serverpod/pull/2763/files#diff-f2dab80fac9835e43d45b78a8fe2a5289e765c1f592ad611304d34ef27742f04) that refactored the stream method manager. Only the endpoint name was stored in the server's stream lookup map, but the client was correctly sending the full endpoint paths (including module name) in its messages which caused the the messages to not reach their endpoints and result in errors instead.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._