### PR TITLE
fix: Ignore output from Serverpod constructor in tests

### DIFF
--- a/packages/serverpod_test/lib/src/io_overrides.dart
+++ b/packages/serverpod_test/lib/src/io_overrides.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// A null implementation of [Stdout] that does nothing.
+class NullStdOut implements Stdout {
+  @override
+  Encoding encoding = utf8;
+
+  /// Line terminator used.
+  String lineTerminator = '\n';
+
+  @override
+  Future get done => Future.value();
+
+  @override
+  bool get hasTerminal => false;
+
+  @override
+  IOSink get nonBlocking => NullStdOut();
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  int get terminalColumns => 80;
+
+  @override
+  int get terminalLines => 24;
+
+  @override
+  void add(List<int> data) {}
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future addStream(Stream<List<int>> stream) async {}
+
+  @override
+  Future close() async {}
+
+  @override
+  Future flush() async {}
+
+  @override
+  void write(Object? object) {}
+
+  @override
+  void writeAll(Iterable objects, [String sep = '']) {}
+
+  @override
+  void writeCharCode(int charCode) {}
+
+  @override
+  void writeln([Object? object = '']) {}
+}

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -136,7 +136,8 @@ class GeneratorConfig {
 
   final List<String>? _relativeServerTestToolsPathParts;
   static const _defaultRelativeServerTestToolsPathParts = [
-    'integration_test',
+    'test',
+    'integration',
     'test_tools'
   ];
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/expected_files_created_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/expected_files_created_test.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:serverpod_cli/src/config/serverpod_feature.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
 import 'package:serverpod_cli/src/test_util/builders/enum_definition_builder.dart';
 import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
@@ -156,7 +157,7 @@ void main() {
   });
 
   group(
-      'Given relativeServerTestToolsPathParts is set when generating protocol code',
+      'Given relativeServerTestToolsPathParts is set and database enabled when generating protocol code',
       () {
     var configWithTestToolsPath = GeneratorConfigBuilder()
         .withName(projectName)
@@ -164,10 +165,14 @@ void main() {
       [
         ExperimentalFeature.testTools,
       ],
+    ).withEnabledFeatures(
+      [
+        ServerpodFeature.database,
+      ],
     ).withRelativeServerTestToolsPathParts(
       [
-        'integration_test',
-        'serverpod_test_tools',
+        'test_integration',
+        'my_custom_folder',
       ],
     ).build();
 
@@ -183,8 +188,8 @@ void main() {
       expect(
         codeMap.keys,
         contains(path.join(
-          'integration_test',
-          'serverpod_test_tools',
+          'test_integration',
+          'my_custom_folder',
           'serverpod_test_tools.dart',
         )),
         reason:
@@ -194,7 +199,86 @@ void main() {
   });
 
   group(
-      'Given relativeServerTestToolsPathParts is not set when generating protocol code',
+      'Given relativeServerTestToolsPathParts is not set and database enabled when generating protocol code',
+      () {
+    var configWithTestToolsPath = GeneratorConfigBuilder()
+        .withName(projectName)
+        .withEnabledFeatures(
+          [
+            ServerpodFeature.database,
+          ],
+        )
+        .withEnabledExperimentalFeatures(
+          [
+            ExperimentalFeature.testTools,
+          ],
+        )
+        .withRelativeServerTestToolsPathParts(null)
+        .build();
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: const ProtocolDefinition(
+        endpoints: [],
+        models: [],
+      ),
+      config: configWithTestToolsPath,
+    );
+    var serverpodTestToolsFileName = 'serverpod_test_tools.dart';
+
+    test('then the serverpod test tools file is not created', () {
+      var listContainsTestToolsFilename = codeMap.keys.any(
+        (filePath) => filePath.endsWith(serverpodTestToolsFileName),
+      );
+
+      expect(
+        listContainsTestToolsFilename,
+        false,
+        reason:
+            'Expected serverpod_test_tools.dart file to not be present, but it was found.',
+      );
+    });
+  });
+
+  group(
+      'Given relativeServerTestToolsPathParts is not set and database is disabled when generating protocol code',
+      () {
+    var configWithTestToolsPath = GeneratorConfigBuilder()
+        .withName(projectName)
+        .withEnabledExperimentalFeatures(
+          [
+            ExperimentalFeature.testTools,
+          ],
+        )
+        // Disable database feature
+        .withEnabledFeatures([])
+        .withRelativeServerTestToolsPathParts(null)
+        .build();
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: const ProtocolDefinition(
+        endpoints: [],
+        models: [],
+      ),
+      config: configWithTestToolsPath,
+    );
+
+    test('then the serverpod test tools file is created at default location',
+        () {
+      expect(
+        codeMap.keys,
+        contains(path.join(
+          'test',
+          'integration',
+          'test_tools',
+          'serverpod_test_tools.dart',
+        )),
+        reason:
+            'Expected serverpod_test_tools.dart file to be present, found none.',
+      );
+    });
+  });
+  group(
+      'Given the experimental flag testTools is not set when generating protocol code',
       () {
     var configWithTestToolsPath = GeneratorConfigBuilder()
         .withName(projectName)

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/expected_files_created_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/expected_files_created_test.dart
@@ -280,10 +280,8 @@ void main() {
   group(
       'Given the experimental flag testTools is not set when generating protocol code',
       () {
-    var configWithTestToolsPath = GeneratorConfigBuilder()
-        .withName(projectName)
-        .withRelativeServerTestToolsPathParts(null)
-        .build();
+    var configWithTestToolsPath =
+        GeneratorConfigBuilder().withName(projectName).build();
 
     var codeMap = generator.generateProtocolCode(
       protocolDefinition: const ProtocolDefinition(


### PR DESCRIPTION
## Changes
- Changes the default test tools path for Serverpod mini (out of context of the PR, but its a tiny change)
- Ignores the output of the Serverpod constructor in tests to avoid spamming the logs.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.