### PR TITLE
fix: Change repository class arg type back to `Session`

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -189,7 +191,7 @@ class ChannelRepository {
   const ChannelRepository._();
 
   Future<List<Channel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChannelTable>? where,
     int? limit,
     int? offset,
@@ -210,7 +212,7 @@ class ChannelRepository {
   }
 
   Future<Channel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChannelTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChannelTable>? orderBy,
@@ -229,7 +231,7 @@ class ChannelRepository {
   }
 
   Future<Channel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -240,7 +242,7 @@ class ChannelRepository {
   }
 
   Future<List<Channel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Channel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -251,7 +253,7 @@ class ChannelRepository {
   }
 
   Future<Channel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Channel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -262,7 +264,7 @@ class ChannelRepository {
   }
 
   Future<List<Channel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Channel> rows, {
     _i1.ColumnSelections<ChannelTable>? columns,
     _i1.Transaction? transaction,
@@ -275,7 +277,7 @@ class ChannelRepository {
   }
 
   Future<Channel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Channel row, {
     _i1.ColumnSelections<ChannelTable>? columns,
     _i1.Transaction? transaction,
@@ -288,7 +290,7 @@ class ChannelRepository {
   }
 
   Future<List<Channel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Channel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class ChannelRepository {
   }
 
   Future<Channel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Channel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -310,7 +312,7 @@ class ChannelRepository {
   }
 
   Future<List<Channel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ChannelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -321,7 +323,7 @@ class ChannelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChannelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -248,7 +250,7 @@ class AuthKeyRepository {
   const AuthKeyRepository._();
 
   Future<List<AuthKey>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<AuthKeyTable>? where,
     int? limit,
     int? offset,
@@ -269,7 +271,7 @@ class AuthKeyRepository {
   }
 
   Future<AuthKey?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<AuthKeyTable>? where,
     int? offset,
     _i1.OrderByBuilder<AuthKeyTable>? orderBy,
@@ -288,7 +290,7 @@ class AuthKeyRepository {
   }
 
   Future<AuthKey?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class AuthKeyRepository {
   }
 
   Future<List<AuthKey>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<AuthKey> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -310,7 +312,7 @@ class AuthKeyRepository {
   }
 
   Future<AuthKey> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     AuthKey row, {
     _i1.Transaction? transaction,
   }) async {
@@ -321,7 +323,7 @@ class AuthKeyRepository {
   }
 
   Future<List<AuthKey>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<AuthKey> rows, {
     _i1.ColumnSelections<AuthKeyTable>? columns,
     _i1.Transaction? transaction,
@@ -334,7 +336,7 @@ class AuthKeyRepository {
   }
 
   Future<AuthKey> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     AuthKey row, {
     _i1.ColumnSelections<AuthKeyTable>? columns,
     _i1.Transaction? transaction,
@@ -347,7 +349,7 @@ class AuthKeyRepository {
   }
 
   Future<List<AuthKey>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<AuthKey> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -358,7 +360,7 @@ class AuthKeyRepository {
   }
 
   Future<AuthKey> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     AuthKey row, {
     _i1.Transaction? transaction,
   }) async {
@@ -369,7 +371,7 @@ class AuthKeyRepository {
   }
 
   Future<List<AuthKey>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<AuthKeyTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -380,7 +382,7 @@ class AuthKeyRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<AuthKeyTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -211,7 +213,7 @@ class EmailAuthRepository {
   const EmailAuthRepository._();
 
   Future<List<EmailAuth>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailAuthTable>? where,
     int? limit,
     int? offset,
@@ -232,7 +234,7 @@ class EmailAuthRepository {
   }
 
   Future<EmailAuth?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailAuthTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailAuthTable>? orderBy,
@@ -251,7 +253,7 @@ class EmailAuthRepository {
   }
 
   Future<EmailAuth?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -262,7 +264,7 @@ class EmailAuthRepository {
   }
 
   Future<List<EmailAuth>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailAuth> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -273,7 +275,7 @@ class EmailAuthRepository {
   }
 
   Future<EmailAuth> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailAuth row, {
     _i1.Transaction? transaction,
   }) async {
@@ -284,7 +286,7 @@ class EmailAuthRepository {
   }
 
   Future<List<EmailAuth>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailAuth> rows, {
     _i1.ColumnSelections<EmailAuthTable>? columns,
     _i1.Transaction? transaction,
@@ -297,7 +299,7 @@ class EmailAuthRepository {
   }
 
   Future<EmailAuth> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailAuth row, {
     _i1.ColumnSelections<EmailAuthTable>? columns,
     _i1.Transaction? transaction,
@@ -310,7 +312,7 @@ class EmailAuthRepository {
   }
 
   Future<List<EmailAuth>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailAuth> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -321,7 +323,7 @@ class EmailAuthRepository {
   }
 
   Future<EmailAuth> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailAuth row, {
     _i1.Transaction? transaction,
   }) async {
@@ -332,7 +334,7 @@ class EmailAuthRepository {
   }
 
   Future<List<EmailAuth>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailAuthTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -343,7 +345,7 @@ class EmailAuthRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailAuthTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -235,7 +237,7 @@ class EmailCreateAccountRequestRepository {
   const EmailCreateAccountRequestRepository._();
 
   Future<List<EmailCreateAccountRequest>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? where,
     int? limit,
     int? offset,
@@ -256,7 +258,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<EmailCreateAccountRequest?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
@@ -275,7 +277,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<EmailCreateAccountRequest?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -286,7 +288,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<List<EmailCreateAccountRequest>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailCreateAccountRequest> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -297,7 +299,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<EmailCreateAccountRequest> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailCreateAccountRequest row, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<List<EmailCreateAccountRequest>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailCreateAccountRequest> rows, {
     _i1.ColumnSelections<EmailCreateAccountRequestTable>? columns,
     _i1.Transaction? transaction,
@@ -321,7 +323,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<EmailCreateAccountRequest> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailCreateAccountRequest row, {
     _i1.ColumnSelections<EmailCreateAccountRequestTable>? columns,
     _i1.Transaction? transaction,
@@ -334,7 +336,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<List<EmailCreateAccountRequest>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailCreateAccountRequest> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -345,7 +347,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<EmailCreateAccountRequest> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailCreateAccountRequest row, {
     _i1.Transaction? transaction,
   }) async {
@@ -356,7 +358,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<List<EmailCreateAccountRequest>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -367,7 +369,7 @@ class EmailCreateAccountRequestRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -213,7 +215,7 @@ class EmailFailedSignInRepository {
   const EmailFailedSignInRepository._();
 
   Future<List<EmailFailedSignIn>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? where,
     int? limit,
     int? offset,
@@ -234,7 +236,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<EmailFailedSignIn?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
@@ -253,7 +255,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<EmailFailedSignIn?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -264,7 +266,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<List<EmailFailedSignIn>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailFailedSignIn> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -275,7 +277,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<EmailFailedSignIn> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailFailedSignIn row, {
     _i1.Transaction? transaction,
   }) async {
@@ -286,7 +288,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<List<EmailFailedSignIn>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailFailedSignIn> rows, {
     _i1.ColumnSelections<EmailFailedSignInTable>? columns,
     _i1.Transaction? transaction,
@@ -299,7 +301,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<EmailFailedSignIn> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailFailedSignIn row, {
     _i1.ColumnSelections<EmailFailedSignInTable>? columns,
     _i1.Transaction? transaction,
@@ -312,7 +314,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<List<EmailFailedSignIn>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailFailedSignIn> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -323,7 +325,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<EmailFailedSignIn> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailFailedSignIn row, {
     _i1.Transaction? transaction,
   }) async {
@@ -334,7 +336,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<List<EmailFailedSignIn>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailFailedSignInTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -345,7 +347,7 @@ class EmailFailedSignInRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -212,7 +214,7 @@ class EmailResetRepository {
   const EmailResetRepository._();
 
   Future<List<EmailReset>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailResetTable>? where,
     int? limit,
     int? offset,
@@ -233,7 +235,7 @@ class EmailResetRepository {
   }
 
   Future<EmailReset?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailResetTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailResetTable>? orderBy,
@@ -252,7 +254,7 @@ class EmailResetRepository {
   }
 
   Future<EmailReset?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -263,7 +265,7 @@ class EmailResetRepository {
   }
 
   Future<List<EmailReset>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailReset> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -274,7 +276,7 @@ class EmailResetRepository {
   }
 
   Future<EmailReset> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailReset row, {
     _i1.Transaction? transaction,
   }) async {
@@ -285,7 +287,7 @@ class EmailResetRepository {
   }
 
   Future<List<EmailReset>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailReset> rows, {
     _i1.ColumnSelections<EmailResetTable>? columns,
     _i1.Transaction? transaction,
@@ -298,7 +300,7 @@ class EmailResetRepository {
   }
 
   Future<EmailReset> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailReset row, {
     _i1.ColumnSelections<EmailResetTable>? columns,
     _i1.Transaction? transaction,
@@ -311,7 +313,7 @@ class EmailResetRepository {
   }
 
   Future<List<EmailReset>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmailReset> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -322,7 +324,7 @@ class EmailResetRepository {
   }
 
   Future<EmailReset> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmailReset row, {
     _i1.Transaction? transaction,
   }) async {
@@ -333,7 +335,7 @@ class EmailResetRepository {
   }
 
   Future<List<EmailReset>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmailResetTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -344,7 +346,7 @@ class EmailResetRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmailResetTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -191,7 +193,7 @@ class GoogleRefreshTokenRepository {
   const GoogleRefreshTokenRepository._();
 
   Future<List<GoogleRefreshToken>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? where,
     int? limit,
     int? offset,
@@ -212,7 +214,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<GoogleRefreshToken?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? where,
     int? offset,
     _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
@@ -231,7 +233,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<GoogleRefreshToken?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -242,7 +244,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<List<GoogleRefreshToken>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<GoogleRefreshToken> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -253,7 +255,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<GoogleRefreshToken> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     GoogleRefreshToken row, {
     _i1.Transaction? transaction,
   }) async {
@@ -264,7 +266,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<List<GoogleRefreshToken>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<GoogleRefreshToken> rows, {
     _i1.ColumnSelections<GoogleRefreshTokenTable>? columns,
     _i1.Transaction? transaction,
@@ -277,7 +279,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<GoogleRefreshToken> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     GoogleRefreshToken row, {
     _i1.ColumnSelections<GoogleRefreshTokenTable>? columns,
     _i1.Transaction? transaction,
@@ -290,7 +292,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<List<GoogleRefreshToken>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<GoogleRefreshToken> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -301,7 +303,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<GoogleRefreshToken> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     GoogleRefreshToken row, {
     _i1.Transaction? transaction,
   }) async {
@@ -312,7 +314,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<List<GoogleRefreshToken>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<GoogleRefreshTokenTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -323,7 +325,7 @@ class GoogleRefreshTokenRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -211,7 +213,7 @@ class UserImageRepository {
   const UserImageRepository._();
 
   Future<List<UserImage>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserImageTable>? where,
     int? limit,
     int? offset,
@@ -232,7 +234,7 @@ class UserImageRepository {
   }
 
   Future<UserImage?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserImageTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserImageTable>? orderBy,
@@ -251,7 +253,7 @@ class UserImageRepository {
   }
 
   Future<UserImage?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -262,7 +264,7 @@ class UserImageRepository {
   }
 
   Future<List<UserImage>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserImage> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -273,7 +275,7 @@ class UserImageRepository {
   }
 
   Future<UserImage> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserImage row, {
     _i1.Transaction? transaction,
   }) async {
@@ -284,7 +286,7 @@ class UserImageRepository {
   }
 
   Future<List<UserImage>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserImage> rows, {
     _i1.ColumnSelections<UserImageTable>? columns,
     _i1.Transaction? transaction,
@@ -297,7 +299,7 @@ class UserImageRepository {
   }
 
   Future<UserImage> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserImage row, {
     _i1.ColumnSelections<UserImageTable>? columns,
     _i1.Transaction? transaction,
@@ -310,7 +312,7 @@ class UserImageRepository {
   }
 
   Future<List<UserImage>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserImage> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -321,7 +323,7 @@ class UserImageRepository {
   }
 
   Future<UserImage> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserImage row, {
     _i1.Transaction? transaction,
   }) async {
@@ -332,7 +334,7 @@ class UserImageRepository {
   }
 
   Future<List<UserImage>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserImageTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -343,7 +345,7 @@ class UserImageRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserImageTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -324,7 +326,7 @@ class UserInfoRepository {
   const UserInfoRepository._();
 
   Future<List<UserInfo>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserInfoTable>? where,
     int? limit,
     int? offset,
@@ -345,7 +347,7 @@ class UserInfoRepository {
   }
 
   Future<UserInfo?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserInfoTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserInfoTable>? orderBy,
@@ -364,7 +366,7 @@ class UserInfoRepository {
   }
 
   Future<UserInfo?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -375,7 +377,7 @@ class UserInfoRepository {
   }
 
   Future<List<UserInfo>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -386,7 +388,7 @@ class UserInfoRepository {
   }
 
   Future<UserInfo> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserInfo row, {
     _i1.Transaction? transaction,
   }) async {
@@ -397,7 +399,7 @@ class UserInfoRepository {
   }
 
   Future<List<UserInfo>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserInfo> rows, {
     _i1.ColumnSelections<UserInfoTable>? columns,
     _i1.Transaction? transaction,
@@ -410,7 +412,7 @@ class UserInfoRepository {
   }
 
   Future<UserInfo> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserInfo row, {
     _i1.ColumnSelections<UserInfoTable>? columns,
     _i1.Transaction? transaction,
@@ -423,7 +425,7 @@ class UserInfoRepository {
   }
 
   Future<List<UserInfo>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -434,7 +436,7 @@ class UserInfoRepository {
   }
 
   Future<UserInfo> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserInfo row, {
     _i1.Transaction? transaction,
   }) async {
@@ -445,7 +447,7 @@ class UserInfoRepository {
   }
 
   Future<List<UserInfo>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserInfoTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -456,7 +458,7 @@ class UserInfoRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserInfoTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
@@ -329,7 +331,7 @@ class ChatMessageRepository {
   const ChatMessageRepository._();
 
   Future<List<ChatMessage>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatMessageTable>? where,
     int? limit,
     int? offset,
@@ -350,7 +352,7 @@ class ChatMessageRepository {
   }
 
   Future<ChatMessage?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatMessageTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChatMessageTable>? orderBy,
@@ -369,7 +371,7 @@ class ChatMessageRepository {
   }
 
   Future<ChatMessage?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -380,7 +382,7 @@ class ChatMessageRepository {
   }
 
   Future<List<ChatMessage>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ChatMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -391,7 +393,7 @@ class ChatMessageRepository {
   }
 
   Future<ChatMessage> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ChatMessage row, {
     _i1.Transaction? transaction,
   }) async {
@@ -402,7 +404,7 @@ class ChatMessageRepository {
   }
 
   Future<List<ChatMessage>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ChatMessage> rows, {
     _i1.ColumnSelections<ChatMessageTable>? columns,
     _i1.Transaction? transaction,
@@ -415,7 +417,7 @@ class ChatMessageRepository {
   }
 
   Future<ChatMessage> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ChatMessage row, {
     _i1.ColumnSelections<ChatMessageTable>? columns,
     _i1.Transaction? transaction,
@@ -428,7 +430,7 @@ class ChatMessageRepository {
   }
 
   Future<List<ChatMessage>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ChatMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -439,7 +441,7 @@ class ChatMessageRepository {
   }
 
   Future<ChatMessage> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ChatMessage row, {
     _i1.Transaction? transaction,
   }) async {
@@ -450,7 +452,7 @@ class ChatMessageRepository {
   }
 
   Future<List<ChatMessage>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ChatMessageTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -461,7 +463,7 @@ class ChatMessageRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatMessageTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -212,7 +214,7 @@ class ChatReadMessageRepository {
   const ChatReadMessageRepository._();
 
   Future<List<ChatReadMessage>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? where,
     int? limit,
     int? offset,
@@ -233,7 +235,7 @@ class ChatReadMessageRepository {
   }
 
   Future<ChatReadMessage?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
@@ -252,7 +254,7 @@ class ChatReadMessageRepository {
   }
 
   Future<ChatReadMessage?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -263,7 +265,7 @@ class ChatReadMessageRepository {
   }
 
   Future<List<ChatReadMessage>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ChatReadMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -274,7 +276,7 @@ class ChatReadMessageRepository {
   }
 
   Future<ChatReadMessage> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ChatReadMessage row, {
     _i1.Transaction? transaction,
   }) async {
@@ -285,7 +287,7 @@ class ChatReadMessageRepository {
   }
 
   Future<List<ChatReadMessage>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ChatReadMessage> rows, {
     _i1.ColumnSelections<ChatReadMessageTable>? columns,
     _i1.Transaction? transaction,
@@ -298,7 +300,7 @@ class ChatReadMessageRepository {
   }
 
   Future<ChatReadMessage> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ChatReadMessage row, {
     _i1.ColumnSelections<ChatReadMessageTable>? columns,
     _i1.Transaction? transaction,
@@ -311,7 +313,7 @@ class ChatReadMessageRepository {
   }
 
   Future<List<ChatReadMessage>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ChatReadMessage> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -322,7 +324,7 @@ class ChatReadMessageRepository {
   }
 
   Future<ChatReadMessage> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ChatReadMessage row, {
     _i1.Transaction? transaction,
   }) async {
@@ -333,7 +335,7 @@ class ChatReadMessageRepository {
   }
 
   Future<List<ChatReadMessage>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ChatReadMessageTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -344,7 +346,7 @@ class ChatReadMessageRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
@@ -280,7 +282,7 @@ class CloudStorageEntryRepository {
   const CloudStorageEntryRepository._();
 
   Future<List<CloudStorageEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? where,
     int? limit,
     int? offset,
@@ -301,7 +303,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<CloudStorageEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
@@ -320,7 +322,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<CloudStorageEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -331,7 +333,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<List<CloudStorageEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CloudStorageEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -342,7 +344,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<CloudStorageEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CloudStorageEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -353,7 +355,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<List<CloudStorageEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CloudStorageEntry> rows, {
     _i1.ColumnSelections<CloudStorageEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -366,7 +368,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<CloudStorageEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CloudStorageEntry row, {
     _i1.ColumnSelections<CloudStorageEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -379,7 +381,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<List<CloudStorageEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CloudStorageEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -390,7 +392,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<CloudStorageEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CloudStorageEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -401,7 +403,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<List<CloudStorageEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CloudStorageEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -412,7 +414,7 @@ class CloudStorageEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -235,7 +237,7 @@ class CloudStorageDirectUploadEntryRepository {
   const CloudStorageDirectUploadEntryRepository._();
 
   Future<List<CloudStorageDirectUploadEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? where,
     int? limit,
     int? offset,
@@ -256,7 +258,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<CloudStorageDirectUploadEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
@@ -275,7 +277,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<CloudStorageDirectUploadEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -286,7 +288,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<List<CloudStorageDirectUploadEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -297,7 +299,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<CloudStorageDirectUploadEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CloudStorageDirectUploadEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<List<CloudStorageDirectUploadEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.ColumnSelections<CloudStorageDirectUploadEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -321,7 +323,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<CloudStorageDirectUploadEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CloudStorageDirectUploadEntry row, {
     _i1.ColumnSelections<CloudStorageDirectUploadEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -334,7 +336,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<List<CloudStorageDirectUploadEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -345,7 +347,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<CloudStorageDirectUploadEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CloudStorageDirectUploadEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -356,7 +358,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<List<CloudStorageDirectUploadEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>
         where,
     _i1.Transaction? transaction,
@@ -368,7 +370,7 @@ class CloudStorageDirectUploadEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -215,7 +217,7 @@ class DatabaseMigrationVersionRepository {
   const DatabaseMigrationVersionRepository._();
 
   Future<List<DatabaseMigrationVersion>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DatabaseMigrationVersionTable>? where,
     int? limit,
     int? offset,
@@ -236,7 +238,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<DatabaseMigrationVersion?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DatabaseMigrationVersionTable>? where,
     int? offset,
     _i1.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
@@ -255,7 +257,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<DatabaseMigrationVersion?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -266,7 +268,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<List<DatabaseMigrationVersion>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DatabaseMigrationVersion> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -277,7 +279,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<DatabaseMigrationVersion> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DatabaseMigrationVersion row, {
     _i1.Transaction? transaction,
   }) async {
@@ -288,7 +290,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<List<DatabaseMigrationVersion>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DatabaseMigrationVersion> rows, {
     _i1.ColumnSelections<DatabaseMigrationVersionTable>? columns,
     _i1.Transaction? transaction,
@@ -301,7 +303,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<DatabaseMigrationVersion> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DatabaseMigrationVersion row, {
     _i1.ColumnSelections<DatabaseMigrationVersionTable>? columns,
     _i1.Transaction? transaction,
@@ -314,7 +316,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<List<DatabaseMigrationVersion>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DatabaseMigrationVersion> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -325,7 +327,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<DatabaseMigrationVersion> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DatabaseMigrationVersion row, {
     _i1.Transaction? transaction,
   }) async {
@@ -336,7 +338,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<List<DatabaseMigrationVersion>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DatabaseMigrationVersionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -347,7 +349,7 @@ class DatabaseMigrationVersionRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DatabaseMigrationVersionTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -256,7 +258,7 @@ class FutureCallEntryRepository {
   const FutureCallEntryRepository._();
 
   Future<List<FutureCallEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? where,
     int? limit,
     int? offset,
@@ -277,7 +279,7 @@ class FutureCallEntryRepository {
   }
 
   Future<FutureCallEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
@@ -296,7 +298,7 @@ class FutureCallEntryRepository {
   }
 
   Future<FutureCallEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -307,7 +309,7 @@ class FutureCallEntryRepository {
   }
 
   Future<List<FutureCallEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<FutureCallEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -318,7 +320,7 @@ class FutureCallEntryRepository {
   }
 
   Future<FutureCallEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     FutureCallEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -329,7 +331,7 @@ class FutureCallEntryRepository {
   }
 
   Future<List<FutureCallEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<FutureCallEntry> rows, {
     _i1.ColumnSelections<FutureCallEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -342,7 +344,7 @@ class FutureCallEntryRepository {
   }
 
   Future<FutureCallEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     FutureCallEntry row, {
     _i1.ColumnSelections<FutureCallEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -355,7 +357,7 @@ class FutureCallEntryRepository {
   }
 
   Future<List<FutureCallEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<FutureCallEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -366,7 +368,7 @@ class FutureCallEntryRepository {
   }
 
   Future<FutureCallEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     FutureCallEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -377,7 +379,7 @@ class FutureCallEntryRepository {
   }
 
   Future<List<FutureCallEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<FutureCallEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -388,7 +390,7 @@ class FutureCallEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -359,7 +361,7 @@ class LogEntryRepository {
   const LogEntryRepository._();
 
   Future<List<LogEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LogEntryTable>? where,
     int? limit,
     int? offset,
@@ -380,7 +382,7 @@ class LogEntryRepository {
   }
 
   Future<LogEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<LogEntryTable>? orderBy,
@@ -399,7 +401,7 @@ class LogEntryRepository {
   }
 
   Future<LogEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -410,7 +412,7 @@ class LogEntryRepository {
   }
 
   Future<List<LogEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -421,7 +423,7 @@ class LogEntryRepository {
   }
 
   Future<LogEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -432,7 +434,7 @@ class LogEntryRepository {
   }
 
   Future<List<LogEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LogEntry> rows, {
     _i1.ColumnSelections<LogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -445,7 +447,7 @@ class LogEntryRepository {
   }
 
   Future<LogEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LogEntry row, {
     _i1.ColumnSelections<LogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -458,7 +460,7 @@ class LogEntryRepository {
   }
 
   Future<List<LogEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -469,7 +471,7 @@ class LogEntryRepository {
   }
 
   Future<LogEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -480,7 +482,7 @@ class LogEntryRepository {
   }
 
   Future<List<LogEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<LogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -491,7 +493,7 @@ class LogEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LogEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -363,7 +365,7 @@ class MessageLogEntryRepository {
   const MessageLogEntryRepository._();
 
   Future<List<MessageLogEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? where,
     int? limit,
     int? offset,
@@ -384,7 +386,7 @@ class MessageLogEntryRepository {
   }
 
   Future<MessageLogEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
@@ -403,7 +405,7 @@ class MessageLogEntryRepository {
   }
 
   Future<MessageLogEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -414,7 +416,7 @@ class MessageLogEntryRepository {
   }
 
   Future<List<MessageLogEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MessageLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -425,7 +427,7 @@ class MessageLogEntryRepository {
   }
 
   Future<MessageLogEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MessageLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -436,7 +438,7 @@ class MessageLogEntryRepository {
   }
 
   Future<List<MessageLogEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MessageLogEntry> rows, {
     _i1.ColumnSelections<MessageLogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -449,7 +451,7 @@ class MessageLogEntryRepository {
   }
 
   Future<MessageLogEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MessageLogEntry row, {
     _i1.ColumnSelections<MessageLogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -462,7 +464,7 @@ class MessageLogEntryRepository {
   }
 
   Future<List<MessageLogEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MessageLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -473,7 +475,7 @@ class MessageLogEntryRepository {
   }
 
   Future<MessageLogEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MessageLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -484,7 +486,7 @@ class MessageLogEntryRepository {
   }
 
   Future<List<MessageLogEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<MessageLogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -495,7 +497,7 @@ class MessageLogEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -190,7 +192,7 @@ class MethodInfoRepository {
   const MethodInfoRepository._();
 
   Future<List<MethodInfo>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MethodInfoTable>? where,
     int? limit,
     int? offset,
@@ -211,7 +213,7 @@ class MethodInfoRepository {
   }
 
   Future<MethodInfo?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MethodInfoTable>? where,
     int? offset,
     _i1.OrderByBuilder<MethodInfoTable>? orderBy,
@@ -230,7 +232,7 @@ class MethodInfoRepository {
   }
 
   Future<MethodInfo?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -241,7 +243,7 @@ class MethodInfoRepository {
   }
 
   Future<List<MethodInfo>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MethodInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -252,7 +254,7 @@ class MethodInfoRepository {
   }
 
   Future<MethodInfo> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MethodInfo row, {
     _i1.Transaction? transaction,
   }) async {
@@ -263,7 +265,7 @@ class MethodInfoRepository {
   }
 
   Future<List<MethodInfo>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MethodInfo> rows, {
     _i1.ColumnSelections<MethodInfoTable>? columns,
     _i1.Transaction? transaction,
@@ -276,7 +278,7 @@ class MethodInfoRepository {
   }
 
   Future<MethodInfo> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MethodInfo row, {
     _i1.ColumnSelections<MethodInfoTable>? columns,
     _i1.Transaction? transaction,
@@ -289,7 +291,7 @@ class MethodInfoRepository {
   }
 
   Future<List<MethodInfo>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MethodInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -300,7 +302,7 @@ class MethodInfoRepository {
   }
 
   Future<MethodInfo> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MethodInfo row, {
     _i1.Transaction? transaction,
   }) async {
@@ -311,7 +313,7 @@ class MethodInfoRepository {
   }
 
   Future<List<MethodInfo>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<MethodInfoTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -322,7 +324,7 @@ class MethodInfoRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MethodInfoTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -363,7 +365,7 @@ class QueryLogEntryRepository {
   const QueryLogEntryRepository._();
 
   Future<List<QueryLogEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? where,
     int? limit,
     int? offset,
@@ -384,7 +386,7 @@ class QueryLogEntryRepository {
   }
 
   Future<QueryLogEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
@@ -403,7 +405,7 @@ class QueryLogEntryRepository {
   }
 
   Future<QueryLogEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -414,7 +416,7 @@ class QueryLogEntryRepository {
   }
 
   Future<List<QueryLogEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<QueryLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -425,7 +427,7 @@ class QueryLogEntryRepository {
   }
 
   Future<QueryLogEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     QueryLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -436,7 +438,7 @@ class QueryLogEntryRepository {
   }
 
   Future<List<QueryLogEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<QueryLogEntry> rows, {
     _i1.ColumnSelections<QueryLogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -449,7 +451,7 @@ class QueryLogEntryRepository {
   }
 
   Future<QueryLogEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     QueryLogEntry row, {
     _i1.ColumnSelections<QueryLogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -462,7 +464,7 @@ class QueryLogEntryRepository {
   }
 
   Future<List<QueryLogEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<QueryLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -473,7 +475,7 @@ class QueryLogEntryRepository {
   }
 
   Future<QueryLogEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     QueryLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -484,7 +486,7 @@ class QueryLogEntryRepository {
   }
 
   Future<List<QueryLogEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<QueryLogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -495,7 +497,7 @@ class QueryLogEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -171,7 +173,7 @@ class ReadWriteTestEntryRepository {
   const ReadWriteTestEntryRepository._();
 
   Future<List<ReadWriteTestEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? where,
     int? limit,
     int? offset,
@@ -192,7 +194,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<ReadWriteTestEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
@@ -211,7 +213,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<ReadWriteTestEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -222,7 +224,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<List<ReadWriteTestEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ReadWriteTestEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -233,7 +235,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<ReadWriteTestEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ReadWriteTestEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -244,7 +246,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<List<ReadWriteTestEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ReadWriteTestEntry> rows, {
     _i1.ColumnSelections<ReadWriteTestEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -257,7 +259,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<ReadWriteTestEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ReadWriteTestEntry row, {
     _i1.ColumnSelections<ReadWriteTestEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -270,7 +272,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<List<ReadWriteTestEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ReadWriteTestEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -281,7 +283,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<ReadWriteTestEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ReadWriteTestEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -292,7 +294,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<List<ReadWriteTestEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ReadWriteTestEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -303,7 +305,7 @@ class ReadWriteTestEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -241,7 +243,7 @@ class RuntimeSettingsRepository {
   const RuntimeSettingsRepository._();
 
   Future<List<RuntimeSettings>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? where,
     int? limit,
     int? offset,
@@ -262,7 +264,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<RuntimeSettings?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? where,
     int? offset,
     _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
@@ -281,7 +283,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<RuntimeSettings?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -292,7 +294,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<List<RuntimeSettings>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RuntimeSettings> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -303,7 +305,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<RuntimeSettings> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RuntimeSettings row, {
     _i1.Transaction? transaction,
   }) async {
@@ -314,7 +316,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<List<RuntimeSettings>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RuntimeSettings> rows, {
     _i1.ColumnSelections<RuntimeSettingsTable>? columns,
     _i1.Transaction? transaction,
@@ -327,7 +329,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<RuntimeSettings> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RuntimeSettings row, {
     _i1.ColumnSelections<RuntimeSettingsTable>? columns,
     _i1.Transaction? transaction,
@@ -340,7 +342,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<List<RuntimeSettings>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RuntimeSettings> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -351,7 +353,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<RuntimeSettings> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RuntimeSettings row, {
     _i1.Transaction? transaction,
   }) async {
@@ -362,7 +364,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<List<RuntimeSettings>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<RuntimeSettingsTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -373,7 +375,7 @@ class RuntimeSettingsRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -281,7 +283,7 @@ class ServerHealthConnectionInfoRepository {
   const ServerHealthConnectionInfoRepository._();
 
   Future<List<ServerHealthConnectionInfo>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? where,
     int? limit,
     int? offset,
@@ -302,7 +304,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<ServerHealthConnectionInfo?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
@@ -321,7 +323,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<ServerHealthConnectionInfo?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -332,7 +334,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<List<ServerHealthConnectionInfo>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ServerHealthConnectionInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -343,7 +345,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<ServerHealthConnectionInfo> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ServerHealthConnectionInfo row, {
     _i1.Transaction? transaction,
   }) async {
@@ -354,7 +356,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<List<ServerHealthConnectionInfo>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ServerHealthConnectionInfo> rows, {
     _i1.ColumnSelections<ServerHealthConnectionInfoTable>? columns,
     _i1.Transaction? transaction,
@@ -367,7 +369,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<ServerHealthConnectionInfo> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ServerHealthConnectionInfo row, {
     _i1.ColumnSelections<ServerHealthConnectionInfoTable>? columns,
     _i1.Transaction? transaction,
@@ -380,7 +382,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<List<ServerHealthConnectionInfo>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ServerHealthConnectionInfo> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -391,7 +393,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<ServerHealthConnectionInfo> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ServerHealthConnectionInfo row, {
     _i1.Transaction? transaction,
   }) async {
@@ -402,7 +404,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<List<ServerHealthConnectionInfo>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -413,7 +415,7 @@ class ServerHealthConnectionInfoRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -280,7 +282,7 @@ class ServerHealthMetricRepository {
   const ServerHealthMetricRepository._();
 
   Future<List<ServerHealthMetric>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? where,
     int? limit,
     int? offset,
@@ -301,7 +303,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<ServerHealthMetric?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
@@ -320,7 +322,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<ServerHealthMetric?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -331,7 +333,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<List<ServerHealthMetric>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ServerHealthMetric> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -342,7 +344,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<ServerHealthMetric> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ServerHealthMetric row, {
     _i1.Transaction? transaction,
   }) async {
@@ -353,7 +355,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<List<ServerHealthMetric>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ServerHealthMetric> rows, {
     _i1.ColumnSelections<ServerHealthMetricTable>? columns,
     _i1.Transaction? transaction,
@@ -366,7 +368,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<ServerHealthMetric> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ServerHealthMetric row, {
     _i1.ColumnSelections<ServerHealthMetricTable>? columns,
     _i1.Transaction? transaction,
@@ -379,7 +381,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<List<ServerHealthMetric>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ServerHealthMetric> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -390,7 +392,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<ServerHealthMetric> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ServerHealthMetric row, {
     _i1.Transaction? transaction,
   }) async {
@@ -401,7 +403,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<List<ServerHealthMetric>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ServerHealthMetricTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -412,7 +414,7 @@ class ServerHealthMetricRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -434,7 +436,7 @@ class SessionLogEntryRepository {
   const SessionLogEntryRepository._();
 
   Future<List<SessionLogEntry>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? where,
     int? limit,
     int? offset,
@@ -455,7 +457,7 @@ class SessionLogEntryRepository {
   }
 
   Future<SessionLogEntry?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
@@ -474,7 +476,7 @@ class SessionLogEntryRepository {
   }
 
   Future<SessionLogEntry?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -485,7 +487,7 @@ class SessionLogEntryRepository {
   }
 
   Future<List<SessionLogEntry>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SessionLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -496,7 +498,7 @@ class SessionLogEntryRepository {
   }
 
   Future<SessionLogEntry> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SessionLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -507,7 +509,7 @@ class SessionLogEntryRepository {
   }
 
   Future<List<SessionLogEntry>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SessionLogEntry> rows, {
     _i1.ColumnSelections<SessionLogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -520,7 +522,7 @@ class SessionLogEntryRepository {
   }
 
   Future<SessionLogEntry> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SessionLogEntry row, {
     _i1.ColumnSelections<SessionLogEntryTable>? columns,
     _i1.Transaction? transaction,
@@ -533,7 +535,7 @@ class SessionLogEntryRepository {
   }
 
   Future<List<SessionLogEntry>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SessionLogEntry> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -544,7 +546,7 @@ class SessionLogEntryRepository {
   }
 
   Future<SessionLogEntry> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SessionLogEntry row, {
     _i1.Transaction? transaction,
   }) async {
@@ -555,7 +557,7 @@ class SessionLogEntryRepository {
   }
 
   Future<List<SessionLogEntry>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<SessionLogEntryTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -566,7 +568,7 @@ class SessionLogEntryRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -212,7 +214,7 @@ class BoolDefaultRepository {
   const BoolDefaultRepository._();
 
   Future<List<BoolDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultTable>? where,
     int? limit,
     int? offset,
@@ -233,7 +235,7 @@ class BoolDefaultRepository {
   }
 
   Future<BoolDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
@@ -252,7 +254,7 @@ class BoolDefaultRepository {
   }
 
   Future<BoolDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -263,7 +265,7 @@ class BoolDefaultRepository {
   }
 
   Future<List<BoolDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -274,7 +276,7 @@ class BoolDefaultRepository {
   }
 
   Future<BoolDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -285,7 +287,7 @@ class BoolDefaultRepository {
   }
 
   Future<List<BoolDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefault> rows, {
     _i1.ColumnSelections<BoolDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -298,7 +300,7 @@ class BoolDefaultRepository {
   }
 
   Future<BoolDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefault row, {
     _i1.ColumnSelections<BoolDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -311,7 +313,7 @@ class BoolDefaultRepository {
   }
 
   Future<List<BoolDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -322,7 +324,7 @@ class BoolDefaultRepository {
   }
 
   Future<BoolDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -333,7 +335,7 @@ class BoolDefaultRepository {
   }
 
   Future<List<BoolDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<BoolDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -344,7 +346,7 @@ class BoolDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -217,7 +219,7 @@ class BoolDefaultMixRepository {
   const BoolDefaultMixRepository._();
 
   Future<List<BoolDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -238,7 +240,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<BoolDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
@@ -257,7 +259,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<BoolDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -268,7 +270,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<List<BoolDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -279,7 +281,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<BoolDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -290,7 +292,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<List<BoolDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultMix> rows, {
     _i1.ColumnSelections<BoolDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -303,7 +305,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<BoolDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultMix row, {
     _i1.ColumnSelections<BoolDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -316,7 +318,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<List<BoolDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -327,7 +329,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<BoolDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -338,7 +340,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<List<BoolDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<BoolDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -349,7 +351,7 @@ class BoolDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -210,7 +212,7 @@ class BoolDefaultModelRepository {
   const BoolDefaultModelRepository._();
 
   Future<List<BoolDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -231,7 +233,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<BoolDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
@@ -250,7 +252,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<BoolDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -261,7 +263,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<List<BoolDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -272,7 +274,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<BoolDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -283,7 +285,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<List<BoolDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultModel> rows, {
     _i1.ColumnSelections<BoolDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -296,7 +298,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<BoolDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultModel row, {
     _i1.ColumnSelections<BoolDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -309,7 +311,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<List<BoolDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -320,7 +322,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<BoolDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -331,7 +333,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<List<BoolDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<BoolDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -342,7 +344,7 @@ class BoolDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -198,7 +200,7 @@ class BoolDefaultPersistRepository {
   const BoolDefaultPersistRepository._();
 
   Future<List<BoolDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -219,7 +221,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<BoolDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
@@ -238,7 +240,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<BoolDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -249,7 +251,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<List<BoolDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -260,7 +262,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<BoolDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -271,7 +273,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<List<BoolDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultPersist> rows, {
     _i1.ColumnSelections<BoolDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -284,7 +286,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<BoolDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultPersist row, {
     _i1.ColumnSelections<BoolDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -297,7 +299,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<List<BoolDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<BoolDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<BoolDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     BoolDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -319,7 +321,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<List<BoolDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<BoolDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -330,7 +332,7 @@ class BoolDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BoolDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -222,7 +224,7 @@ class DateTimeDefaultRepository {
   const DateTimeDefaultRepository._();
 
   Future<List<DateTimeDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultTable>? where,
     int? limit,
     int? offset,
@@ -243,7 +245,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<DateTimeDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
@@ -262,7 +264,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<DateTimeDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -273,7 +275,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<List<DateTimeDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -284,7 +286,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<DateTimeDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -295,7 +297,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<List<DateTimeDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefault> rows, {
     _i1.ColumnSelections<DateTimeDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -308,7 +310,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<DateTimeDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefault row, {
     _i1.ColumnSelections<DateTimeDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -321,7 +323,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<List<DateTimeDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -332,7 +334,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<DateTimeDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -343,7 +345,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<List<DateTimeDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -354,7 +356,7 @@ class DateTimeDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -226,7 +228,7 @@ class DateTimeDefaultMixRepository {
   const DateTimeDefaultMixRepository._();
 
   Future<List<DateTimeDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -247,7 +249,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<DateTimeDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
@@ -266,7 +268,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<DateTimeDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -277,7 +279,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<List<DateTimeDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -288,7 +290,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<DateTimeDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<List<DateTimeDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultMix> rows, {
     _i1.ColumnSelections<DateTimeDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -312,7 +314,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<DateTimeDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultMix row, {
     _i1.ColumnSelections<DateTimeDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -325,7 +327,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<List<DateTimeDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -336,7 +338,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<DateTimeDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -347,7 +349,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<List<DateTimeDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -358,7 +360,7 @@ class DateTimeDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -222,7 +224,7 @@ class DateTimeDefaultModelRepository {
   const DateTimeDefaultModelRepository._();
 
   Future<List<DateTimeDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -243,7 +245,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<DateTimeDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
@@ -262,7 +264,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<DateTimeDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -273,7 +275,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<List<DateTimeDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -284,7 +286,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<DateTimeDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -295,7 +297,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<List<DateTimeDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultModel> rows, {
     _i1.ColumnSelections<DateTimeDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -308,7 +310,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<DateTimeDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultModel row, {
     _i1.ColumnSelections<DateTimeDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -321,7 +323,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<List<DateTimeDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -332,7 +334,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<DateTimeDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -343,7 +345,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<List<DateTimeDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -354,7 +356,7 @@ class DateTimeDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -205,7 +207,7 @@ class DateTimeDefaultPersistRepository {
   const DateTimeDefaultPersistRepository._();
 
   Future<List<DateTimeDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -226,7 +228,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<DateTimeDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
@@ -245,7 +247,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<DateTimeDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -256,7 +258,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<List<DateTimeDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -267,7 +269,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<DateTimeDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -278,7 +280,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<List<DateTimeDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultPersist> rows, {
     _i1.ColumnSelections<DateTimeDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -291,7 +293,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<DateTimeDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultPersist row, {
     _i1.ColumnSelections<DateTimeDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -304,7 +306,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<List<DateTimeDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DateTimeDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -315,7 +317,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<DateTimeDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DateTimeDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -326,7 +328,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<List<DateTimeDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -337,7 +339,7 @@ class DateTimeDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -192,7 +194,7 @@ class DoubleDefaultRepository {
   const DoubleDefaultRepository._();
 
   Future<List<DoubleDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultTable>? where,
     int? limit,
     int? offset,
@@ -213,7 +215,7 @@ class DoubleDefaultRepository {
   }
 
   Future<DoubleDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
@@ -232,7 +234,7 @@ class DoubleDefaultRepository {
   }
 
   Future<DoubleDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -243,7 +245,7 @@ class DoubleDefaultRepository {
   }
 
   Future<List<DoubleDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -254,7 +256,7 @@ class DoubleDefaultRepository {
   }
 
   Future<DoubleDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -265,7 +267,7 @@ class DoubleDefaultRepository {
   }
 
   Future<List<DoubleDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefault> rows, {
     _i1.ColumnSelections<DoubleDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -278,7 +280,7 @@ class DoubleDefaultRepository {
   }
 
   Future<DoubleDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefault row, {
     _i1.ColumnSelections<DoubleDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -291,7 +293,7 @@ class DoubleDefaultRepository {
   }
 
   Future<List<DoubleDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -302,7 +304,7 @@ class DoubleDefaultRepository {
   }
 
   Future<DoubleDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -313,7 +315,7 @@ class DoubleDefaultRepository {
   }
 
   Future<List<DoubleDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -324,7 +326,7 @@ class DoubleDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -223,7 +225,7 @@ class DoubleDefaultMixRepository {
   const DoubleDefaultMixRepository._();
 
   Future<List<DoubleDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -244,7 +246,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<DoubleDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
@@ -263,7 +265,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<DoubleDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -274,7 +276,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<List<DoubleDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -285,7 +287,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<DoubleDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -296,7 +298,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<List<DoubleDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultMix> rows, {
     _i1.ColumnSelections<DoubleDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -309,7 +311,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<DoubleDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultMix row, {
     _i1.ColumnSelections<DoubleDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -322,7 +324,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<List<DoubleDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -333,7 +335,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<DoubleDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -344,7 +346,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<List<DoubleDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -355,7 +357,7 @@ class DoubleDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -190,7 +192,7 @@ class DoubleDefaultModelRepository {
   const DoubleDefaultModelRepository._();
 
   Future<List<DoubleDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -211,7 +213,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<DoubleDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
@@ -230,7 +232,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<DoubleDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -241,7 +243,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<List<DoubleDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -252,7 +254,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<DoubleDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -263,7 +265,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<List<DoubleDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultModel> rows, {
     _i1.ColumnSelections<DoubleDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -276,7 +278,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<DoubleDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultModel row, {
     _i1.ColumnSelections<DoubleDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -289,7 +291,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<List<DoubleDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -300,7 +302,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<DoubleDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -311,7 +313,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<List<DoubleDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -322,7 +324,7 @@ class DoubleDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -174,7 +176,7 @@ class DoubleDefaultPersistRepository {
   const DoubleDefaultPersistRepository._();
 
   Future<List<DoubleDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -195,7 +197,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<DoubleDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
@@ -214,7 +216,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<DoubleDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -225,7 +227,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<List<DoubleDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -236,7 +238,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<DoubleDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -247,7 +249,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<List<DoubleDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultPersist> rows, {
     _i1.ColumnSelections<DoubleDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -260,7 +262,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<DoubleDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultPersist row, {
     _i1.ColumnSelections<DoubleDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -273,7 +275,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<List<DoubleDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DoubleDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -284,7 +286,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<DoubleDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DoubleDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -295,7 +297,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<List<DoubleDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -306,7 +308,7 @@ class DoubleDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DoubleDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -211,7 +213,7 @@ class DurationDefaultRepository {
   const DurationDefaultRepository._();
 
   Future<List<DurationDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultTable>? where,
     int? limit,
     int? offset,
@@ -232,7 +234,7 @@ class DurationDefaultRepository {
   }
 
   Future<DurationDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
@@ -251,7 +253,7 @@ class DurationDefaultRepository {
   }
 
   Future<DurationDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -262,7 +264,7 @@ class DurationDefaultRepository {
   }
 
   Future<List<DurationDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -273,7 +275,7 @@ class DurationDefaultRepository {
   }
 
   Future<DurationDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -284,7 +286,7 @@ class DurationDefaultRepository {
   }
 
   Future<List<DurationDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefault> rows, {
     _i1.ColumnSelections<DurationDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -297,7 +299,7 @@ class DurationDefaultRepository {
   }
 
   Future<DurationDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefault row, {
     _i1.ColumnSelections<DurationDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -310,7 +312,7 @@ class DurationDefaultRepository {
   }
 
   Future<List<DurationDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -321,7 +323,7 @@ class DurationDefaultRepository {
   }
 
   Future<DurationDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -332,7 +334,7 @@ class DurationDefaultRepository {
   }
 
   Future<List<DurationDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DurationDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -343,7 +345,7 @@ class DurationDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -244,7 +246,7 @@ class DurationDefaultMixRepository {
   const DurationDefaultMixRepository._();
 
   Future<List<DurationDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -265,7 +267,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<DurationDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
@@ -284,7 +286,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<DurationDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -295,7 +297,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<List<DurationDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -306,7 +308,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<DurationDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -317,7 +319,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<List<DurationDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultMix> rows, {
     _i1.ColumnSelections<DurationDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -330,7 +332,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<DurationDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultMix row, {
     _i1.ColumnSelections<DurationDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -343,7 +345,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<List<DurationDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -354,7 +356,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<DurationDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -365,7 +367,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<List<DurationDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DurationDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -376,7 +378,7 @@ class DurationDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -211,7 +213,7 @@ class DurationDefaultModelRepository {
   const DurationDefaultModelRepository._();
 
   Future<List<DurationDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -232,7 +234,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<DurationDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
@@ -251,7 +253,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<DurationDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -262,7 +264,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<List<DurationDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -273,7 +275,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<DurationDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -284,7 +286,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<List<DurationDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultModel> rows, {
     _i1.ColumnSelections<DurationDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -297,7 +299,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<DurationDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultModel row, {
     _i1.ColumnSelections<DurationDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -310,7 +312,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<List<DurationDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -321,7 +323,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<DurationDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -332,7 +334,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<List<DurationDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DurationDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -343,7 +345,7 @@ class DurationDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -177,7 +179,7 @@ class DurationDefaultPersistRepository {
   const DurationDefaultPersistRepository._();
 
   Future<List<DurationDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -198,7 +200,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<DurationDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
@@ -217,7 +219,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<DurationDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -228,7 +230,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<List<DurationDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -239,7 +241,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<DurationDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -250,7 +252,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<List<DurationDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultPersist> rows, {
     _i1.ColumnSelections<DurationDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -263,7 +265,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<DurationDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultPersist row, {
     _i1.ColumnSelections<DurationDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -276,7 +278,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<List<DurationDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<DurationDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -287,7 +289,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<DurationDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     DurationDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -298,7 +300,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<List<DurationDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<DurationDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -309,7 +311,7 @@ class DurationDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<DurationDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -252,7 +254,7 @@ class EnumDefaultRepository {
   const EnumDefaultRepository._();
 
   Future<List<EnumDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultTable>? where,
     int? limit,
     int? offset,
@@ -273,7 +275,7 @@ class EnumDefaultRepository {
   }
 
   Future<EnumDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
@@ -292,7 +294,7 @@ class EnumDefaultRepository {
   }
 
   Future<EnumDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -303,7 +305,7 @@ class EnumDefaultRepository {
   }
 
   Future<List<EnumDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -314,7 +316,7 @@ class EnumDefaultRepository {
   }
 
   Future<EnumDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -325,7 +327,7 @@ class EnumDefaultRepository {
   }
 
   Future<List<EnumDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefault> rows, {
     _i1.ColumnSelections<EnumDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -338,7 +340,7 @@ class EnumDefaultRepository {
   }
 
   Future<EnumDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefault row, {
     _i1.ColumnSelections<EnumDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -351,7 +353,7 @@ class EnumDefaultRepository {
   }
 
   Future<List<EnumDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -362,7 +364,7 @@ class EnumDefaultRepository {
   }
 
   Future<EnumDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -373,7 +375,7 @@ class EnumDefaultRepository {
   }
 
   Future<List<EnumDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EnumDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -384,7 +386,7 @@ class EnumDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -234,7 +236,7 @@ class EnumDefaultMixRepository {
   const EnumDefaultMixRepository._();
 
   Future<List<EnumDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -255,7 +257,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<EnumDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
@@ -274,7 +276,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<EnumDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -285,7 +287,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<List<EnumDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -296,7 +298,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<EnumDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -307,7 +309,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<List<EnumDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultMix> rows, {
     _i1.ColumnSelections<EnumDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -320,7 +322,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<EnumDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultMix row, {
     _i1.ColumnSelections<EnumDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -333,7 +335,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<List<EnumDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -344,7 +346,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<EnumDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -355,7 +357,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<List<EnumDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EnumDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -366,7 +368,7 @@ class EnumDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -257,7 +259,7 @@ class EnumDefaultModelRepository {
   const EnumDefaultModelRepository._();
 
   Future<List<EnumDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -278,7 +280,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<EnumDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
@@ -297,7 +299,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<EnumDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<List<EnumDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -319,7 +321,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<EnumDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -330,7 +332,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<List<EnumDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultModel> rows, {
     _i1.ColumnSelections<EnumDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -343,7 +345,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<EnumDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultModel row, {
     _i1.ColumnSelections<EnumDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -356,7 +358,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<List<EnumDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -367,7 +369,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<EnumDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -378,7 +380,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<List<EnumDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EnumDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -389,7 +391,7 @@ class EnumDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -207,7 +209,7 @@ class EnumDefaultPersistRepository {
   const EnumDefaultPersistRepository._();
 
   Future<List<EnumDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -228,7 +230,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<EnumDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
@@ -247,7 +249,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<EnumDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -258,7 +260,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<List<EnumDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -269,7 +271,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<EnumDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -280,7 +282,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<List<EnumDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultPersist> rows, {
     _i1.ColumnSelections<EnumDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -293,7 +295,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<EnumDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultPersist row, {
     _i1.ColumnSelections<EnumDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -306,7 +308,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<List<EnumDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EnumDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -317,7 +319,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<EnumDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EnumDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -328,7 +330,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<List<EnumDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EnumDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -339,7 +341,7 @@ class EnumDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnumDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -188,7 +190,7 @@ class IntDefaultRepository {
   const IntDefaultRepository._();
 
   Future<List<IntDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultTable>? where,
     int? limit,
     int? offset,
@@ -209,7 +211,7 @@ class IntDefaultRepository {
   }
 
   Future<IntDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
@@ -228,7 +230,7 @@ class IntDefaultRepository {
   }
 
   Future<IntDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -239,7 +241,7 @@ class IntDefaultRepository {
   }
 
   Future<List<IntDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -250,7 +252,7 @@ class IntDefaultRepository {
   }
 
   Future<IntDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -261,7 +263,7 @@ class IntDefaultRepository {
   }
 
   Future<List<IntDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefault> rows, {
     _i1.ColumnSelections<IntDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -274,7 +276,7 @@ class IntDefaultRepository {
   }
 
   Future<IntDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefault row, {
     _i1.ColumnSelections<IntDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -287,7 +289,7 @@ class IntDefaultRepository {
   }
 
   Future<List<IntDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -298,7 +300,7 @@ class IntDefaultRepository {
   }
 
   Future<IntDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -309,7 +311,7 @@ class IntDefaultRepository {
   }
 
   Future<List<IntDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<IntDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -320,7 +322,7 @@ class IntDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -217,7 +219,7 @@ class IntDefaultMixRepository {
   const IntDefaultMixRepository._();
 
   Future<List<IntDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -238,7 +240,7 @@ class IntDefaultMixRepository {
   }
 
   Future<IntDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
@@ -257,7 +259,7 @@ class IntDefaultMixRepository {
   }
 
   Future<IntDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -268,7 +270,7 @@ class IntDefaultMixRepository {
   }
 
   Future<List<IntDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -279,7 +281,7 @@ class IntDefaultMixRepository {
   }
 
   Future<IntDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -290,7 +292,7 @@ class IntDefaultMixRepository {
   }
 
   Future<List<IntDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultMix> rows, {
     _i1.ColumnSelections<IntDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -303,7 +305,7 @@ class IntDefaultMixRepository {
   }
 
   Future<IntDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultMix row, {
     _i1.ColumnSelections<IntDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -316,7 +318,7 @@ class IntDefaultMixRepository {
   }
 
   Future<List<IntDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -327,7 +329,7 @@ class IntDefaultMixRepository {
   }
 
   Future<IntDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -338,7 +340,7 @@ class IntDefaultMixRepository {
   }
 
   Future<List<IntDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<IntDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -349,7 +351,7 @@ class IntDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -187,7 +189,7 @@ class IntDefaultModelRepository {
   const IntDefaultModelRepository._();
 
   Future<List<IntDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -208,7 +210,7 @@ class IntDefaultModelRepository {
   }
 
   Future<IntDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
@@ -227,7 +229,7 @@ class IntDefaultModelRepository {
   }
 
   Future<IntDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -238,7 +240,7 @@ class IntDefaultModelRepository {
   }
 
   Future<List<IntDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -249,7 +251,7 @@ class IntDefaultModelRepository {
   }
 
   Future<IntDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -260,7 +262,7 @@ class IntDefaultModelRepository {
   }
 
   Future<List<IntDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultModel> rows, {
     _i1.ColumnSelections<IntDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -273,7 +275,7 @@ class IntDefaultModelRepository {
   }
 
   Future<IntDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultModel row, {
     _i1.ColumnSelections<IntDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -286,7 +288,7 @@ class IntDefaultModelRepository {
   }
 
   Future<List<IntDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -297,7 +299,7 @@ class IntDefaultModelRepository {
   }
 
   Future<IntDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class IntDefaultModelRepository {
   }
 
   Future<List<IntDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<IntDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -319,7 +321,7 @@ class IntDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -170,7 +172,7 @@ class IntDefaultPersistRepository {
   const IntDefaultPersistRepository._();
 
   Future<List<IntDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -191,7 +193,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<IntDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
@@ -210,7 +212,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<IntDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -221,7 +223,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<List<IntDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -232,7 +234,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<IntDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -243,7 +245,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<List<IntDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultPersist> rows, {
     _i1.ColumnSelections<IntDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -256,7 +258,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<IntDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultPersist row, {
     _i1.ColumnSelections<IntDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -269,7 +271,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<List<IntDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<IntDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -280,7 +282,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<IntDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     IntDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -291,7 +293,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<List<IntDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<IntDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -302,7 +304,7 @@ class IntDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<IntDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -191,7 +193,7 @@ class StringDefaultRepository {
   const StringDefaultRepository._();
 
   Future<List<StringDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultTable>? where,
     int? limit,
     int? offset,
@@ -212,7 +214,7 @@ class StringDefaultRepository {
   }
 
   Future<StringDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
@@ -231,7 +233,7 @@ class StringDefaultRepository {
   }
 
   Future<StringDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -242,7 +244,7 @@ class StringDefaultRepository {
   }
 
   Future<List<StringDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -253,7 +255,7 @@ class StringDefaultRepository {
   }
 
   Future<StringDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -264,7 +266,7 @@ class StringDefaultRepository {
   }
 
   Future<List<StringDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefault> rows, {
     _i1.ColumnSelections<StringDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -277,7 +279,7 @@ class StringDefaultRepository {
   }
 
   Future<StringDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefault row, {
     _i1.ColumnSelections<StringDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -290,7 +292,7 @@ class StringDefaultRepository {
   }
 
   Future<List<StringDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -301,7 +303,7 @@ class StringDefaultRepository {
   }
 
   Future<StringDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -312,7 +314,7 @@ class StringDefaultRepository {
   }
 
   Future<List<StringDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<StringDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -323,7 +325,7 @@ class StringDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -223,7 +225,7 @@ class StringDefaultMixRepository {
   const StringDefaultMixRepository._();
 
   Future<List<StringDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -244,7 +246,7 @@ class StringDefaultMixRepository {
   }
 
   Future<StringDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
@@ -263,7 +265,7 @@ class StringDefaultMixRepository {
   }
 
   Future<StringDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -274,7 +276,7 @@ class StringDefaultMixRepository {
   }
 
   Future<List<StringDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -285,7 +287,7 @@ class StringDefaultMixRepository {
   }
 
   Future<StringDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -296,7 +298,7 @@ class StringDefaultMixRepository {
   }
 
   Future<List<StringDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultMix> rows, {
     _i1.ColumnSelections<StringDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -309,7 +311,7 @@ class StringDefaultMixRepository {
   }
 
   Future<StringDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultMix row, {
     _i1.ColumnSelections<StringDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -322,7 +324,7 @@ class StringDefaultMixRepository {
   }
 
   Future<List<StringDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -333,7 +335,7 @@ class StringDefaultMixRepository {
   }
 
   Future<StringDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -344,7 +346,7 @@ class StringDefaultMixRepository {
   }
 
   Future<List<StringDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<StringDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -355,7 +357,7 @@ class StringDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -191,7 +193,7 @@ class StringDefaultModelRepository {
   const StringDefaultModelRepository._();
 
   Future<List<StringDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -212,7 +214,7 @@ class StringDefaultModelRepository {
   }
 
   Future<StringDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
@@ -231,7 +233,7 @@ class StringDefaultModelRepository {
   }
 
   Future<StringDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -242,7 +244,7 @@ class StringDefaultModelRepository {
   }
 
   Future<List<StringDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -253,7 +255,7 @@ class StringDefaultModelRepository {
   }
 
   Future<StringDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -264,7 +266,7 @@ class StringDefaultModelRepository {
   }
 
   Future<List<StringDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultModel> rows, {
     _i1.ColumnSelections<StringDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -277,7 +279,7 @@ class StringDefaultModelRepository {
   }
 
   Future<StringDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultModel row, {
     _i1.ColumnSelections<StringDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -290,7 +292,7 @@ class StringDefaultModelRepository {
   }
 
   Future<List<StringDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -301,7 +303,7 @@ class StringDefaultModelRepository {
   }
 
   Future<StringDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -312,7 +314,7 @@ class StringDefaultModelRepository {
   }
 
   Future<List<StringDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<StringDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -323,7 +325,7 @@ class StringDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -426,7 +428,7 @@ class StringDefaultPersistRepository {
   const StringDefaultPersistRepository._();
 
   Future<List<StringDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -447,7 +449,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<StringDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
@@ -466,7 +468,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<StringDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -477,7 +479,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<List<StringDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -488,7 +490,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<StringDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -499,7 +501,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<List<StringDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultPersist> rows, {
     _i1.ColumnSelections<StringDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -512,7 +514,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<StringDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultPersist row, {
     _i1.ColumnSelections<StringDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -525,7 +527,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<List<StringDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<StringDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -536,7 +538,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<StringDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     StringDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -547,7 +549,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<List<StringDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<StringDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -558,7 +560,7 @@ class StringDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StringDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
@@ -248,7 +250,7 @@ class UuidDefaultRepository {
   const UuidDefaultRepository._();
 
   Future<List<UuidDefault>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultTable>? where,
     int? limit,
     int? offset,
@@ -269,7 +271,7 @@ class UuidDefaultRepository {
   }
 
   Future<UuidDefault?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
@@ -288,7 +290,7 @@ class UuidDefaultRepository {
   }
 
   Future<UuidDefault?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class UuidDefaultRepository {
   }
 
   Future<List<UuidDefault>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -310,7 +312,7 @@ class UuidDefaultRepository {
   }
 
   Future<UuidDefault> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -321,7 +323,7 @@ class UuidDefaultRepository {
   }
 
   Future<List<UuidDefault>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefault> rows, {
     _i1.ColumnSelections<UuidDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -334,7 +336,7 @@ class UuidDefaultRepository {
   }
 
   Future<UuidDefault> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefault row, {
     _i1.ColumnSelections<UuidDefaultTable>? columns,
     _i1.Transaction? transaction,
@@ -347,7 +349,7 @@ class UuidDefaultRepository {
   }
 
   Future<List<UuidDefault>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefault> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -358,7 +360,7 @@ class UuidDefaultRepository {
   }
 
   Future<UuidDefault> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefault row, {
     _i1.Transaction? transaction,
   }) async {
@@ -369,7 +371,7 @@ class UuidDefaultRepository {
   }
 
   Future<List<UuidDefault>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UuidDefaultTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -380,7 +382,7 @@ class UuidDefaultRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -221,7 +223,7 @@ class UuidDefaultMixRepository {
   const UuidDefaultMixRepository._();
 
   Future<List<UuidDefaultMix>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultMixTable>? where,
     int? limit,
     int? offset,
@@ -242,7 +244,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<UuidDefaultMix?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
@@ -261,7 +263,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<UuidDefaultMix?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -272,7 +274,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<List<UuidDefaultMix>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -283,7 +285,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<UuidDefaultMix> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -294,7 +296,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<List<UuidDefaultMix>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultMix> rows, {
     _i1.ColumnSelections<UuidDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -307,7 +309,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<UuidDefaultMix> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultMix row, {
     _i1.ColumnSelections<UuidDefaultMixTable>? columns,
     _i1.Transaction? transaction,
@@ -320,7 +322,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<List<UuidDefaultMix>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultMix> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -331,7 +333,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<UuidDefaultMix> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultMix row, {
     _i1.Transaction? transaction,
   }) async {
@@ -342,7 +344,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<List<UuidDefaultMix>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UuidDefaultMixTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -353,7 +355,7 @@ class UuidDefaultMixRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultMixTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
@@ -250,7 +252,7 @@ class UuidDefaultModelRepository {
   const UuidDefaultModelRepository._();
 
   Future<List<UuidDefaultModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultModelTable>? where,
     int? limit,
     int? offset,
@@ -271,7 +273,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<UuidDefaultModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
@@ -290,7 +292,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<UuidDefaultModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -301,7 +303,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<List<UuidDefaultModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -312,7 +314,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<UuidDefaultModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -323,7 +325,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<List<UuidDefaultModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultModel> rows, {
     _i1.ColumnSelections<UuidDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -336,7 +338,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<UuidDefaultModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultModel row, {
     _i1.ColumnSelections<UuidDefaultModelTable>? columns,
     _i1.Transaction? transaction,
@@ -349,7 +351,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<List<UuidDefaultModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -360,7 +362,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<UuidDefaultModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -371,7 +373,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<List<UuidDefaultModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UuidDefaultModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -382,7 +384,7 @@ class UuidDefaultModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -203,7 +205,7 @@ class UuidDefaultPersistRepository {
   const UuidDefaultPersistRepository._();
 
   Future<List<UuidDefaultPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultPersistTable>? where,
     int? limit,
     int? offset,
@@ -224,7 +226,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<UuidDefaultPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
@@ -243,7 +245,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<UuidDefaultPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -254,7 +256,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<List<UuidDefaultPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -265,7 +267,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<UuidDefaultPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -276,7 +278,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<List<UuidDefaultPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultPersist> rows, {
     _i1.ColumnSelections<UuidDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -289,7 +291,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<UuidDefaultPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultPersist row, {
     _i1.ColumnSelections<UuidDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -302,7 +304,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<List<UuidDefaultPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UuidDefaultPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -313,7 +315,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<UuidDefaultPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UuidDefaultPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -324,7 +326,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<List<UuidDefaultPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UuidDefaultPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -335,7 +337,7 @@ class UuidDefaultPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UuidDefaultPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -215,7 +217,7 @@ class EmptyModelRelationItemRepository {
   const EmptyModelRelationItemRepository._();
 
   Future<List<EmptyModelRelationItem>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? where,
     int? limit,
     int? offset,
@@ -236,7 +238,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<EmptyModelRelationItem?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
@@ -255,7 +257,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<EmptyModelRelationItem?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -266,7 +268,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<List<EmptyModelRelationItem>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmptyModelRelationItem> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -277,7 +279,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<EmptyModelRelationItem> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmptyModelRelationItem row, {
     _i1.Transaction? transaction,
   }) async {
@@ -288,7 +290,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<List<EmptyModelRelationItem>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmptyModelRelationItem> rows, {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? columns,
     _i1.Transaction? transaction,
@@ -301,7 +303,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<EmptyModelRelationItem> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmptyModelRelationItem row, {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? columns,
     _i1.Transaction? transaction,
@@ -314,7 +316,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<List<EmptyModelRelationItem>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmptyModelRelationItem> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -325,7 +327,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<EmptyModelRelationItem> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmptyModelRelationItem row, {
     _i1.Transaction? transaction,
   }) async {
@@ -336,7 +338,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<List<EmptyModelRelationItem>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmptyModelRelationItemTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -347,7 +349,7 @@ class EmptyModelRelationItemRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -125,7 +127,7 @@ class EmptyModelWithTableRepository {
   const EmptyModelWithTableRepository._();
 
   Future<List<EmptyModelWithTable>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? where,
     int? limit,
     int? offset,
@@ -146,7 +148,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<EmptyModelWithTable?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
@@ -165,7 +167,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<EmptyModelWithTable?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -176,7 +178,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<List<EmptyModelWithTable>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmptyModelWithTable> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -187,7 +189,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<EmptyModelWithTable> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmptyModelWithTable row, {
     _i1.Transaction? transaction,
   }) async {
@@ -198,7 +200,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<List<EmptyModelWithTable>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmptyModelWithTable> rows, {
     _i1.ColumnSelections<EmptyModelWithTableTable>? columns,
     _i1.Transaction? transaction,
@@ -211,7 +213,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<EmptyModelWithTable> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmptyModelWithTable row, {
     _i1.ColumnSelections<EmptyModelWithTableTable>? columns,
     _i1.Transaction? transaction,
@@ -224,7 +226,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<List<EmptyModelWithTable>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<EmptyModelWithTable> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -235,7 +237,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<EmptyModelWithTable> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     EmptyModelWithTable row, {
     _i1.Transaction? transaction,
   }) async {
@@ -246,7 +248,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<List<EmptyModelWithTable>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EmptyModelWithTableTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -257,7 +259,7 @@ class EmptyModelWithTableRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -222,7 +224,7 @@ class RelationEmptyModelRepository {
   final detachRow = const RelationEmptyModelDetachRowRepository._();
 
   Future<List<RelationEmptyModel>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? where,
     int? limit,
     int? offset,
@@ -245,7 +247,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<RelationEmptyModel?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
@@ -266,7 +268,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<RelationEmptyModel?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     RelationEmptyModelInclude? include,
@@ -279,7 +281,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<List<RelationEmptyModel>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelationEmptyModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -290,7 +292,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<RelationEmptyModel> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationEmptyModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -301,7 +303,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<List<RelationEmptyModel>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelationEmptyModel> rows, {
     _i1.ColumnSelections<RelationEmptyModelTable>? columns,
     _i1.Transaction? transaction,
@@ -314,7 +316,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<RelationEmptyModel> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationEmptyModel row, {
     _i1.ColumnSelections<RelationEmptyModelTable>? columns,
     _i1.Transaction? transaction,
@@ -327,7 +329,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<List<RelationEmptyModel>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelationEmptyModel> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -338,7 +340,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<RelationEmptyModel> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationEmptyModel row, {
     _i1.Transaction? transaction,
   }) async {
@@ -349,7 +351,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<List<RelationEmptyModel>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<RelationEmptyModelTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -360,7 +362,7 @@ class RelationEmptyModelRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -377,7 +379,7 @@ class RelationEmptyModelAttachRepository {
   const RelationEmptyModelAttachRepository._();
 
   Future<void> items(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationEmptyModel relationEmptyModel,
     List<_i2.EmptyModelRelationItem> emptyModelRelationItem, {
     _i1.Transaction? transaction,
@@ -411,7 +413,7 @@ class RelationEmptyModelAttachRowRepository {
   const RelationEmptyModelAttachRowRepository._();
 
   Future<void> items(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationEmptyModel relationEmptyModel,
     _i2.EmptyModelRelationItem emptyModelRelationItem, {
     _i1.Transaction? transaction,
@@ -442,7 +444,7 @@ class RelationEmptyModelDetachRepository {
   const RelationEmptyModelDetachRepository._();
 
   Future<void> items(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.EmptyModelRelationItem> emptyModelRelationItem, {
     _i1.Transaction? transaction,
   }) async {
@@ -471,7 +473,7 @@ class RelationEmptyModelDetachRowRepository {
   const RelationEmptyModelDetachRowRepository._();
 
   Future<void> items(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.EmptyModelRelationItem emptyModelRelationItem, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
@@ -161,7 +163,7 @@ class ParentClassRepository {
   const ParentClassRepository._();
 
   Future<List<ParentClass>> find(
-    _i2.DatabaseAccessor session, {
+    _i2.Session session, {
     _i2.WhereExpressionBuilder<ParentClassTable>? where,
     int? limit,
     int? offset,
@@ -182,7 +184,7 @@ class ParentClassRepository {
   }
 
   Future<ParentClass?> findFirstRow(
-    _i2.DatabaseAccessor session, {
+    _i2.Session session, {
     _i2.WhereExpressionBuilder<ParentClassTable>? where,
     int? offset,
     _i2.OrderByBuilder<ParentClassTable>? orderBy,
@@ -201,7 +203,7 @@ class ParentClassRepository {
   }
 
   Future<ParentClass?> findById(
-    _i2.DatabaseAccessor session,
+    _i2.Session session,
     int id, {
     _i2.Transaction? transaction,
   }) async {
@@ -212,7 +214,7 @@ class ParentClassRepository {
   }
 
   Future<List<ParentClass>> insert(
-    _i2.DatabaseAccessor session,
+    _i2.Session session,
     List<ParentClass> rows, {
     _i2.Transaction? transaction,
   }) async {
@@ -223,7 +225,7 @@ class ParentClassRepository {
   }
 
   Future<ParentClass> insertRow(
-    _i2.DatabaseAccessor session,
+    _i2.Session session,
     ParentClass row, {
     _i2.Transaction? transaction,
   }) async {
@@ -234,7 +236,7 @@ class ParentClassRepository {
   }
 
   Future<List<ParentClass>> update(
-    _i2.DatabaseAccessor session,
+    _i2.Session session,
     List<ParentClass> rows, {
     _i2.ColumnSelections<ParentClassTable>? columns,
     _i2.Transaction? transaction,
@@ -247,7 +249,7 @@ class ParentClassRepository {
   }
 
   Future<ParentClass> updateRow(
-    _i2.DatabaseAccessor session,
+    _i2.Session session,
     ParentClass row, {
     _i2.ColumnSelections<ParentClassTable>? columns,
     _i2.Transaction? transaction,
@@ -260,7 +262,7 @@ class ParentClassRepository {
   }
 
   Future<List<ParentClass>> delete(
-    _i2.DatabaseAccessor session,
+    _i2.Session session,
     List<ParentClass> rows, {
     _i2.Transaction? transaction,
   }) async {
@@ -271,7 +273,7 @@ class ParentClassRepository {
   }
 
   Future<ParentClass> deleteRow(
-    _i2.DatabaseAccessor session,
+    _i2.Session session,
     ParentClass row, {
     _i2.Transaction? transaction,
   }) async {
@@ -282,7 +284,7 @@ class ParentClassRepository {
   }
 
   Future<List<ParentClass>> deleteWhere(
-    _i2.DatabaseAccessor session, {
+    _i2.Session session, {
     required _i2.WhereExpressionBuilder<ParentClassTable> where,
     _i2.Transaction? transaction,
   }) async {
@@ -293,7 +295,7 @@ class ParentClassRepository {
   }
 
   Future<int> count(
-    _i2.DatabaseAccessor session, {
+    _i2.Session session, {
     _i2.WhereExpressionBuilder<ParentClassTable>? where,
     int? limit,
     _i2.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -320,7 +322,7 @@ class CityWithLongTableNameRepository {
   final detachRow = const CityWithLongTableNameDetachRowRepository._();
 
   Future<List<CityWithLongTableName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CityWithLongTableNameTable>? where,
     int? limit,
     int? offset,
@@ -343,7 +345,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<CityWithLongTableName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CityWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
@@ -364,7 +366,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<CityWithLongTableName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
@@ -377,7 +379,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<List<CityWithLongTableName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CityWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -388,7 +390,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<CityWithLongTableName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CityWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -399,7 +401,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<List<CityWithLongTableName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CityWithLongTableName> rows, {
     _i1.ColumnSelections<CityWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
@@ -412,7 +414,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<CityWithLongTableName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CityWithLongTableName row, {
     _i1.ColumnSelections<CityWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
@@ -425,7 +427,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<List<CityWithLongTableName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<CityWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -436,7 +438,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<CityWithLongTableName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CityWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -447,7 +449,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<List<CityWithLongTableName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CityWithLongTableNameTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -458,7 +460,7 @@ class CityWithLongTableNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CityWithLongTableNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -475,7 +477,7 @@ class CityWithLongTableNameAttachRepository {
   const CityWithLongTableNameAttachRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
     List<_i2.PersonWithLongTableName> personWithLongTableName, {
     _i1.Transaction? transaction,
@@ -505,7 +507,7 @@ class CityWithLongTableNameAttachRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
     List<_i2.OrganizationWithLongTableName> organizationWithLongTableName, {
     _i1.Transaction? transaction,
@@ -532,7 +534,7 @@ class CityWithLongTableNameAttachRowRepository {
   const CityWithLongTableNameAttachRowRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
     _i2.PersonWithLongTableName personWithLongTableName, {
     _i1.Transaction? transaction,
@@ -560,7 +562,7 @@ class CityWithLongTableNameAttachRowRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     CityWithLongTableName cityWithLongTableName,
     _i2.OrganizationWithLongTableName organizationWithLongTableName, {
     _i1.Transaction? transaction,
@@ -586,7 +588,7 @@ class CityWithLongTableNameDetachRepository {
   const CityWithLongTableNameDetachRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.PersonWithLongTableName> personWithLongTableName, {
     _i1.Transaction? transaction,
   }) async {
@@ -612,7 +614,7 @@ class CityWithLongTableNameDetachRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.OrganizationWithLongTableName> organizationWithLongTableName, {
     _i1.Transaction? transaction,
   }) async {
@@ -635,7 +637,7 @@ class CityWithLongTableNameDetachRowRepository {
   const CityWithLongTableNameDetachRowRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.PersonWithLongTableName personWithLongTableName, {
     _i1.Transaction? transaction,
   }) async {
@@ -658,7 +660,7 @@ class CityWithLongTableNameDetachRowRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.OrganizationWithLongTableName organizationWithLongTableName, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -312,7 +314,7 @@ class OrganizationWithLongTableNameRepository {
   final detachRow = const OrganizationWithLongTableNameDetachRowRepository._();
 
   Future<List<OrganizationWithLongTableName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>? where,
     int? limit,
     int? offset,
@@ -335,7 +337,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<OrganizationWithLongTableName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
@@ -356,7 +358,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<OrganizationWithLongTableName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
@@ -369,7 +371,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<List<OrganizationWithLongTableName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<OrganizationWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -380,7 +382,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<OrganizationWithLongTableName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     OrganizationWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -391,7 +393,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<List<OrganizationWithLongTableName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<OrganizationWithLongTableName> rows, {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
@@ -404,7 +406,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<OrganizationWithLongTableName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     OrganizationWithLongTableName row, {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
@@ -417,7 +419,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<List<OrganizationWithLongTableName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<OrganizationWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -428,7 +430,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<OrganizationWithLongTableName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     OrganizationWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -439,7 +441,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<List<OrganizationWithLongTableName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>
         where,
     _i1.Transaction? transaction,
@@ -451,7 +453,7 @@ class OrganizationWithLongTableNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -468,7 +470,7 @@ class OrganizationWithLongTableNameAttachRepository {
   const OrganizationWithLongTableNameAttachRepository._();
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     OrganizationWithLongTableName organizationWithLongTableName,
     List<_i2.PersonWithLongTableName> personWithLongTableName, {
     _i1.Transaction? transaction,
@@ -496,7 +498,7 @@ class OrganizationWithLongTableNameAttachRowRepository {
   const OrganizationWithLongTableNameAttachRowRepository._();
 
   Future<void> city(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     OrganizationWithLongTableName organizationWithLongTableName,
     _i2.CityWithLongTableName city, {
     _i1.Transaction? transaction,
@@ -518,7 +520,7 @@ class OrganizationWithLongTableNameAttachRowRepository {
   }
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     OrganizationWithLongTableName organizationWithLongTableName,
     _i2.PersonWithLongTableName personWithLongTableName, {
     _i1.Transaction? transaction,
@@ -544,7 +546,7 @@ class OrganizationWithLongTableNameDetachRepository {
   const OrganizationWithLongTableNameDetachRepository._();
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.PersonWithLongTableName> personWithLongTableName, {
     _i1.Transaction? transaction,
   }) async {
@@ -567,7 +569,7 @@ class OrganizationWithLongTableNameDetachRowRepository {
   const OrganizationWithLongTableNameDetachRowRepository._();
 
   Future<void> city(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     OrganizationWithLongTableName organizationwithlongtablename, {
     _i1.Transaction? transaction,
   }) async {
@@ -585,7 +587,7 @@ class OrganizationWithLongTableNameDetachRowRepository {
   }
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.PersonWithLongTableName personWithLongTableName, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -297,7 +299,7 @@ class PersonWithLongTableNameRepository {
   final detachRow = const PersonWithLongTableNameDetachRowRepository._();
 
   Future<List<PersonWithLongTableName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PersonWithLongTableNameTable>? where,
     int? limit,
     int? offset,
@@ -320,7 +322,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<PersonWithLongTableName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PersonWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
@@ -341,7 +343,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<PersonWithLongTableName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
@@ -354,7 +356,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<List<PersonWithLongTableName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<PersonWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -365,7 +367,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<PersonWithLongTableName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     PersonWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -376,7 +378,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<List<PersonWithLongTableName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<PersonWithLongTableName> rows, {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
@@ -389,7 +391,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<PersonWithLongTableName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     PersonWithLongTableName row, {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
@@ -402,7 +404,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<List<PersonWithLongTableName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<PersonWithLongTableName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -413,7 +415,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<PersonWithLongTableName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     PersonWithLongTableName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -424,7 +426,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<List<PersonWithLongTableName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<PersonWithLongTableNameTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -435,7 +437,7 @@ class PersonWithLongTableNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PersonWithLongTableNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -452,7 +454,7 @@ class PersonWithLongTableNameAttachRowRepository {
   const PersonWithLongTableNameAttachRowRepository._();
 
   Future<void> organization(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     PersonWithLongTableName personWithLongTableName,
     _i2.OrganizationWithLongTableName organization, {
     _i1.Transaction? transaction,
@@ -478,7 +480,7 @@ class PersonWithLongTableNameDetachRowRepository {
   const PersonWithLongTableNameDetachRowRepository._();
 
   Future<void> organization(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     PersonWithLongTableName personwithlongtablename, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -178,7 +180,7 @@ class MaxFieldNameRepository {
   const MaxFieldNameRepository._();
 
   Future<List<MaxFieldName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MaxFieldNameTable>? where,
     int? limit,
     int? offset,
@@ -199,7 +201,7 @@ class MaxFieldNameRepository {
   }
 
   Future<MaxFieldName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
@@ -218,7 +220,7 @@ class MaxFieldNameRepository {
   }
 
   Future<MaxFieldName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -229,7 +231,7 @@ class MaxFieldNameRepository {
   }
 
   Future<List<MaxFieldName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -240,7 +242,7 @@ class MaxFieldNameRepository {
   }
 
   Future<MaxFieldName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -251,7 +253,7 @@ class MaxFieldNameRepository {
   }
 
   Future<List<MaxFieldName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MaxFieldName> rows, {
     _i1.ColumnSelections<MaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
@@ -264,7 +266,7 @@ class MaxFieldNameRepository {
   }
 
   Future<MaxFieldName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MaxFieldName row, {
     _i1.ColumnSelections<MaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
@@ -277,7 +279,7 @@ class MaxFieldNameRepository {
   }
 
   Future<List<MaxFieldName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -288,7 +290,7 @@ class MaxFieldNameRepository {
   }
 
   Future<MaxFieldName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class MaxFieldNameRepository {
   }
 
   Future<List<MaxFieldName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<MaxFieldNameTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -310,7 +312,7 @@ class MaxFieldNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MaxFieldNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -217,7 +219,7 @@ class LongImplicitIdFieldRepository {
   const LongImplicitIdFieldRepository._();
 
   Future<List<LongImplicitIdField>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldTable>? where,
     int? limit,
     int? offset,
@@ -238,7 +240,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<LongImplicitIdField?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldTable>? where,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
@@ -257,7 +259,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<LongImplicitIdField?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -268,7 +270,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<List<LongImplicitIdField>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LongImplicitIdField> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -279,7 +281,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<LongImplicitIdField> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdField row, {
     _i1.Transaction? transaction,
   }) async {
@@ -290,7 +292,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<List<LongImplicitIdField>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LongImplicitIdField> rows, {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? columns,
     _i1.Transaction? transaction,
@@ -303,7 +305,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<LongImplicitIdField> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdField row, {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? columns,
     _i1.Transaction? transaction,
@@ -316,7 +318,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<List<LongImplicitIdField>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LongImplicitIdField> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -327,7 +329,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<LongImplicitIdField> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdField row, {
     _i1.Transaction? transaction,
   }) async {
@@ -338,7 +340,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<List<LongImplicitIdField>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -349,7 +351,7 @@ class LongImplicitIdFieldRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -286,7 +288,7 @@ class LongImplicitIdFieldCollectionRepository {
   final detachRow = const LongImplicitIdFieldCollectionDetachRowRepository._();
 
   Future<List<LongImplicitIdFieldCollection>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>? where,
     int? limit,
     int? offset,
@@ -309,7 +311,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<LongImplicitIdFieldCollection?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
@@ -330,7 +332,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<LongImplicitIdFieldCollection?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
@@ -343,7 +345,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<List<LongImplicitIdFieldCollection>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -354,7 +356,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<LongImplicitIdFieldCollection> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdFieldCollection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -365,7 +367,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<List<LongImplicitIdFieldCollection>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? columns,
     _i1.Transaction? transaction,
@@ -378,7 +380,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<LongImplicitIdFieldCollection> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdFieldCollection row, {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? columns,
     _i1.Transaction? transaction,
@@ -391,7 +393,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<List<LongImplicitIdFieldCollection>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -402,7 +404,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<LongImplicitIdFieldCollection> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdFieldCollection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -413,7 +415,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<List<LongImplicitIdFieldCollection>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>
         where,
     _i1.Transaction? transaction,
@@ -425,7 +427,7 @@ class LongImplicitIdFieldCollectionRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -442,7 +444,7 @@ class LongImplicitIdFieldCollectionAttachRepository {
   const LongImplicitIdFieldCollectionAttachRepository._();
 
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdFieldCollection longImplicitIdFieldCollection,
     List<_i2.LongImplicitIdField> longImplicitIdField, {
     _i1.Transaction? transaction,
@@ -476,7 +478,7 @@ class LongImplicitIdFieldCollectionAttachRowRepository {
   const LongImplicitIdFieldCollectionAttachRowRepository._();
 
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     LongImplicitIdFieldCollection longImplicitIdFieldCollection,
     _i2.LongImplicitIdField longImplicitIdField, {
     _i1.Transaction? transaction,
@@ -508,7 +510,7 @@ class LongImplicitIdFieldCollectionDetachRepository {
   const LongImplicitIdFieldCollectionDetachRepository._();
 
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.LongImplicitIdField> longImplicitIdField, {
     _i1.Transaction? transaction,
   }) async {
@@ -538,7 +540,7 @@ class LongImplicitIdFieldCollectionDetachRowRepository {
   const LongImplicitIdFieldCollectionDetachRowRepository._();
 
   Future<void> thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.LongImplicitIdField longImplicitIdField, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -254,7 +256,7 @@ class RelationToMultipleMaxFieldNameRepository {
   final detachRow = const RelationToMultipleMaxFieldNameDetachRowRepository._();
 
   Future<List<RelationToMultipleMaxFieldName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>? where,
     int? limit,
     int? offset,
@@ -277,7 +279,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<RelationToMultipleMaxFieldName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
@@ -298,7 +300,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<RelationToMultipleMaxFieldName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
@@ -311,7 +313,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<List<RelationToMultipleMaxFieldName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -322,7 +324,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<RelationToMultipleMaxFieldName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationToMultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -333,7 +335,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<List<RelationToMultipleMaxFieldName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.ColumnSelections<RelationToMultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
@@ -346,7 +348,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<RelationToMultipleMaxFieldName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationToMultipleMaxFieldName row, {
     _i1.ColumnSelections<RelationToMultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
@@ -359,7 +361,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<List<RelationToMultipleMaxFieldName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -370,7 +372,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<RelationToMultipleMaxFieldName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationToMultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -381,7 +383,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<List<RelationToMultipleMaxFieldName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>
         where,
     _i1.Transaction? transaction,
@@ -393,7 +395,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -410,7 +412,7 @@ class RelationToMultipleMaxFieldNameAttachRepository {
   const RelationToMultipleMaxFieldNameAttachRepository._();
 
   Future<void> multipleMaxFieldNames(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationToMultipleMaxFieldName relationToMultipleMaxFieldName,
     List<_i2.MultipleMaxFieldName> multipleMaxFieldName, {
     _i1.Transaction? transaction,
@@ -444,7 +446,7 @@ class RelationToMultipleMaxFieldNameAttachRowRepository {
   const RelationToMultipleMaxFieldNameAttachRowRepository._();
 
   Future<void> multipleMaxFieldNames(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelationToMultipleMaxFieldName relationToMultipleMaxFieldName,
     _i2.MultipleMaxFieldName multipleMaxFieldName, {
     _i1.Transaction? transaction,
@@ -476,7 +478,7 @@ class RelationToMultipleMaxFieldNameDetachRepository {
   const RelationToMultipleMaxFieldNameDetachRepository._();
 
   Future<void> multipleMaxFieldNames(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.MultipleMaxFieldName> multipleMaxFieldName, {
     _i1.Transaction? transaction,
   }) async {
@@ -506,7 +508,7 @@ class RelationToMultipleMaxFieldNameDetachRowRepository {
   const RelationToMultipleMaxFieldNameDetachRowRepository._();
 
   Future<void> multipleMaxFieldNames(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.MultipleMaxFieldName multipleMaxFieldName, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -215,7 +217,7 @@ class UserNoteRepository {
   const UserNoteRepository._();
 
   Future<List<UserNote>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteTable>? where,
     int? limit,
     int? offset,
@@ -236,7 +238,7 @@ class UserNoteRepository {
   }
 
   Future<UserNote?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
@@ -255,7 +257,7 @@ class UserNoteRepository {
   }
 
   Future<UserNote?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -266,7 +268,7 @@ class UserNoteRepository {
   }
 
   Future<List<UserNote>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNote> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -277,7 +279,7 @@ class UserNoteRepository {
   }
 
   Future<UserNote> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNote row, {
     _i1.Transaction? transaction,
   }) async {
@@ -288,7 +290,7 @@ class UserNoteRepository {
   }
 
   Future<List<UserNote>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNote> rows, {
     _i1.ColumnSelections<UserNoteTable>? columns,
     _i1.Transaction? transaction,
@@ -301,7 +303,7 @@ class UserNoteRepository {
   }
 
   Future<UserNote> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNote row, {
     _i1.ColumnSelections<UserNoteTable>? columns,
     _i1.Transaction? transaction,
@@ -314,7 +316,7 @@ class UserNoteRepository {
   }
 
   Future<List<UserNote>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNote> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -325,7 +327,7 @@ class UserNoteRepository {
   }
 
   Future<UserNote> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNote row, {
     _i1.Transaction? transaction,
   }) async {
@@ -336,7 +338,7 @@ class UserNoteRepository {
   }
 
   Future<List<UserNote>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -347,7 +349,7 @@ class UserNoteRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -250,7 +252,7 @@ class UserNoteCollectionRepository {
   final detachRow = const UserNoteCollectionDetachRowRepository._();
 
   Future<List<UserNoteCollection>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteCollectionTable>? where,
     int? limit,
     int? offset,
@@ -273,7 +275,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<UserNoteCollection?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteCollectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
@@ -294,7 +296,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<UserNoteCollection?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
@@ -307,7 +309,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<List<UserNoteCollection>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -318,7 +320,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<UserNoteCollection> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -329,7 +331,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<List<UserNoteCollection>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteCollection> rows, {
     _i1.ColumnSelections<UserNoteCollectionTable>? columns,
     _i1.Transaction? transaction,
@@ -342,7 +344,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<UserNoteCollection> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollection row, {
     _i1.ColumnSelections<UserNoteCollectionTable>? columns,
     _i1.Transaction? transaction,
@@ -355,7 +357,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<List<UserNoteCollection>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteCollection> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -366,7 +368,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<UserNoteCollection> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollection row, {
     _i1.Transaction? transaction,
   }) async {
@@ -377,7 +379,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<List<UserNoteCollection>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -388,7 +390,7 @@ class UserNoteCollectionRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteCollectionTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -405,7 +407,7 @@ class UserNoteCollectionAttachRepository {
   const UserNoteCollectionAttachRepository._();
 
   Future<void> userNotesPropertyName(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollection userNoteCollection,
     List<_i2.UserNote> userNote, {
     _i1.Transaction? transaction,
@@ -439,7 +441,7 @@ class UserNoteCollectionAttachRowRepository {
   const UserNoteCollectionAttachRowRepository._();
 
   Future<void> userNotesPropertyName(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollection userNoteCollection,
     _i2.UserNote userNote, {
     _i1.Transaction? transaction,
@@ -471,7 +473,7 @@ class UserNoteCollectionDetachRepository {
   const UserNoteCollectionDetachRepository._();
 
   Future<void> userNotesPropertyName(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.UserNote> userNote, {
     _i1.Transaction? transaction,
   }) async {
@@ -501,7 +503,7 @@ class UserNoteCollectionDetachRowRepository {
   const UserNoteCollectionDetachRowRepository._();
 
   Future<void> userNotesPropertyName(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.UserNote userNote, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -249,7 +251,7 @@ class UserNoteCollectionWithALongNameRepository {
       const UserNoteCollectionWithALongNameDetachRowRepository._();
 
   Future<List<UserNoteCollectionWithALongName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>? where,
     int? limit,
     int? offset,
@@ -272,7 +274,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<UserNoteCollectionWithALongName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
@@ -293,7 +295,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<UserNoteCollectionWithALongName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
@@ -306,7 +308,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<List<UserNoteCollectionWithALongName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -317,7 +319,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<UserNoteCollectionWithALongName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollectionWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -328,7 +330,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<List<UserNoteCollectionWithALongName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.ColumnSelections<UserNoteCollectionWithALongNameTable>? columns,
     _i1.Transaction? transaction,
@@ -341,7 +343,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<UserNoteCollectionWithALongName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollectionWithALongName row, {
     _i1.ColumnSelections<UserNoteCollectionWithALongNameTable>? columns,
     _i1.Transaction? transaction,
@@ -354,7 +356,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<List<UserNoteCollectionWithALongName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -365,7 +367,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<UserNoteCollectionWithALongName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollectionWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -376,7 +378,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<List<UserNoteCollectionWithALongName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>
         where,
     _i1.Transaction? transaction,
@@ -388,7 +390,7 @@ class UserNoteCollectionWithALongNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -405,7 +407,7 @@ class UserNoteCollectionWithALongNameAttachRepository {
   const UserNoteCollectionWithALongNameAttachRepository._();
 
   Future<void> notes(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollectionWithALongName userNoteCollectionWithALongName,
     List<_i2.UserNoteWithALongName> userNoteWithALongName, {
     _i1.Transaction? transaction,
@@ -439,7 +441,7 @@ class UserNoteCollectionWithALongNameAttachRowRepository {
   const UserNoteCollectionWithALongNameAttachRowRepository._();
 
   Future<void> notes(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteCollectionWithALongName userNoteCollectionWithALongName,
     _i2.UserNoteWithALongName userNoteWithALongName, {
     _i1.Transaction? transaction,
@@ -471,7 +473,7 @@ class UserNoteCollectionWithALongNameDetachRepository {
   const UserNoteCollectionWithALongNameDetachRepository._();
 
   Future<void> notes(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.UserNoteWithALongName> userNoteWithALongName, {
     _i1.Transaction? transaction,
   }) async {
@@ -501,7 +503,7 @@ class UserNoteCollectionWithALongNameDetachRowRepository {
   const UserNoteCollectionWithALongNameDetachRowRepository._();
 
   Future<void> notes(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.UserNoteWithALongName userNoteWithALongName, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -218,7 +220,7 @@ class UserNoteWithALongNameRepository {
   const UserNoteWithALongNameRepository._();
 
   Future<List<UserNoteWithALongName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteWithALongNameTable>? where,
     int? limit,
     int? offset,
@@ -239,7 +241,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<UserNoteWithALongName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteWithALongNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
@@ -258,7 +260,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<UserNoteWithALongName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -269,7 +271,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<List<UserNoteWithALongName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -280,7 +282,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<UserNoteWithALongName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -291,7 +293,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<List<UserNoteWithALongName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteWithALongName> rows, {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? columns,
     _i1.Transaction? transaction,
@@ -304,7 +306,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<UserNoteWithALongName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteWithALongName row, {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? columns,
     _i1.Transaction? transaction,
@@ -317,7 +319,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<List<UserNoteWithALongName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UserNoteWithALongName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -328,7 +330,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<UserNoteWithALongName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UserNoteWithALongName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -339,7 +341,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<List<UserNoteWithALongName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UserNoteWithALongNameTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -350,7 +352,7 @@ class UserNoteWithALongNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UserNoteWithALongNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -272,7 +274,7 @@ class MultipleMaxFieldNameRepository {
   const MultipleMaxFieldNameRepository._();
 
   Future<List<MultipleMaxFieldName>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable>? where,
     int? limit,
     int? offset,
@@ -293,7 +295,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<MultipleMaxFieldName?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
@@ -312,7 +314,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<MultipleMaxFieldName?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -323,7 +325,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<List<MultipleMaxFieldName>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -334,7 +336,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<MultipleMaxFieldName> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -345,7 +347,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<List<MultipleMaxFieldName>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MultipleMaxFieldName> rows, {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
@@ -358,7 +360,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<MultipleMaxFieldName> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MultipleMaxFieldName row, {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
@@ -371,7 +373,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<List<MultipleMaxFieldName>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<MultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -382,7 +384,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<MultipleMaxFieldName> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     MultipleMaxFieldName row, {
     _i1.Transaction? transaction,
   }) async {
@@ -393,7 +395,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<List<MultipleMaxFieldName>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -404,7 +406,7 @@ class MultipleMaxFieldNameRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -311,7 +313,7 @@ class CityRepository {
   final detachRow = const CityDetachRowRepository._();
 
   Future<List<City>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? limit,
     int? offset,
@@ -334,7 +336,7 @@ class CityRepository {
   }
 
   Future<City?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
@@ -355,7 +357,7 @@ class CityRepository {
   }
 
   Future<City?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CityInclude? include,
@@ -368,7 +370,7 @@ class CityRepository {
   }
 
   Future<List<City>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<City> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -379,7 +381,7 @@ class CityRepository {
   }
 
   Future<City> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     City row, {
     _i1.Transaction? transaction,
   }) async {
@@ -390,7 +392,7 @@ class CityRepository {
   }
 
   Future<List<City>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<City> rows, {
     _i1.ColumnSelections<CityTable>? columns,
     _i1.Transaction? transaction,
@@ -403,7 +405,7 @@ class CityRepository {
   }
 
   Future<City> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     City row, {
     _i1.ColumnSelections<CityTable>? columns,
     _i1.Transaction? transaction,
@@ -416,7 +418,7 @@ class CityRepository {
   }
 
   Future<List<City>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<City> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -427,7 +429,7 @@ class CityRepository {
   }
 
   Future<City> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     City row, {
     _i1.Transaction? transaction,
   }) async {
@@ -438,7 +440,7 @@ class CityRepository {
   }
 
   Future<List<City>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -449,7 +451,7 @@ class CityRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -466,7 +468,7 @@ class CityAttachRepository {
   const CityAttachRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     City city,
     List<_i2.Person> person, {
     _i1.Transaction? transaction,
@@ -492,7 +494,7 @@ class CityAttachRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     City city,
     List<_i2.Organization> organization, {
     _i1.Transaction? transaction,
@@ -518,7 +520,7 @@ class CityAttachRowRepository {
   const CityAttachRowRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     City city,
     _i2.Person person, {
     _i1.Transaction? transaction,
@@ -542,7 +544,7 @@ class CityAttachRowRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     City city,
     _i2.Organization organization, {
     _i1.Transaction? transaction,
@@ -567,7 +569,7 @@ class CityDetachRepository {
   const CityDetachRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.Person> person, {
     _i1.Transaction? transaction,
   }) async {
@@ -589,7 +591,7 @@ class CityDetachRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.Organization> organization, {
     _i1.Transaction? transaction,
   }) async {
@@ -611,7 +613,7 @@ class CityDetachRowRepository {
   const CityDetachRowRepository._();
 
   Future<void> citizens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.Person person, {
     _i1.Transaction? transaction,
   }) async {
@@ -631,7 +633,7 @@ class CityDetachRowRepository {
   }
 
   Future<void> organizations(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.Organization organization, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -306,7 +308,7 @@ class OrganizationRepository {
   final detachRow = const OrganizationDetachRowRepository._();
 
   Future<List<Organization>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? limit,
     int? offset,
@@ -329,7 +331,7 @@ class OrganizationRepository {
   }
 
   Future<Organization?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
@@ -350,7 +352,7 @@ class OrganizationRepository {
   }
 
   Future<Organization?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     OrganizationInclude? include,
@@ -363,7 +365,7 @@ class OrganizationRepository {
   }
 
   Future<List<Organization>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Organization> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -374,7 +376,7 @@ class OrganizationRepository {
   }
 
   Future<Organization> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Organization row, {
     _i1.Transaction? transaction,
   }) async {
@@ -385,7 +387,7 @@ class OrganizationRepository {
   }
 
   Future<List<Organization>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Organization> rows, {
     _i1.ColumnSelections<OrganizationTable>? columns,
     _i1.Transaction? transaction,
@@ -398,7 +400,7 @@ class OrganizationRepository {
   }
 
   Future<Organization> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Organization row, {
     _i1.ColumnSelections<OrganizationTable>? columns,
     _i1.Transaction? transaction,
@@ -411,7 +413,7 @@ class OrganizationRepository {
   }
 
   Future<List<Organization>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Organization> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -422,7 +424,7 @@ class OrganizationRepository {
   }
 
   Future<Organization> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Organization row, {
     _i1.Transaction? transaction,
   }) async {
@@ -433,7 +435,7 @@ class OrganizationRepository {
   }
 
   Future<List<Organization>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -444,7 +446,7 @@ class OrganizationRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -461,7 +463,7 @@ class OrganizationAttachRepository {
   const OrganizationAttachRepository._();
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Organization organization,
     List<_i2.Person> person, {
     _i1.Transaction? transaction,
@@ -487,7 +489,7 @@ class OrganizationAttachRowRepository {
   const OrganizationAttachRowRepository._();
 
   Future<void> city(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Organization organization,
     _i2.City city, {
     _i1.Transaction? transaction,
@@ -508,7 +510,7 @@ class OrganizationAttachRowRepository {
   }
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Organization organization,
     _i2.Person person, {
     _i1.Transaction? transaction,
@@ -533,7 +535,7 @@ class OrganizationDetachRepository {
   const OrganizationDetachRepository._();
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.Person> person, {
     _i1.Transaction? transaction,
   }) async {
@@ -554,7 +556,7 @@ class OrganizationDetachRowRepository {
   const OrganizationDetachRowRepository._();
 
   Future<void> city(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Organization organization, {
     _i1.Transaction? transaction,
   }) async {
@@ -571,7 +573,7 @@ class OrganizationDetachRowRepository {
   }
 
   Future<void> people(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.Person person, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -283,7 +285,7 @@ class PersonRepository {
   final detachRow = const PersonDetachRowRepository._();
 
   Future<List<Person>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? limit,
     int? offset,
@@ -306,7 +308,7 @@ class PersonRepository {
   }
 
   Future<Person?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
@@ -327,7 +329,7 @@ class PersonRepository {
   }
 
   Future<Person?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     PersonInclude? include,
@@ -340,7 +342,7 @@ class PersonRepository {
   }
 
   Future<List<Person>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Person> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -351,7 +353,7 @@ class PersonRepository {
   }
 
   Future<Person> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Person row, {
     _i1.Transaction? transaction,
   }) async {
@@ -362,7 +364,7 @@ class PersonRepository {
   }
 
   Future<List<Person>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Person> rows, {
     _i1.ColumnSelections<PersonTable>? columns,
     _i1.Transaction? transaction,
@@ -375,7 +377,7 @@ class PersonRepository {
   }
 
   Future<Person> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Person row, {
     _i1.ColumnSelections<PersonTable>? columns,
     _i1.Transaction? transaction,
@@ -388,7 +390,7 @@ class PersonRepository {
   }
 
   Future<List<Person>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Person> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -399,7 +401,7 @@ class PersonRepository {
   }
 
   Future<Person> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Person row, {
     _i1.Transaction? transaction,
   }) async {
@@ -410,7 +412,7 @@ class PersonRepository {
   }
 
   Future<List<Person>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -421,7 +423,7 @@ class PersonRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -438,7 +440,7 @@ class PersonAttachRowRepository {
   const PersonAttachRowRepository._();
 
   Future<void> organization(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Person person,
     _i2.Organization organization, {
     _i1.Transaction? transaction,
@@ -463,7 +465,7 @@ class PersonDetachRowRepository {
   const PersonDetachRowRepository._();
 
   Future<void> organization(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Person person, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -240,7 +242,7 @@ class CourseRepository {
   final detachRow = const CourseDetachRowRepository._();
 
   Future<List<Course>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? limit,
     int? offset,
@@ -263,7 +265,7 @@ class CourseRepository {
   }
 
   Future<Course?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
@@ -284,7 +286,7 @@ class CourseRepository {
   }
 
   Future<Course?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CourseInclude? include,
@@ -297,7 +299,7 @@ class CourseRepository {
   }
 
   Future<List<Course>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Course> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class CourseRepository {
   }
 
   Future<Course> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Course row, {
     _i1.Transaction? transaction,
   }) async {
@@ -319,7 +321,7 @@ class CourseRepository {
   }
 
   Future<List<Course>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Course> rows, {
     _i1.ColumnSelections<CourseTable>? columns,
     _i1.Transaction? transaction,
@@ -332,7 +334,7 @@ class CourseRepository {
   }
 
   Future<Course> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Course row, {
     _i1.ColumnSelections<CourseTable>? columns,
     _i1.Transaction? transaction,
@@ -345,7 +347,7 @@ class CourseRepository {
   }
 
   Future<List<Course>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Course> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -356,7 +358,7 @@ class CourseRepository {
   }
 
   Future<Course> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Course row, {
     _i1.Transaction? transaction,
   }) async {
@@ -367,7 +369,7 @@ class CourseRepository {
   }
 
   Future<List<Course>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -378,7 +380,7 @@ class CourseRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -395,7 +397,7 @@ class CourseAttachRepository {
   const CourseAttachRepository._();
 
   Future<void> enrollments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Course course,
     List<_i2.Enrollment> enrollment, {
     _i1.Transaction? transaction,
@@ -421,7 +423,7 @@ class CourseAttachRowRepository {
   const CourseAttachRowRepository._();
 
   Future<void> enrollments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Course course,
     _i2.Enrollment enrollment, {
     _i1.Transaction? transaction,
@@ -446,7 +448,7 @@ class CourseDetachRepository {
   const CourseDetachRepository._();
 
   Future<void> enrollments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.Enrollment> enrollment, {
     _i1.Transaction? transaction,
   }) async {
@@ -468,7 +470,7 @@ class CourseDetachRowRepository {
   const CourseDetachRowRepository._();
 
   Future<void> enrollments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.Enrollment enrollment, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -277,7 +279,7 @@ class EnrollmentRepository {
   final attachRow = const EnrollmentAttachRowRepository._();
 
   Future<List<Enrollment>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? limit,
     int? offset,
@@ -300,7 +302,7 @@ class EnrollmentRepository {
   }
 
   Future<Enrollment?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
@@ -321,7 +323,7 @@ class EnrollmentRepository {
   }
 
   Future<Enrollment?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
@@ -334,7 +336,7 @@ class EnrollmentRepository {
   }
 
   Future<List<Enrollment>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -345,7 +347,7 @@ class EnrollmentRepository {
   }
 
   Future<Enrollment> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Enrollment row, {
     _i1.Transaction? transaction,
   }) async {
@@ -356,7 +358,7 @@ class EnrollmentRepository {
   }
 
   Future<List<Enrollment>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Enrollment> rows, {
     _i1.ColumnSelections<EnrollmentTable>? columns,
     _i1.Transaction? transaction,
@@ -369,7 +371,7 @@ class EnrollmentRepository {
   }
 
   Future<Enrollment> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Enrollment row, {
     _i1.ColumnSelections<EnrollmentTable>? columns,
     _i1.Transaction? transaction,
@@ -382,7 +384,7 @@ class EnrollmentRepository {
   }
 
   Future<List<Enrollment>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -393,7 +395,7 @@ class EnrollmentRepository {
   }
 
   Future<Enrollment> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Enrollment row, {
     _i1.Transaction? transaction,
   }) async {
@@ -404,7 +406,7 @@ class EnrollmentRepository {
   }
 
   Future<List<Enrollment>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -415,7 +417,7 @@ class EnrollmentRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -432,7 +434,7 @@ class EnrollmentAttachRowRepository {
   const EnrollmentAttachRowRepository._();
 
   Future<void> student(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Enrollment enrollment,
     _i2.Student student, {
     _i1.Transaction? transaction,
@@ -453,7 +455,7 @@ class EnrollmentAttachRowRepository {
   }
 
   Future<void> course(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Enrollment enrollment,
     _i2.Course course, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -236,7 +238,7 @@ class StudentRepository {
   final attachRow = const StudentAttachRowRepository._();
 
   Future<List<Student>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? limit,
     int? offset,
@@ -259,7 +261,7 @@ class StudentRepository {
   }
 
   Future<Student?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
@@ -280,7 +282,7 @@ class StudentRepository {
   }
 
   Future<Student?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     StudentInclude? include,
@@ -293,7 +295,7 @@ class StudentRepository {
   }
 
   Future<List<Student>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Student> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -304,7 +306,7 @@ class StudentRepository {
   }
 
   Future<Student> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Student row, {
     _i1.Transaction? transaction,
   }) async {
@@ -315,7 +317,7 @@ class StudentRepository {
   }
 
   Future<List<Student>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Student> rows, {
     _i1.ColumnSelections<StudentTable>? columns,
     _i1.Transaction? transaction,
@@ -328,7 +330,7 @@ class StudentRepository {
   }
 
   Future<Student> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Student row, {
     _i1.ColumnSelections<StudentTable>? columns,
     _i1.Transaction? transaction,
@@ -341,7 +343,7 @@ class StudentRepository {
   }
 
   Future<List<Student>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Student> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -352,7 +354,7 @@ class StudentRepository {
   }
 
   Future<Student> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Student row, {
     _i1.Transaction? transaction,
   }) async {
@@ -363,7 +365,7 @@ class StudentRepository {
   }
 
   Future<List<Student>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -374,7 +376,7 @@ class StudentRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -391,7 +393,7 @@ class StudentAttachRepository {
   const StudentAttachRepository._();
 
   Future<void> enrollments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Student student,
     List<_i2.Enrollment> enrollment, {
     _i1.Transaction? transaction,
@@ -417,7 +419,7 @@ class StudentAttachRowRepository {
   const StudentAttachRowRepository._();
 
   Future<void> enrollments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Student student,
     _i2.Enrollment enrollment, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
@@ -230,7 +232,7 @@ class ObjectUserRepository {
   final attachRow = const ObjectUserAttachRowRepository._();
 
   Future<List<ObjectUser>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectUserTable>? where,
     int? limit,
     int? offset,
@@ -253,7 +255,7 @@ class ObjectUserRepository {
   }
 
   Future<ObjectUser?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectUserTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectUserTable>? orderBy,
@@ -274,7 +276,7 @@ class ObjectUserRepository {
   }
 
   Future<ObjectUser?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     ObjectUserInclude? include,
@@ -287,7 +289,7 @@ class ObjectUserRepository {
   }
 
   Future<List<ObjectUser>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectUser> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -298,7 +300,7 @@ class ObjectUserRepository {
   }
 
   Future<ObjectUser> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectUser row, {
     _i1.Transaction? transaction,
   }) async {
@@ -309,7 +311,7 @@ class ObjectUserRepository {
   }
 
   Future<List<ObjectUser>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectUser> rows, {
     _i1.ColumnSelections<ObjectUserTable>? columns,
     _i1.Transaction? transaction,
@@ -322,7 +324,7 @@ class ObjectUserRepository {
   }
 
   Future<ObjectUser> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectUser row, {
     _i1.ColumnSelections<ObjectUserTable>? columns,
     _i1.Transaction? transaction,
@@ -335,7 +337,7 @@ class ObjectUserRepository {
   }
 
   Future<List<ObjectUser>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectUser> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -346,7 +348,7 @@ class ObjectUserRepository {
   }
 
   Future<ObjectUser> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectUser row, {
     _i1.Transaction? transaction,
   }) async {
@@ -357,7 +359,7 @@ class ObjectUserRepository {
   }
 
   Future<List<ObjectUser>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectUserTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -368,7 +370,7 @@ class ObjectUserRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectUserTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -385,7 +387,7 @@ class ObjectUserAttachRowRepository {
   const ObjectUserAttachRowRepository._();
 
   Future<void> userInfo(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectUser objectUser,
     _i2.UserInfo userInfo, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -184,7 +186,7 @@ class ParentUserRepository {
   const ParentUserRepository._();
 
   Future<List<ParentUser>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ParentUserTable>? where,
     int? limit,
     int? offset,
@@ -205,7 +207,7 @@ class ParentUserRepository {
   }
 
   Future<ParentUser?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ParentUserTable>? where,
     int? offset,
     _i1.OrderByBuilder<ParentUserTable>? orderBy,
@@ -224,7 +226,7 @@ class ParentUserRepository {
   }
 
   Future<ParentUser?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -235,7 +237,7 @@ class ParentUserRepository {
   }
 
   Future<List<ParentUser>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ParentUser> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -246,7 +248,7 @@ class ParentUserRepository {
   }
 
   Future<ParentUser> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ParentUser row, {
     _i1.Transaction? transaction,
   }) async {
@@ -257,7 +259,7 @@ class ParentUserRepository {
   }
 
   Future<List<ParentUser>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ParentUser> rows, {
     _i1.ColumnSelections<ParentUserTable>? columns,
     _i1.Transaction? transaction,
@@ -270,7 +272,7 @@ class ParentUserRepository {
   }
 
   Future<ParentUser> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ParentUser row, {
     _i1.ColumnSelections<ParentUserTable>? columns,
     _i1.Transaction? transaction,
@@ -283,7 +285,7 @@ class ParentUserRepository {
   }
 
   Future<List<ParentUser>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ParentUser> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -294,7 +296,7 @@ class ParentUserRepository {
   }
 
   Future<ParentUser> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ParentUser row, {
     _i1.Transaction? transaction,
   }) async {
@@ -305,7 +307,7 @@ class ParentUserRepository {
   }
 
   Future<List<ParentUser>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ParentUserTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -316,7 +318,7 @@ class ParentUserRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ParentUserTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -212,7 +214,7 @@ class ArenaRepository {
   final detachRow = const ArenaDetachRowRepository._();
 
   Future<List<Arena>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? limit,
     int? offset,
@@ -235,7 +237,7 @@ class ArenaRepository {
   }
 
   Future<Arena?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
@@ -256,7 +258,7 @@ class ArenaRepository {
   }
 
   Future<Arena?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     ArenaInclude? include,
@@ -269,7 +271,7 @@ class ArenaRepository {
   }
 
   Future<List<Arena>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Arena> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -280,7 +282,7 @@ class ArenaRepository {
   }
 
   Future<Arena> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Arena row, {
     _i1.Transaction? transaction,
   }) async {
@@ -291,7 +293,7 @@ class ArenaRepository {
   }
 
   Future<List<Arena>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Arena> rows, {
     _i1.ColumnSelections<ArenaTable>? columns,
     _i1.Transaction? transaction,
@@ -304,7 +306,7 @@ class ArenaRepository {
   }
 
   Future<Arena> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Arena row, {
     _i1.ColumnSelections<ArenaTable>? columns,
     _i1.Transaction? transaction,
@@ -317,7 +319,7 @@ class ArenaRepository {
   }
 
   Future<List<Arena>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Arena> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -328,7 +330,7 @@ class ArenaRepository {
   }
 
   Future<Arena> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Arena row, {
     _i1.Transaction? transaction,
   }) async {
@@ -339,7 +341,7 @@ class ArenaRepository {
   }
 
   Future<List<Arena>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -350,7 +352,7 @@ class ArenaRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -367,7 +369,7 @@ class ArenaAttachRowRepository {
   const ArenaAttachRowRepository._();
 
   Future<void> team(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Arena arena,
     _i2.Team team, {
     _i1.Transaction? transaction,
@@ -392,7 +394,7 @@ class ArenaDetachRowRepository {
   const ArenaDetachRowRepository._();
 
   Future<void> team(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Arena arena, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -231,7 +233,7 @@ class PlayerRepository {
   final detachRow = const PlayerDetachRowRepository._();
 
   Future<List<Player>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? limit,
     int? offset,
@@ -254,7 +256,7 @@ class PlayerRepository {
   }
 
   Future<Player?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
@@ -275,7 +277,7 @@ class PlayerRepository {
   }
 
   Future<Player?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     PlayerInclude? include,
@@ -288,7 +290,7 @@ class PlayerRepository {
   }
 
   Future<List<Player>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Player> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class PlayerRepository {
   }
 
   Future<Player> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Player row, {
     _i1.Transaction? transaction,
   }) async {
@@ -310,7 +312,7 @@ class PlayerRepository {
   }
 
   Future<List<Player>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Player> rows, {
     _i1.ColumnSelections<PlayerTable>? columns,
     _i1.Transaction? transaction,
@@ -323,7 +325,7 @@ class PlayerRepository {
   }
 
   Future<Player> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Player row, {
     _i1.ColumnSelections<PlayerTable>? columns,
     _i1.Transaction? transaction,
@@ -336,7 +338,7 @@ class PlayerRepository {
   }
 
   Future<List<Player>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Player> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -347,7 +349,7 @@ class PlayerRepository {
   }
 
   Future<Player> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Player row, {
     _i1.Transaction? transaction,
   }) async {
@@ -358,7 +360,7 @@ class PlayerRepository {
   }
 
   Future<List<Player>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -369,7 +371,7 @@ class PlayerRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -386,7 +388,7 @@ class PlayerAttachRowRepository {
   const PlayerAttachRowRepository._();
 
   Future<void> team(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Player player,
     _i2.Team team, {
     _i1.Transaction? transaction,
@@ -411,7 +413,7 @@ class PlayerDetachRowRepository {
   const PlayerDetachRowRepository._();
 
   Future<void> team(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Player player, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -306,7 +308,7 @@ class TeamRepository {
   final detachRow = const TeamDetachRowRepository._();
 
   Future<List<Team>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? limit,
     int? offset,
@@ -329,7 +331,7 @@ class TeamRepository {
   }
 
   Future<Team?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
@@ -350,7 +352,7 @@ class TeamRepository {
   }
 
   Future<Team?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     TeamInclude? include,
@@ -363,7 +365,7 @@ class TeamRepository {
   }
 
   Future<List<Team>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Team> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -374,7 +376,7 @@ class TeamRepository {
   }
 
   Future<Team> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Team row, {
     _i1.Transaction? transaction,
   }) async {
@@ -385,7 +387,7 @@ class TeamRepository {
   }
 
   Future<List<Team>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Team> rows, {
     _i1.ColumnSelections<TeamTable>? columns,
     _i1.Transaction? transaction,
@@ -398,7 +400,7 @@ class TeamRepository {
   }
 
   Future<Team> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Team row, {
     _i1.ColumnSelections<TeamTable>? columns,
     _i1.Transaction? transaction,
@@ -411,7 +413,7 @@ class TeamRepository {
   }
 
   Future<List<Team>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Team> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -422,7 +424,7 @@ class TeamRepository {
   }
 
   Future<Team> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Team row, {
     _i1.Transaction? transaction,
   }) async {
@@ -433,7 +435,7 @@ class TeamRepository {
   }
 
   Future<List<Team>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -444,7 +446,7 @@ class TeamRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -461,7 +463,7 @@ class TeamAttachRepository {
   const TeamAttachRepository._();
 
   Future<void> players(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Team team,
     List<_i2.Player> player, {
     _i1.Transaction? transaction,
@@ -486,7 +488,7 @@ class TeamAttachRowRepository {
   const TeamAttachRowRepository._();
 
   Future<void> arena(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Team team,
     _i2.Arena arena, {
     _i1.Transaction? transaction,
@@ -507,7 +509,7 @@ class TeamAttachRowRepository {
   }
 
   Future<void> players(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Team team,
     _i2.Player player, {
     _i1.Transaction? transaction,
@@ -532,7 +534,7 @@ class TeamDetachRepository {
   const TeamDetachRepository._();
 
   Future<void> players(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.Player> player, {
     _i1.Transaction? transaction,
   }) async {
@@ -553,7 +555,7 @@ class TeamDetachRowRepository {
   const TeamDetachRowRepository._();
 
   Future<void> arena(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Team team, {
     _i1.Transaction? transaction,
   }) async {
@@ -570,7 +572,7 @@ class TeamDetachRowRepository {
   }
 
   Future<void> players(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.Player player, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -229,7 +231,7 @@ class CommentRepository {
   final attachRow = const CommentAttachRowRepository._();
 
   Future<List<Comment>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? limit,
     int? offset,
@@ -252,7 +254,7 @@ class CommentRepository {
   }
 
   Future<Comment?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
@@ -273,7 +275,7 @@ class CommentRepository {
   }
 
   Future<Comment?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CommentInclude? include,
@@ -286,7 +288,7 @@ class CommentRepository {
   }
 
   Future<List<Comment>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Comment> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -297,7 +299,7 @@ class CommentRepository {
   }
 
   Future<Comment> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Comment row, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class CommentRepository {
   }
 
   Future<List<Comment>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Comment> rows, {
     _i1.ColumnSelections<CommentTable>? columns,
     _i1.Transaction? transaction,
@@ -321,7 +323,7 @@ class CommentRepository {
   }
 
   Future<Comment> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Comment row, {
     _i1.ColumnSelections<CommentTable>? columns,
     _i1.Transaction? transaction,
@@ -334,7 +336,7 @@ class CommentRepository {
   }
 
   Future<List<Comment>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Comment> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -345,7 +347,7 @@ class CommentRepository {
   }
 
   Future<Comment> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Comment row, {
     _i1.Transaction? transaction,
   }) async {
@@ -356,7 +358,7 @@ class CommentRepository {
   }
 
   Future<List<Comment>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -367,7 +369,7 @@ class CommentRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -384,7 +386,7 @@ class CommentAttachRowRepository {
   const CommentAttachRowRepository._();
 
   Future<void> order(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Comment comment,
     _i2.Order order, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -239,7 +241,7 @@ class CustomerRepository {
   final detachRow = const CustomerDetachRowRepository._();
 
   Future<List<Customer>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? limit,
     int? offset,
@@ -262,7 +264,7 @@ class CustomerRepository {
   }
 
   Future<Customer?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
@@ -283,7 +285,7 @@ class CustomerRepository {
   }
 
   Future<Customer?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CustomerInclude? include,
@@ -296,7 +298,7 @@ class CustomerRepository {
   }
 
   Future<List<Customer>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Customer> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -307,7 +309,7 @@ class CustomerRepository {
   }
 
   Future<Customer> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Customer row, {
     _i1.Transaction? transaction,
   }) async {
@@ -318,7 +320,7 @@ class CustomerRepository {
   }
 
   Future<List<Customer>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Customer> rows, {
     _i1.ColumnSelections<CustomerTable>? columns,
     _i1.Transaction? transaction,
@@ -331,7 +333,7 @@ class CustomerRepository {
   }
 
   Future<Customer> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Customer row, {
     _i1.ColumnSelections<CustomerTable>? columns,
     _i1.Transaction? transaction,
@@ -344,7 +346,7 @@ class CustomerRepository {
   }
 
   Future<List<Customer>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Customer> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -355,7 +357,7 @@ class CustomerRepository {
   }
 
   Future<Customer> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Customer row, {
     _i1.Transaction? transaction,
   }) async {
@@ -366,7 +368,7 @@ class CustomerRepository {
   }
 
   Future<List<Customer>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -377,7 +379,7 @@ class CustomerRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -394,7 +396,7 @@ class CustomerAttachRepository {
   const CustomerAttachRepository._();
 
   Future<void> orders(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Customer customer,
     List<_i2.Order> order, {
     _i1.Transaction? transaction,
@@ -419,7 +421,7 @@ class CustomerAttachRowRepository {
   const CustomerAttachRowRepository._();
 
   Future<void> orders(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Customer customer,
     _i2.Order order, {
     _i1.Transaction? transaction,
@@ -444,7 +446,7 @@ class CustomerDetachRepository {
   const CustomerDetachRepository._();
 
   Future<void> orders(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.Order> order, {
     _i1.Transaction? transaction,
   }) async {
@@ -465,7 +467,7 @@ class CustomerDetachRowRepository {
   const CustomerDetachRowRepository._();
 
   Future<void> orders(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.Order order, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -303,7 +305,7 @@ class OrderRepository {
   final attachRow = const OrderAttachRowRepository._();
 
   Future<List<Order>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? limit,
     int? offset,
@@ -326,7 +328,7 @@ class OrderRepository {
   }
 
   Future<Order?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
@@ -347,7 +349,7 @@ class OrderRepository {
   }
 
   Future<Order?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     OrderInclude? include,
@@ -360,7 +362,7 @@ class OrderRepository {
   }
 
   Future<List<Order>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Order> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -371,7 +373,7 @@ class OrderRepository {
   }
 
   Future<Order> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Order row, {
     _i1.Transaction? transaction,
   }) async {
@@ -382,7 +384,7 @@ class OrderRepository {
   }
 
   Future<List<Order>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Order> rows, {
     _i1.ColumnSelections<OrderTable>? columns,
     _i1.Transaction? transaction,
@@ -395,7 +397,7 @@ class OrderRepository {
   }
 
   Future<Order> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Order row, {
     _i1.ColumnSelections<OrderTable>? columns,
     _i1.Transaction? transaction,
@@ -408,7 +410,7 @@ class OrderRepository {
   }
 
   Future<List<Order>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Order> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -419,7 +421,7 @@ class OrderRepository {
   }
 
   Future<Order> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Order row, {
     _i1.Transaction? transaction,
   }) async {
@@ -430,7 +432,7 @@ class OrderRepository {
   }
 
   Future<List<Order>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -441,7 +443,7 @@ class OrderRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -458,7 +460,7 @@ class OrderAttachRepository {
   const OrderAttachRepository._();
 
   Future<void> comments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Order order,
     List<_i2.Comment> comment, {
     _i1.Transaction? transaction,
@@ -483,7 +485,7 @@ class OrderAttachRowRepository {
   const OrderAttachRowRepository._();
 
   Future<void> customer(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Order order,
     _i2.Customer customer, {
     _i1.Transaction? transaction,
@@ -504,7 +506,7 @@ class OrderAttachRowRepository {
   }
 
   Future<void> comments(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Order order,
     _i2.Comment comment, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -232,7 +234,7 @@ class AddressRepository {
   final detachRow = const AddressDetachRowRepository._();
 
   Future<List<Address>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? limit,
     int? offset,
@@ -255,7 +257,7 @@ class AddressRepository {
   }
 
   Future<Address?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
@@ -276,7 +278,7 @@ class AddressRepository {
   }
 
   Future<Address?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     AddressInclude? include,
@@ -289,7 +291,7 @@ class AddressRepository {
   }
 
   Future<List<Address>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Address> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -300,7 +302,7 @@ class AddressRepository {
   }
 
   Future<Address> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Address row, {
     _i1.Transaction? transaction,
   }) async {
@@ -311,7 +313,7 @@ class AddressRepository {
   }
 
   Future<List<Address>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Address> rows, {
     _i1.ColumnSelections<AddressTable>? columns,
     _i1.Transaction? transaction,
@@ -324,7 +326,7 @@ class AddressRepository {
   }
 
   Future<Address> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Address row, {
     _i1.ColumnSelections<AddressTable>? columns,
     _i1.Transaction? transaction,
@@ -337,7 +339,7 @@ class AddressRepository {
   }
 
   Future<List<Address>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Address> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -348,7 +350,7 @@ class AddressRepository {
   }
 
   Future<Address> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Address row, {
     _i1.Transaction? transaction,
   }) async {
@@ -359,7 +361,7 @@ class AddressRepository {
   }
 
   Future<List<Address>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -370,7 +372,7 @@ class AddressRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -387,7 +389,7 @@ class AddressAttachRowRepository {
   const AddressAttachRowRepository._();
 
   Future<void> inhabitant(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Address address,
     _i2.Citizen inhabitant, {
     _i1.Transaction? transaction,
@@ -412,7 +414,7 @@ class AddressDetachRowRepository {
   const AddressDetachRowRepository._();
 
   Future<void> inhabitant(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Address address, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -339,7 +341,7 @@ class CitizenRepository {
   final detachRow = const CitizenDetachRowRepository._();
 
   Future<List<Citizen>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? limit,
     int? offset,
@@ -362,7 +364,7 @@ class CitizenRepository {
   }
 
   Future<Citizen?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
@@ -383,7 +385,7 @@ class CitizenRepository {
   }
 
   Future<Citizen?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CitizenInclude? include,
@@ -396,7 +398,7 @@ class CitizenRepository {
   }
 
   Future<List<Citizen>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Citizen> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -407,7 +409,7 @@ class CitizenRepository {
   }
 
   Future<Citizen> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen row, {
     _i1.Transaction? transaction,
   }) async {
@@ -418,7 +420,7 @@ class CitizenRepository {
   }
 
   Future<List<Citizen>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Citizen> rows, {
     _i1.ColumnSelections<CitizenTable>? columns,
     _i1.Transaction? transaction,
@@ -431,7 +433,7 @@ class CitizenRepository {
   }
 
   Future<Citizen> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen row, {
     _i1.ColumnSelections<CitizenTable>? columns,
     _i1.Transaction? transaction,
@@ -444,7 +446,7 @@ class CitizenRepository {
   }
 
   Future<List<Citizen>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Citizen> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -455,7 +457,7 @@ class CitizenRepository {
   }
 
   Future<Citizen> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen row, {
     _i1.Transaction? transaction,
   }) async {
@@ -466,7 +468,7 @@ class CitizenRepository {
   }
 
   Future<List<Citizen>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -477,7 +479,7 @@ class CitizenRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -494,7 +496,7 @@ class CitizenAttachRowRepository {
   const CitizenAttachRowRepository._();
 
   Future<void> address(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen citizen,
     _i2.Address address, {
     _i1.Transaction? transaction,
@@ -515,7 +517,7 @@ class CitizenAttachRowRepository {
   }
 
   Future<void> company(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen citizen,
     _i2.Company company, {
     _i1.Transaction? transaction,
@@ -536,7 +538,7 @@ class CitizenAttachRowRepository {
   }
 
   Future<void> oldCompany(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen citizen,
     _i2.Company oldCompany, {
     _i1.Transaction? transaction,
@@ -561,7 +563,7 @@ class CitizenDetachRowRepository {
   const CitizenDetachRowRepository._();
 
   Future<void> address(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen citizen, {
     _i1.Transaction? transaction,
   }) async {
@@ -586,7 +588,7 @@ class CitizenDetachRowRepository {
   }
 
   Future<void> oldCompany(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Citizen citizen, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -229,7 +231,7 @@ class CompanyRepository {
   final attachRow = const CompanyAttachRowRepository._();
 
   Future<List<Company>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? limit,
     int? offset,
@@ -252,7 +254,7 @@ class CompanyRepository {
   }
 
   Future<Company?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
@@ -273,7 +275,7 @@ class CompanyRepository {
   }
 
   Future<Company?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CompanyInclude? include,
@@ -286,7 +288,7 @@ class CompanyRepository {
   }
 
   Future<List<Company>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Company> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -297,7 +299,7 @@ class CompanyRepository {
   }
 
   Future<Company> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Company row, {
     _i1.Transaction? transaction,
   }) async {
@@ -308,7 +310,7 @@ class CompanyRepository {
   }
 
   Future<List<Company>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Company> rows, {
     _i1.ColumnSelections<CompanyTable>? columns,
     _i1.Transaction? transaction,
@@ -321,7 +323,7 @@ class CompanyRepository {
   }
 
   Future<Company> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Company row, {
     _i1.ColumnSelections<CompanyTable>? columns,
     _i1.Transaction? transaction,
@@ -334,7 +336,7 @@ class CompanyRepository {
   }
 
   Future<List<Company>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Company> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -345,7 +347,7 @@ class CompanyRepository {
   }
 
   Future<Company> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Company row, {
     _i1.Transaction? transaction,
   }) async {
@@ -356,7 +358,7 @@ class CompanyRepository {
   }
 
   Future<List<Company>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -367,7 +369,7 @@ class CompanyRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -384,7 +386,7 @@ class CompanyAttachRowRepository {
   const CompanyAttachRowRepository._();
 
   Future<void> town(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Company company,
     _i2.Town town, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -231,7 +233,7 @@ class TownRepository {
   final detachRow = const TownDetachRowRepository._();
 
   Future<List<Town>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? limit,
     int? offset,
@@ -254,7 +256,7 @@ class TownRepository {
   }
 
   Future<Town?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
@@ -275,7 +277,7 @@ class TownRepository {
   }
 
   Future<Town?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     TownInclude? include,
@@ -288,7 +290,7 @@ class TownRepository {
   }
 
   Future<List<Town>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Town> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class TownRepository {
   }
 
   Future<Town> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Town row, {
     _i1.Transaction? transaction,
   }) async {
@@ -310,7 +312,7 @@ class TownRepository {
   }
 
   Future<List<Town>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Town> rows, {
     _i1.ColumnSelections<TownTable>? columns,
     _i1.Transaction? transaction,
@@ -323,7 +325,7 @@ class TownRepository {
   }
 
   Future<Town> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Town row, {
     _i1.ColumnSelections<TownTable>? columns,
     _i1.Transaction? transaction,
@@ -336,7 +338,7 @@ class TownRepository {
   }
 
   Future<List<Town>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Town> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -347,7 +349,7 @@ class TownRepository {
   }
 
   Future<Town> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Town row, {
     _i1.Transaction? transaction,
   }) async {
@@ -358,7 +360,7 @@ class TownRepository {
   }
 
   Future<List<Town>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -369,7 +371,7 @@ class TownRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -386,7 +388,7 @@ class TownAttachRowRepository {
   const TownAttachRowRepository._();
 
   Future<void> mayor(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Town town,
     _i2.Citizen mayor, {
     _i1.Transaction? transaction,
@@ -411,7 +413,7 @@ class TownDetachRowRepository {
   const TownDetachRowRepository._();
 
   Future<void> mayor(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Town town, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -278,7 +280,7 @@ class BlockingRepository {
   final attachRow = const BlockingAttachRowRepository._();
 
   Future<List<Blocking>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? limit,
     int? offset,
@@ -301,7 +303,7 @@ class BlockingRepository {
   }
 
   Future<Blocking?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
@@ -322,7 +324,7 @@ class BlockingRepository {
   }
 
   Future<Blocking?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     BlockingInclude? include,
@@ -335,7 +337,7 @@ class BlockingRepository {
   }
 
   Future<List<Blocking>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Blocking> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -346,7 +348,7 @@ class BlockingRepository {
   }
 
   Future<Blocking> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Blocking row, {
     _i1.Transaction? transaction,
   }) async {
@@ -357,7 +359,7 @@ class BlockingRepository {
   }
 
   Future<List<Blocking>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Blocking> rows, {
     _i1.ColumnSelections<BlockingTable>? columns,
     _i1.Transaction? transaction,
@@ -370,7 +372,7 @@ class BlockingRepository {
   }
 
   Future<Blocking> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Blocking row, {
     _i1.ColumnSelections<BlockingTable>? columns,
     _i1.Transaction? transaction,
@@ -383,7 +385,7 @@ class BlockingRepository {
   }
 
   Future<List<Blocking>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Blocking> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -394,7 +396,7 @@ class BlockingRepository {
   }
 
   Future<Blocking> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Blocking row, {
     _i1.Transaction? transaction,
   }) async {
@@ -405,7 +407,7 @@ class BlockingRepository {
   }
 
   Future<List<Blocking>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -416,7 +418,7 @@ class BlockingRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -433,7 +435,7 @@ class BlockingAttachRowRepository {
   const BlockingAttachRowRepository._();
 
   Future<void> blocked(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Blocking blocking,
     _i2.Member blocked, {
     _i1.Transaction? transaction,
@@ -454,7 +456,7 @@ class BlockingAttachRowRepository {
   }
 
   Future<void> blockedBy(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Blocking blocking,
     _i2.Member blockedBy, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -307,7 +309,7 @@ class MemberRepository {
   final attachRow = const MemberAttachRowRepository._();
 
   Future<List<Member>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? limit,
     int? offset,
@@ -330,7 +332,7 @@ class MemberRepository {
   }
 
   Future<Member?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
@@ -351,7 +353,7 @@ class MemberRepository {
   }
 
   Future<Member?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     MemberInclude? include,
@@ -364,7 +366,7 @@ class MemberRepository {
   }
 
   Future<List<Member>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Member> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -375,7 +377,7 @@ class MemberRepository {
   }
 
   Future<Member> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Member row, {
     _i1.Transaction? transaction,
   }) async {
@@ -386,7 +388,7 @@ class MemberRepository {
   }
 
   Future<List<Member>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Member> rows, {
     _i1.ColumnSelections<MemberTable>? columns,
     _i1.Transaction? transaction,
@@ -399,7 +401,7 @@ class MemberRepository {
   }
 
   Future<Member> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Member row, {
     _i1.ColumnSelections<MemberTable>? columns,
     _i1.Transaction? transaction,
@@ -412,7 +414,7 @@ class MemberRepository {
   }
 
   Future<List<Member>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Member> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -423,7 +425,7 @@ class MemberRepository {
   }
 
   Future<Member> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Member row, {
     _i1.Transaction? transaction,
   }) async {
@@ -434,7 +436,7 @@ class MemberRepository {
   }
 
   Future<List<Member>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -445,7 +447,7 @@ class MemberRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -462,7 +464,7 @@ class MemberAttachRepository {
   const MemberAttachRepository._();
 
   Future<void> blocking(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Member member,
     List<_i2.Blocking> blocking, {
     _i1.Transaction? transaction,
@@ -484,7 +486,7 @@ class MemberAttachRepository {
   }
 
   Future<void> blockedBy(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Member member,
     List<_i2.Blocking> blocking, {
     _i1.Transaction? transaction,
@@ -510,7 +512,7 @@ class MemberAttachRowRepository {
   const MemberAttachRowRepository._();
 
   Future<void> blocking(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Member member,
     _i2.Blocking blocking, {
     _i1.Transaction? transaction,
@@ -531,7 +533,7 @@ class MemberAttachRowRepository {
   }
 
   Future<void> blockedBy(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Member member,
     _i2.Blocking blocking, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -306,7 +308,7 @@ class CatRepository {
   final detachRow = const CatDetachRowRepository._();
 
   Future<List<Cat>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? limit,
     int? offset,
@@ -329,7 +331,7 @@ class CatRepository {
   }
 
   Future<Cat?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
@@ -350,7 +352,7 @@ class CatRepository {
   }
 
   Future<Cat?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     CatInclude? include,
@@ -363,7 +365,7 @@ class CatRepository {
   }
 
   Future<List<Cat>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Cat> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -374,7 +376,7 @@ class CatRepository {
   }
 
   Future<Cat> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Cat row, {
     _i1.Transaction? transaction,
   }) async {
@@ -385,7 +387,7 @@ class CatRepository {
   }
 
   Future<List<Cat>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Cat> rows, {
     _i1.ColumnSelections<CatTable>? columns,
     _i1.Transaction? transaction,
@@ -398,7 +400,7 @@ class CatRepository {
   }
 
   Future<Cat> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Cat row, {
     _i1.ColumnSelections<CatTable>? columns,
     _i1.Transaction? transaction,
@@ -411,7 +413,7 @@ class CatRepository {
   }
 
   Future<List<Cat>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Cat> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -422,7 +424,7 @@ class CatRepository {
   }
 
   Future<Cat> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Cat row, {
     _i1.Transaction? transaction,
   }) async {
@@ -433,7 +435,7 @@ class CatRepository {
   }
 
   Future<List<Cat>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -444,7 +446,7 @@ class CatRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -461,7 +463,7 @@ class CatAttachRepository {
   const CatAttachRepository._();
 
   Future<void> kittens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Cat cat,
     List<_i2.Cat> nestedCat, {
     _i1.Transaction? transaction,
@@ -487,7 +489,7 @@ class CatAttachRowRepository {
   const CatAttachRowRepository._();
 
   Future<void> mother(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Cat cat,
     _i2.Cat mother, {
     _i1.Transaction? transaction,
@@ -508,7 +510,7 @@ class CatAttachRowRepository {
   }
 
   Future<void> kittens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Cat cat,
     _i2.Cat nestedCat, {
     _i1.Transaction? transaction,
@@ -533,7 +535,7 @@ class CatDetachRepository {
   const CatDetachRepository._();
 
   Future<void> kittens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<_i2.Cat> cat, {
     _i1.Transaction? transaction,
   }) async {
@@ -554,7 +556,7 @@ class CatDetachRowRepository {
   const CatDetachRowRepository._();
 
   Future<void> mother(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Cat cat, {
     _i1.Transaction? transaction,
   }) async {
@@ -571,7 +573,7 @@ class CatDetachRowRepository {
   }
 
   Future<void> kittens(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     _i2.Cat cat, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -279,7 +281,7 @@ class PostRepository {
   final detachRow = const PostDetachRowRepository._();
 
   Future<List<Post>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? limit,
     int? offset,
@@ -302,7 +304,7 @@ class PostRepository {
   }
 
   Future<Post?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
@@ -323,7 +325,7 @@ class PostRepository {
   }
 
   Future<Post?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     PostInclude? include,
@@ -336,7 +338,7 @@ class PostRepository {
   }
 
   Future<List<Post>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Post> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -347,7 +349,7 @@ class PostRepository {
   }
 
   Future<Post> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Post row, {
     _i1.Transaction? transaction,
   }) async {
@@ -358,7 +360,7 @@ class PostRepository {
   }
 
   Future<List<Post>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Post> rows, {
     _i1.ColumnSelections<PostTable>? columns,
     _i1.Transaction? transaction,
@@ -371,7 +373,7 @@ class PostRepository {
   }
 
   Future<Post> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Post row, {
     _i1.ColumnSelections<PostTable>? columns,
     _i1.Transaction? transaction,
@@ -384,7 +386,7 @@ class PostRepository {
   }
 
   Future<List<Post>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Post> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -395,7 +397,7 @@ class PostRepository {
   }
 
   Future<Post> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Post row, {
     _i1.Transaction? transaction,
   }) async {
@@ -406,7 +408,7 @@ class PostRepository {
   }
 
   Future<List<Post>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -417,7 +419,7 @@ class PostRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -434,7 +436,7 @@ class PostAttachRowRepository {
   const PostAttachRowRepository._();
 
   Future<void> previous(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Post post,
     _i2.Post previous, {
     _i1.Transaction? transaction,
@@ -455,7 +457,7 @@ class PostAttachRowRepository {
   }
 
   Future<void> next(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Post post,
     _i2.Post next, {
     _i1.Transaction? transaction,
@@ -480,7 +482,7 @@ class PostDetachRowRepository {
   const PostDetachRowRepository._();
 
   Future<void> previous(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Post post, {
     _i1.Transaction? transaction,
   }) async {
@@ -505,7 +507,7 @@ class PostDetachRowRepository {
   }
 
   Future<void> next(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Post post, {
     _i1.Transaction? transaction,
   }) async {

--- a/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -195,7 +197,7 @@ class ObjectFieldPersistRepository {
   const ObjectFieldPersistRepository._();
 
   Future<List<ObjectFieldPersist>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? where,
     int? limit,
     int? offset,
@@ -216,7 +218,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<ObjectFieldPersist?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
@@ -235,7 +237,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<ObjectFieldPersist?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -246,7 +248,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<List<ObjectFieldPersist>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectFieldPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -257,7 +259,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<ObjectFieldPersist> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectFieldPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -268,7 +270,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<List<ObjectFieldPersist>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectFieldPersist> rows, {
     _i1.ColumnSelections<ObjectFieldPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -281,7 +283,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<ObjectFieldPersist> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectFieldPersist row, {
     _i1.ColumnSelections<ObjectFieldPersistTable>? columns,
     _i1.Transaction? transaction,
@@ -294,7 +296,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<List<ObjectFieldPersist>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectFieldPersist> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -305,7 +307,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<ObjectFieldPersist> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectFieldPersist row, {
     _i1.Transaction? transaction,
   }) async {
@@ -316,7 +318,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<List<ObjectFieldPersist>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectFieldPersistTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -327,7 +329,7 @@ class ObjectFieldPersistRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -197,7 +199,7 @@ class ObjectFieldScopesRepository {
   const ObjectFieldScopesRepository._();
 
   Future<List<ObjectFieldScopes>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? limit,
     int? offset,
@@ -218,7 +220,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<ObjectFieldScopes?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
@@ -237,7 +239,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<ObjectFieldScopes?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -248,7 +250,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<List<ObjectFieldScopes>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectFieldScopes> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -259,7 +261,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<ObjectFieldScopes> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectFieldScopes row, {
     _i1.Transaction? transaction,
   }) async {
@@ -270,7 +272,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<List<ObjectFieldScopes>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectFieldScopes> rows, {
     _i1.ColumnSelections<ObjectFieldScopesTable>? columns,
     _i1.Transaction? transaction,
@@ -283,7 +285,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<ObjectFieldScopes> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectFieldScopes row, {
     _i1.ColumnSelections<ObjectFieldScopesTable>? columns,
     _i1.Transaction? transaction,
@@ -296,7 +298,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<List<ObjectFieldScopes>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectFieldScopes> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -307,7 +309,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<ObjectFieldScopes> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectFieldScopes row, {
     _i1.Transaction? transaction,
   }) async {
@@ -318,7 +320,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<List<ObjectFieldScopes>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectFieldScopesTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -329,7 +331,7 @@ class ObjectFieldScopesRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
@@ -169,7 +171,7 @@ class ObjectWithByteDataRepository {
   const ObjectWithByteDataRepository._();
 
   Future<List<ObjectWithByteData>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? limit,
     int? offset,
@@ -190,7 +192,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<ObjectWithByteData?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
@@ -209,7 +211,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<ObjectWithByteData?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -220,7 +222,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<List<ObjectWithByteData>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithByteData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -231,7 +233,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<ObjectWithByteData> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithByteData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -242,7 +244,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<List<ObjectWithByteData>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithByteData> rows, {
     _i1.ColumnSelections<ObjectWithByteDataTable>? columns,
     _i1.Transaction? transaction,
@@ -255,7 +257,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<ObjectWithByteData> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithByteData row, {
     _i1.ColumnSelections<ObjectWithByteDataTable>? columns,
     _i1.Transaction? transaction,
@@ -268,7 +270,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<List<ObjectWithByteData>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithByteData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -279,7 +281,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<ObjectWithByteData> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithByteData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -290,7 +292,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<List<ObjectWithByteData>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithByteDataTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -301,7 +303,7 @@ class ObjectWithByteDataRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -168,7 +170,7 @@ class ObjectWithDurationRepository {
   const ObjectWithDurationRepository._();
 
   Future<List<ObjectWithDuration>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? limit,
     int? offset,
@@ -189,7 +191,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<ObjectWithDuration?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
@@ -208,7 +210,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<ObjectWithDuration?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -219,7 +221,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<List<ObjectWithDuration>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithDuration> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -230,7 +232,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<ObjectWithDuration> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithDuration row, {
     _i1.Transaction? transaction,
   }) async {
@@ -241,7 +243,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<List<ObjectWithDuration>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithDuration> rows, {
     _i1.ColumnSelections<ObjectWithDurationTable>? columns,
     _i1.Transaction? transaction,
@@ -254,7 +256,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<ObjectWithDuration> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithDuration row, {
     _i1.ColumnSelections<ObjectWithDurationTable>? columns,
     _i1.Transaction? transaction,
@@ -267,7 +269,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<List<ObjectWithDuration>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithDuration> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -278,7 +280,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<ObjectWithDuration> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithDuration row, {
     _i1.Transaction? transaction,
   }) async {
@@ -289,7 +291,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<List<ObjectWithDuration>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithDurationTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -300,7 +302,7 @@ class ObjectWithDurationRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -263,7 +265,7 @@ class ObjectWithEnumRepository {
   const ObjectWithEnumRepository._();
 
   Future<List<ObjectWithEnum>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? limit,
     int? offset,
@@ -284,7 +286,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<ObjectWithEnum?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
@@ -303,7 +305,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<ObjectWithEnum?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -314,7 +316,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<List<ObjectWithEnum>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithEnum> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -325,7 +327,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<ObjectWithEnum> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithEnum row, {
     _i1.Transaction? transaction,
   }) async {
@@ -336,7 +338,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<List<ObjectWithEnum>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithEnum> rows, {
     _i1.ColumnSelections<ObjectWithEnumTable>? columns,
     _i1.Transaction? transaction,
@@ -349,7 +351,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<ObjectWithEnum> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithEnum row, {
     _i1.ColumnSelections<ObjectWithEnumTable>? columns,
     _i1.Transaction? transaction,
@@ -362,7 +364,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<List<ObjectWithEnum>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithEnum> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -373,7 +375,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<ObjectWithEnum> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithEnum row, {
     _i1.Transaction? transaction,
   }) async {
@@ -384,7 +386,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<List<ObjectWithEnum>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -395,7 +397,7 @@ class ObjectWithEnumRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -186,7 +188,7 @@ class ObjectWithIndexRepository {
   const ObjectWithIndexRepository._();
 
   Future<List<ObjectWithIndex>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? limit,
     int? offset,
@@ -207,7 +209,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<ObjectWithIndex?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
@@ -226,7 +228,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<ObjectWithIndex?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -237,7 +239,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<List<ObjectWithIndex>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithIndex> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -248,7 +250,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<ObjectWithIndex> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithIndex row, {
     _i1.Transaction? transaction,
   }) async {
@@ -259,7 +261,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<List<ObjectWithIndex>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithIndex> rows, {
     _i1.ColumnSelections<ObjectWithIndexTable>? columns,
     _i1.Transaction? transaction,
@@ -272,7 +274,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<ObjectWithIndex> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithIndex row, {
     _i1.ColumnSelections<ObjectWithIndexTable>? columns,
     _i1.Transaction? transaction,
@@ -285,7 +287,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<List<ObjectWithIndex>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithIndex> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -296,7 +298,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<ObjectWithIndex> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithIndex row, {
     _i1.Transaction? transaction,
   }) async {
@@ -307,7 +309,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<List<ObjectWithIndex>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithIndexTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -318,7 +320,7 @@ class ObjectWithIndexRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -449,7 +451,7 @@ class ObjectWithObjectRepository {
   const ObjectWithObjectRepository._();
 
   Future<List<ObjectWithObject>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? limit,
     int? offset,
@@ -470,7 +472,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<ObjectWithObject?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
@@ -489,7 +491,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<ObjectWithObject?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -500,7 +502,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<List<ObjectWithObject>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithObject> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -511,7 +513,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<ObjectWithObject> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithObject row, {
     _i1.Transaction? transaction,
   }) async {
@@ -522,7 +524,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<List<ObjectWithObject>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithObject> rows, {
     _i1.ColumnSelections<ObjectWithObjectTable>? columns,
     _i1.Transaction? transaction,
@@ -535,7 +537,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<ObjectWithObject> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithObject row, {
     _i1.ColumnSelections<ObjectWithObjectTable>? columns,
     _i1.Transaction? transaction,
@@ -548,7 +550,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<List<ObjectWithObject>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithObject> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -559,7 +561,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<ObjectWithObject> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithObject row, {
     _i1.Transaction? transaction,
   }) async {
@@ -570,7 +572,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<List<ObjectWithObject>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithObjectTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -581,7 +583,7 @@ class ObjectWithObjectRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -167,7 +169,7 @@ class ObjectWithParentRepository {
   const ObjectWithParentRepository._();
 
   Future<List<ObjectWithParent>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? limit,
     int? offset,
@@ -188,7 +190,7 @@ class ObjectWithParentRepository {
   }
 
   Future<ObjectWithParent?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
@@ -207,7 +209,7 @@ class ObjectWithParentRepository {
   }
 
   Future<ObjectWithParent?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -218,7 +220,7 @@ class ObjectWithParentRepository {
   }
 
   Future<List<ObjectWithParent>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithParent> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -229,7 +231,7 @@ class ObjectWithParentRepository {
   }
 
   Future<ObjectWithParent> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithParent row, {
     _i1.Transaction? transaction,
   }) async {
@@ -240,7 +242,7 @@ class ObjectWithParentRepository {
   }
 
   Future<List<ObjectWithParent>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithParent> rows, {
     _i1.ColumnSelections<ObjectWithParentTable>? columns,
     _i1.Transaction? transaction,
@@ -253,7 +255,7 @@ class ObjectWithParentRepository {
   }
 
   Future<ObjectWithParent> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithParent row, {
     _i1.ColumnSelections<ObjectWithParentTable>? columns,
     _i1.Transaction? transaction,
@@ -266,7 +268,7 @@ class ObjectWithParentRepository {
   }
 
   Future<List<ObjectWithParent>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithParent> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -277,7 +279,7 @@ class ObjectWithParentRepository {
   }
 
   Future<ObjectWithParent> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithParent row, {
     _i1.Transaction? transaction,
   }) async {
@@ -288,7 +290,7 @@ class ObjectWithParentRepository {
   }
 
   Future<List<ObjectWithParent>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithParentTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -299,7 +301,7 @@ class ObjectWithParentRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -168,7 +170,7 @@ class ObjectWithSelfParentRepository {
   const ObjectWithSelfParentRepository._();
 
   Future<List<ObjectWithSelfParent>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? limit,
     int? offset,
@@ -189,7 +191,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<ObjectWithSelfParent?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
@@ -208,7 +210,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<ObjectWithSelfParent?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -219,7 +221,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<List<ObjectWithSelfParent>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithSelfParent> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -230,7 +232,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<ObjectWithSelfParent> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithSelfParent row, {
     _i1.Transaction? transaction,
   }) async {
@@ -241,7 +243,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<List<ObjectWithSelfParent>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithSelfParent> rows, {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? columns,
     _i1.Transaction? transaction,
@@ -254,7 +256,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<ObjectWithSelfParent> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithSelfParent row, {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? columns,
     _i1.Transaction? transaction,
@@ -267,7 +269,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<List<ObjectWithSelfParent>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithSelfParent> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -278,7 +280,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<ObjectWithSelfParent> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithSelfParent row, {
     _i1.Transaction? transaction,
   }) async {
@@ -289,7 +291,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<List<ObjectWithSelfParent>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithSelfParentTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -300,7 +302,7 @@ class ObjectWithSelfParentRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -190,7 +192,7 @@ class ObjectWithUuidRepository {
   const ObjectWithUuidRepository._();
 
   Future<List<ObjectWithUuid>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? limit,
     int? offset,
@@ -211,7 +213,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<ObjectWithUuid?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
@@ -230,7 +232,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<ObjectWithUuid?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -241,7 +243,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<List<ObjectWithUuid>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithUuid> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -252,7 +254,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<ObjectWithUuid> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithUuid row, {
     _i1.Transaction? transaction,
   }) async {
@@ -263,7 +265,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<List<ObjectWithUuid>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithUuid> rows, {
     _i1.ColumnSelections<ObjectWithUuidTable>? columns,
     _i1.Transaction? transaction,
@@ -276,7 +278,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<ObjectWithUuid> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithUuid row, {
     _i1.ColumnSelections<ObjectWithUuidTable>? columns,
     _i1.Transaction? transaction,
@@ -289,7 +291,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<List<ObjectWithUuid>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ObjectWithUuid> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -300,7 +302,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<ObjectWithUuid> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ObjectWithUuid row, {
     _i1.Transaction? transaction,
   }) async {
@@ -311,7 +313,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<List<ObjectWithUuid>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ObjectWithUuidTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -322,7 +324,7 @@ class ObjectWithUuidRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -233,7 +235,7 @@ class RelatedUniqueDataRepository {
   final attachRow = const RelatedUniqueDataAttachRowRepository._();
 
   Future<List<RelatedUniqueData>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? limit,
     int? offset,
@@ -256,7 +258,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<RelatedUniqueData?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
@@ -277,7 +279,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<RelatedUniqueData?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
@@ -290,7 +292,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<List<RelatedUniqueData>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -301,7 +303,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<RelatedUniqueData> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelatedUniqueData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -312,7 +314,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<List<RelatedUniqueData>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelatedUniqueData> rows, {
     _i1.ColumnSelections<RelatedUniqueDataTable>? columns,
     _i1.Transaction? transaction,
@@ -325,7 +327,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<RelatedUniqueData> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelatedUniqueData row, {
     _i1.ColumnSelections<RelatedUniqueDataTable>? columns,
     _i1.Transaction? transaction,
@@ -338,7 +340,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<List<RelatedUniqueData>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -349,7 +351,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<RelatedUniqueData> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelatedUniqueData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -360,7 +362,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<List<RelatedUniqueData>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -371,7 +373,7 @@ class RelatedUniqueDataRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? limit,
     _i1.Transaction? transaction,
@@ -388,7 +390,7 @@ class RelatedUniqueDataAttachRowRepository {
   const RelatedUniqueDataAttachRowRepository._();
 
   Future<void> uniqueData(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     RelatedUniqueData relatedUniqueData,
     _i2.UniqueData uniqueData, {
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -166,7 +168,7 @@ class ScopeNoneFieldsRepository {
   const ScopeNoneFieldsRepository._();
 
   Future<List<ScopeNoneFields>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ScopeNoneFieldsTable>? where,
     int? limit,
     int? offset,
@@ -187,7 +189,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<ScopeNoneFields?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ScopeNoneFieldsTable>? where,
     int? offset,
     _i1.OrderByBuilder<ScopeNoneFieldsTable>? orderBy,
@@ -206,7 +208,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<ScopeNoneFields?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -217,7 +219,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<List<ScopeNoneFields>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ScopeNoneFields> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -228,7 +230,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<ScopeNoneFields> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ScopeNoneFields row, {
     _i1.Transaction? transaction,
   }) async {
@@ -239,7 +241,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<List<ScopeNoneFields>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ScopeNoneFields> rows, {
     _i1.ColumnSelections<ScopeNoneFieldsTable>? columns,
     _i1.Transaction? transaction,
@@ -252,7 +254,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<ScopeNoneFields> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ScopeNoneFields row, {
     _i1.ColumnSelections<ScopeNoneFieldsTable>? columns,
     _i1.Transaction? transaction,
@@ -265,7 +267,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<List<ScopeNoneFields>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<ScopeNoneFields> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -276,7 +278,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<ScopeNoneFields> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     ScopeNoneFields row, {
     _i1.Transaction? transaction,
   }) async {
@@ -287,7 +289,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<List<ScopeNoneFields>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<ScopeNoneFieldsTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -298,7 +300,7 @@ class ScopeNoneFieldsRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<ScopeNoneFieldsTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -172,7 +174,7 @@ class SimpleDataRepository {
   const SimpleDataRepository._();
 
   Future<List<SimpleData>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? limit,
     int? offset,
@@ -193,7 +195,7 @@ class SimpleDataRepository {
   }
 
   Future<SimpleData?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
@@ -212,7 +214,7 @@ class SimpleDataRepository {
   }
 
   Future<SimpleData?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -223,7 +225,7 @@ class SimpleDataRepository {
   }
 
   Future<List<SimpleData>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -234,7 +236,7 @@ class SimpleDataRepository {
   }
 
   Future<SimpleData> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SimpleData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -245,7 +247,7 @@ class SimpleDataRepository {
   }
 
   Future<List<SimpleData>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SimpleData> rows, {
     _i1.ColumnSelections<SimpleDataTable>? columns,
     _i1.Transaction? transaction,
@@ -258,7 +260,7 @@ class SimpleDataRepository {
   }
 
   Future<SimpleData> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SimpleData row, {
     _i1.ColumnSelections<SimpleDataTable>? columns,
     _i1.Transaction? transaction,
@@ -271,7 +273,7 @@ class SimpleDataRepository {
   }
 
   Future<List<SimpleData>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -282,7 +284,7 @@ class SimpleDataRepository {
   }
 
   Future<SimpleData> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SimpleData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -293,7 +295,7 @@ class SimpleDataRepository {
   }
 
   Future<List<SimpleData>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -304,7 +306,7 @@ class SimpleDataRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -171,7 +173,7 @@ class SimpleDateTimeRepository {
   const SimpleDateTimeRepository._();
 
   Future<List<SimpleDateTime>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? limit,
     int? offset,
@@ -192,7 +194,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<SimpleDateTime?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
@@ -211,7 +213,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<SimpleDateTime?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -222,7 +224,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<List<SimpleDateTime>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -233,7 +235,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<SimpleDateTime> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SimpleDateTime row, {
     _i1.Transaction? transaction,
   }) async {
@@ -244,7 +246,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<List<SimpleDateTime>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SimpleDateTime> rows, {
     _i1.ColumnSelections<SimpleDateTimeTable>? columns,
     _i1.Transaction? transaction,
@@ -257,7 +259,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<SimpleDateTime> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SimpleDateTime row, {
     _i1.ColumnSelections<SimpleDateTimeTable>? columns,
     _i1.Transaction? transaction,
@@ -270,7 +272,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<List<SimpleDateTime>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -281,7 +283,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<SimpleDateTime> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     SimpleDateTime row, {
     _i1.Transaction? transaction,
   }) async {
@@ -292,7 +294,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<List<SimpleDateTime>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -303,7 +305,7 @@ class SimpleDateTimeRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
@@ -358,7 +360,7 @@ class TypesRepository {
   const TypesRepository._();
 
   Future<List<Types>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? limit,
     int? offset,
@@ -379,7 +381,7 @@ class TypesRepository {
   }
 
   Future<Types?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
@@ -398,7 +400,7 @@ class TypesRepository {
   }
 
   Future<Types?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -409,7 +411,7 @@ class TypesRepository {
   }
 
   Future<List<Types>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Types> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -420,7 +422,7 @@ class TypesRepository {
   }
 
   Future<Types> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Types row, {
     _i1.Transaction? transaction,
   }) async {
@@ -431,7 +433,7 @@ class TypesRepository {
   }
 
   Future<List<Types>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Types> rows, {
     _i1.ColumnSelections<TypesTable>? columns,
     _i1.Transaction? transaction,
@@ -444,7 +446,7 @@ class TypesRepository {
   }
 
   Future<Types> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Types row, {
     _i1.ColumnSelections<TypesTable>? columns,
     _i1.Transaction? transaction,
@@ -457,7 +459,7 @@ class TypesRepository {
   }
 
   Future<List<Types>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<Types> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -468,7 +470,7 @@ class TypesRepository {
   }
 
   Future<Types> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     Types row, {
     _i1.Transaction? transaction,
   }) async {
@@ -479,7 +481,7 @@ class TypesRepository {
   }
 
   Future<List<Types>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -490,7 +492,7 @@ class TypesRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -8,6 +8,8 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -184,7 +186,7 @@ class UniqueDataRepository {
   const UniqueDataRepository._();
 
   Future<List<UniqueData>> find(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? limit,
     int? offset,
@@ -205,7 +207,7 @@ class UniqueDataRepository {
   }
 
   Future<UniqueData?> findFirstRow(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
@@ -224,7 +226,7 @@ class UniqueDataRepository {
   }
 
   Future<UniqueData?> findById(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     int id, {
     _i1.Transaction? transaction,
   }) async {
@@ -235,7 +237,7 @@ class UniqueDataRepository {
   }
 
   Future<List<UniqueData>> insert(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -246,7 +248,7 @@ class UniqueDataRepository {
   }
 
   Future<UniqueData> insertRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UniqueData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -257,7 +259,7 @@ class UniqueDataRepository {
   }
 
   Future<List<UniqueData>> update(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UniqueData> rows, {
     _i1.ColumnSelections<UniqueDataTable>? columns,
     _i1.Transaction? transaction,
@@ -270,7 +272,7 @@ class UniqueDataRepository {
   }
 
   Future<UniqueData> updateRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UniqueData row, {
     _i1.ColumnSelections<UniqueDataTable>? columns,
     _i1.Transaction? transaction,
@@ -283,7 +285,7 @@ class UniqueDataRepository {
   }
 
   Future<List<UniqueData>> delete(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
   }) async {
@@ -294,7 +296,7 @@ class UniqueDataRepository {
   }
 
   Future<UniqueData> deleteRow(
-    _i1.DatabaseAccessor session,
+    _i1.Session session,
     UniqueData row, {
     _i1.Transaction? transaction,
   }) async {
@@ -305,7 +307,7 @@ class UniqueDataRepository {
   }
 
   Future<List<UniqueData>> deleteWhere(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
     _i1.Transaction? transaction,
   }) async {
@@ -316,7 +318,7 @@ class UniqueDataRepository {
   }
 
   Future<int> count(
-    _i1.DatabaseAccessor session, {
+    _i1.Session session, {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? limit,
     _i1.Transaction? transaction,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -225,7 +225,7 @@ class BuildRepositoryClass {
       )
       ..requiredParameters.addAll([
         Parameter((p) => p
-          ..type = refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+          ..type = refer('Session', 'package:serverpod/serverpod.dart')
           ..name = 'session'),
       ])
       ..optionalParameters.addAll([
@@ -320,7 +320,7 @@ class BuildRepositoryClass {
       )
       ..requiredParameters.addAll([
         Parameter((p) => p
-          ..type = refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+          ..type = refer('Session', 'package:serverpod/serverpod.dart')
           ..name = 'session'),
       ])
       ..optionalParameters.addAll([
@@ -408,7 +408,7 @@ class BuildRepositoryClass {
       )
       ..requiredParameters.addAll([
         Parameter((p) => p
-          ..type = refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+          ..type = refer('Session', 'package:serverpod/serverpod.dart')
           ..name = 'session'),
         Parameter((p) => p
           ..type = refer('int')
@@ -458,8 +458,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
           Parameter((p) => p
             ..type = refer('List<$className>')
@@ -502,8 +501,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
           Parameter((p) => p
             ..type = refer(className)
@@ -546,8 +544,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
           Parameter((p) => p
             ..type = refer('List<$className>')
@@ -600,8 +597,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
           Parameter((p) => p
             ..type = refer(className)
@@ -662,8 +658,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
           Parameter((p) => p
             ..type = refer('List<$className>')
@@ -708,8 +703,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
           Parameter((p) => p
             ..type = refer(className)
@@ -760,8 +754,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
         ])
         ..optionalParameters.addAll([
@@ -809,8 +802,7 @@ class BuildRepositoryClass {
         )
         ..requiredParameters.addAll([
           Parameter((p) => p
-            ..type =
-                refer('DatabaseAccessor', 'package:serverpod/serverpod.dart')
+            ..type = refer('Session', 'package:serverpod/serverpod.dart')
             ..name = 'session'),
         ])
         ..optionalParameters.addAll([
@@ -918,8 +910,7 @@ class BuildRepositoryClass {
           Parameter((parameterBuilder) {
             parameterBuilder
               ..name = 'session'
-              ..type =
-                  refer('DatabaseAccessor', 'package:serverpod/serverpod.dart');
+              ..type = refer('Session', 'package:serverpod/serverpod.dart');
           }),
           Parameter((parameterBuilder) {
             parameterBuilder
@@ -992,8 +983,7 @@ class BuildRepositoryClass {
           Parameter((parameterBuilder) {
             parameterBuilder
               ..name = 'session'
-              ..type =
-                  refer('DatabaseAccessor', 'package:serverpod/serverpod.dart');
+              ..type = refer('Session', 'package:serverpod/serverpod.dart');
           }),
           Parameter((parameterBuilder) {
             parameterBuilder
@@ -1060,8 +1050,7 @@ class BuildRepositoryClass {
           Parameter((parameterBuilder) {
             parameterBuilder
               ..name = 'session'
-              ..type =
-                  refer('DatabaseAccessor', 'package:serverpod/serverpod.dart');
+              ..type = refer('Session', 'package:serverpod/serverpod.dart');
           }),
           Parameter((parameterBuilder) {
             parameterBuilder
@@ -1272,8 +1261,7 @@ class BuildRepositoryClass {
           Parameter((parameterBuilder) {
             parameterBuilder
               ..name = 'session'
-              ..type =
-                  refer('DatabaseAccessor', 'package:serverpod/serverpod.dart');
+              ..type = refer('Session', 'package:serverpod/serverpod.dart');
           }),
           Parameter((parameterBuilder) {
             parameterBuilder
@@ -1340,8 +1328,7 @@ class BuildRepositoryClass {
           Parameter((parameterBuilder) {
             parameterBuilder
               ..name = 'session'
-              ..type =
-                  refer('DatabaseAccessor', 'package:serverpod/serverpod.dart');
+              ..type = refer('Session', 'package:serverpod/serverpod.dart');
           }),
           Parameter((parameterBuilder) {
             parameterBuilder
@@ -1399,8 +1386,7 @@ class BuildRepositoryClass {
           Parameter((parameterBuilder) {
             parameterBuilder
               ..name = 'session'
-              ..type =
-                  refer('DatabaseAccessor', 'package:serverpod/serverpod.dart');
+              ..type = refer('Session', 'package:serverpod/serverpod.dart');
           }),
           Parameter((parameterBuilder) {
             parameterBuilder

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -72,6 +72,8 @@ class SerializableModelLibraryGenerator {
         ]);
 
         if (serverCode && tableName != null) {
+          libraryBuilder.ignoreForFile
+              .add('invalid_use_of_visible_for_testing_member');
           libraryBuilder.body.addAll([
             _buildModelTableClass(
               className,

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
@@ -177,7 +177,7 @@ void main() {
         expect(
           peopleMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Example example, Person person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Example example, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     });
@@ -228,7 +228,7 @@ void main() {
         expect(
           peopleMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Example example, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Example example, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -267,7 +267,7 @@ void main() {
         expect(
           peopleMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Person person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryClass == null);
@@ -318,7 +318,7 @@ void main() {
         expect(
           peopleMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: peopleMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -376,7 +376,7 @@ void main() {
         expect(
           citizensMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Example example, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Example example, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizensMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -403,7 +403,7 @@ void main() {
         expect(
           citizenMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Example example, Person person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Example example, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizenMethod == null);
     });
@@ -441,7 +441,7 @@ void main() {
         expect(
           citizensMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, List<Person> person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizensMethod == null);
     }, skip: repositoryAttachClass == null);
@@ -468,7 +468,7 @@ void main() {
         expect(
           citizenMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Person person, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Person person, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: citizenMethod == null);
     });

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_object_relation_additions_test.dart
@@ -169,7 +169,7 @@ void main() {
         expect(
           companyMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Example example, Company company, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Example example, Company company, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: companyMethod == null);
 
@@ -188,7 +188,7 @@ void main() {
         expect(
           addressMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Example example, Address address, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Example example, Address address, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: addressMethod == null);
 
@@ -268,7 +268,7 @@ void main() {
         expect(
           companyMethod?.parameters?.toSource(),
           matches(
-              r'\(_i\d\.DatabaseAccessor session, Example example, \{_i\d\.Transaction\? transaction\}\)'),
+              r'\(_i\d\.Session session, Example example, \{_i\d\.Transaction\? transaction\}\)'),
         );
       }, skip: companyMethod == null);
 
@@ -439,7 +439,7 @@ void main() {
         expect(
           method?.parameters?.toSource(),
           matches(
-            r'(_i\d.DatabaseAccessor session, Example example, Example nestedExample)',
+            r'(_i\d.Session session, Example example, Example nestedExample)',
           ),
         );
       });

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
@@ -94,7 +94,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             findMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -179,7 +179,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             findRowMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -263,7 +263,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             findByIdMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -307,7 +307,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             insertMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -356,7 +356,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             insertRowMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -400,7 +400,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             updateMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -449,7 +449,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             updateRowMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -493,7 +493,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             deleteMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -542,7 +542,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             deleteRowMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -591,7 +591,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             deleteWhereMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 
@@ -641,7 +641,7 @@ void main() {
         test('that takes the session as a required param', () {
           expect(
             countMethod?.parameters?.toSource(),
-            contains('DatabaseAccessor session'),
+            contains('Session session'),
           );
         });
 


### PR DESCRIPTION
## Description
To not degrade the DevEx of using the repository classes, the `Session` type should be used as the argument type to make it intuitive what to pass.

## Changes
- Reverts the change to `DatabaseAccessor` type and uses `Session` as it used to be

## Pre-launch Checklist
- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.nges, make sure to outline them here, so that they can be included in the notes for the next release._