### PR TITLE
fix: Add description to client method stream exceptions.

### DIFF
--- a/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
+++ b/packages/serverpod_client/lib/src/method_stream/method_stream_manager_exceptions.dart
@@ -4,6 +4,11 @@ import 'package:serverpod_client/serverpod_client.dart';
 abstract class MethodStreamException implements Exception {
   /// Creates a new [MethodStreamException].
   const MethodStreamException();
+
+  @override
+  String toString() {
+    return 'Method stream exception occurred';
+  }
 }
 
 /// Thrown if the WebSocket connection fails.
@@ -16,10 +21,20 @@ class WebSocketConnectException extends MethodStreamException {
 
   /// Creates a new [WebSocketConnectException].
   const WebSocketConnectException(this.error, [this.stackTrace]);
+
+  @override
+  String toString() {
+    return 'Method stream WebSocket failed to connect with error: $error';
+  }
 }
 
 /// Thrown if connection attempt timed out.
-class ConnectionAttemptTimedOutException extends MethodStreamException {}
+class ConnectionAttemptTimedOutException extends MethodStreamException {
+  @override
+  String toString() {
+    return 'Method stream connection attempt timed out';
+  }
+}
 
 /// Thrown if an error occurs when listening to the WebSocket connection.
 class WebSocketListenException extends MethodStreamException {
@@ -31,12 +46,22 @@ class WebSocketListenException extends MethodStreamException {
 
   /// Creates a new [WebSocketListenException].
   const WebSocketListenException(this.error, [this.stackTrace]);
+
+  @override
+  String toString() {
+    return 'Method stream WebSocket listen error: $error';
+  }
 }
 
 /// Thrown if the WebSocket connection is closed.
 class WebSocketClosedException extends MethodStreamException {
   /// Creates a new [WebSocketClosedException].
   const WebSocketClosedException();
+
+  @override
+  String toString() {
+    return 'Method stream WebSocket connection closed';
+  }
 }
 
 /// Thrown if opening a method stream fails.
@@ -46,10 +71,20 @@ class OpenMethodStreamException extends MethodStreamException {
 
   /// Creates a new [OpenMethodStreamException].
   const OpenMethodStreamException(this.responseType);
+
+  @override
+  String toString() {
+    return 'Failed to open method stream with response type "${responseType.name}"';
+  }
 }
 
 /// Thrown if the connection is closed with an error.
 class ConnectionClosedException extends MethodStreamException {
   /// Creates a new [ConnectionClosedException].
   const ConnectionClosedException();
+
+  @override
+  String toString() {
+    return 'Method stream connection closed with an error';
+  }
 }


### PR DESCRIPTION
Adds descriptions to client method stream exceptions.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this just adds descriptions to the client side error messages.