### PR TITLE
test: Add additional tests to modules and test tools

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2248,6 +2248,16 @@ class EndpointTestTools extends _i1.EndpointRef {
         {'numbers': numbers},
       );
 
+  _i2.Stream<_i10.SimpleData> returnsSimpleDataStreamFromInputStream(
+          _i2.Stream<_i10.SimpleData> simpleDatas) =>
+      caller.callStreamingServerEndpoint<_i2.Stream<_i10.SimpleData>,
+          _i10.SimpleData>(
+        'testTools',
+        'returnsSimpleDataStreamFromInputStream',
+        {},
+        {'simpleDatas': simpleDatas},
+      );
+
   _i2.Future<void> postNumberToSharedStream(int number) =>
       caller.callServerEndpoint<void>(
         'testTools',

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/client.dart
@@ -61,6 +61,14 @@ class EndpointStreaming extends _i1.EndpointRef {
         {},
         {'stream': stream},
       );
+
+  _i2.Future<int> simpleInputReturnStream(_i2.Stream<int> stream) =>
+      caller.callStreamingServerEndpoint<_i2.Future<int>, int>(
+        'serverpod_test_module.streaming',
+        'simpleInputReturnStream',
+        {},
+        {'stream': stream},
+      );
 }
 
 class Caller extends _i1.ModuleEndpointCaller {

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/endpoints/streaming.dart
@@ -47,4 +47,11 @@ class StreamingEndpoint extends Endpoint {
       yield value;
     }
   }
+
+  Future<int> simpleInputReturnStream(
+    Session session,
+    Stream<int> stream,
+  ) async {
+    return stream.first;
+  }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
@@ -118,6 +118,27 @@ class Endpoints extends _i1.EndpointDispatch {
             streamParams['stream']!.cast<int>(),
           ),
         ),
+        'simpleInputReturnStream': _i1.MethodStreamConnector(
+          name: 'simpleInputReturnStream',
+          params: {},
+          streamParams: {
+            'stream': _i1.StreamParameterDescription<int>(
+              name: 'stream',
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.futureType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['streaming'] as _i3.StreamingEndpoint)
+                  .simpleInputReturnStream(
+            session,
+            streamParams['stream']!.cast<int>(),
+          ),
+        ),
       },
     );
   }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.yaml
@@ -5,3 +5,4 @@ streaming:
   - wasStreamOpenCalled:
   - wasStreamClosedCalled:
   - intEchoStream:
+  - simpleInputReturnStream:

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -222,4 +222,34 @@ class _StreamingEndpoint {
     );
     return _localTestStreamManager.outputStreamController.stream;
   }
+
+  _i3.Future<int> simpleInputReturnStream(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i3.Stream<int> stream,
+  ) async {
+    var _localTestStreamManager = _i1.TestStreamManager<int>();
+    return _i1
+        .callAwaitableFunctionWithStreamInputAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'streaming',
+        method: 'simpleInputReturnStream',
+      );
+      var _localCallContext =
+          await _endpointDispatch.getMethodStreamCallContext(
+        createSessionCallback: (_) => _localUniqueSession,
+        endpointPath: 'streaming',
+        methodName: 'simpleInputReturnStream',
+        arguments: {},
+        requestedInputStreams: ['stream'],
+        serializationManager: _serializationManager,
+      );
+      await _localTestStreamManager.callStreamMethod(
+        _localCallContext,
+        _localUniqueSession,
+        {'stream': stream},
+      );
+      return _localTestStreamManager.outputStreamController.stream;
+    });
+  }
 }

--- a/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
@@ -47,6 +47,13 @@ class TestToolsEndpoint extends Endpoint {
     }
   }
 
+  Stream<SimpleData> returnsSimpleDataStreamFromInputStream(
+      Session session, Stream<SimpleData> simpleDatas) async* {
+    await for (var simpleData in simpleDatas) {
+      yield simpleData;
+    }
+  }
+
   static const sharedStreamName = 'shared-stream';
   Future<void> postNumberToSharedStream(Session session, int number) async {
     await session.messages

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -4939,6 +4939,27 @@ class Endpoints extends _i1.EndpointDispatch {
             streamParams['numbers']!.cast<int>(),
           ),
         ),
+        'returnsSimpleDataStreamFromInputStream': _i1.MethodStreamConnector(
+          name: 'returnsSimpleDataStreamFromInputStream',
+          params: {},
+          streamParams: {
+            'simpleDatas': _i1.StreamParameterDescription<_i42.SimpleData>(
+              name: 'simpleDatas',
+              nullable: false,
+            )
+          },
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
+                  .returnsSimpleDataStreamFromInputStream(
+            session,
+            streamParams['simpleDatas']!.cast<_i42.SimpleData>(),
+          ),
+        ),
         'postNumberToSharedStreamAndReturnStream': _i1.MethodStreamConnector(
           name: 'postNumberToSharedStreamAndReturnStream',
           params: {

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -273,6 +273,7 @@ testTools:
   - returnsListFromInputStream:
   - returnsSimpleDataListFromInputStream:
   - returnsStreamFromInputStream:
+  - returnsSimpleDataStreamFromInputStream:
   - postNumberToSharedStream:
   - postNumberToSharedStreamAndReturnStream:
   - listenForNumbersOnSharedStream:

--- a/tests/serverpod_test_server/test_e2e/module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/module_test.dart
@@ -110,6 +110,16 @@ void main() {
       await streamComplete.future;
       expect(received, numberGenerator);
     });
+
+    test(
+        'when calling future-returning method that takes stream as a parameter '
+        'then should return a future value', () async {
+      var inputStream = Stream<int>.fromIterable([1]);
+      var value = await client.modules.module.streaming
+          .simpleInputReturnStream(inputStream);
+
+      expect(value, 1);
+    });
   });
 
   group('Nested modules classes.', () {

--- a/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/return_and_input_types_test.dart
@@ -51,6 +51,21 @@ void main() {
       });
 
       test(
+          'when calling returnsSimpleDataStreamFromInputStream then echoes the input stream back',
+          () async {
+        final stream = Stream<SimpleData>.fromIterable([
+          SimpleData(num: 1),
+          SimpleData(num: 2),
+          SimpleData(num: 3),
+        ]);
+
+        final result = await endpoints.testTools
+            .returnsSimpleDataStreamFromInputStream(sessionBuilder, stream)
+            .toList();
+        expect(result.map((s) => s.num), [1, 2, 3]);
+      });
+
+      test(
           'when calling postNumberToSharedStream and listenForNumbersOnSharedStream with different sessions then number should be echoed',
           () async {
         var userSession1 = sessionBuilder.copyWith(

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -7105,6 +7105,38 @@ class _TestToolsEndpoint {
     return _localTestStreamManager.outputStreamController.stream;
   }
 
+  _i3.Stream<_i11.SimpleData> returnsSimpleDataStreamFromInputStream(
+    _i1.TestSessionBuilder sessionBuilder,
+    _i3.Stream<_i11.SimpleData> simpleDatas,
+  ) {
+    var _localTestStreamManager = _i1.TestStreamManager<_i11.SimpleData>();
+    _i1.callStreamFunctionAndHandleExceptions(
+      () async {
+        var _localUniqueSession =
+            (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+          endpoint: 'testTools',
+          method: 'returnsSimpleDataStreamFromInputStream',
+        );
+        var _localCallContext =
+            await _endpointDispatch.getMethodStreamCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'returnsSimpleDataStreamFromInputStream',
+          arguments: {},
+          requestedInputStreams: ['simpleDatas'],
+          serializationManager: _serializationManager,
+        );
+        await _localTestStreamManager.callStreamMethod(
+          _localCallContext,
+          _localUniqueSession,
+          {'simpleDatas': simpleDatas},
+        );
+      },
+      _localTestStreamManager.outputStreamController,
+    );
+    return _localTestStreamManager.outputStreamController.stream;
+  }
+
   _i3.Future<void> postNumberToSharedStream(
     _i1.TestSessionBuilder sessionBuilder,
     int number,


### PR DESCRIPTION
## Description
Adds additional tests for streams for modules and test tools.

- The code path for future returning functions with stream input was not covered for modules.
- The case for methods that takes a stream and returns a stream with serializable objects was not covered

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.