### PR TITLE
fix: Correctly handle errors in method streams.

### DIFF
--- a/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
@@ -358,6 +358,8 @@ class MethodStreamManager {
         );
         _updateCloseReason(streamKey, CloseReason.error);
 
+        await session.close(error: e, stackTrace: s);
+
         /// Required to close stream when error occurs.
         /// This will also close the input streams.
         /// We can't use the "cancelOnError" option

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
@@ -542,12 +542,19 @@ class MethodStreamManager {
     required StreamController outputController,
     required StreamSubscription subscription,
   }) {
-    outputController
-        .addStream(
-      methodStreamCallContext.method
-          .call(session, methodStreamCallContext.arguments, streamParams),
-    )
-        .whenComplete(
+    Stream<dynamic> methodStream;
+    try {
+      methodStream = methodStreamCallContext.method.call(
+        session,
+        methodStreamCallContext.arguments,
+        streamParams,
+      );
+    } catch (e, stackTrace) {
+      outputController.addError(e, stackTrace);
+      return;
+    }
+
+    outputController.addStream(methodStream).whenComplete(
       () async {
         var streamKey = _buildStreamKey(
           endpoint: methodStreamCallContext.endpoint.name,

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1784,6 +1784,22 @@ class EndpointMethodStreaming extends _i1.EndpointRef {
         {},
       );
 
+  _i2.Stream<int> exceptionThrownBeforeStreamReturn() =>
+      caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
+        'methodStreaming',
+        'exceptionThrownBeforeStreamReturn',
+        {},
+        {},
+      );
+
+  _i2.Stream<int> exceptionThrownInStreamReturn() =>
+      caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
+        'methodStreaming',
+        'exceptionThrownInStreamReturn',
+        {},
+        {},
+      );
+
   _i2.Stream<int> throwsSerializableExceptionStream() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'methodStreaming',

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -1132,6 +1132,14 @@ class EndpointLogging extends _i1.EndpointRef {
         {},
         {'input': input},
       );
+
+  _i2.Stream<int> streamException() =>
+      caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
+        'logging',
+        'streamException',
+        {},
+        {},
+      );
 }
 
 /// {@category Endpoint}

--- a/tests/serverpod_test_server/lib/src/endpoints/logging.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/logging.dart
@@ -80,6 +80,10 @@ class LoggingEndpoint extends Endpoint {
     }
   }
 
+  Stream<int> streamException(Session session) async* {
+    throw Exception('This is an exception');
+  }
+
   @override
   Future<void> handleStreamMessage(
     StreamingSession session,

--- a/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/method_streaming.dart
@@ -331,6 +331,16 @@ class MethodStreaming extends Endpoint {
     throw Exception('This is an exception');
   }
 
+  Stream<int> exceptionThrownBeforeStreamReturn(Session session) {
+    throw Exception('This is an exception');
+  }
+
+  Stream<int> exceptionThrownInStreamReturn(Session session) {
+    var controller = StreamController<int>();
+    controller.addError(Exception('This is an exception'));
+    return controller.stream;
+  }
+
   Stream<int> throwsSerializableExceptionStream(Session session) async* {
     throw ExceptionWithData(
       message: 'Throwing an exception',

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -4035,6 +4035,32 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['methodStreaming'] as _i23.MethodStreaming)
                   .throwsExceptionStream(session),
         ),
+        'exceptionThrownBeforeStreamReturn': _i1.MethodStreamConnector(
+          name: 'exceptionThrownBeforeStreamReturn',
+          params: {},
+          streamParams: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['methodStreaming'] as _i23.MethodStreaming)
+                  .exceptionThrownBeforeStreamReturn(session),
+        ),
+        'exceptionThrownInStreamReturn': _i1.MethodStreamConnector(
+          name: 'exceptionThrownInStreamReturn',
+          params: {},
+          streamParams: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['methodStreaming'] as _i23.MethodStreaming)
+                  .exceptionThrownInStreamReturn(session),
+        ),
         'throwsSerializableExceptionStream': _i1.MethodStreamConnector(
           name: 'throwsSerializableExceptionStream',
           params: {},

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -2580,6 +2580,19 @@ class Endpoints extends _i1.EndpointDispatch {
             streamParams['input']!.cast<int>(),
           ),
         ),
+        'streamException': _i1.MethodStreamConnector(
+          name: 'streamException',
+          params: {},
+          streamParams: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['logging'] as _i19.LoggingEndpoint)
+                  .streamException(session),
+        ),
       },
     );
     connectors['streamLogging'] = _i1.EndpointConnector(

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -217,6 +217,8 @@ methodStreaming:
   - throwsException:
   - throwsSerializableException:
   - throwsExceptionStream:
+  - exceptionThrownBeforeStreamReturn:
+  - exceptionThrownInStreamReturn:
   - throwsSerializableExceptionStream:
   - didInputStreamHaveError:
   - didInputStreamHaveSerializableExceptionError:

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -138,6 +138,7 @@ logging:
   - streamEmpty:
   - streamLogging:
   - streamQueryLogging:
+  - streamException:
 streamLogging:
 streamQueryLogging:
 loggingDisabled:

--- a/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:serverpod_test_client/serverpod_test_client.dart';
 import 'package:serverpod_test_server/test_util/config.dart';
 import 'package:serverpod_test_server/test_util/test_key_manager.dart';
@@ -14,100 +12,67 @@ void main() {
   test(
       'Given a streaming method that returns a stream of integers, when calling the method, then the expected integers are received.',
       () async {
-    var streamComplete = Completer();
     var stream = client.methodStreaming.simpleStream();
-    var received = <int>[];
-    stream.listen((event) {
-      received.add(event);
-    }, onDone: () {
-      streamComplete.complete();
-    });
 
-    await streamComplete.future;
-    expect(received, List.generate(10, (index) => index++));
+    await expectLater(
+      stream,
+      emitsInOrder(List.generate(10, (index) => index++)),
+    );
   });
 
   test(
       'Given a streaming method that returns a stream of integers based on the parameter when calling the method, then the expected integers are received.',
       () async {
-    var streamComplete = Completer();
-    var stream = client.methodStreaming.intStreamFromValue(5);
-    var received = <int>[];
-    stream.listen((event) {
-      received.add(event);
-    }, onDone: () {
-      streamComplete.complete();
-    });
+    var value = 5;
+    var stream = client.methodStreaming.intStreamFromValue(value);
 
-    await streamComplete.future;
-    expect(received, List.generate(5, (index) => index++));
+    await expectLater(
+      stream,
+      emitsInOrder(List.generate(value, (index) => index++)),
+    );
   });
 
   test(
-      'Given a streaming method that throws an exception when calling the method, then stream is closed ServerpodClientException.',
+      'Given a streaming method that throws an exception when calling the method, then stream is closed with a ConnectionClosedException.',
       () async {
-    var streamComplete = Completer<dynamic>();
     var stream = client.methodStreaming.outStreamThrowsException();
-    stream.listen((event) {
-      // Do nothing
-    }, onError: (error) {
-      streamComplete.complete(error);
-    });
 
     await expectLater(
-      await streamComplete.future,
-      isA<ConnectionClosedException>(),
+      stream,
+      emitsError(isA<ConnectionClosedException>()),
     );
   });
 
   test(
       'Given a streaming method that throws a serializable exception when calling the method, then stream is closed with the Serializable exception thrown',
       () async {
-    var streamComplete = Completer<dynamic>();
     var stream = client.methodStreaming.outStreamThrowsSerializableException();
-    stream.listen((event) {
-      // Do nothing
-    }, onError: (error) {
-      streamComplete.complete(error);
-    });
 
     await expectLater(
-      await streamComplete.future,
-      isA<ExceptionWithData>(),
+      stream,
+      emitsError(isA<ExceptionWithData>()),
     );
   });
 
   test(
-      'Given a streaming method that is not a generator that throws an exception before the stream is returned, then stream is closed with ServerpodClientException.',
+      'Given a streaming method that is not a generator that throws an exception before the stream is returned when calling the method, then stream is closed with ServerpodClientException.',
       () async {
-    var streamComplete = Completer<dynamic>();
     var stream = client.methodStreaming.exceptionThrownBeforeStreamReturn();
-    stream.listen((event) {
-      // Do nothing
-    }, onError: (error) {
-      streamComplete.complete(error);
-    });
 
     await expectLater(
-      await streamComplete.future,
-      isA<ConnectionClosedException>(),
+      stream,
+      emitsError(isA<ConnectionClosedException>()),
     );
   });
 
   test(
       'Given a streaming method that is not a generator that throws an exception as its first message when calling method, then stream is closed with ServerpodClientException.',
       () async {
-    var streamComplete = Completer<dynamic>();
     var stream = client.methodStreaming.exceptionThrownInStreamReturn();
-    stream.listen((event) {
-      // Do nothing
-    }, onError: (error) {
-      streamComplete.complete(error);
-    });
 
     await expectLater(
-      await streamComplete.future,
-      isA<ConnectionClosedException>(),
+      stream,
+      emitsError(isA<ConnectionClosedException>()),
     );
   });
 }

--- a/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
@@ -76,4 +76,38 @@ void main() {
       isA<ExceptionWithData>(),
     );
   });
+
+  test(
+      'Given a streaming method that is not a generator that throws an exception before the stream is returned, then stream is closed with ServerpodClientException.',
+      () async {
+    var streamComplete = Completer<dynamic>();
+    var stream = client.methodStreaming.exceptionThrownBeforeStreamReturn();
+    stream.listen((event) {
+      // Do nothing
+    }, onError: (error) {
+      streamComplete.complete(error);
+    });
+
+    await expectLater(
+      await streamComplete.future,
+      isA<ConnectionClosedException>(),
+    );
+  });
+
+  test(
+      'Given a streaming method that is not a generator that throws an exception as its first message when calling method, then stream is closed with ServerpodClientException.',
+      () async {
+    var streamComplete = Completer<dynamic>();
+    var stream = client.methodStreaming.exceptionThrownInStreamReturn();
+    stream.listen((event) {
+      // Do nothing
+    }, onError: (error) {
+      streamComplete.complete(error);
+    });
+
+    await expectLater(
+      await streamComplete.future,
+      isA<ConnectionClosedException>(),
+    );
+  });
 }

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_method_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_method_stream_logging_test.dart
@@ -142,6 +142,31 @@ void main() async {
 
       expect(logs, isEmpty);
     });
+
+    test(
+        'when connecting to a stream method that throws an exception then session logs error.',
+        () async {
+      var streamComplete = Completer<dynamic>();
+      var stream = client.logging.streamException();
+      stream.listen((event) {
+        // Do nothing
+      }, onError: (error) {
+        streamComplete.complete(error);
+      });
+
+      await expectLater(
+        await streamComplete.future,
+        isA<ConnectionClosedException>(),
+      );
+
+      // Wait for the log to be written
+      await Future.delayed(Duration(milliseconds: 100));
+      var logs = await LoggingUtil.findAllLogs(session);
+
+      expect(logs, hasLength(1));
+      var log = logs.firstOrNull;
+      expect(log?.sessionLogEntry.error, isNotNull);
+    });
   });
 
   group('Given that continuous logging is turned off', () {

--- a/tests/serverpod_test_server/test_integration/logging/endpoint_method_stream_logging_test.dart
+++ b/tests/serverpod_test_server/test_integration/logging/endpoint_method_stream_logging_test.dart
@@ -146,17 +146,11 @@ void main() async {
     test(
         'when connecting to a stream method that throws an exception then session logs error.',
         () async {
-      var streamComplete = Completer<dynamic>();
       var stream = client.logging.streamException();
-      stream.listen((event) {
-        // Do nothing
-      }, onError: (error) {
-        streamComplete.complete(error);
-      });
 
       await expectLater(
-        await streamComplete.future,
-        isA<ConnectionClosedException>(),
+        stream,
+        emitsError(isA<ConnectionClosedException>()),
       );
 
       // Wait for the log to be written

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -3694,6 +3694,35 @@ class _LoggingEndpoint {
     );
     return _localTestStreamManager.outputStreamController.stream;
   }
+
+  _i3.Stream<int> streamException(_i1.TestSessionBuilder sessionBuilder) {
+    var _localTestStreamManager = _i1.TestStreamManager<int>();
+    _i1.callStreamFunctionAndHandleExceptions(
+      () async {
+        var _localUniqueSession =
+            (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+          endpoint: 'logging',
+          method: 'streamException',
+        );
+        var _localCallContext =
+            await _endpointDispatch.getMethodStreamCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'streamException',
+          arguments: {},
+          requestedInputStreams: [],
+          serializationManager: _serializationManager,
+        );
+        await _localTestStreamManager.callStreamMethod(
+          _localCallContext,
+          _localUniqueSession,
+          {},
+        );
+      },
+      _localTestStreamManager.outputStreamController,
+    );
+    return _localTestStreamManager.outputStreamController.stream;
+  }
 }
 
 class _StreamLogging {

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -5816,6 +5816,66 @@ class _MethodStreaming {
     return _localTestStreamManager.outputStreamController.stream;
   }
 
+  _i3.Stream<int> exceptionThrownBeforeStreamReturn(
+      _i1.TestSessionBuilder sessionBuilder) {
+    var _localTestStreamManager = _i1.TestStreamManager<int>();
+    _i1.callStreamFunctionAndHandleExceptions(
+      () async {
+        var _localUniqueSession =
+            (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+          endpoint: 'methodStreaming',
+          method: 'exceptionThrownBeforeStreamReturn',
+        );
+        var _localCallContext =
+            await _endpointDispatch.getMethodStreamCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'exceptionThrownBeforeStreamReturn',
+          arguments: {},
+          requestedInputStreams: [],
+          serializationManager: _serializationManager,
+        );
+        await _localTestStreamManager.callStreamMethod(
+          _localCallContext,
+          _localUniqueSession,
+          {},
+        );
+      },
+      _localTestStreamManager.outputStreamController,
+    );
+    return _localTestStreamManager.outputStreamController.stream;
+  }
+
+  _i3.Stream<int> exceptionThrownInStreamReturn(
+      _i1.TestSessionBuilder sessionBuilder) {
+    var _localTestStreamManager = _i1.TestStreamManager<int>();
+    _i1.callStreamFunctionAndHandleExceptions(
+      () async {
+        var _localUniqueSession =
+            (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+          endpoint: 'methodStreaming',
+          method: 'exceptionThrownInStreamReturn',
+        );
+        var _localCallContext =
+            await _endpointDispatch.getMethodStreamCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'exceptionThrownInStreamReturn',
+          arguments: {},
+          requestedInputStreams: [],
+          serializationManager: _serializationManager,
+        );
+        await _localTestStreamManager.callStreamMethod(
+          _localCallContext,
+          _localUniqueSession,
+          {},
+        );
+      },
+      _localTestStreamManager.outputStreamController,
+    );
+    return _localTestStreamManager.outputStreamController.stream;
+  }
+
   _i3.Stream<int> throwsSerializableExceptionStream(
       _i1.TestSessionBuilder sessionBuilder) {
     var _localTestStreamManager = _i1.TestStreamManager<int>();


### PR DESCRIPTION
Two issue where identified in the method stream interface:


### Catch non generator "Stream" exceptions
When a streaming endpoint returns a stream instead of being a generator and an exception occurs before the stream is returned our error handling didn't manage to catch the error.

This resulted in the stream not being closed on the client and the exception being propagated up on the server.

### No error logging
During a refactor for how streams are closed to not produce memory leaks, closing the session with any errors that occurred was accidentally removed. PR here: https://github.com/serverpod/serverpod/pull/2573
This PR reintroduces closing sessions with errors if one has occurred.

This is tested through the logging interface since that is the only output that displays if an error has occurred in a session.


## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - these are stability and reporting fixes inside of the streaming interface.