### PR TITLE
fix: Support unsafe queries in test tools.

### DIFF
--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -207,7 +205,7 @@ class ChannelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -226,7 +224,7 @@ class ChannelRepository {
       orderByList: orderByList?.call(Channel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -237,7 +235,7 @@ class ChannelRepository {
   }) async {
     return session.db.findById<Channel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -248,7 +246,7 @@ class ChannelRepository {
   }) async {
     return session.db.insert<Channel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -259,7 +257,7 @@ class ChannelRepository {
   }) async {
     return session.db.insertRow<Channel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -272,7 +270,7 @@ class ChannelRepository {
     return session.db.update<Channel>(
       rows,
       columns: columns?.call(Channel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class ChannelRepository {
     return session.db.updateRow<Channel>(
       row,
       columns: columns?.call(Channel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -296,7 +294,7 @@ class ChannelRepository {
   }) async {
     return session.db.delete<Channel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class ChannelRepository {
   }) async {
     return session.db.deleteRow<Channel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class ChannelRepository {
   }) async {
     return session.db.deleteWhere<Channel>(
       where: where(Channel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class ChannelRepository {
     return session.db.count<Channel>(
       where: where?.call(Channel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -266,7 +264,7 @@ class AuthKeyRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class AuthKeyRepository {
       orderByList: orderByList?.call(AuthKey.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -296,7 +294,7 @@ class AuthKeyRepository {
   }) async {
     return session.db.findById<AuthKey>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class AuthKeyRepository {
   }) async {
     return session.db.insert<AuthKey>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class AuthKeyRepository {
   }) async {
     return session.db.insertRow<AuthKey>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class AuthKeyRepository {
     return session.db.update<AuthKey>(
       rows,
       columns: columns?.call(AuthKey.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class AuthKeyRepository {
     return session.db.updateRow<AuthKey>(
       row,
       columns: columns?.call(AuthKey.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class AuthKeyRepository {
   }) async {
     return session.db.delete<AuthKey>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -366,7 +364,7 @@ class AuthKeyRepository {
   }) async {
     return session.db.deleteRow<AuthKey>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -377,7 +375,7 @@ class AuthKeyRepository {
   }) async {
     return session.db.deleteWhere<AuthKey>(
       where: where(AuthKey.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -390,7 +388,7 @@ class AuthKeyRepository {
     return session.db.count<AuthKey>(
       where: where?.call(AuthKey.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -229,7 +227,7 @@ class EmailAuthRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -248,7 +246,7 @@ class EmailAuthRepository {
       orderByList: orderByList?.call(EmailAuth.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -259,7 +257,7 @@ class EmailAuthRepository {
   }) async {
     return session.db.findById<EmailAuth>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class EmailAuthRepository {
   }) async {
     return session.db.insert<EmailAuth>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class EmailAuthRepository {
   }) async {
     return session.db.insertRow<EmailAuth>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class EmailAuthRepository {
     return session.db.update<EmailAuth>(
       rows,
       columns: columns?.call(EmailAuth.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class EmailAuthRepository {
     return session.db.updateRow<EmailAuth>(
       row,
       columns: columns?.call(EmailAuth.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class EmailAuthRepository {
   }) async {
     return session.db.delete<EmailAuth>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class EmailAuthRepository {
   }) async {
     return session.db.deleteRow<EmailAuth>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class EmailAuthRepository {
   }) async {
     return session.db.deleteWhere<EmailAuth>(
       where: where(EmailAuth.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class EmailAuthRepository {
     return session.db.count<EmailAuth>(
       where: where?.call(EmailAuth.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -253,7 +251,7 @@ class EmailCreateAccountRequestRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -272,7 +270,7 @@ class EmailCreateAccountRequestRepository {
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -283,7 +281,7 @@ class EmailCreateAccountRequestRepository {
   }) async {
     return session.db.findById<EmailCreateAccountRequest>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class EmailCreateAccountRequestRepository {
   }) async {
     return session.db.insert<EmailCreateAccountRequest>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class EmailCreateAccountRequestRepository {
   }) async {
     return session.db.insertRow<EmailCreateAccountRequest>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class EmailCreateAccountRequestRepository {
     return session.db.update<EmailCreateAccountRequest>(
       rows,
       columns: columns?.call(EmailCreateAccountRequest.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class EmailCreateAccountRequestRepository {
     return session.db.updateRow<EmailCreateAccountRequest>(
       row,
       columns: columns?.call(EmailCreateAccountRequest.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -342,7 +340,7 @@ class EmailCreateAccountRequestRepository {
   }) async {
     return session.db.delete<EmailCreateAccountRequest>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class EmailCreateAccountRequestRepository {
   }) async {
     return session.db.deleteRow<EmailCreateAccountRequest>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class EmailCreateAccountRequestRepository {
   }) async {
     return session.db.deleteWhere<EmailCreateAccountRequest>(
       where: where(EmailCreateAccountRequest.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -377,7 +375,7 @@ class EmailCreateAccountRequestRepository {
     return session.db.count<EmailCreateAccountRequest>(
       where: where?.call(EmailCreateAccountRequest.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -231,7 +229,7 @@ class EmailFailedSignInRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -250,7 +248,7 @@ class EmailFailedSignInRepository {
       orderByList: orderByList?.call(EmailFailedSignIn.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -261,7 +259,7 @@ class EmailFailedSignInRepository {
   }) async {
     return session.db.findById<EmailFailedSignIn>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -272,7 +270,7 @@ class EmailFailedSignInRepository {
   }) async {
     return session.db.insert<EmailFailedSignIn>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -283,7 +281,7 @@ class EmailFailedSignInRepository {
   }) async {
     return session.db.insertRow<EmailFailedSignIn>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -296,7 +294,7 @@ class EmailFailedSignInRepository {
     return session.db.update<EmailFailedSignIn>(
       rows,
       columns: columns?.call(EmailFailedSignIn.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class EmailFailedSignInRepository {
     return session.db.updateRow<EmailFailedSignIn>(
       row,
       columns: columns?.call(EmailFailedSignIn.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class EmailFailedSignInRepository {
   }) async {
     return session.db.delete<EmailFailedSignIn>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class EmailFailedSignInRepository {
   }) async {
     return session.db.deleteRow<EmailFailedSignIn>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -342,7 +340,7 @@ class EmailFailedSignInRepository {
   }) async {
     return session.db.deleteWhere<EmailFailedSignIn>(
       where: where(EmailFailedSignIn.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class EmailFailedSignInRepository {
     return session.db.count<EmailFailedSignIn>(
       where: where?.call(EmailFailedSignIn.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -230,7 +228,7 @@ class EmailResetRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -249,7 +247,7 @@ class EmailResetRepository {
       orderByList: orderByList?.call(EmailReset.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class EmailResetRepository {
   }) async {
     return session.db.findById<EmailReset>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -271,7 +269,7 @@ class EmailResetRepository {
   }) async {
     return session.db.insert<EmailReset>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -282,7 +280,7 @@ class EmailResetRepository {
   }) async {
     return session.db.insertRow<EmailReset>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -295,7 +293,7 @@ class EmailResetRepository {
     return session.db.update<EmailReset>(
       rows,
       columns: columns?.call(EmailReset.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class EmailResetRepository {
     return session.db.updateRow<EmailReset>(
       row,
       columns: columns?.call(EmailReset.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class EmailResetRepository {
   }) async {
     return session.db.delete<EmailReset>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class EmailResetRepository {
   }) async {
     return session.db.deleteRow<EmailReset>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -341,7 +339,7 @@ class EmailResetRepository {
   }) async {
     return session.db.deleteWhere<EmailReset>(
       where: where(EmailReset.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -354,7 +352,7 @@ class EmailResetRepository {
     return session.db.count<EmailReset>(
       where: where?.call(EmailReset.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -209,7 +207,7 @@ class GoogleRefreshTokenRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -228,7 +226,7 @@ class GoogleRefreshTokenRepository {
       orderByList: orderByList?.call(GoogleRefreshToken.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -239,7 +237,7 @@ class GoogleRefreshTokenRepository {
   }) async {
     return session.db.findById<GoogleRefreshToken>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -250,7 +248,7 @@ class GoogleRefreshTokenRepository {
   }) async {
     return session.db.insert<GoogleRefreshToken>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -261,7 +259,7 @@ class GoogleRefreshTokenRepository {
   }) async {
     return session.db.insertRow<GoogleRefreshToken>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class GoogleRefreshTokenRepository {
     return session.db.update<GoogleRefreshToken>(
       rows,
       columns: columns?.call(GoogleRefreshToken.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class GoogleRefreshTokenRepository {
     return session.db.updateRow<GoogleRefreshToken>(
       row,
       columns: columns?.call(GoogleRefreshToken.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class GoogleRefreshTokenRepository {
   }) async {
     return session.db.delete<GoogleRefreshToken>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class GoogleRefreshTokenRepository {
   }) async {
     return session.db.deleteRow<GoogleRefreshToken>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class GoogleRefreshTokenRepository {
   }) async {
     return session.db.deleteWhere<GoogleRefreshToken>(
       where: where(GoogleRefreshToken.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class GoogleRefreshTokenRepository {
     return session.db.count<GoogleRefreshToken>(
       where: where?.call(GoogleRefreshToken.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -229,7 +227,7 @@ class UserImageRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -248,7 +246,7 @@ class UserImageRepository {
       orderByList: orderByList?.call(UserImage.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -259,7 +257,7 @@ class UserImageRepository {
   }) async {
     return session.db.findById<UserImage>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class UserImageRepository {
   }) async {
     return session.db.insert<UserImage>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class UserImageRepository {
   }) async {
     return session.db.insertRow<UserImage>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class UserImageRepository {
     return session.db.update<UserImage>(
       rows,
       columns: columns?.call(UserImage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class UserImageRepository {
     return session.db.updateRow<UserImage>(
       row,
       columns: columns?.call(UserImage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class UserImageRepository {
   }) async {
     return session.db.delete<UserImage>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class UserImageRepository {
   }) async {
     return session.db.deleteRow<UserImage>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class UserImageRepository {
   }) async {
     return session.db.deleteWhere<UserImage>(
       where: where(UserImage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class UserImageRepository {
     return session.db.count<UserImage>(
       where: where?.call(UserImage.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -342,7 +340,7 @@ class UserInfoRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -361,7 +359,7 @@ class UserInfoRepository {
       orderByList: orderByList?.call(UserInfo.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -372,7 +370,7 @@ class UserInfoRepository {
   }) async {
     return session.db.findById<UserInfo>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -383,7 +381,7 @@ class UserInfoRepository {
   }) async {
     return session.db.insert<UserInfo>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -394,7 +392,7 @@ class UserInfoRepository {
   }) async {
     return session.db.insertRow<UserInfo>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -407,7 +405,7 @@ class UserInfoRepository {
     return session.db.update<UserInfo>(
       rows,
       columns: columns?.call(UserInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -420,7 +418,7 @@ class UserInfoRepository {
     return session.db.updateRow<UserInfo>(
       row,
       columns: columns?.call(UserInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -431,7 +429,7 @@ class UserInfoRepository {
   }) async {
     return session.db.delete<UserInfo>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -442,7 +440,7 @@ class UserInfoRepository {
   }) async {
     return session.db.deleteRow<UserInfo>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -453,7 +451,7 @@ class UserInfoRepository {
   }) async {
     return session.db.deleteWhere<UserInfo>(
       where: where(UserInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -466,7 +464,7 @@ class UserInfoRepository {
     return session.db.count<UserInfo>(
       where: where?.call(UserInfo.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
@@ -347,7 +345,7 @@ class ChatMessageRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -366,7 +364,7 @@ class ChatMessageRepository {
       orderByList: orderByList?.call(ChatMessage.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -377,7 +375,7 @@ class ChatMessageRepository {
   }) async {
     return session.db.findById<ChatMessage>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -388,7 +386,7 @@ class ChatMessageRepository {
   }) async {
     return session.db.insert<ChatMessage>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -399,7 +397,7 @@ class ChatMessageRepository {
   }) async {
     return session.db.insertRow<ChatMessage>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -412,7 +410,7 @@ class ChatMessageRepository {
     return session.db.update<ChatMessage>(
       rows,
       columns: columns?.call(ChatMessage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -425,7 +423,7 @@ class ChatMessageRepository {
     return session.db.updateRow<ChatMessage>(
       row,
       columns: columns?.call(ChatMessage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -436,7 +434,7 @@ class ChatMessageRepository {
   }) async {
     return session.db.delete<ChatMessage>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -447,7 +445,7 @@ class ChatMessageRepository {
   }) async {
     return session.db.deleteRow<ChatMessage>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -458,7 +456,7 @@ class ChatMessageRepository {
   }) async {
     return session.db.deleteWhere<ChatMessage>(
       where: where(ChatMessage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -471,7 +469,7 @@ class ChatMessageRepository {
     return session.db.count<ChatMessage>(
       where: where?.call(ChatMessage.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -230,7 +228,7 @@ class ChatReadMessageRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -249,7 +247,7 @@ class ChatReadMessageRepository {
       orderByList: orderByList?.call(ChatReadMessage.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class ChatReadMessageRepository {
   }) async {
     return session.db.findById<ChatReadMessage>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -271,7 +269,7 @@ class ChatReadMessageRepository {
   }) async {
     return session.db.insert<ChatReadMessage>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -282,7 +280,7 @@ class ChatReadMessageRepository {
   }) async {
     return session.db.insertRow<ChatReadMessage>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -295,7 +293,7 @@ class ChatReadMessageRepository {
     return session.db.update<ChatReadMessage>(
       rows,
       columns: columns?.call(ChatReadMessage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class ChatReadMessageRepository {
     return session.db.updateRow<ChatReadMessage>(
       row,
       columns: columns?.call(ChatReadMessage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class ChatReadMessageRepository {
   }) async {
     return session.db.delete<ChatReadMessage>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class ChatReadMessageRepository {
   }) async {
     return session.db.deleteRow<ChatReadMessage>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -341,7 +339,7 @@ class ChatReadMessageRepository {
   }) async {
     return session.db.deleteWhere<ChatReadMessage>(
       where: where(ChatReadMessage.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -354,7 +352,7 @@ class ChatReadMessageRepository {
     return session.db.count<ChatReadMessage>(
       where: where?.call(ChatReadMessage.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/database/database.dart
+++ b/packages/serverpod/lib/src/database/database.dart
@@ -61,7 +61,8 @@ class Database {
       orderBy: orderBy,
       orderByList: orderByList,
       orderDescending: orderDescending,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
       include: include,
     );
   }
@@ -83,7 +84,8 @@ class Database {
       orderBy: orderBy,
       orderByList: orderByList,
       orderDescending: orderDescending,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
       include: include,
     );
   }
@@ -100,7 +102,8 @@ class Database {
     return _databaseConnection.findById<T>(
       _session,
       id,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
       include: include,
     );
   }
@@ -119,7 +122,8 @@ class Database {
       _session,
       rows,
       columns: columns,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -135,7 +139,8 @@ class Database {
       _session,
       row,
       columns: columns,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -149,7 +154,8 @@ class Database {
     return _databaseConnection.insert<T>(
       _session,
       rows,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -161,7 +167,8 @@ class Database {
     return _databaseConnection.insertRow<T>(
       _session,
       row,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -175,7 +182,8 @@ class Database {
     return _databaseConnection.delete<T>(
       _session,
       rows,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -187,7 +195,8 @@ class Database {
     return await _databaseConnection.deleteRow<T>(
       _session,
       row,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -199,7 +208,8 @@ class Database {
     return _databaseConnection.deleteWhere<T>(
       _session,
       where,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -215,7 +225,8 @@ class Database {
       _session,
       where: where,
       limit: limit,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -234,7 +245,8 @@ class Database {
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
       parameters: parameters,
     );
   }
@@ -254,7 +266,8 @@ class Database {
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
       parameters: parameters,
     );
   }
@@ -276,7 +289,8 @@ class Database {
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 
@@ -296,7 +310,8 @@ class Database {
       _session,
       query,
       timeoutInSeconds: timeoutInSeconds,
-      transaction: transaction,
+      // ignore: invalid_use_of_visible_for_testing_member
+      transaction: transaction ?? _session.transaction,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
@@ -298,7 +296,7 @@ class CloudStorageEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -317,7 +315,7 @@ class CloudStorageEntryRepository {
       orderByList: orderByList?.call(CloudStorageEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -328,7 +326,7 @@ class CloudStorageEntryRepository {
   }) async {
     return session.db.findById<CloudStorageEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -339,7 +337,7 @@ class CloudStorageEntryRepository {
   }) async {
     return session.db.insert<CloudStorageEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -350,7 +348,7 @@ class CloudStorageEntryRepository {
   }) async {
     return session.db.insertRow<CloudStorageEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -363,7 +361,7 @@ class CloudStorageEntryRepository {
     return session.db.update<CloudStorageEntry>(
       rows,
       columns: columns?.call(CloudStorageEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -376,7 +374,7 @@ class CloudStorageEntryRepository {
     return session.db.updateRow<CloudStorageEntry>(
       row,
       columns: columns?.call(CloudStorageEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -387,7 +385,7 @@ class CloudStorageEntryRepository {
   }) async {
     return session.db.delete<CloudStorageEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -398,7 +396,7 @@ class CloudStorageEntryRepository {
   }) async {
     return session.db.deleteRow<CloudStorageEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -409,7 +407,7 @@ class CloudStorageEntryRepository {
   }) async {
     return session.db.deleteWhere<CloudStorageEntry>(
       where: where(CloudStorageEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -422,7 +420,7 @@ class CloudStorageEntryRepository {
     return session.db.count<CloudStorageEntry>(
       where: where?.call(CloudStorageEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -253,7 +251,7 @@ class CloudStorageDirectUploadEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -272,7 +270,7 @@ class CloudStorageDirectUploadEntryRepository {
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -283,7 +281,7 @@ class CloudStorageDirectUploadEntryRepository {
   }) async {
     return session.db.findById<CloudStorageDirectUploadEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class CloudStorageDirectUploadEntryRepository {
   }) async {
     return session.db.insert<CloudStorageDirectUploadEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class CloudStorageDirectUploadEntryRepository {
   }) async {
     return session.db.insertRow<CloudStorageDirectUploadEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class CloudStorageDirectUploadEntryRepository {
     return session.db.update<CloudStorageDirectUploadEntry>(
       rows,
       columns: columns?.call(CloudStorageDirectUploadEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class CloudStorageDirectUploadEntryRepository {
     return session.db.updateRow<CloudStorageDirectUploadEntry>(
       row,
       columns: columns?.call(CloudStorageDirectUploadEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -342,7 +340,7 @@ class CloudStorageDirectUploadEntryRepository {
   }) async {
     return session.db.delete<CloudStorageDirectUploadEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class CloudStorageDirectUploadEntryRepository {
   }) async {
     return session.db.deleteRow<CloudStorageDirectUploadEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -365,7 +363,7 @@ class CloudStorageDirectUploadEntryRepository {
   }) async {
     return session.db.deleteWhere<CloudStorageDirectUploadEntry>(
       where: where(CloudStorageDirectUploadEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -378,7 +376,7 @@ class CloudStorageDirectUploadEntryRepository {
     return session.db.count<CloudStorageDirectUploadEntry>(
       where: where?.call(CloudStorageDirectUploadEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -233,7 +231,7 @@ class DatabaseMigrationVersionRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -252,7 +250,7 @@ class DatabaseMigrationVersionRepository {
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -263,7 +261,7 @@ class DatabaseMigrationVersionRepository {
   }) async {
     return session.db.findById<DatabaseMigrationVersion>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class DatabaseMigrationVersionRepository {
   }) async {
     return session.db.insert<DatabaseMigrationVersion>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class DatabaseMigrationVersionRepository {
   }) async {
     return session.db.insertRow<DatabaseMigrationVersion>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class DatabaseMigrationVersionRepository {
     return session.db.update<DatabaseMigrationVersion>(
       rows,
       columns: columns?.call(DatabaseMigrationVersion.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class DatabaseMigrationVersionRepository {
     return session.db.updateRow<DatabaseMigrationVersion>(
       row,
       columns: columns?.call(DatabaseMigrationVersion.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -322,7 +320,7 @@ class DatabaseMigrationVersionRepository {
   }) async {
     return session.db.delete<DatabaseMigrationVersion>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class DatabaseMigrationVersionRepository {
   }) async {
     return session.db.deleteRow<DatabaseMigrationVersion>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class DatabaseMigrationVersionRepository {
   }) async {
     return session.db.deleteWhere<DatabaseMigrationVersion>(
       where: where(DatabaseMigrationVersion.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -357,7 +355,7 @@ class DatabaseMigrationVersionRepository {
     return session.db.count<DatabaseMigrationVersion>(
       where: where?.call(DatabaseMigrationVersion.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -274,7 +272,7 @@ class FutureCallEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -293,7 +291,7 @@ class FutureCallEntryRepository {
       orderByList: orderByList?.call(FutureCallEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -304,7 +302,7 @@ class FutureCallEntryRepository {
   }) async {
     return session.db.findById<FutureCallEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -315,7 +313,7 @@ class FutureCallEntryRepository {
   }) async {
     return session.db.insert<FutureCallEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -326,7 +324,7 @@ class FutureCallEntryRepository {
   }) async {
     return session.db.insertRow<FutureCallEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -339,7 +337,7 @@ class FutureCallEntryRepository {
     return session.db.update<FutureCallEntry>(
       rows,
       columns: columns?.call(FutureCallEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -352,7 +350,7 @@ class FutureCallEntryRepository {
     return session.db.updateRow<FutureCallEntry>(
       row,
       columns: columns?.call(FutureCallEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -363,7 +361,7 @@ class FutureCallEntryRepository {
   }) async {
     return session.db.delete<FutureCallEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -374,7 +372,7 @@ class FutureCallEntryRepository {
   }) async {
     return session.db.deleteRow<FutureCallEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -385,7 +383,7 @@ class FutureCallEntryRepository {
   }) async {
     return session.db.deleteWhere<FutureCallEntry>(
       where: where(FutureCallEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -398,7 +396,7 @@ class FutureCallEntryRepository {
     return session.db.count<FutureCallEntry>(
       where: where?.call(FutureCallEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -377,7 +375,7 @@ class LogEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -396,7 +394,7 @@ class LogEntryRepository {
       orderByList: orderByList?.call(LogEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -407,7 +405,7 @@ class LogEntryRepository {
   }) async {
     return session.db.findById<LogEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -418,7 +416,7 @@ class LogEntryRepository {
   }) async {
     return session.db.insert<LogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -429,7 +427,7 @@ class LogEntryRepository {
   }) async {
     return session.db.insertRow<LogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -442,7 +440,7 @@ class LogEntryRepository {
     return session.db.update<LogEntry>(
       rows,
       columns: columns?.call(LogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -455,7 +453,7 @@ class LogEntryRepository {
     return session.db.updateRow<LogEntry>(
       row,
       columns: columns?.call(LogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -466,7 +464,7 @@ class LogEntryRepository {
   }) async {
     return session.db.delete<LogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -477,7 +475,7 @@ class LogEntryRepository {
   }) async {
     return session.db.deleteRow<LogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -488,7 +486,7 @@ class LogEntryRepository {
   }) async {
     return session.db.deleteWhere<LogEntry>(
       where: where(LogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -501,7 +499,7 @@ class LogEntryRepository {
     return session.db.count<LogEntry>(
       where: where?.call(LogEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -381,7 +379,7 @@ class MessageLogEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -400,7 +398,7 @@ class MessageLogEntryRepository {
       orderByList: orderByList?.call(MessageLogEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -411,7 +409,7 @@ class MessageLogEntryRepository {
   }) async {
     return session.db.findById<MessageLogEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -422,7 +420,7 @@ class MessageLogEntryRepository {
   }) async {
     return session.db.insert<MessageLogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -433,7 +431,7 @@ class MessageLogEntryRepository {
   }) async {
     return session.db.insertRow<MessageLogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -446,7 +444,7 @@ class MessageLogEntryRepository {
     return session.db.update<MessageLogEntry>(
       rows,
       columns: columns?.call(MessageLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -459,7 +457,7 @@ class MessageLogEntryRepository {
     return session.db.updateRow<MessageLogEntry>(
       row,
       columns: columns?.call(MessageLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -470,7 +468,7 @@ class MessageLogEntryRepository {
   }) async {
     return session.db.delete<MessageLogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -481,7 +479,7 @@ class MessageLogEntryRepository {
   }) async {
     return session.db.deleteRow<MessageLogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -492,7 +490,7 @@ class MessageLogEntryRepository {
   }) async {
     return session.db.deleteWhere<MessageLogEntry>(
       where: where(MessageLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -505,7 +503,7 @@ class MessageLogEntryRepository {
     return session.db.count<MessageLogEntry>(
       where: where?.call(MessageLogEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -208,7 +206,7 @@ class MethodInfoRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -227,7 +225,7 @@ class MethodInfoRepository {
       orderByList: orderByList?.call(MethodInfo.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -238,7 +236,7 @@ class MethodInfoRepository {
   }) async {
     return session.db.findById<MethodInfo>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -249,7 +247,7 @@ class MethodInfoRepository {
   }) async {
     return session.db.insert<MethodInfo>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class MethodInfoRepository {
   }) async {
     return session.db.insertRow<MethodInfo>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -273,7 +271,7 @@ class MethodInfoRepository {
     return session.db.update<MethodInfo>(
       rows,
       columns: columns?.call(MethodInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -286,7 +284,7 @@ class MethodInfoRepository {
     return session.db.updateRow<MethodInfo>(
       row,
       columns: columns?.call(MethodInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -297,7 +295,7 @@ class MethodInfoRepository {
   }) async {
     return session.db.delete<MethodInfo>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class MethodInfoRepository {
   }) async {
     return session.db.deleteRow<MethodInfo>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class MethodInfoRepository {
   }) async {
     return session.db.deleteWhere<MethodInfo>(
       where: where(MethodInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -332,7 +330,7 @@ class MethodInfoRepository {
     return session.db.count<MethodInfo>(
       where: where?.call(MethodInfo.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -381,7 +379,7 @@ class QueryLogEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -400,7 +398,7 @@ class QueryLogEntryRepository {
       orderByList: orderByList?.call(QueryLogEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -411,7 +409,7 @@ class QueryLogEntryRepository {
   }) async {
     return session.db.findById<QueryLogEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -422,7 +420,7 @@ class QueryLogEntryRepository {
   }) async {
     return session.db.insert<QueryLogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -433,7 +431,7 @@ class QueryLogEntryRepository {
   }) async {
     return session.db.insertRow<QueryLogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -446,7 +444,7 @@ class QueryLogEntryRepository {
     return session.db.update<QueryLogEntry>(
       rows,
       columns: columns?.call(QueryLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -459,7 +457,7 @@ class QueryLogEntryRepository {
     return session.db.updateRow<QueryLogEntry>(
       row,
       columns: columns?.call(QueryLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -470,7 +468,7 @@ class QueryLogEntryRepository {
   }) async {
     return session.db.delete<QueryLogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -481,7 +479,7 @@ class QueryLogEntryRepository {
   }) async {
     return session.db.deleteRow<QueryLogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -492,7 +490,7 @@ class QueryLogEntryRepository {
   }) async {
     return session.db.deleteWhere<QueryLogEntry>(
       where: where(QueryLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -505,7 +503,7 @@ class QueryLogEntryRepository {
     return session.db.count<QueryLogEntry>(
       where: where?.call(QueryLogEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -189,7 +187,7 @@ class ReadWriteTestEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -208,7 +206,7 @@ class ReadWriteTestEntryRepository {
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -219,7 +217,7 @@ class ReadWriteTestEntryRepository {
   }) async {
     return session.db.findById<ReadWriteTestEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -230,7 +228,7 @@ class ReadWriteTestEntryRepository {
   }) async {
     return session.db.insert<ReadWriteTestEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -241,7 +239,7 @@ class ReadWriteTestEntryRepository {
   }) async {
     return session.db.insertRow<ReadWriteTestEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class ReadWriteTestEntryRepository {
     return session.db.update<ReadWriteTestEntry>(
       rows,
       columns: columns?.call(ReadWriteTestEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -267,7 +265,7 @@ class ReadWriteTestEntryRepository {
     return session.db.updateRow<ReadWriteTestEntry>(
       row,
       columns: columns?.call(ReadWriteTestEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -278,7 +276,7 @@ class ReadWriteTestEntryRepository {
   }) async {
     return session.db.delete<ReadWriteTestEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -289,7 +287,7 @@ class ReadWriteTestEntryRepository {
   }) async {
     return session.db.deleteRow<ReadWriteTestEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class ReadWriteTestEntryRepository {
   }) async {
     return session.db.deleteWhere<ReadWriteTestEntry>(
       where: where(ReadWriteTestEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class ReadWriteTestEntryRepository {
     return session.db.count<ReadWriteTestEntry>(
       where: where?.call(ReadWriteTestEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -259,7 +257,7 @@ class RuntimeSettingsRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -278,7 +276,7 @@ class RuntimeSettingsRepository {
       orderByList: orderByList?.call(RuntimeSettings.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -289,7 +287,7 @@ class RuntimeSettingsRepository {
   }) async {
     return session.db.findById<RuntimeSettings>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class RuntimeSettingsRepository {
   }) async {
     return session.db.insert<RuntimeSettings>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class RuntimeSettingsRepository {
   }) async {
     return session.db.insertRow<RuntimeSettings>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -324,7 +322,7 @@ class RuntimeSettingsRepository {
     return session.db.update<RuntimeSettings>(
       rows,
       columns: columns?.call(RuntimeSettings.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -337,7 +335,7 @@ class RuntimeSettingsRepository {
     return session.db.updateRow<RuntimeSettings>(
       row,
       columns: columns?.call(RuntimeSettings.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -348,7 +346,7 @@ class RuntimeSettingsRepository {
   }) async {
     return session.db.delete<RuntimeSettings>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -359,7 +357,7 @@ class RuntimeSettingsRepository {
   }) async {
     return session.db.deleteRow<RuntimeSettings>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -370,7 +368,7 @@ class RuntimeSettingsRepository {
   }) async {
     return session.db.deleteWhere<RuntimeSettings>(
       where: where(RuntimeSettings.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -383,7 +381,7 @@ class RuntimeSettingsRepository {
     return session.db.count<RuntimeSettings>(
       where: where?.call(RuntimeSettings.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -299,7 +297,7 @@ class ServerHealthConnectionInfoRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class ServerHealthConnectionInfoRepository {
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class ServerHealthConnectionInfoRepository {
   }) async {
     return session.db.findById<ServerHealthConnectionInfo>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class ServerHealthConnectionInfoRepository {
   }) async {
     return session.db.insert<ServerHealthConnectionInfo>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -351,7 +349,7 @@ class ServerHealthConnectionInfoRepository {
   }) async {
     return session.db.insertRow<ServerHealthConnectionInfo>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class ServerHealthConnectionInfoRepository {
     return session.db.update<ServerHealthConnectionInfo>(
       rows,
       columns: columns?.call(ServerHealthConnectionInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -377,7 +375,7 @@ class ServerHealthConnectionInfoRepository {
     return session.db.updateRow<ServerHealthConnectionInfo>(
       row,
       columns: columns?.call(ServerHealthConnectionInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -388,7 +386,7 @@ class ServerHealthConnectionInfoRepository {
   }) async {
     return session.db.delete<ServerHealthConnectionInfo>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -399,7 +397,7 @@ class ServerHealthConnectionInfoRepository {
   }) async {
     return session.db.deleteRow<ServerHealthConnectionInfo>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -410,7 +408,7 @@ class ServerHealthConnectionInfoRepository {
   }) async {
     return session.db.deleteWhere<ServerHealthConnectionInfo>(
       where: where(ServerHealthConnectionInfo.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -423,7 +421,7 @@ class ServerHealthConnectionInfoRepository {
     return session.db.count<ServerHealthConnectionInfo>(
       where: where?.call(ServerHealthConnectionInfo.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -298,7 +296,7 @@ class ServerHealthMetricRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -317,7 +315,7 @@ class ServerHealthMetricRepository {
       orderByList: orderByList?.call(ServerHealthMetric.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -328,7 +326,7 @@ class ServerHealthMetricRepository {
   }) async {
     return session.db.findById<ServerHealthMetric>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -339,7 +337,7 @@ class ServerHealthMetricRepository {
   }) async {
     return session.db.insert<ServerHealthMetric>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -350,7 +348,7 @@ class ServerHealthMetricRepository {
   }) async {
     return session.db.insertRow<ServerHealthMetric>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -363,7 +361,7 @@ class ServerHealthMetricRepository {
     return session.db.update<ServerHealthMetric>(
       rows,
       columns: columns?.call(ServerHealthMetric.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -376,7 +374,7 @@ class ServerHealthMetricRepository {
     return session.db.updateRow<ServerHealthMetric>(
       row,
       columns: columns?.call(ServerHealthMetric.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -387,7 +385,7 @@ class ServerHealthMetricRepository {
   }) async {
     return session.db.delete<ServerHealthMetric>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -398,7 +396,7 @@ class ServerHealthMetricRepository {
   }) async {
     return session.db.deleteRow<ServerHealthMetric>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -409,7 +407,7 @@ class ServerHealthMetricRepository {
   }) async {
     return session.db.deleteWhere<ServerHealthMetric>(
       where: where(ServerHealthMetric.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -422,7 +420,7 @@ class ServerHealthMetricRepository {
     return session.db.count<ServerHealthMetric>(
       where: where?.call(ServerHealthMetric.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -452,7 +450,7 @@ class SessionLogEntryRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -471,7 +469,7 @@ class SessionLogEntryRepository {
       orderByList: orderByList?.call(SessionLogEntry.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -482,7 +480,7 @@ class SessionLogEntryRepository {
   }) async {
     return session.db.findById<SessionLogEntry>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -493,7 +491,7 @@ class SessionLogEntryRepository {
   }) async {
     return session.db.insert<SessionLogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -504,7 +502,7 @@ class SessionLogEntryRepository {
   }) async {
     return session.db.insertRow<SessionLogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -517,7 +515,7 @@ class SessionLogEntryRepository {
     return session.db.update<SessionLogEntry>(
       rows,
       columns: columns?.call(SessionLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -530,7 +528,7 @@ class SessionLogEntryRepository {
     return session.db.updateRow<SessionLogEntry>(
       row,
       columns: columns?.call(SessionLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -541,7 +539,7 @@ class SessionLogEntryRepository {
   }) async {
     return session.db.delete<SessionLogEntry>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -552,7 +550,7 @@ class SessionLogEntryRepository {
   }) async {
     return session.db.deleteRow<SessionLogEntry>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -563,7 +561,7 @@ class SessionLogEntryRepository {
   }) async {
     return session.db.deleteWhere<SessionLogEntry>(
       where: where(SessionLogEntry.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -576,7 +574,7 @@ class SessionLogEntryRepository {
     return session.db.count<SessionLogEntry>(
       where: where?.call(SessionLogEntry.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -230,7 +228,7 @@ class BoolDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -249,7 +247,7 @@ class BoolDefaultRepository {
       orderByList: orderByList?.call(BoolDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class BoolDefaultRepository {
   }) async {
     return session.db.findById<BoolDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -271,7 +269,7 @@ class BoolDefaultRepository {
   }) async {
     return session.db.insert<BoolDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -282,7 +280,7 @@ class BoolDefaultRepository {
   }) async {
     return session.db.insertRow<BoolDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -295,7 +293,7 @@ class BoolDefaultRepository {
     return session.db.update<BoolDefault>(
       rows,
       columns: columns?.call(BoolDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class BoolDefaultRepository {
     return session.db.updateRow<BoolDefault>(
       row,
       columns: columns?.call(BoolDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class BoolDefaultRepository {
   }) async {
     return session.db.delete<BoolDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class BoolDefaultRepository {
   }) async {
     return session.db.deleteRow<BoolDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -341,7 +339,7 @@ class BoolDefaultRepository {
   }) async {
     return session.db.deleteWhere<BoolDefault>(
       where: where(BoolDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -354,7 +352,7 @@ class BoolDefaultRepository {
     return session.db.count<BoolDefault>(
       where: where?.call(BoolDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -235,7 +233,7 @@ class BoolDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class BoolDefaultMixRepository {
       orderByList: orderByList?.call(BoolDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -265,7 +263,7 @@ class BoolDefaultMixRepository {
   }) async {
     return session.db.findById<BoolDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -276,7 +274,7 @@ class BoolDefaultMixRepository {
   }) async {
     return session.db.insert<BoolDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class BoolDefaultMixRepository {
   }) async {
     return session.db.insertRow<BoolDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class BoolDefaultMixRepository {
     return session.db.update<BoolDefaultMix>(
       rows,
       columns: columns?.call(BoolDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class BoolDefaultMixRepository {
     return session.db.updateRow<BoolDefaultMix>(
       row,
       columns: columns?.call(BoolDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -324,7 +322,7 @@ class BoolDefaultMixRepository {
   }) async {
     return session.db.delete<BoolDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -335,7 +333,7 @@ class BoolDefaultMixRepository {
   }) async {
     return session.db.deleteRow<BoolDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -346,7 +344,7 @@ class BoolDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<BoolDefaultMix>(
       where: where(BoolDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -359,7 +357,7 @@ class BoolDefaultMixRepository {
     return session.db.count<BoolDefaultMix>(
       where: where?.call(BoolDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -228,7 +226,7 @@ class BoolDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -247,7 +245,7 @@ class BoolDefaultModelRepository {
       orderByList: orderByList?.call(BoolDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -258,7 +256,7 @@ class BoolDefaultModelRepository {
   }) async {
     return session.db.findById<BoolDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -269,7 +267,7 @@ class BoolDefaultModelRepository {
   }) async {
     return session.db.insert<BoolDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -280,7 +278,7 @@ class BoolDefaultModelRepository {
   }) async {
     return session.db.insertRow<BoolDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -293,7 +291,7 @@ class BoolDefaultModelRepository {
     return session.db.update<BoolDefaultModel>(
       rows,
       columns: columns?.call(BoolDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -306,7 +304,7 @@ class BoolDefaultModelRepository {
     return session.db.updateRow<BoolDefaultModel>(
       row,
       columns: columns?.call(BoolDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -317,7 +315,7 @@ class BoolDefaultModelRepository {
   }) async {
     return session.db.delete<BoolDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -328,7 +326,7 @@ class BoolDefaultModelRepository {
   }) async {
     return session.db.deleteRow<BoolDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -339,7 +337,7 @@ class BoolDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<BoolDefaultModel>(
       where: where(BoolDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -352,7 +350,7 @@ class BoolDefaultModelRepository {
     return session.db.count<BoolDefaultModel>(
       where: where?.call(BoolDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -216,7 +214,7 @@ class BoolDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -235,7 +233,7 @@ class BoolDefaultPersistRepository {
       orderByList: orderByList?.call(BoolDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -246,7 +244,7 @@ class BoolDefaultPersistRepository {
   }) async {
     return session.db.findById<BoolDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -257,7 +255,7 @@ class BoolDefaultPersistRepository {
   }) async {
     return session.db.insert<BoolDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -268,7 +266,7 @@ class BoolDefaultPersistRepository {
   }) async {
     return session.db.insertRow<BoolDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class BoolDefaultPersistRepository {
     return session.db.update<BoolDefaultPersist>(
       rows,
       columns: columns?.call(BoolDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class BoolDefaultPersistRepository {
     return session.db.updateRow<BoolDefaultPersist>(
       row,
       columns: columns?.call(BoolDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class BoolDefaultPersistRepository {
   }) async {
     return session.db.delete<BoolDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -316,7 +314,7 @@ class BoolDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<BoolDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -327,7 +325,7 @@ class BoolDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<BoolDefaultPersist>(
       where: where(BoolDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class BoolDefaultPersistRepository {
     return session.db.count<BoolDefaultPersist>(
       where: where?.call(BoolDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -240,7 +238,7 @@ class DateTimeDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -259,7 +257,7 @@ class DateTimeDefaultRepository {
       orderByList: orderByList?.call(DateTimeDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class DateTimeDefaultRepository {
   }) async {
     return session.db.findById<DateTimeDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class DateTimeDefaultRepository {
   }) async {
     return session.db.insert<DateTimeDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -292,7 +290,7 @@ class DateTimeDefaultRepository {
   }) async {
     return session.db.insertRow<DateTimeDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class DateTimeDefaultRepository {
     return session.db.update<DateTimeDefault>(
       rows,
       columns: columns?.call(DateTimeDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class DateTimeDefaultRepository {
     return session.db.updateRow<DateTimeDefault>(
       row,
       columns: columns?.call(DateTimeDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class DateTimeDefaultRepository {
   }) async {
     return session.db.delete<DateTimeDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class DateTimeDefaultRepository {
   }) async {
     return session.db.deleteRow<DateTimeDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -351,7 +349,7 @@ class DateTimeDefaultRepository {
   }) async {
     return session.db.deleteWhere<DateTimeDefault>(
       where: where(DateTimeDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class DateTimeDefaultRepository {
     return session.db.count<DateTimeDefault>(
       where: where?.call(DateTimeDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -244,7 +242,7 @@ class DateTimeDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -263,7 +261,7 @@ class DateTimeDefaultMixRepository {
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class DateTimeDefaultMixRepository {
   }) async {
     return session.db.findById<DateTimeDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class DateTimeDefaultMixRepository {
   }) async {
     return session.db.insert<DateTimeDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -296,7 +294,7 @@ class DateTimeDefaultMixRepository {
   }) async {
     return session.db.insertRow<DateTimeDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class DateTimeDefaultMixRepository {
     return session.db.update<DateTimeDefaultMix>(
       rows,
       columns: columns?.call(DateTimeDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -322,7 +320,7 @@ class DateTimeDefaultMixRepository {
     return session.db.updateRow<DateTimeDefaultMix>(
       row,
       columns: columns?.call(DateTimeDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class DateTimeDefaultMixRepository {
   }) async {
     return session.db.delete<DateTimeDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class DateTimeDefaultMixRepository {
   }) async {
     return session.db.deleteRow<DateTimeDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class DateTimeDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<DateTimeDefaultMix>(
       where: where(DateTimeDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -368,7 +366,7 @@ class DateTimeDefaultMixRepository {
     return session.db.count<DateTimeDefaultMix>(
       where: where?.call(DateTimeDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -240,7 +238,7 @@ class DateTimeDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -259,7 +257,7 @@ class DateTimeDefaultModelRepository {
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class DateTimeDefaultModelRepository {
   }) async {
     return session.db.findById<DateTimeDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class DateTimeDefaultModelRepository {
   }) async {
     return session.db.insert<DateTimeDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -292,7 +290,7 @@ class DateTimeDefaultModelRepository {
   }) async {
     return session.db.insertRow<DateTimeDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class DateTimeDefaultModelRepository {
     return session.db.update<DateTimeDefaultModel>(
       rows,
       columns: columns?.call(DateTimeDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class DateTimeDefaultModelRepository {
     return session.db.updateRow<DateTimeDefaultModel>(
       row,
       columns: columns?.call(DateTimeDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class DateTimeDefaultModelRepository {
   }) async {
     return session.db.delete<DateTimeDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class DateTimeDefaultModelRepository {
   }) async {
     return session.db.deleteRow<DateTimeDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -351,7 +349,7 @@ class DateTimeDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<DateTimeDefaultModel>(
       where: where(DateTimeDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class DateTimeDefaultModelRepository {
     return session.db.count<DateTimeDefaultModel>(
       where: where?.call(DateTimeDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -223,7 +221,7 @@ class DateTimeDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -242,7 +240,7 @@ class DateTimeDefaultPersistRepository {
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -253,7 +251,7 @@ class DateTimeDefaultPersistRepository {
   }) async {
     return session.db.findById<DateTimeDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -264,7 +262,7 @@ class DateTimeDefaultPersistRepository {
   }) async {
     return session.db.insert<DateTimeDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -275,7 +273,7 @@ class DateTimeDefaultPersistRepository {
   }) async {
     return session.db.insertRow<DateTimeDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -288,7 +286,7 @@ class DateTimeDefaultPersistRepository {
     return session.db.update<DateTimeDefaultPersist>(
       rows,
       columns: columns?.call(DateTimeDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -301,7 +299,7 @@ class DateTimeDefaultPersistRepository {
     return session.db.updateRow<DateTimeDefaultPersist>(
       row,
       columns: columns?.call(DateTimeDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -312,7 +310,7 @@ class DateTimeDefaultPersistRepository {
   }) async {
     return session.db.delete<DateTimeDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -323,7 +321,7 @@ class DateTimeDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<DateTimeDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -334,7 +332,7 @@ class DateTimeDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<DateTimeDefaultPersist>(
       where: where(DateTimeDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -347,7 +345,7 @@ class DateTimeDefaultPersistRepository {
     return session.db.count<DateTimeDefaultPersist>(
       where: where?.call(DateTimeDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -210,7 +208,7 @@ class DoubleDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -229,7 +227,7 @@ class DoubleDefaultRepository {
       orderByList: orderByList?.call(DoubleDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -240,7 +238,7 @@ class DoubleDefaultRepository {
   }) async {
     return session.db.findById<DoubleDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -251,7 +249,7 @@ class DoubleDefaultRepository {
   }) async {
     return session.db.insert<DoubleDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -262,7 +260,7 @@ class DoubleDefaultRepository {
   }) async {
     return session.db.insertRow<DoubleDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -275,7 +273,7 @@ class DoubleDefaultRepository {
     return session.db.update<DoubleDefault>(
       rows,
       columns: columns?.call(DoubleDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -288,7 +286,7 @@ class DoubleDefaultRepository {
     return session.db.updateRow<DoubleDefault>(
       row,
       columns: columns?.call(DoubleDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -299,7 +297,7 @@ class DoubleDefaultRepository {
   }) async {
     return session.db.delete<DoubleDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -310,7 +308,7 @@ class DoubleDefaultRepository {
   }) async {
     return session.db.deleteRow<DoubleDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -321,7 +319,7 @@ class DoubleDefaultRepository {
   }) async {
     return session.db.deleteWhere<DoubleDefault>(
       where: where(DoubleDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -334,7 +332,7 @@ class DoubleDefaultRepository {
     return session.db.count<DoubleDefault>(
       where: where?.call(DoubleDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -241,7 +239,7 @@ class DoubleDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class DoubleDefaultMixRepository {
       orderByList: orderByList?.call(DoubleDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -271,7 +269,7 @@ class DoubleDefaultMixRepository {
   }) async {
     return session.db.findById<DoubleDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -282,7 +280,7 @@ class DoubleDefaultMixRepository {
   }) async {
     return session.db.insert<DoubleDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -293,7 +291,7 @@ class DoubleDefaultMixRepository {
   }) async {
     return session.db.insertRow<DoubleDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -306,7 +304,7 @@ class DoubleDefaultMixRepository {
     return session.db.update<DoubleDefaultMix>(
       rows,
       columns: columns?.call(DoubleDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class DoubleDefaultMixRepository {
     return session.db.updateRow<DoubleDefaultMix>(
       row,
       columns: columns?.call(DoubleDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class DoubleDefaultMixRepository {
   }) async {
     return session.db.delete<DoubleDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -341,7 +339,7 @@ class DoubleDefaultMixRepository {
   }) async {
     return session.db.deleteRow<DoubleDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -352,7 +350,7 @@ class DoubleDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<DoubleDefaultMix>(
       where: where(DoubleDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -365,7 +363,7 @@ class DoubleDefaultMixRepository {
     return session.db.count<DoubleDefaultMix>(
       where: where?.call(DoubleDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -208,7 +206,7 @@ class DoubleDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -227,7 +225,7 @@ class DoubleDefaultModelRepository {
       orderByList: orderByList?.call(DoubleDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -238,7 +236,7 @@ class DoubleDefaultModelRepository {
   }) async {
     return session.db.findById<DoubleDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -249,7 +247,7 @@ class DoubleDefaultModelRepository {
   }) async {
     return session.db.insert<DoubleDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class DoubleDefaultModelRepository {
   }) async {
     return session.db.insertRow<DoubleDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -273,7 +271,7 @@ class DoubleDefaultModelRepository {
     return session.db.update<DoubleDefaultModel>(
       rows,
       columns: columns?.call(DoubleDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -286,7 +284,7 @@ class DoubleDefaultModelRepository {
     return session.db.updateRow<DoubleDefaultModel>(
       row,
       columns: columns?.call(DoubleDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -297,7 +295,7 @@ class DoubleDefaultModelRepository {
   }) async {
     return session.db.delete<DoubleDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class DoubleDefaultModelRepository {
   }) async {
     return session.db.deleteRow<DoubleDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class DoubleDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<DoubleDefaultModel>(
       where: where(DoubleDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -332,7 +330,7 @@ class DoubleDefaultModelRepository {
     return session.db.count<DoubleDefaultModel>(
       where: where?.call(DoubleDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -192,7 +190,7 @@ class DoubleDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -211,7 +209,7 @@ class DoubleDefaultPersistRepository {
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -222,7 +220,7 @@ class DoubleDefaultPersistRepository {
   }) async {
     return session.db.findById<DoubleDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -233,7 +231,7 @@ class DoubleDefaultPersistRepository {
   }) async {
     return session.db.insert<DoubleDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -244,7 +242,7 @@ class DoubleDefaultPersistRepository {
   }) async {
     return session.db.insertRow<DoubleDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -257,7 +255,7 @@ class DoubleDefaultPersistRepository {
     return session.db.update<DoubleDefaultPersist>(
       rows,
       columns: columns?.call(DoubleDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class DoubleDefaultPersistRepository {
     return session.db.updateRow<DoubleDefaultPersist>(
       row,
       columns: columns?.call(DoubleDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class DoubleDefaultPersistRepository {
   }) async {
     return session.db.delete<DoubleDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -292,7 +290,7 @@ class DoubleDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<DoubleDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -303,7 +301,7 @@ class DoubleDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<DoubleDefaultPersist>(
       where: where(DoubleDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -316,7 +314,7 @@ class DoubleDefaultPersistRepository {
     return session.db.count<DoubleDefaultPersist>(
       where: where?.call(DoubleDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -229,7 +227,7 @@ class DurationDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -248,7 +246,7 @@ class DurationDefaultRepository {
       orderByList: orderByList?.call(DurationDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -259,7 +257,7 @@ class DurationDefaultRepository {
   }) async {
     return session.db.findById<DurationDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class DurationDefaultRepository {
   }) async {
     return session.db.insert<DurationDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class DurationDefaultRepository {
   }) async {
     return session.db.insertRow<DurationDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class DurationDefaultRepository {
     return session.db.update<DurationDefault>(
       rows,
       columns: columns?.call(DurationDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class DurationDefaultRepository {
     return session.db.updateRow<DurationDefault>(
       row,
       columns: columns?.call(DurationDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class DurationDefaultRepository {
   }) async {
     return session.db.delete<DurationDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class DurationDefaultRepository {
   }) async {
     return session.db.deleteRow<DurationDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class DurationDefaultRepository {
   }) async {
     return session.db.deleteWhere<DurationDefault>(
       where: where(DurationDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class DurationDefaultRepository {
     return session.db.count<DurationDefault>(
       where: where?.call(DurationDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -262,7 +260,7 @@ class DurationDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class DurationDefaultMixRepository {
       orderByList: orderByList?.call(DurationDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -292,7 +290,7 @@ class DurationDefaultMixRepository {
   }) async {
     return session.db.findById<DurationDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -303,7 +301,7 @@ class DurationDefaultMixRepository {
   }) async {
     return session.db.insert<DurationDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -314,7 +312,7 @@ class DurationDefaultMixRepository {
   }) async {
     return session.db.insertRow<DurationDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -327,7 +325,7 @@ class DurationDefaultMixRepository {
     return session.db.update<DurationDefaultMix>(
       rows,
       columns: columns?.call(DurationDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class DurationDefaultMixRepository {
     return session.db.updateRow<DurationDefaultMix>(
       row,
       columns: columns?.call(DurationDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -351,7 +349,7 @@ class DurationDefaultMixRepository {
   }) async {
     return session.db.delete<DurationDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -362,7 +360,7 @@ class DurationDefaultMixRepository {
   }) async {
     return session.db.deleteRow<DurationDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -373,7 +371,7 @@ class DurationDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<DurationDefaultMix>(
       where: where(DurationDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -386,7 +384,7 @@ class DurationDefaultMixRepository {
     return session.db.count<DurationDefaultMix>(
       where: where?.call(DurationDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -229,7 +227,7 @@ class DurationDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -248,7 +246,7 @@ class DurationDefaultModelRepository {
       orderByList: orderByList?.call(DurationDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -259,7 +257,7 @@ class DurationDefaultModelRepository {
   }) async {
     return session.db.findById<DurationDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class DurationDefaultModelRepository {
   }) async {
     return session.db.insert<DurationDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -281,7 +279,7 @@ class DurationDefaultModelRepository {
   }) async {
     return session.db.insertRow<DurationDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class DurationDefaultModelRepository {
     return session.db.update<DurationDefaultModel>(
       rows,
       columns: columns?.call(DurationDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class DurationDefaultModelRepository {
     return session.db.updateRow<DurationDefaultModel>(
       row,
       columns: columns?.call(DurationDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class DurationDefaultModelRepository {
   }) async {
     return session.db.delete<DurationDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class DurationDefaultModelRepository {
   }) async {
     return session.db.deleteRow<DurationDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class DurationDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<DurationDefaultModel>(
       where: where(DurationDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class DurationDefaultModelRepository {
     return session.db.count<DurationDefaultModel>(
       where: where?.call(DurationDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -195,7 +193,7 @@ class DurationDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -214,7 +212,7 @@ class DurationDefaultPersistRepository {
       orderByList: orderByList?.call(DurationDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -225,7 +223,7 @@ class DurationDefaultPersistRepository {
   }) async {
     return session.db.findById<DurationDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -236,7 +234,7 @@ class DurationDefaultPersistRepository {
   }) async {
     return session.db.insert<DurationDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -247,7 +245,7 @@ class DurationDefaultPersistRepository {
   }) async {
     return session.db.insertRow<DurationDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class DurationDefaultPersistRepository {
     return session.db.update<DurationDefaultPersist>(
       rows,
       columns: columns?.call(DurationDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -273,7 +271,7 @@ class DurationDefaultPersistRepository {
     return session.db.updateRow<DurationDefaultPersist>(
       row,
       columns: columns?.call(DurationDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -284,7 +282,7 @@ class DurationDefaultPersistRepository {
   }) async {
     return session.db.delete<DurationDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -295,7 +293,7 @@ class DurationDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<DurationDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -306,7 +304,7 @@ class DurationDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<DurationDefaultPersist>(
       where: where(DurationDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class DurationDefaultPersistRepository {
     return session.db.count<DurationDefaultPersist>(
       where: where?.call(DurationDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -270,7 +268,7 @@ class EnumDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -289,7 +287,7 @@ class EnumDefaultRepository {
       orderByList: orderByList?.call(EnumDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class EnumDefaultRepository {
   }) async {
     return session.db.findById<EnumDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class EnumDefaultRepository {
   }) async {
     return session.db.insert<EnumDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -322,7 +320,7 @@ class EnumDefaultRepository {
   }) async {
     return session.db.insertRow<EnumDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -335,7 +333,7 @@ class EnumDefaultRepository {
     return session.db.update<EnumDefault>(
       rows,
       columns: columns?.call(EnumDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -348,7 +346,7 @@ class EnumDefaultRepository {
     return session.db.updateRow<EnumDefault>(
       row,
       columns: columns?.call(EnumDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -359,7 +357,7 @@ class EnumDefaultRepository {
   }) async {
     return session.db.delete<EnumDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -370,7 +368,7 @@ class EnumDefaultRepository {
   }) async {
     return session.db.deleteRow<EnumDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -381,7 +379,7 @@ class EnumDefaultRepository {
   }) async {
     return session.db.deleteWhere<EnumDefault>(
       where: where(EnumDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -394,7 +392,7 @@ class EnumDefaultRepository {
     return session.db.count<EnumDefault>(
       where: where?.call(EnumDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -252,7 +250,7 @@ class EnumDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -271,7 +269,7 @@ class EnumDefaultMixRepository {
       orderByList: orderByList?.call(EnumDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -282,7 +280,7 @@ class EnumDefaultMixRepository {
   }) async {
     return session.db.findById<EnumDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -293,7 +291,7 @@ class EnumDefaultMixRepository {
   }) async {
     return session.db.insert<EnumDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -304,7 +302,7 @@ class EnumDefaultMixRepository {
   }) async {
     return session.db.insertRow<EnumDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -317,7 +315,7 @@ class EnumDefaultMixRepository {
     return session.db.update<EnumDefaultMix>(
       rows,
       columns: columns?.call(EnumDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class EnumDefaultMixRepository {
     return session.db.updateRow<EnumDefaultMix>(
       row,
       columns: columns?.call(EnumDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -341,7 +339,7 @@ class EnumDefaultMixRepository {
   }) async {
     return session.db.delete<EnumDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -352,7 +350,7 @@ class EnumDefaultMixRepository {
   }) async {
     return session.db.deleteRow<EnumDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -363,7 +361,7 @@ class EnumDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<EnumDefaultMix>(
       where: where(EnumDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -376,7 +374,7 @@ class EnumDefaultMixRepository {
     return session.db.count<EnumDefaultMix>(
       where: where?.call(EnumDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -275,7 +273,7 @@ class EnumDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class EnumDefaultModelRepository {
       orderByList: orderByList?.call(EnumDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class EnumDefaultModelRepository {
   }) async {
     return session.db.findById<EnumDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -316,7 +314,7 @@ class EnumDefaultModelRepository {
   }) async {
     return session.db.insert<EnumDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -327,7 +325,7 @@ class EnumDefaultModelRepository {
   }) async {
     return session.db.insertRow<EnumDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -340,7 +338,7 @@ class EnumDefaultModelRepository {
     return session.db.update<EnumDefaultModel>(
       rows,
       columns: columns?.call(EnumDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class EnumDefaultModelRepository {
     return session.db.updateRow<EnumDefaultModel>(
       row,
       columns: columns?.call(EnumDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class EnumDefaultModelRepository {
   }) async {
     return session.db.delete<EnumDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -375,7 +373,7 @@ class EnumDefaultModelRepository {
   }) async {
     return session.db.deleteRow<EnumDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -386,7 +384,7 @@ class EnumDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<EnumDefaultModel>(
       where: where(EnumDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -399,7 +397,7 @@ class EnumDefaultModelRepository {
     return session.db.count<EnumDefaultModel>(
       where: where?.call(EnumDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -225,7 +223,7 @@ class EnumDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -244,7 +242,7 @@ class EnumDefaultPersistRepository {
       orderByList: orderByList?.call(EnumDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -255,7 +253,7 @@ class EnumDefaultPersistRepository {
   }) async {
     return session.db.findById<EnumDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -266,7 +264,7 @@ class EnumDefaultPersistRepository {
   }) async {
     return session.db.insert<EnumDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -277,7 +275,7 @@ class EnumDefaultPersistRepository {
   }) async {
     return session.db.insertRow<EnumDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -290,7 +288,7 @@ class EnumDefaultPersistRepository {
     return session.db.update<EnumDefaultPersist>(
       rows,
       columns: columns?.call(EnumDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -303,7 +301,7 @@ class EnumDefaultPersistRepository {
     return session.db.updateRow<EnumDefaultPersist>(
       row,
       columns: columns?.call(EnumDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -314,7 +312,7 @@ class EnumDefaultPersistRepository {
   }) async {
     return session.db.delete<EnumDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -325,7 +323,7 @@ class EnumDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<EnumDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -336,7 +334,7 @@ class EnumDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<EnumDefaultPersist>(
       where: where(EnumDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -349,7 +347,7 @@ class EnumDefaultPersistRepository {
     return session.db.count<EnumDefaultPersist>(
       where: where?.call(EnumDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -206,7 +204,7 @@ class IntDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -225,7 +223,7 @@ class IntDefaultRepository {
       orderByList: orderByList?.call(IntDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -236,7 +234,7 @@ class IntDefaultRepository {
   }) async {
     return session.db.findById<IntDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -247,7 +245,7 @@ class IntDefaultRepository {
   }) async {
     return session.db.insert<IntDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -258,7 +256,7 @@ class IntDefaultRepository {
   }) async {
     return session.db.insertRow<IntDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -271,7 +269,7 @@ class IntDefaultRepository {
     return session.db.update<IntDefault>(
       rows,
       columns: columns?.call(IntDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -284,7 +282,7 @@ class IntDefaultRepository {
     return session.db.updateRow<IntDefault>(
       row,
       columns: columns?.call(IntDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -295,7 +293,7 @@ class IntDefaultRepository {
   }) async {
     return session.db.delete<IntDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -306,7 +304,7 @@ class IntDefaultRepository {
   }) async {
     return session.db.deleteRow<IntDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -317,7 +315,7 @@ class IntDefaultRepository {
   }) async {
     return session.db.deleteWhere<IntDefault>(
       where: where(IntDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class IntDefaultRepository {
     return session.db.count<IntDefault>(
       where: where?.call(IntDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -235,7 +233,7 @@ class IntDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class IntDefaultMixRepository {
       orderByList: orderByList?.call(IntDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -265,7 +263,7 @@ class IntDefaultMixRepository {
   }) async {
     return session.db.findById<IntDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -276,7 +274,7 @@ class IntDefaultMixRepository {
   }) async {
     return session.db.insert<IntDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class IntDefaultMixRepository {
   }) async {
     return session.db.insertRow<IntDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class IntDefaultMixRepository {
     return session.db.update<IntDefaultMix>(
       rows,
       columns: columns?.call(IntDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class IntDefaultMixRepository {
     return session.db.updateRow<IntDefaultMix>(
       row,
       columns: columns?.call(IntDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -324,7 +322,7 @@ class IntDefaultMixRepository {
   }) async {
     return session.db.delete<IntDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -335,7 +333,7 @@ class IntDefaultMixRepository {
   }) async {
     return session.db.deleteRow<IntDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -346,7 +344,7 @@ class IntDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<IntDefaultMix>(
       where: where(IntDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -359,7 +357,7 @@ class IntDefaultMixRepository {
     return session.db.count<IntDefaultMix>(
       where: where?.call(IntDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -205,7 +203,7 @@ class IntDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -224,7 +222,7 @@ class IntDefaultModelRepository {
       orderByList: orderByList?.call(IntDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -235,7 +233,7 @@ class IntDefaultModelRepository {
   }) async {
     return session.db.findById<IntDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -246,7 +244,7 @@ class IntDefaultModelRepository {
   }) async {
     return session.db.insert<IntDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -257,7 +255,7 @@ class IntDefaultModelRepository {
   }) async {
     return session.db.insertRow<IntDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -270,7 +268,7 @@ class IntDefaultModelRepository {
     return session.db.update<IntDefaultModel>(
       rows,
       columns: columns?.call(IntDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -283,7 +281,7 @@ class IntDefaultModelRepository {
     return session.db.updateRow<IntDefaultModel>(
       row,
       columns: columns?.call(IntDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -294,7 +292,7 @@ class IntDefaultModelRepository {
   }) async {
     return session.db.delete<IntDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class IntDefaultModelRepository {
   }) async {
     return session.db.deleteRow<IntDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -316,7 +314,7 @@ class IntDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<IntDefaultModel>(
       where: where(IntDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class IntDefaultModelRepository {
     return session.db.count<IntDefaultModel>(
       where: where?.call(IntDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -188,7 +186,7 @@ class IntDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -207,7 +205,7 @@ class IntDefaultPersistRepository {
       orderByList: orderByList?.call(IntDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -218,7 +216,7 @@ class IntDefaultPersistRepository {
   }) async {
     return session.db.findById<IntDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -229,7 +227,7 @@ class IntDefaultPersistRepository {
   }) async {
     return session.db.insert<IntDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -240,7 +238,7 @@ class IntDefaultPersistRepository {
   }) async {
     return session.db.insertRow<IntDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -253,7 +251,7 @@ class IntDefaultPersistRepository {
     return session.db.update<IntDefaultPersist>(
       rows,
       columns: columns?.call(IntDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -266,7 +264,7 @@ class IntDefaultPersistRepository {
     return session.db.updateRow<IntDefaultPersist>(
       row,
       columns: columns?.call(IntDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -277,7 +275,7 @@ class IntDefaultPersistRepository {
   }) async {
     return session.db.delete<IntDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -288,7 +286,7 @@ class IntDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<IntDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -299,7 +297,7 @@ class IntDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<IntDefaultPersist>(
       where: where(IntDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -312,7 +310,7 @@ class IntDefaultPersistRepository {
     return session.db.count<IntDefaultPersist>(
       where: where?.call(IntDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -209,7 +207,7 @@ class StringDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -228,7 +226,7 @@ class StringDefaultRepository {
       orderByList: orderByList?.call(StringDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -239,7 +237,7 @@ class StringDefaultRepository {
   }) async {
     return session.db.findById<StringDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -250,7 +248,7 @@ class StringDefaultRepository {
   }) async {
     return session.db.insert<StringDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -261,7 +259,7 @@ class StringDefaultRepository {
   }) async {
     return session.db.insertRow<StringDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class StringDefaultRepository {
     return session.db.update<StringDefault>(
       rows,
       columns: columns?.call(StringDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class StringDefaultRepository {
     return session.db.updateRow<StringDefault>(
       row,
       columns: columns?.call(StringDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class StringDefaultRepository {
   }) async {
     return session.db.delete<StringDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class StringDefaultRepository {
   }) async {
     return session.db.deleteRow<StringDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class StringDefaultRepository {
   }) async {
     return session.db.deleteWhere<StringDefault>(
       where: where(StringDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class StringDefaultRepository {
     return session.db.count<StringDefault>(
       where: where?.call(StringDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -241,7 +239,7 @@ class StringDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class StringDefaultMixRepository {
       orderByList: orderByList?.call(StringDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -271,7 +269,7 @@ class StringDefaultMixRepository {
   }) async {
     return session.db.findById<StringDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -282,7 +280,7 @@ class StringDefaultMixRepository {
   }) async {
     return session.db.insert<StringDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -293,7 +291,7 @@ class StringDefaultMixRepository {
   }) async {
     return session.db.insertRow<StringDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -306,7 +304,7 @@ class StringDefaultMixRepository {
     return session.db.update<StringDefaultMix>(
       rows,
       columns: columns?.call(StringDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class StringDefaultMixRepository {
     return session.db.updateRow<StringDefaultMix>(
       row,
       columns: columns?.call(StringDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class StringDefaultMixRepository {
   }) async {
     return session.db.delete<StringDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -341,7 +339,7 @@ class StringDefaultMixRepository {
   }) async {
     return session.db.deleteRow<StringDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -352,7 +350,7 @@ class StringDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<StringDefaultMix>(
       where: where(StringDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -365,7 +363,7 @@ class StringDefaultMixRepository {
     return session.db.count<StringDefaultMix>(
       where: where?.call(StringDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -209,7 +207,7 @@ class StringDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -228,7 +226,7 @@ class StringDefaultModelRepository {
       orderByList: orderByList?.call(StringDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -239,7 +237,7 @@ class StringDefaultModelRepository {
   }) async {
     return session.db.findById<StringDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -250,7 +248,7 @@ class StringDefaultModelRepository {
   }) async {
     return session.db.insert<StringDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -261,7 +259,7 @@ class StringDefaultModelRepository {
   }) async {
     return session.db.insertRow<StringDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class StringDefaultModelRepository {
     return session.db.update<StringDefaultModel>(
       rows,
       columns: columns?.call(StringDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class StringDefaultModelRepository {
     return session.db.updateRow<StringDefaultModel>(
       row,
       columns: columns?.call(StringDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class StringDefaultModelRepository {
   }) async {
     return session.db.delete<StringDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class StringDefaultModelRepository {
   }) async {
     return session.db.deleteRow<StringDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class StringDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<StringDefaultModel>(
       where: where(StringDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class StringDefaultModelRepository {
     return session.db.count<StringDefaultModel>(
       where: where?.call(StringDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -444,7 +442,7 @@ class StringDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -463,7 +461,7 @@ class StringDefaultPersistRepository {
       orderByList: orderByList?.call(StringDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -474,7 +472,7 @@ class StringDefaultPersistRepository {
   }) async {
     return session.db.findById<StringDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -485,7 +483,7 @@ class StringDefaultPersistRepository {
   }) async {
     return session.db.insert<StringDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -496,7 +494,7 @@ class StringDefaultPersistRepository {
   }) async {
     return session.db.insertRow<StringDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -509,7 +507,7 @@ class StringDefaultPersistRepository {
     return session.db.update<StringDefaultPersist>(
       rows,
       columns: columns?.call(StringDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -522,7 +520,7 @@ class StringDefaultPersistRepository {
     return session.db.updateRow<StringDefaultPersist>(
       row,
       columns: columns?.call(StringDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -533,7 +531,7 @@ class StringDefaultPersistRepository {
   }) async {
     return session.db.delete<StringDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -544,7 +542,7 @@ class StringDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<StringDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -555,7 +553,7 @@ class StringDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<StringDefaultPersist>(
       where: where(StringDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -568,7 +566,7 @@ class StringDefaultPersistRepository {
     return session.db.count<StringDefaultPersist>(
       where: where?.call(StringDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
@@ -266,7 +264,7 @@ class UuidDefaultRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class UuidDefaultRepository {
       orderByList: orderByList?.call(UuidDefault.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -296,7 +294,7 @@ class UuidDefaultRepository {
   }) async {
     return session.db.findById<UuidDefault>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class UuidDefaultRepository {
   }) async {
     return session.db.insert<UuidDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class UuidDefaultRepository {
   }) async {
     return session.db.insertRow<UuidDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class UuidDefaultRepository {
     return session.db.update<UuidDefault>(
       rows,
       columns: columns?.call(UuidDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class UuidDefaultRepository {
     return session.db.updateRow<UuidDefault>(
       row,
       columns: columns?.call(UuidDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class UuidDefaultRepository {
   }) async {
     return session.db.delete<UuidDefault>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -366,7 +364,7 @@ class UuidDefaultRepository {
   }) async {
     return session.db.deleteRow<UuidDefault>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -377,7 +375,7 @@ class UuidDefaultRepository {
   }) async {
     return session.db.deleteWhere<UuidDefault>(
       where: where(UuidDefault.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -390,7 +388,7 @@ class UuidDefaultRepository {
     return session.db.count<UuidDefault>(
       where: where?.call(UuidDefault.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -239,7 +237,7 @@ class UuidDefaultMixRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -258,7 +256,7 @@ class UuidDefaultMixRepository {
       orderByList: orderByList?.call(UuidDefaultMix.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -269,7 +267,7 @@ class UuidDefaultMixRepository {
   }) async {
     return session.db.findById<UuidDefaultMix>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -280,7 +278,7 @@ class UuidDefaultMixRepository {
   }) async {
     return session.db.insert<UuidDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -291,7 +289,7 @@ class UuidDefaultMixRepository {
   }) async {
     return session.db.insertRow<UuidDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -304,7 +302,7 @@ class UuidDefaultMixRepository {
     return session.db.update<UuidDefaultMix>(
       rows,
       columns: columns?.call(UuidDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -317,7 +315,7 @@ class UuidDefaultMixRepository {
     return session.db.updateRow<UuidDefaultMix>(
       row,
       columns: columns?.call(UuidDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -328,7 +326,7 @@ class UuidDefaultMixRepository {
   }) async {
     return session.db.delete<UuidDefaultMix>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -339,7 +337,7 @@ class UuidDefaultMixRepository {
   }) async {
     return session.db.deleteRow<UuidDefaultMix>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -350,7 +348,7 @@ class UuidDefaultMixRepository {
   }) async {
     return session.db.deleteWhere<UuidDefaultMix>(
       where: where(UuidDefaultMix.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -363,7 +361,7 @@ class UuidDefaultMixRepository {
     return session.db.count<UuidDefaultMix>(
       where: where?.call(UuidDefaultMix.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
@@ -268,7 +266,7 @@ class UuidDefaultModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class UuidDefaultModelRepository {
       orderByList: orderByList?.call(UuidDefaultModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class UuidDefaultModelRepository {
   }) async {
     return session.db.findById<UuidDefaultModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class UuidDefaultModelRepository {
   }) async {
     return session.db.insert<UuidDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class UuidDefaultModelRepository {
   }) async {
     return session.db.insertRow<UuidDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class UuidDefaultModelRepository {
     return session.db.update<UuidDefaultModel>(
       rows,
       columns: columns?.call(UuidDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -346,7 +344,7 @@ class UuidDefaultModelRepository {
     return session.db.updateRow<UuidDefaultModel>(
       row,
       columns: columns?.call(UuidDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -357,7 +355,7 @@ class UuidDefaultModelRepository {
   }) async {
     return session.db.delete<UuidDefaultModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -368,7 +366,7 @@ class UuidDefaultModelRepository {
   }) async {
     return session.db.deleteRow<UuidDefaultModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -379,7 +377,7 @@ class UuidDefaultModelRepository {
   }) async {
     return session.db.deleteWhere<UuidDefaultModel>(
       where: where(UuidDefaultModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -392,7 +390,7 @@ class UuidDefaultModelRepository {
     return session.db.count<UuidDefaultModel>(
       where: where?.call(UuidDefaultModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -221,7 +219,7 @@ class UuidDefaultPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -240,7 +238,7 @@ class UuidDefaultPersistRepository {
       orderByList: orderByList?.call(UuidDefaultPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -251,7 +249,7 @@ class UuidDefaultPersistRepository {
   }) async {
     return session.db.findById<UuidDefaultPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -262,7 +260,7 @@ class UuidDefaultPersistRepository {
   }) async {
     return session.db.insert<UuidDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -273,7 +271,7 @@ class UuidDefaultPersistRepository {
   }) async {
     return session.db.insertRow<UuidDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -286,7 +284,7 @@ class UuidDefaultPersistRepository {
     return session.db.update<UuidDefaultPersist>(
       rows,
       columns: columns?.call(UuidDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -299,7 +297,7 @@ class UuidDefaultPersistRepository {
     return session.db.updateRow<UuidDefaultPersist>(
       row,
       columns: columns?.call(UuidDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -310,7 +308,7 @@ class UuidDefaultPersistRepository {
   }) async {
     return session.db.delete<UuidDefaultPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -321,7 +319,7 @@ class UuidDefaultPersistRepository {
   }) async {
     return session.db.deleteRow<UuidDefaultPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -332,7 +330,7 @@ class UuidDefaultPersistRepository {
   }) async {
     return session.db.deleteWhere<UuidDefaultPersist>(
       where: where(UuidDefaultPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -345,7 +343,7 @@ class UuidDefaultPersistRepository {
     return session.db.count<UuidDefaultPersist>(
       where: where?.call(UuidDefaultPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -233,7 +231,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -252,7 +250,7 @@ class EmptyModelRelationItemRepository {
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -263,7 +261,7 @@ class EmptyModelRelationItemRepository {
   }) async {
     return session.db.findById<EmptyModelRelationItem>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class EmptyModelRelationItemRepository {
   }) async {
     return session.db.insert<EmptyModelRelationItem>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class EmptyModelRelationItemRepository {
   }) async {
     return session.db.insertRow<EmptyModelRelationItem>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class EmptyModelRelationItemRepository {
     return session.db.update<EmptyModelRelationItem>(
       rows,
       columns: columns?.call(EmptyModelRelationItem.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class EmptyModelRelationItemRepository {
     return session.db.updateRow<EmptyModelRelationItem>(
       row,
       columns: columns?.call(EmptyModelRelationItem.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -322,7 +320,7 @@ class EmptyModelRelationItemRepository {
   }) async {
     return session.db.delete<EmptyModelRelationItem>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class EmptyModelRelationItemRepository {
   }) async {
     return session.db.deleteRow<EmptyModelRelationItem>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class EmptyModelRelationItemRepository {
   }) async {
     return session.db.deleteWhere<EmptyModelRelationItem>(
       where: where(EmptyModelRelationItem.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -357,7 +355,7 @@ class EmptyModelRelationItemRepository {
     return session.db.count<EmptyModelRelationItem>(
       where: where?.call(EmptyModelRelationItem.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -143,7 +141,7 @@ class EmptyModelWithTableRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -162,7 +160,7 @@ class EmptyModelWithTableRepository {
       orderByList: orderByList?.call(EmptyModelWithTable.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -173,7 +171,7 @@ class EmptyModelWithTableRepository {
   }) async {
     return session.db.findById<EmptyModelWithTable>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -184,7 +182,7 @@ class EmptyModelWithTableRepository {
   }) async {
     return session.db.insert<EmptyModelWithTable>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -195,7 +193,7 @@ class EmptyModelWithTableRepository {
   }) async {
     return session.db.insertRow<EmptyModelWithTable>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -208,7 +206,7 @@ class EmptyModelWithTableRepository {
     return session.db.update<EmptyModelWithTable>(
       rows,
       columns: columns?.call(EmptyModelWithTable.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -221,7 +219,7 @@ class EmptyModelWithTableRepository {
     return session.db.updateRow<EmptyModelWithTable>(
       row,
       columns: columns?.call(EmptyModelWithTable.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -232,7 +230,7 @@ class EmptyModelWithTableRepository {
   }) async {
     return session.db.delete<EmptyModelWithTable>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -243,7 +241,7 @@ class EmptyModelWithTableRepository {
   }) async {
     return session.db.deleteRow<EmptyModelWithTable>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class EmptyModelWithTableRepository {
   }) async {
     return session.db.deleteWhere<EmptyModelWithTable>(
       where: where(EmptyModelWithTable.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -267,7 +265,7 @@ class EmptyModelWithTableRepository {
     return session.db.count<EmptyModelWithTable>(
       where: where?.call(EmptyModelWithTable.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -241,7 +239,7 @@ class RelationEmptyModelRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -262,7 +260,7 @@ class RelationEmptyModelRepository {
       orderByList: orderByList?.call(RelationEmptyModel.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -275,7 +273,7 @@ class RelationEmptyModelRepository {
   }) async {
     return session.db.findById<RelationEmptyModel>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -287,7 +285,7 @@ class RelationEmptyModelRepository {
   }) async {
     return session.db.insert<RelationEmptyModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class RelationEmptyModelRepository {
   }) async {
     return session.db.insertRow<RelationEmptyModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class RelationEmptyModelRepository {
     return session.db.update<RelationEmptyModel>(
       rows,
       columns: columns?.call(RelationEmptyModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -324,7 +322,7 @@ class RelationEmptyModelRepository {
     return session.db.updateRow<RelationEmptyModel>(
       row,
       columns: columns?.call(RelationEmptyModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -335,7 +333,7 @@ class RelationEmptyModelRepository {
   }) async {
     return session.db.delete<RelationEmptyModel>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -346,7 +344,7 @@ class RelationEmptyModelRepository {
   }) async {
     return session.db.deleteRow<RelationEmptyModel>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -357,7 +355,7 @@ class RelationEmptyModelRepository {
   }) async {
     return session.db.deleteWhere<RelationEmptyModel>(
       where: where(RelationEmptyModel.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -370,7 +368,7 @@ class RelationEmptyModelRepository {
     return session.db.count<RelationEmptyModel>(
       where: where?.call(RelationEmptyModel.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -404,7 +402,7 @@ class RelationEmptyModelAttachRepository {
         _i2.EmptyModelRelationItem.t
             .$_relationEmptyModelItemsRelationEmptyModelId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -435,7 +433,7 @@ class RelationEmptyModelAttachRowRepository {
         _i2.EmptyModelRelationItem.t
             .$_relationEmptyModelItemsRelationEmptyModelId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -464,7 +462,7 @@ class RelationEmptyModelDetachRepository {
         _i2.EmptyModelRelationItem.t
             .$_relationEmptyModelItemsRelationEmptyModelId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -491,7 +489,7 @@ class RelationEmptyModelDetachRowRepository {
         _i2.EmptyModelRelationItem.t
             .$_relationEmptyModelItemsRelationEmptyModelId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
@@ -179,7 +177,7 @@ class ParentClassRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -198,7 +196,7 @@ class ParentClassRepository {
       orderByList: orderByList?.call(ParentClass.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -209,7 +207,7 @@ class ParentClassRepository {
   }) async {
     return session.db.findById<ParentClass>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -220,7 +218,7 @@ class ParentClassRepository {
   }) async {
     return session.db.insert<ParentClass>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -231,7 +229,7 @@ class ParentClassRepository {
   }) async {
     return session.db.insertRow<ParentClass>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -244,7 +242,7 @@ class ParentClassRepository {
     return session.db.update<ParentClass>(
       rows,
       columns: columns?.call(ParentClass.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -257,7 +255,7 @@ class ParentClassRepository {
     return session.db.updateRow<ParentClass>(
       row,
       columns: columns?.call(ParentClass.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -268,7 +266,7 @@ class ParentClassRepository {
   }) async {
     return session.db.delete<ParentClass>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -279,7 +277,7 @@ class ParentClassRepository {
   }) async {
     return session.db.deleteRow<ParentClass>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -290,7 +288,7 @@ class ParentClassRepository {
   }) async {
     return session.db.deleteWhere<ParentClass>(
       where: where(ParentClass.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -303,7 +301,7 @@ class ParentClassRepository {
     return session.db.count<ParentClass>(
       where: where?.call(ParentClass.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -339,7 +337,7 @@ class CityWithLongTableNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -360,7 +358,7 @@ class CityWithLongTableNameRepository {
       orderByList: orderByList?.call(CityWithLongTableName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -373,7 +371,7 @@ class CityWithLongTableNameRepository {
   }) async {
     return session.db.findById<CityWithLongTableName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -385,7 +383,7 @@ class CityWithLongTableNameRepository {
   }) async {
     return session.db.insert<CityWithLongTableName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -396,7 +394,7 @@ class CityWithLongTableNameRepository {
   }) async {
     return session.db.insertRow<CityWithLongTableName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -409,7 +407,7 @@ class CityWithLongTableNameRepository {
     return session.db.update<CityWithLongTableName>(
       rows,
       columns: columns?.call(CityWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -422,7 +420,7 @@ class CityWithLongTableNameRepository {
     return session.db.updateRow<CityWithLongTableName>(
       row,
       columns: columns?.call(CityWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -433,7 +431,7 @@ class CityWithLongTableNameRepository {
   }) async {
     return session.db.delete<CityWithLongTableName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -444,7 +442,7 @@ class CityWithLongTableNameRepository {
   }) async {
     return session.db.deleteRow<CityWithLongTableName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -455,7 +453,7 @@ class CityWithLongTableNameRepository {
   }) async {
     return session.db.deleteWhere<CityWithLongTableName>(
       where: where(CityWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -468,7 +466,7 @@ class CityWithLongTableNameRepository {
     return session.db.count<CityWithLongTableName>(
       where: where?.call(CityWithLongTableName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -502,7 +500,7 @@ class CityWithLongTableNameAttachRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -525,7 +523,7 @@ class CityWithLongTableNameAttachRepository {
     await session.db.update<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -557,7 +555,7 @@ class CityWithLongTableNameAttachRowRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -579,7 +577,7 @@ class CityWithLongTableNameAttachRowRepository {
     await session.db.updateRow<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -609,7 +607,7 @@ class CityWithLongTableNameDetachRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -628,7 +626,7 @@ class CityWithLongTableNameDetachRepository {
     await session.db.update<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -655,7 +653,7 @@ class CityWithLongTableNameDetachRowRepository {
         _i2.PersonWithLongTableName.t
             .$_cityWithLongTableNameThatIsStillValidCitizensCityWithLon4fe0Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -673,7 +671,7 @@ class CityWithLongTableNameDetachRowRepository {
     await session.db.updateRow<_i2.OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [_i2.OrganizationWithLongTableName.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -331,7 +329,7 @@ class OrganizationWithLongTableNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -352,7 +350,7 @@ class OrganizationWithLongTableNameRepository {
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -365,7 +363,7 @@ class OrganizationWithLongTableNameRepository {
   }) async {
     return session.db.findById<OrganizationWithLongTableName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -377,7 +375,7 @@ class OrganizationWithLongTableNameRepository {
   }) async {
     return session.db.insert<OrganizationWithLongTableName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -388,7 +386,7 @@ class OrganizationWithLongTableNameRepository {
   }) async {
     return session.db.insertRow<OrganizationWithLongTableName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -401,7 +399,7 @@ class OrganizationWithLongTableNameRepository {
     return session.db.update<OrganizationWithLongTableName>(
       rows,
       columns: columns?.call(OrganizationWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -414,7 +412,7 @@ class OrganizationWithLongTableNameRepository {
     return session.db.updateRow<OrganizationWithLongTableName>(
       row,
       columns: columns?.call(OrganizationWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -425,7 +423,7 @@ class OrganizationWithLongTableNameRepository {
   }) async {
     return session.db.delete<OrganizationWithLongTableName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -436,7 +434,7 @@ class OrganizationWithLongTableNameRepository {
   }) async {
     return session.db.deleteRow<OrganizationWithLongTableName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -448,7 +446,7 @@ class OrganizationWithLongTableNameRepository {
   }) async {
     return session.db.deleteWhere<OrganizationWithLongTableName>(
       where: where(OrganizationWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -461,7 +459,7 @@ class OrganizationWithLongTableNameRepository {
     return session.db.count<OrganizationWithLongTableName>(
       where: where?.call(OrganizationWithLongTableName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -489,7 +487,7 @@ class OrganizationWithLongTableNameAttachRepository {
     await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -515,7 +513,7 @@ class OrganizationWithLongTableNameAttachRowRepository {
     await session.db.updateRow<OrganizationWithLongTableName>(
       $organizationWithLongTableName,
       columns: [OrganizationWithLongTableName.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -537,7 +535,7 @@ class OrganizationWithLongTableNameAttachRowRepository {
     await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -560,7 +558,7 @@ class OrganizationWithLongTableNameDetachRepository {
     await session.db.update<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -582,7 +580,7 @@ class OrganizationWithLongTableNameDetachRowRepository {
     await session.db.updateRow<OrganizationWithLongTableName>(
       $organizationwithlongtablename,
       columns: [OrganizationWithLongTableName.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -600,7 +598,7 @@ class OrganizationWithLongTableNameDetachRowRepository {
     await session.db.updateRow<_i2.PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [_i2.PersonWithLongTableName.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -316,7 +314,7 @@ class PersonWithLongTableNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -337,7 +335,7 @@ class PersonWithLongTableNameRepository {
       orderByList: orderByList?.call(PersonWithLongTableName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -350,7 +348,7 @@ class PersonWithLongTableNameRepository {
   }) async {
     return session.db.findById<PersonWithLongTableName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -362,7 +360,7 @@ class PersonWithLongTableNameRepository {
   }) async {
     return session.db.insert<PersonWithLongTableName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -373,7 +371,7 @@ class PersonWithLongTableNameRepository {
   }) async {
     return session.db.insertRow<PersonWithLongTableName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -386,7 +384,7 @@ class PersonWithLongTableNameRepository {
     return session.db.update<PersonWithLongTableName>(
       rows,
       columns: columns?.call(PersonWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -399,7 +397,7 @@ class PersonWithLongTableNameRepository {
     return session.db.updateRow<PersonWithLongTableName>(
       row,
       columns: columns?.call(PersonWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -410,7 +408,7 @@ class PersonWithLongTableNameRepository {
   }) async {
     return session.db.delete<PersonWithLongTableName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -421,7 +419,7 @@ class PersonWithLongTableNameRepository {
   }) async {
     return session.db.deleteRow<PersonWithLongTableName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -432,7 +430,7 @@ class PersonWithLongTableNameRepository {
   }) async {
     return session.db.deleteWhere<PersonWithLongTableName>(
       where: where(PersonWithLongTableName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -445,7 +443,7 @@ class PersonWithLongTableNameRepository {
     return session.db.count<PersonWithLongTableName>(
       where: where?.call(PersonWithLongTableName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -471,7 +469,7 @@ class PersonWithLongTableNameAttachRowRepository {
     await session.db.updateRow<PersonWithLongTableName>(
       $personWithLongTableName,
       columns: [PersonWithLongTableName.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -493,7 +491,7 @@ class PersonWithLongTableNameDetachRowRepository {
     await session.db.updateRow<PersonWithLongTableName>(
       $personwithlongtablename,
       columns: [PersonWithLongTableName.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -196,7 +194,7 @@ class MaxFieldNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -215,7 +213,7 @@ class MaxFieldNameRepository {
       orderByList: orderByList?.call(MaxFieldName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -226,7 +224,7 @@ class MaxFieldNameRepository {
   }) async {
     return session.db.findById<MaxFieldName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -237,7 +235,7 @@ class MaxFieldNameRepository {
   }) async {
     return session.db.insert<MaxFieldName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -248,7 +246,7 @@ class MaxFieldNameRepository {
   }) async {
     return session.db.insertRow<MaxFieldName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -261,7 +259,7 @@ class MaxFieldNameRepository {
     return session.db.update<MaxFieldName>(
       rows,
       columns: columns?.call(MaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class MaxFieldNameRepository {
     return session.db.updateRow<MaxFieldName>(
       row,
       columns: columns?.call(MaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class MaxFieldNameRepository {
   }) async {
     return session.db.delete<MaxFieldName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -296,7 +294,7 @@ class MaxFieldNameRepository {
   }) async {
     return session.db.deleteRow<MaxFieldName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class MaxFieldNameRepository {
   }) async {
     return session.db.deleteWhere<MaxFieldName>(
       where: where(MaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class MaxFieldNameRepository {
     return session.db.count<MaxFieldName>(
       where: where?.call(MaxFieldName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -235,7 +233,7 @@ class LongImplicitIdFieldRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class LongImplicitIdFieldRepository {
       orderByList: orderByList?.call(LongImplicitIdField.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -265,7 +263,7 @@ class LongImplicitIdFieldRepository {
   }) async {
     return session.db.findById<LongImplicitIdField>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -276,7 +274,7 @@ class LongImplicitIdFieldRepository {
   }) async {
     return session.db.insert<LongImplicitIdField>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class LongImplicitIdFieldRepository {
   }) async {
     return session.db.insertRow<LongImplicitIdField>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class LongImplicitIdFieldRepository {
     return session.db.update<LongImplicitIdField>(
       rows,
       columns: columns?.call(LongImplicitIdField.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class LongImplicitIdFieldRepository {
     return session.db.updateRow<LongImplicitIdField>(
       row,
       columns: columns?.call(LongImplicitIdField.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -324,7 +322,7 @@ class LongImplicitIdFieldRepository {
   }) async {
     return session.db.delete<LongImplicitIdField>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -335,7 +333,7 @@ class LongImplicitIdFieldRepository {
   }) async {
     return session.db.deleteRow<LongImplicitIdField>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -346,7 +344,7 @@ class LongImplicitIdFieldRepository {
   }) async {
     return session.db.deleteWhere<LongImplicitIdField>(
       where: where(LongImplicitIdField.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -359,7 +357,7 @@ class LongImplicitIdFieldRepository {
     return session.db.count<LongImplicitIdField>(
       where: where?.call(LongImplicitIdField.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -305,7 +303,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -326,7 +324,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -339,7 +337,7 @@ class LongImplicitIdFieldCollectionRepository {
   }) async {
     return session.db.findById<LongImplicitIdFieldCollection>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -351,7 +349,7 @@ class LongImplicitIdFieldCollectionRepository {
   }) async {
     return session.db.insert<LongImplicitIdFieldCollection>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -362,7 +360,7 @@ class LongImplicitIdFieldCollectionRepository {
   }) async {
     return session.db.insertRow<LongImplicitIdFieldCollection>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -375,7 +373,7 @@ class LongImplicitIdFieldCollectionRepository {
     return session.db.update<LongImplicitIdFieldCollection>(
       rows,
       columns: columns?.call(LongImplicitIdFieldCollection.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -388,7 +386,7 @@ class LongImplicitIdFieldCollectionRepository {
     return session.db.updateRow<LongImplicitIdFieldCollection>(
       row,
       columns: columns?.call(LongImplicitIdFieldCollection.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -399,7 +397,7 @@ class LongImplicitIdFieldCollectionRepository {
   }) async {
     return session.db.delete<LongImplicitIdFieldCollection>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -410,7 +408,7 @@ class LongImplicitIdFieldCollectionRepository {
   }) async {
     return session.db.deleteRow<LongImplicitIdFieldCollection>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -422,7 +420,7 @@ class LongImplicitIdFieldCollectionRepository {
   }) async {
     return session.db.deleteWhere<LongImplicitIdFieldCollection>(
       where: where(LongImplicitIdFieldCollection.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -435,7 +433,7 @@ class LongImplicitIdFieldCollectionRepository {
     return session.db.count<LongImplicitIdFieldCollection>(
       where: where?.call(LongImplicitIdFieldCollection.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -469,7 +467,7 @@ class LongImplicitIdFieldCollectionAttachRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -501,7 +499,7 @@ class LongImplicitIdFieldCollectionAttachRowRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -531,7 +529,7 @@ class LongImplicitIdFieldCollectionDetachRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -558,7 +556,7 @@ class LongImplicitIdFieldCollectionDetachRowRepository {
         _i2.LongImplicitIdField.t
             .$_longImplicitIdFieldCollectionThisfieldisexactly61charact0008Id
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -273,7 +271,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -294,7 +292,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -307,7 +305,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }) async {
     return session.db.findById<RelationToMultipleMaxFieldName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -319,7 +317,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }) async {
     return session.db.insert<RelationToMultipleMaxFieldName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -330,7 +328,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }) async {
     return session.db.insertRow<RelationToMultipleMaxFieldName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -343,7 +341,7 @@ class RelationToMultipleMaxFieldNameRepository {
     return session.db.update<RelationToMultipleMaxFieldName>(
       rows,
       columns: columns?.call(RelationToMultipleMaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -356,7 +354,7 @@ class RelationToMultipleMaxFieldNameRepository {
     return session.db.updateRow<RelationToMultipleMaxFieldName>(
       row,
       columns: columns?.call(RelationToMultipleMaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -367,7 +365,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }) async {
     return session.db.delete<RelationToMultipleMaxFieldName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -378,7 +376,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }) async {
     return session.db.deleteRow<RelationToMultipleMaxFieldName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -390,7 +388,7 @@ class RelationToMultipleMaxFieldNameRepository {
   }) async {
     return session.db.deleteWhere<RelationToMultipleMaxFieldName>(
       where: where(RelationToMultipleMaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -403,7 +401,7 @@ class RelationToMultipleMaxFieldNameRepository {
     return session.db.count<RelationToMultipleMaxFieldName>(
       where: where?.call(RelationToMultipleMaxFieldName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -437,7 +435,7 @@ class RelationToMultipleMaxFieldNameAttachRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -469,7 +467,7 @@ class RelationToMultipleMaxFieldNameAttachRowRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -499,7 +497,7 @@ class RelationToMultipleMaxFieldNameDetachRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -526,7 +524,7 @@ class RelationToMultipleMaxFieldNameDetachRowRepository {
         _i2.MultipleMaxFieldName.t
             .$_relationToMultipleMaxFieldNameMultiplemaxfieldnamesRelat674eId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -233,7 +231,7 @@ class UserNoteRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -252,7 +250,7 @@ class UserNoteRepository {
       orderByList: orderByList?.call(UserNote.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -263,7 +261,7 @@ class UserNoteRepository {
   }) async {
     return session.db.findById<UserNote>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class UserNoteRepository {
   }) async {
     return session.db.insert<UserNote>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class UserNoteRepository {
   }) async {
     return session.db.insertRow<UserNote>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class UserNoteRepository {
     return session.db.update<UserNote>(
       rows,
       columns: columns?.call(UserNote.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class UserNoteRepository {
     return session.db.updateRow<UserNote>(
       row,
       columns: columns?.call(UserNote.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -322,7 +320,7 @@ class UserNoteRepository {
   }) async {
     return session.db.delete<UserNote>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class UserNoteRepository {
   }) async {
     return session.db.deleteRow<UserNote>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class UserNoteRepository {
   }) async {
     return session.db.deleteWhere<UserNote>(
       where: where(UserNote.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -357,7 +355,7 @@ class UserNoteRepository {
     return session.db.count<UserNote>(
       where: where?.call(UserNote.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -269,7 +267,7 @@ class UserNoteCollectionRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -290,7 +288,7 @@ class UserNoteCollectionRepository {
       orderByList: orderByList?.call(UserNoteCollection.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -303,7 +301,7 @@ class UserNoteCollectionRepository {
   }) async {
     return session.db.findById<UserNoteCollection>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -315,7 +313,7 @@ class UserNoteCollectionRepository {
   }) async {
     return session.db.insert<UserNoteCollection>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -326,7 +324,7 @@ class UserNoteCollectionRepository {
   }) async {
     return session.db.insertRow<UserNoteCollection>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -339,7 +337,7 @@ class UserNoteCollectionRepository {
     return session.db.update<UserNoteCollection>(
       rows,
       columns: columns?.call(UserNoteCollection.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -352,7 +350,7 @@ class UserNoteCollectionRepository {
     return session.db.updateRow<UserNoteCollection>(
       row,
       columns: columns?.call(UserNoteCollection.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -363,7 +361,7 @@ class UserNoteCollectionRepository {
   }) async {
     return session.db.delete<UserNoteCollection>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -374,7 +372,7 @@ class UserNoteCollectionRepository {
   }) async {
     return session.db.deleteRow<UserNoteCollection>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -385,7 +383,7 @@ class UserNoteCollectionRepository {
   }) async {
     return session.db.deleteWhere<UserNoteCollection>(
       where: where(UserNoteCollection.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -398,7 +396,7 @@ class UserNoteCollectionRepository {
     return session.db.count<UserNoteCollection>(
       where: where?.call(UserNoteCollection.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -432,7 +430,7 @@ class UserNoteCollectionAttachRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -464,7 +462,7 @@ class UserNoteCollectionAttachRowRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -494,7 +492,7 @@ class UserNoteCollectionDetachRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -521,7 +519,7 @@ class UserNoteCollectionDetachRowRepository {
         _i2.UserNote.t
             .$_userNoteCollectionsUsernotespropertynameUserNoteCollectionsId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -268,7 +266,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -289,7 +287,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -302,7 +300,7 @@ class UserNoteCollectionWithALongNameRepository {
   }) async {
     return session.db.findById<UserNoteCollectionWithALongName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -314,7 +312,7 @@ class UserNoteCollectionWithALongNameRepository {
   }) async {
     return session.db.insert<UserNoteCollectionWithALongName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -325,7 +323,7 @@ class UserNoteCollectionWithALongNameRepository {
   }) async {
     return session.db.insertRow<UserNoteCollectionWithALongName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -338,7 +336,7 @@ class UserNoteCollectionWithALongNameRepository {
     return session.db.update<UserNoteCollectionWithALongName>(
       rows,
       columns: columns?.call(UserNoteCollectionWithALongName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -351,7 +349,7 @@ class UserNoteCollectionWithALongNameRepository {
     return session.db.updateRow<UserNoteCollectionWithALongName>(
       row,
       columns: columns?.call(UserNoteCollectionWithALongName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -362,7 +360,7 @@ class UserNoteCollectionWithALongNameRepository {
   }) async {
     return session.db.delete<UserNoteCollectionWithALongName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -373,7 +371,7 @@ class UserNoteCollectionWithALongNameRepository {
   }) async {
     return session.db.deleteRow<UserNoteCollectionWithALongName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -385,7 +383,7 @@ class UserNoteCollectionWithALongNameRepository {
   }) async {
     return session.db.deleteWhere<UserNoteCollectionWithALongName>(
       where: where(UserNoteCollectionWithALongName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -398,7 +396,7 @@ class UserNoteCollectionWithALongNameRepository {
     return session.db.count<UserNoteCollectionWithALongName>(
       where: where?.call(UserNoteCollectionWithALongName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -432,7 +430,7 @@ class UserNoteCollectionWithALongNameAttachRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -464,7 +462,7 @@ class UserNoteCollectionWithALongNameAttachRowRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -494,7 +492,7 @@ class UserNoteCollectionWithALongNameDetachRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -521,7 +519,7 @@ class UserNoteCollectionWithALongNameDetachRowRepository {
         _i2.UserNoteWithALongName.t
             .$_userNoteCollectionWithALongNameNotesUserNoteCollectionWi06adId
       ],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -236,7 +234,7 @@ class UserNoteWithALongNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -255,7 +253,7 @@ class UserNoteWithALongNameRepository {
       orderByList: orderByList?.call(UserNoteWithALongName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -266,7 +264,7 @@ class UserNoteWithALongNameRepository {
   }) async {
     return session.db.findById<UserNoteWithALongName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -277,7 +275,7 @@ class UserNoteWithALongNameRepository {
   }) async {
     return session.db.insert<UserNoteWithALongName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -288,7 +286,7 @@ class UserNoteWithALongNameRepository {
   }) async {
     return session.db.insertRow<UserNoteWithALongName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -301,7 +299,7 @@ class UserNoteWithALongNameRepository {
     return session.db.update<UserNoteWithALongName>(
       rows,
       columns: columns?.call(UserNoteWithALongName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -314,7 +312,7 @@ class UserNoteWithALongNameRepository {
     return session.db.updateRow<UserNoteWithALongName>(
       row,
       columns: columns?.call(UserNoteWithALongName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -325,7 +323,7 @@ class UserNoteWithALongNameRepository {
   }) async {
     return session.db.delete<UserNoteWithALongName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -336,7 +334,7 @@ class UserNoteWithALongNameRepository {
   }) async {
     return session.db.deleteRow<UserNoteWithALongName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -347,7 +345,7 @@ class UserNoteWithALongNameRepository {
   }) async {
     return session.db.deleteWhere<UserNoteWithALongName>(
       where: where(UserNoteWithALongName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -360,7 +358,7 @@ class UserNoteWithALongNameRepository {
     return session.db.count<UserNoteWithALongName>(
       where: where?.call(UserNoteWithALongName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -290,7 +288,7 @@ class MultipleMaxFieldNameRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class MultipleMaxFieldNameRepository {
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class MultipleMaxFieldNameRepository {
   }) async {
     return session.db.findById<MultipleMaxFieldName>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class MultipleMaxFieldNameRepository {
   }) async {
     return session.db.insert<MultipleMaxFieldName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -342,7 +340,7 @@ class MultipleMaxFieldNameRepository {
   }) async {
     return session.db.insertRow<MultipleMaxFieldName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class MultipleMaxFieldNameRepository {
     return session.db.update<MultipleMaxFieldName>(
       rows,
       columns: columns?.call(MultipleMaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -368,7 +366,7 @@ class MultipleMaxFieldNameRepository {
     return session.db.updateRow<MultipleMaxFieldName>(
       row,
       columns: columns?.call(MultipleMaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -379,7 +377,7 @@ class MultipleMaxFieldNameRepository {
   }) async {
     return session.db.delete<MultipleMaxFieldName>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -390,7 +388,7 @@ class MultipleMaxFieldNameRepository {
   }) async {
     return session.db.deleteRow<MultipleMaxFieldName>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -401,7 +399,7 @@ class MultipleMaxFieldNameRepository {
   }) async {
     return session.db.deleteWhere<MultipleMaxFieldName>(
       where: where(MultipleMaxFieldName.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -414,7 +412,7 @@ class MultipleMaxFieldNameRepository {
     return session.db.count<MultipleMaxFieldName>(
       where: where?.call(MultipleMaxFieldName.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -330,7 +328,7 @@ class CityRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -351,7 +349,7 @@ class CityRepository {
       orderByList: orderByList?.call(City.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -364,7 +362,7 @@ class CityRepository {
   }) async {
     return session.db.findById<City>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -376,7 +374,7 @@ class CityRepository {
   }) async {
     return session.db.insert<City>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -387,7 +385,7 @@ class CityRepository {
   }) async {
     return session.db.insertRow<City>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -400,7 +398,7 @@ class CityRepository {
     return session.db.update<City>(
       rows,
       columns: columns?.call(City.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -413,7 +411,7 @@ class CityRepository {
     return session.db.updateRow<City>(
       row,
       columns: columns?.call(City.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -424,7 +422,7 @@ class CityRepository {
   }) async {
     return session.db.delete<City>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -435,7 +433,7 @@ class CityRepository {
   }) async {
     return session.db.deleteRow<City>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -446,7 +444,7 @@ class CityRepository {
   }) async {
     return session.db.deleteWhere<City>(
       where: where(City.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -459,7 +457,7 @@ class CityRepository {
     return session.db.count<City>(
       where: where?.call(City.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -489,7 +487,7 @@ class CityAttachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -511,7 +509,7 @@ class CityAttachRepository {
     await session.db.update<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -539,7 +537,7 @@ class CityAttachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -560,7 +558,7 @@ class CityAttachRowRepository {
     await session.db.updateRow<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -586,7 +584,7 @@ class CityDetachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -604,7 +602,7 @@ class CityDetachRepository {
     await session.db.update<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -628,7 +626,7 @@ class CityDetachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.$_cityCitizensCityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -645,7 +643,7 @@ class CityDetachRowRepository {
     await session.db.updateRow<_i2.Organization>(
       $organization,
       columns: [_i2.Organization.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -325,7 +323,7 @@ class OrganizationRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -346,7 +344,7 @@ class OrganizationRepository {
       orderByList: orderByList?.call(Organization.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -359,7 +357,7 @@ class OrganizationRepository {
   }) async {
     return session.db.findById<Organization>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -371,7 +369,7 @@ class OrganizationRepository {
   }) async {
     return session.db.insert<Organization>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -382,7 +380,7 @@ class OrganizationRepository {
   }) async {
     return session.db.insertRow<Organization>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -395,7 +393,7 @@ class OrganizationRepository {
     return session.db.update<Organization>(
       rows,
       columns: columns?.call(Organization.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -408,7 +406,7 @@ class OrganizationRepository {
     return session.db.updateRow<Organization>(
       row,
       columns: columns?.call(Organization.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -419,7 +417,7 @@ class OrganizationRepository {
   }) async {
     return session.db.delete<Organization>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -430,7 +428,7 @@ class OrganizationRepository {
   }) async {
     return session.db.deleteRow<Organization>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -441,7 +439,7 @@ class OrganizationRepository {
   }) async {
     return session.db.deleteWhere<Organization>(
       where: where(Organization.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -454,7 +452,7 @@ class OrganizationRepository {
     return session.db.count<Organization>(
       where: where?.call(Organization.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -480,7 +478,7 @@ class OrganizationAttachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -505,7 +503,7 @@ class OrganizationAttachRowRepository {
     await session.db.updateRow<Organization>(
       $organization,
       columns: [Organization.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -526,7 +524,7 @@ class OrganizationAttachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -547,7 +545,7 @@ class OrganizationDetachRepository {
     await session.db.update<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -568,7 +566,7 @@ class OrganizationDetachRowRepository {
     await session.db.updateRow<Organization>(
       $organization,
       columns: [Organization.t.cityId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -585,7 +583,7 @@ class OrganizationDetachRowRepository {
     await session.db.updateRow<_i2.Person>(
       $person,
       columns: [_i2.Person.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../protocol.dart' as _i2;
@@ -302,7 +300,7 @@ class PersonRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -323,7 +321,7 @@ class PersonRepository {
       orderByList: orderByList?.call(Person.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -336,7 +334,7 @@ class PersonRepository {
   }) async {
     return session.db.findById<Person>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -348,7 +346,7 @@ class PersonRepository {
   }) async {
     return session.db.insert<Person>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -359,7 +357,7 @@ class PersonRepository {
   }) async {
     return session.db.insertRow<Person>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -372,7 +370,7 @@ class PersonRepository {
     return session.db.update<Person>(
       rows,
       columns: columns?.call(Person.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -385,7 +383,7 @@ class PersonRepository {
     return session.db.updateRow<Person>(
       row,
       columns: columns?.call(Person.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -396,7 +394,7 @@ class PersonRepository {
   }) async {
     return session.db.delete<Person>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -407,7 +405,7 @@ class PersonRepository {
   }) async {
     return session.db.deleteRow<Person>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -418,7 +416,7 @@ class PersonRepository {
   }) async {
     return session.db.deleteWhere<Person>(
       where: where(Person.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -431,7 +429,7 @@ class PersonRepository {
     return session.db.count<Person>(
       where: where?.call(Person.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -456,7 +454,7 @@ class PersonAttachRowRepository {
     await session.db.updateRow<Person>(
       $person,
       columns: [Person.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -477,7 +475,7 @@ class PersonDetachRowRepository {
     await session.db.updateRow<Person>(
       $person,
       columns: [Person.t.organizationId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -259,7 +257,7 @@ class CourseRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -280,7 +278,7 @@ class CourseRepository {
       orderByList: orderByList?.call(Course.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -293,7 +291,7 @@ class CourseRepository {
   }) async {
     return session.db.findById<Course>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -305,7 +303,7 @@ class CourseRepository {
   }) async {
     return session.db.insert<Course>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -316,7 +314,7 @@ class CourseRepository {
   }) async {
     return session.db.insertRow<Course>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -329,7 +327,7 @@ class CourseRepository {
     return session.db.update<Course>(
       rows,
       columns: columns?.call(Course.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -342,7 +340,7 @@ class CourseRepository {
     return session.db.updateRow<Course>(
       row,
       columns: columns?.call(Course.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class CourseRepository {
   }) async {
     return session.db.delete<Course>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class CourseRepository {
   }) async {
     return session.db.deleteRow<Course>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -375,7 +373,7 @@ class CourseRepository {
   }) async {
     return session.db.deleteWhere<Course>(
       where: where(Course.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -388,7 +386,7 @@ class CourseRepository {
     return session.db.count<Course>(
       where: where?.call(Course.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -414,7 +412,7 @@ class CourseAttachRepository {
     await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -439,7 +437,7 @@ class CourseAttachRowRepository {
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -461,7 +459,7 @@ class CourseDetachRepository {
     await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -482,7 +480,7 @@ class CourseDetachRowRepository {
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -296,7 +294,7 @@ class EnrollmentRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -317,7 +315,7 @@ class EnrollmentRepository {
       orderByList: orderByList?.call(Enrollment.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -330,7 +328,7 @@ class EnrollmentRepository {
   }) async {
     return session.db.findById<Enrollment>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -342,7 +340,7 @@ class EnrollmentRepository {
   }) async {
     return session.db.insert<Enrollment>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class EnrollmentRepository {
   }) async {
     return session.db.insertRow<Enrollment>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -366,7 +364,7 @@ class EnrollmentRepository {
     return session.db.update<Enrollment>(
       rows,
       columns: columns?.call(Enrollment.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -379,7 +377,7 @@ class EnrollmentRepository {
     return session.db.updateRow<Enrollment>(
       row,
       columns: columns?.call(Enrollment.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -390,7 +388,7 @@ class EnrollmentRepository {
   }) async {
     return session.db.delete<Enrollment>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -401,7 +399,7 @@ class EnrollmentRepository {
   }) async {
     return session.db.deleteRow<Enrollment>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -412,7 +410,7 @@ class EnrollmentRepository {
   }) async {
     return session.db.deleteWhere<Enrollment>(
       where: where(Enrollment.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -425,7 +423,7 @@ class EnrollmentRepository {
     return session.db.count<Enrollment>(
       where: where?.call(Enrollment.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -450,7 +448,7 @@ class EnrollmentAttachRowRepository {
     await session.db.updateRow<Enrollment>(
       $enrollment,
       columns: [Enrollment.t.studentId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -471,7 +469,7 @@ class EnrollmentAttachRowRepository {
     await session.db.updateRow<Enrollment>(
       $enrollment,
       columns: [Enrollment.t.courseId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -255,7 +253,7 @@ class StudentRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -276,7 +274,7 @@ class StudentRepository {
       orderByList: orderByList?.call(Student.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -289,7 +287,7 @@ class StudentRepository {
   }) async {
     return session.db.findById<Student>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -301,7 +299,7 @@ class StudentRepository {
   }) async {
     return session.db.insert<Student>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -312,7 +310,7 @@ class StudentRepository {
   }) async {
     return session.db.insertRow<Student>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -325,7 +323,7 @@ class StudentRepository {
     return session.db.update<Student>(
       rows,
       columns: columns?.call(Student.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -338,7 +336,7 @@ class StudentRepository {
     return session.db.updateRow<Student>(
       row,
       columns: columns?.call(Student.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -349,7 +347,7 @@ class StudentRepository {
   }) async {
     return session.db.delete<Student>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -360,7 +358,7 @@ class StudentRepository {
   }) async {
     return session.db.deleteRow<Student>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -371,7 +369,7 @@ class StudentRepository {
   }) async {
     return session.db.deleteWhere<Student>(
       where: where(Student.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -384,7 +382,7 @@ class StudentRepository {
     return session.db.count<Student>(
       where: where?.call(Student.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -410,7 +408,7 @@ class StudentAttachRepository {
     await session.db.update<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.studentId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -435,7 +433,7 @@ class StudentAttachRowRepository {
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.studentId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
@@ -249,7 +247,7 @@ class ObjectUserRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -270,7 +268,7 @@ class ObjectUserRepository {
       orderByList: orderByList?.call(ObjectUser.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -283,7 +281,7 @@ class ObjectUserRepository {
   }) async {
     return session.db.findById<ObjectUser>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -295,7 +293,7 @@ class ObjectUserRepository {
   }) async {
     return session.db.insert<ObjectUser>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -306,7 +304,7 @@ class ObjectUserRepository {
   }) async {
     return session.db.insertRow<ObjectUser>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class ObjectUserRepository {
     return session.db.update<ObjectUser>(
       rows,
       columns: columns?.call(ObjectUser.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -332,7 +330,7 @@ class ObjectUserRepository {
     return session.db.updateRow<ObjectUser>(
       row,
       columns: columns?.call(ObjectUser.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -343,7 +341,7 @@ class ObjectUserRepository {
   }) async {
     return session.db.delete<ObjectUser>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -354,7 +352,7 @@ class ObjectUserRepository {
   }) async {
     return session.db.deleteRow<ObjectUser>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -365,7 +363,7 @@ class ObjectUserRepository {
   }) async {
     return session.db.deleteWhere<ObjectUser>(
       where: where(ObjectUser.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -378,7 +376,7 @@ class ObjectUserRepository {
     return session.db.count<ObjectUser>(
       where: where?.call(ObjectUser.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -403,7 +401,7 @@ class ObjectUserAttachRowRepository {
     await session.db.updateRow<ObjectUser>(
       $objectUser,
       columns: [ObjectUser.t.userInfoId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -202,7 +200,7 @@ class ParentUserRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -221,7 +219,7 @@ class ParentUserRepository {
       orderByList: orderByList?.call(ParentUser.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -232,7 +230,7 @@ class ParentUserRepository {
   }) async {
     return session.db.findById<ParentUser>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -243,7 +241,7 @@ class ParentUserRepository {
   }) async {
     return session.db.insert<ParentUser>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class ParentUserRepository {
   }) async {
     return session.db.insertRow<ParentUser>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -267,7 +265,7 @@ class ParentUserRepository {
     return session.db.update<ParentUser>(
       rows,
       columns: columns?.call(ParentUser.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -280,7 +278,7 @@ class ParentUserRepository {
     return session.db.updateRow<ParentUser>(
       row,
       columns: columns?.call(ParentUser.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -291,7 +289,7 @@ class ParentUserRepository {
   }) async {
     return session.db.delete<ParentUser>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -302,7 +300,7 @@ class ParentUserRepository {
   }) async {
     return session.db.deleteRow<ParentUser>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class ParentUserRepository {
   }) async {
     return session.db.deleteWhere<ParentUser>(
       where: where(ParentUser.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -326,7 +324,7 @@ class ParentUserRepository {
     return session.db.count<ParentUser>(
       where: where?.call(ParentUser.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -231,7 +229,7 @@ class ArenaRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -252,7 +250,7 @@ class ArenaRepository {
       orderByList: orderByList?.call(Arena.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -265,7 +263,7 @@ class ArenaRepository {
   }) async {
     return session.db.findById<Arena>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -277,7 +275,7 @@ class ArenaRepository {
   }) async {
     return session.db.insert<Arena>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -288,7 +286,7 @@ class ArenaRepository {
   }) async {
     return session.db.insertRow<Arena>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -301,7 +299,7 @@ class ArenaRepository {
     return session.db.update<Arena>(
       rows,
       columns: columns?.call(Arena.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -314,7 +312,7 @@ class ArenaRepository {
     return session.db.updateRow<Arena>(
       row,
       columns: columns?.call(Arena.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -325,7 +323,7 @@ class ArenaRepository {
   }) async {
     return session.db.delete<Arena>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -336,7 +334,7 @@ class ArenaRepository {
   }) async {
     return session.db.deleteRow<Arena>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -347,7 +345,7 @@ class ArenaRepository {
   }) async {
     return session.db.deleteWhere<Arena>(
       where: where(Arena.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -360,7 +358,7 @@ class ArenaRepository {
     return session.db.count<Arena>(
       where: where?.call(Arena.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -385,7 +383,7 @@ class ArenaAttachRowRepository {
     await session.db.updateRow<_i2.Team>(
       $team,
       columns: [_i2.Team.t.arenaId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -414,7 +412,7 @@ class ArenaDetachRowRepository {
     await session.db.updateRow<_i2.Team>(
       $$team,
       columns: [_i2.Team.t.arenaId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -250,7 +248,7 @@ class PlayerRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -271,7 +269,7 @@ class PlayerRepository {
       orderByList: orderByList?.call(Player.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -284,7 +282,7 @@ class PlayerRepository {
   }) async {
     return session.db.findById<Player>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -296,7 +294,7 @@ class PlayerRepository {
   }) async {
     return session.db.insert<Player>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class PlayerRepository {
   }) async {
     return session.db.insertRow<Player>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class PlayerRepository {
     return session.db.update<Player>(
       rows,
       columns: columns?.call(Player.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class PlayerRepository {
     return session.db.updateRow<Player>(
       row,
       columns: columns?.call(Player.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class PlayerRepository {
   }) async {
     return session.db.delete<Player>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class PlayerRepository {
   }) async {
     return session.db.deleteRow<Player>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -366,7 +364,7 @@ class PlayerRepository {
   }) async {
     return session.db.deleteWhere<Player>(
       where: where(Player.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -379,7 +377,7 @@ class PlayerRepository {
     return session.db.count<Player>(
       where: where?.call(Player.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -404,7 +402,7 @@ class PlayerAttachRowRepository {
     await session.db.updateRow<Player>(
       $player,
       columns: [Player.t.teamId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -425,7 +423,7 @@ class PlayerDetachRowRepository {
     await session.db.updateRow<Player>(
       $player,
       columns: [Player.t.teamId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -325,7 +323,7 @@ class TeamRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -346,7 +344,7 @@ class TeamRepository {
       orderByList: orderByList?.call(Team.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -359,7 +357,7 @@ class TeamRepository {
   }) async {
     return session.db.findById<Team>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -371,7 +369,7 @@ class TeamRepository {
   }) async {
     return session.db.insert<Team>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -382,7 +380,7 @@ class TeamRepository {
   }) async {
     return session.db.insertRow<Team>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -395,7 +393,7 @@ class TeamRepository {
     return session.db.update<Team>(
       rows,
       columns: columns?.call(Team.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -408,7 +406,7 @@ class TeamRepository {
     return session.db.updateRow<Team>(
       row,
       columns: columns?.call(Team.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -419,7 +417,7 @@ class TeamRepository {
   }) async {
     return session.db.delete<Team>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -430,7 +428,7 @@ class TeamRepository {
   }) async {
     return session.db.deleteRow<Team>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -441,7 +439,7 @@ class TeamRepository {
   }) async {
     return session.db.deleteWhere<Team>(
       where: where(Team.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -454,7 +452,7 @@ class TeamRepository {
     return session.db.count<Team>(
       where: where?.call(Team.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -479,7 +477,7 @@ class TeamAttachRepository {
     await session.db.update<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -504,7 +502,7 @@ class TeamAttachRowRepository {
     await session.db.updateRow<Team>(
       $team,
       columns: [Team.t.arenaId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -525,7 +523,7 @@ class TeamAttachRowRepository {
     await session.db.updateRow<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -546,7 +544,7 @@ class TeamDetachRepository {
     await session.db.update<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -567,7 +565,7 @@ class TeamDetachRowRepository {
     await session.db.updateRow<Team>(
       $team,
       columns: [Team.t.arenaId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -584,7 +582,7 @@ class TeamDetachRowRepository {
     await session.db.updateRow<_i2.Player>(
       $player,
       columns: [_i2.Player.t.teamId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -248,7 +246,7 @@ class CommentRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -269,7 +267,7 @@ class CommentRepository {
       orderByList: orderByList?.call(Comment.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -282,7 +280,7 @@ class CommentRepository {
   }) async {
     return session.db.findById<Comment>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -294,7 +292,7 @@ class CommentRepository {
   }) async {
     return session.db.insert<Comment>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class CommentRepository {
   }) async {
     return session.db.insertRow<Comment>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class CommentRepository {
     return session.db.update<Comment>(
       rows,
       columns: columns?.call(Comment.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class CommentRepository {
     return session.db.updateRow<Comment>(
       row,
       columns: columns?.call(Comment.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -342,7 +340,7 @@ class CommentRepository {
   }) async {
     return session.db.delete<Comment>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class CommentRepository {
   }) async {
     return session.db.deleteRow<Comment>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class CommentRepository {
   }) async {
     return session.db.deleteWhere<Comment>(
       where: where(Comment.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -377,7 +375,7 @@ class CommentRepository {
     return session.db.count<Comment>(
       where: where?.call(Comment.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -402,7 +400,7 @@ class CommentAttachRowRepository {
     await session.db.updateRow<Comment>(
       $comment,
       columns: [Comment.t.orderId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -258,7 +256,7 @@ class CustomerRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -279,7 +277,7 @@ class CustomerRepository {
       orderByList: orderByList?.call(Customer.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -292,7 +290,7 @@ class CustomerRepository {
   }) async {
     return session.db.findById<Customer>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -304,7 +302,7 @@ class CustomerRepository {
   }) async {
     return session.db.insert<Customer>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -315,7 +313,7 @@ class CustomerRepository {
   }) async {
     return session.db.insertRow<Customer>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -328,7 +326,7 @@ class CustomerRepository {
     return session.db.update<Customer>(
       rows,
       columns: columns?.call(Customer.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -341,7 +339,7 @@ class CustomerRepository {
     return session.db.updateRow<Customer>(
       row,
       columns: columns?.call(Customer.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -352,7 +350,7 @@ class CustomerRepository {
   }) async {
     return session.db.delete<Customer>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -363,7 +361,7 @@ class CustomerRepository {
   }) async {
     return session.db.deleteRow<Customer>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -374,7 +372,7 @@ class CustomerRepository {
   }) async {
     return session.db.deleteWhere<Customer>(
       where: where(Customer.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -387,7 +385,7 @@ class CustomerRepository {
     return session.db.count<Customer>(
       where: where?.call(Customer.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -412,7 +410,7 @@ class CustomerAttachRepository {
     await session.db.update<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -437,7 +435,7 @@ class CustomerAttachRowRepository {
     await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -458,7 +456,7 @@ class CustomerDetachRepository {
     await session.db.update<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -479,7 +477,7 @@ class CustomerDetachRowRepository {
     await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -322,7 +320,7 @@ class OrderRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -343,7 +341,7 @@ class OrderRepository {
       orderByList: orderByList?.call(Order.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -356,7 +354,7 @@ class OrderRepository {
   }) async {
     return session.db.findById<Order>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -368,7 +366,7 @@ class OrderRepository {
   }) async {
     return session.db.insert<Order>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -379,7 +377,7 @@ class OrderRepository {
   }) async {
     return session.db.insertRow<Order>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -392,7 +390,7 @@ class OrderRepository {
     return session.db.update<Order>(
       rows,
       columns: columns?.call(Order.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -405,7 +403,7 @@ class OrderRepository {
     return session.db.updateRow<Order>(
       row,
       columns: columns?.call(Order.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -416,7 +414,7 @@ class OrderRepository {
   }) async {
     return session.db.delete<Order>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -427,7 +425,7 @@ class OrderRepository {
   }) async {
     return session.db.deleteRow<Order>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -438,7 +436,7 @@ class OrderRepository {
   }) async {
     return session.db.deleteWhere<Order>(
       where: where(Order.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -451,7 +449,7 @@ class OrderRepository {
     return session.db.count<Order>(
       where: where?.call(Order.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -476,7 +474,7 @@ class OrderAttachRepository {
     await session.db.update<_i2.Comment>(
       $comment,
       columns: [_i2.Comment.t.orderId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -501,7 +499,7 @@ class OrderAttachRowRepository {
     await session.db.updateRow<Order>(
       $order,
       columns: [Order.t.customerId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -522,7 +520,7 @@ class OrderAttachRowRepository {
     await session.db.updateRow<_i2.Comment>(
       $comment,
       columns: [_i2.Comment.t.orderId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -251,7 +249,7 @@ class AddressRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -272,7 +270,7 @@ class AddressRepository {
       orderByList: orderByList?.call(Address.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -285,7 +283,7 @@ class AddressRepository {
   }) async {
     return session.db.findById<Address>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -297,7 +295,7 @@ class AddressRepository {
   }) async {
     return session.db.insert<Address>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class AddressRepository {
   }) async {
     return session.db.insertRow<Address>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -321,7 +319,7 @@ class AddressRepository {
     return session.db.update<Address>(
       rows,
       columns: columns?.call(Address.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -334,7 +332,7 @@ class AddressRepository {
     return session.db.updateRow<Address>(
       row,
       columns: columns?.call(Address.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -345,7 +343,7 @@ class AddressRepository {
   }) async {
     return session.db.delete<Address>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -356,7 +354,7 @@ class AddressRepository {
   }) async {
     return session.db.deleteRow<Address>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -367,7 +365,7 @@ class AddressRepository {
   }) async {
     return session.db.deleteWhere<Address>(
       where: where(Address.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -380,7 +378,7 @@ class AddressRepository {
     return session.db.count<Address>(
       where: where?.call(Address.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -405,7 +403,7 @@ class AddressAttachRowRepository {
     await session.db.updateRow<Address>(
       $address,
       columns: [Address.t.inhabitantId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -426,7 +424,7 @@ class AddressDetachRowRepository {
     await session.db.updateRow<Address>(
       $address,
       columns: [Address.t.inhabitantId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -358,7 +356,7 @@ class CitizenRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -379,7 +377,7 @@ class CitizenRepository {
       orderByList: orderByList?.call(Citizen.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -392,7 +390,7 @@ class CitizenRepository {
   }) async {
     return session.db.findById<Citizen>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -404,7 +402,7 @@ class CitizenRepository {
   }) async {
     return session.db.insert<Citizen>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -415,7 +413,7 @@ class CitizenRepository {
   }) async {
     return session.db.insertRow<Citizen>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -428,7 +426,7 @@ class CitizenRepository {
     return session.db.update<Citizen>(
       rows,
       columns: columns?.call(Citizen.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -441,7 +439,7 @@ class CitizenRepository {
     return session.db.updateRow<Citizen>(
       row,
       columns: columns?.call(Citizen.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -452,7 +450,7 @@ class CitizenRepository {
   }) async {
     return session.db.delete<Citizen>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -463,7 +461,7 @@ class CitizenRepository {
   }) async {
     return session.db.deleteRow<Citizen>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -474,7 +472,7 @@ class CitizenRepository {
   }) async {
     return session.db.deleteWhere<Citizen>(
       where: where(Citizen.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -487,7 +485,7 @@ class CitizenRepository {
     return session.db.count<Citizen>(
       where: where?.call(Citizen.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -512,7 +510,7 @@ class CitizenAttachRowRepository {
     await session.db.updateRow<_i2.Address>(
       $address,
       columns: [_i2.Address.t.inhabitantId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -533,7 +531,7 @@ class CitizenAttachRowRepository {
     await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.companyId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -554,7 +552,7 @@ class CitizenAttachRowRepository {
     await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.oldCompanyId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -583,7 +581,7 @@ class CitizenDetachRowRepository {
     await session.db.updateRow<_i2.Address>(
       $$address,
       columns: [_i2.Address.t.inhabitantId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -600,7 +598,7 @@ class CitizenDetachRowRepository {
     await session.db.updateRow<Citizen>(
       $citizen,
       columns: [Citizen.t.oldCompanyId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -248,7 +246,7 @@ class CompanyRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -269,7 +267,7 @@ class CompanyRepository {
       orderByList: orderByList?.call(Company.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -282,7 +280,7 @@ class CompanyRepository {
   }) async {
     return session.db.findById<Company>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -294,7 +292,7 @@ class CompanyRepository {
   }) async {
     return session.db.insert<Company>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -305,7 +303,7 @@ class CompanyRepository {
   }) async {
     return session.db.insertRow<Company>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -318,7 +316,7 @@ class CompanyRepository {
     return session.db.update<Company>(
       rows,
       columns: columns?.call(Company.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -331,7 +329,7 @@ class CompanyRepository {
     return session.db.updateRow<Company>(
       row,
       columns: columns?.call(Company.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -342,7 +340,7 @@ class CompanyRepository {
   }) async {
     return session.db.delete<Company>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -353,7 +351,7 @@ class CompanyRepository {
   }) async {
     return session.db.deleteRow<Company>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -364,7 +362,7 @@ class CompanyRepository {
   }) async {
     return session.db.deleteWhere<Company>(
       where: where(Company.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -377,7 +375,7 @@ class CompanyRepository {
     return session.db.count<Company>(
       where: where?.call(Company.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -402,7 +400,7 @@ class CompanyAttachRowRepository {
     await session.db.updateRow<Company>(
       $company,
       columns: [Company.t.townId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../protocol.dart' as _i2;
@@ -250,7 +248,7 @@ class TownRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -271,7 +269,7 @@ class TownRepository {
       orderByList: orderByList?.call(Town.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -284,7 +282,7 @@ class TownRepository {
   }) async {
     return session.db.findById<Town>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -296,7 +294,7 @@ class TownRepository {
   }) async {
     return session.db.insert<Town>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -307,7 +305,7 @@ class TownRepository {
   }) async {
     return session.db.insertRow<Town>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -320,7 +318,7 @@ class TownRepository {
     return session.db.update<Town>(
       rows,
       columns: columns?.call(Town.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class TownRepository {
     return session.db.updateRow<Town>(
       row,
       columns: columns?.call(Town.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -344,7 +342,7 @@ class TownRepository {
   }) async {
     return session.db.delete<Town>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class TownRepository {
   }) async {
     return session.db.deleteRow<Town>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -366,7 +364,7 @@ class TownRepository {
   }) async {
     return session.db.deleteWhere<Town>(
       where: where(Town.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -379,7 +377,7 @@ class TownRepository {
     return session.db.count<Town>(
       where: where?.call(Town.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -404,7 +402,7 @@ class TownAttachRowRepository {
     await session.db.updateRow<Town>(
       $town,
       columns: [Town.t.mayorId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -425,7 +423,7 @@ class TownDetachRowRepository {
     await session.db.updateRow<Town>(
       $town,
       columns: [Town.t.mayorId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -297,7 +295,7 @@ class BlockingRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -318,7 +316,7 @@ class BlockingRepository {
       orderByList: orderByList?.call(Blocking.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -331,7 +329,7 @@ class BlockingRepository {
   }) async {
     return session.db.findById<Blocking>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -343,7 +341,7 @@ class BlockingRepository {
   }) async {
     return session.db.insert<Blocking>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -354,7 +352,7 @@ class BlockingRepository {
   }) async {
     return session.db.insertRow<Blocking>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -367,7 +365,7 @@ class BlockingRepository {
     return session.db.update<Blocking>(
       rows,
       columns: columns?.call(Blocking.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -380,7 +378,7 @@ class BlockingRepository {
     return session.db.updateRow<Blocking>(
       row,
       columns: columns?.call(Blocking.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -391,7 +389,7 @@ class BlockingRepository {
   }) async {
     return session.db.delete<Blocking>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -402,7 +400,7 @@ class BlockingRepository {
   }) async {
     return session.db.deleteRow<Blocking>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -413,7 +411,7 @@ class BlockingRepository {
   }) async {
     return session.db.deleteWhere<Blocking>(
       where: where(Blocking.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -426,7 +424,7 @@ class BlockingRepository {
     return session.db.count<Blocking>(
       where: where?.call(Blocking.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -451,7 +449,7 @@ class BlockingAttachRowRepository {
     await session.db.updateRow<Blocking>(
       $blocking,
       columns: [Blocking.t.blockedId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -472,7 +470,7 @@ class BlockingAttachRowRepository {
     await session.db.updateRow<Blocking>(
       $blocking,
       columns: [Blocking.t.blockedById],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -326,7 +324,7 @@ class MemberRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -347,7 +345,7 @@ class MemberRepository {
       orderByList: orderByList?.call(Member.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -360,7 +358,7 @@ class MemberRepository {
   }) async {
     return session.db.findById<Member>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -372,7 +370,7 @@ class MemberRepository {
   }) async {
     return session.db.insert<Member>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -383,7 +381,7 @@ class MemberRepository {
   }) async {
     return session.db.insertRow<Member>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -396,7 +394,7 @@ class MemberRepository {
     return session.db.update<Member>(
       rows,
       columns: columns?.call(Member.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -409,7 +407,7 @@ class MemberRepository {
     return session.db.updateRow<Member>(
       row,
       columns: columns?.call(Member.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -420,7 +418,7 @@ class MemberRepository {
   }) async {
     return session.db.delete<Member>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -431,7 +429,7 @@ class MemberRepository {
   }) async {
     return session.db.deleteRow<Member>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -442,7 +440,7 @@ class MemberRepository {
   }) async {
     return session.db.deleteWhere<Member>(
       where: where(Member.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -455,7 +453,7 @@ class MemberRepository {
     return session.db.count<Member>(
       where: where?.call(Member.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -481,7 +479,7 @@ class MemberAttachRepository {
     await session.db.update<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedById],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -503,7 +501,7 @@ class MemberAttachRepository {
     await session.db.update<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -528,7 +526,7 @@ class MemberAttachRowRepository {
     await session.db.updateRow<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedById],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -549,7 +547,7 @@ class MemberAttachRowRepository {
     await session.db.updateRow<_i2.Blocking>(
       $blocking,
       columns: [_i2.Blocking.t.blockedId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -325,7 +323,7 @@ class CatRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -346,7 +344,7 @@ class CatRepository {
       orderByList: orderByList?.call(Cat.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -359,7 +357,7 @@ class CatRepository {
   }) async {
     return session.db.findById<Cat>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -371,7 +369,7 @@ class CatRepository {
   }) async {
     return session.db.insert<Cat>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -382,7 +380,7 @@ class CatRepository {
   }) async {
     return session.db.insertRow<Cat>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -395,7 +393,7 @@ class CatRepository {
     return session.db.update<Cat>(
       rows,
       columns: columns?.call(Cat.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -408,7 +406,7 @@ class CatRepository {
     return session.db.updateRow<Cat>(
       row,
       columns: columns?.call(Cat.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -419,7 +417,7 @@ class CatRepository {
   }) async {
     return session.db.delete<Cat>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -430,7 +428,7 @@ class CatRepository {
   }) async {
     return session.db.deleteRow<Cat>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -441,7 +439,7 @@ class CatRepository {
   }) async {
     return session.db.deleteWhere<Cat>(
       where: where(Cat.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -454,7 +452,7 @@ class CatRepository {
     return session.db.count<Cat>(
       where: where?.call(Cat.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -480,7 +478,7 @@ class CatAttachRepository {
     await session.db.update<_i2.Cat>(
       $nestedCat,
       columns: [_i2.Cat.t.motherId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -505,7 +503,7 @@ class CatAttachRowRepository {
     await session.db.updateRow<Cat>(
       $cat,
       columns: [Cat.t.motherId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -526,7 +524,7 @@ class CatAttachRowRepository {
     await session.db.updateRow<_i2.Cat>(
       $nestedCat,
       columns: [_i2.Cat.t.motherId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -547,7 +545,7 @@ class CatDetachRepository {
     await session.db.update<_i2.Cat>(
       $cat,
       columns: [_i2.Cat.t.motherId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -568,7 +566,7 @@ class CatDetachRowRepository {
     await session.db.updateRow<Cat>(
       $cat,
       columns: [Cat.t.motherId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -585,7 +583,7 @@ class CatDetachRowRepository {
     await session.db.updateRow<_i2.Cat>(
       $cat,
       columns: [_i2.Cat.t.motherId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../protocol.dart' as _i2;
@@ -298,7 +296,7 @@ class PostRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -319,7 +317,7 @@ class PostRepository {
       orderByList: orderByList?.call(Post.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -332,7 +330,7 @@ class PostRepository {
   }) async {
     return session.db.findById<Post>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -344,7 +342,7 @@ class PostRepository {
   }) async {
     return session.db.insert<Post>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -355,7 +353,7 @@ class PostRepository {
   }) async {
     return session.db.insertRow<Post>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -368,7 +366,7 @@ class PostRepository {
     return session.db.update<Post>(
       rows,
       columns: columns?.call(Post.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -381,7 +379,7 @@ class PostRepository {
     return session.db.updateRow<Post>(
       row,
       columns: columns?.call(Post.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -392,7 +390,7 @@ class PostRepository {
   }) async {
     return session.db.delete<Post>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -403,7 +401,7 @@ class PostRepository {
   }) async {
     return session.db.deleteRow<Post>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -414,7 +412,7 @@ class PostRepository {
   }) async {
     return session.db.deleteWhere<Post>(
       where: where(Post.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -427,7 +425,7 @@ class PostRepository {
     return session.db.count<Post>(
       where: where?.call(Post.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -452,7 +450,7 @@ class PostAttachRowRepository {
     await session.db.updateRow<_i2.Post>(
       $previous,
       columns: [_i2.Post.t.nextId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -473,7 +471,7 @@ class PostAttachRowRepository {
     await session.db.updateRow<Post>(
       $post,
       columns: [Post.t.nextId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -502,7 +500,7 @@ class PostDetachRowRepository {
     await session.db.updateRow<_i2.Post>(
       $$previous,
       columns: [_i2.Post.t.nextId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -519,7 +517,7 @@ class PostDetachRowRepository {
     await session.db.updateRow<Post>(
       $post,
       columns: [Post.t.nextId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -213,7 +211,7 @@ class ObjectFieldPersistRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -232,7 +230,7 @@ class ObjectFieldPersistRepository {
       orderByList: orderByList?.call(ObjectFieldPersist.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -243,7 +241,7 @@ class ObjectFieldPersistRepository {
   }) async {
     return session.db.findById<ObjectFieldPersist>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class ObjectFieldPersistRepository {
   }) async {
     return session.db.insert<ObjectFieldPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -265,7 +263,7 @@ class ObjectFieldPersistRepository {
   }) async {
     return session.db.insertRow<ObjectFieldPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -278,7 +276,7 @@ class ObjectFieldPersistRepository {
     return session.db.update<ObjectFieldPersist>(
       rows,
       columns: columns?.call(ObjectFieldPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -291,7 +289,7 @@ class ObjectFieldPersistRepository {
     return session.db.updateRow<ObjectFieldPersist>(
       row,
       columns: columns?.call(ObjectFieldPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -302,7 +300,7 @@ class ObjectFieldPersistRepository {
   }) async {
     return session.db.delete<ObjectFieldPersist>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class ObjectFieldPersistRepository {
   }) async {
     return session.db.deleteRow<ObjectFieldPersist>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -324,7 +322,7 @@ class ObjectFieldPersistRepository {
   }) async {
     return session.db.deleteWhere<ObjectFieldPersist>(
       where: where(ObjectFieldPersist.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -337,7 +335,7 @@ class ObjectFieldPersistRepository {
     return session.db.count<ObjectFieldPersist>(
       where: where?.call(ObjectFieldPersist.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -215,7 +213,7 @@ class ObjectFieldScopesRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -234,7 +232,7 @@ class ObjectFieldScopesRepository {
       orderByList: orderByList?.call(ObjectFieldScopes.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -245,7 +243,7 @@ class ObjectFieldScopesRepository {
   }) async {
     return session.db.findById<ObjectFieldScopes>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -256,7 +254,7 @@ class ObjectFieldScopesRepository {
   }) async {
     return session.db.insert<ObjectFieldScopes>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -267,7 +265,7 @@ class ObjectFieldScopesRepository {
   }) async {
     return session.db.insertRow<ObjectFieldScopes>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -280,7 +278,7 @@ class ObjectFieldScopesRepository {
     return session.db.update<ObjectFieldScopes>(
       rows,
       columns: columns?.call(ObjectFieldScopes.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -293,7 +291,7 @@ class ObjectFieldScopesRepository {
     return session.db.updateRow<ObjectFieldScopes>(
       row,
       columns: columns?.call(ObjectFieldScopes.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -304,7 +302,7 @@ class ObjectFieldScopesRepository {
   }) async {
     return session.db.delete<ObjectFieldScopes>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -315,7 +313,7 @@ class ObjectFieldScopesRepository {
   }) async {
     return session.db.deleteRow<ObjectFieldScopes>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -326,7 +324,7 @@ class ObjectFieldScopesRepository {
   }) async {
     return session.db.deleteWhere<ObjectFieldScopes>(
       where: where(ObjectFieldScopes.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -339,7 +337,7 @@ class ObjectFieldScopesRepository {
     return session.db.count<ObjectFieldScopes>(
       where: where?.call(ObjectFieldScopes.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
@@ -187,7 +185,7 @@ class ObjectWithByteDataRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -206,7 +204,7 @@ class ObjectWithByteDataRepository {
       orderByList: orderByList?.call(ObjectWithByteData.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -217,7 +215,7 @@ class ObjectWithByteDataRepository {
   }) async {
     return session.db.findById<ObjectWithByteData>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -228,7 +226,7 @@ class ObjectWithByteDataRepository {
   }) async {
     return session.db.insert<ObjectWithByteData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -239,7 +237,7 @@ class ObjectWithByteDataRepository {
   }) async {
     return session.db.insertRow<ObjectWithByteData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -252,7 +250,7 @@ class ObjectWithByteDataRepository {
     return session.db.update<ObjectWithByteData>(
       rows,
       columns: columns?.call(ObjectWithByteData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -265,7 +263,7 @@ class ObjectWithByteDataRepository {
     return session.db.updateRow<ObjectWithByteData>(
       row,
       columns: columns?.call(ObjectWithByteData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -276,7 +274,7 @@ class ObjectWithByteDataRepository {
   }) async {
     return session.db.delete<ObjectWithByteData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -287,7 +285,7 @@ class ObjectWithByteDataRepository {
   }) async {
     return session.db.deleteRow<ObjectWithByteData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -298,7 +296,7 @@ class ObjectWithByteDataRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithByteData>(
       where: where(ObjectWithByteData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class ObjectWithByteDataRepository {
     return session.db.count<ObjectWithByteData>(
       where: where?.call(ObjectWithByteData.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -186,7 +184,7 @@ class ObjectWithDurationRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -205,7 +203,7 @@ class ObjectWithDurationRepository {
       orderByList: orderByList?.call(ObjectWithDuration.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -216,7 +214,7 @@ class ObjectWithDurationRepository {
   }) async {
     return session.db.findById<ObjectWithDuration>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -227,7 +225,7 @@ class ObjectWithDurationRepository {
   }) async {
     return session.db.insert<ObjectWithDuration>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -238,7 +236,7 @@ class ObjectWithDurationRepository {
   }) async {
     return session.db.insertRow<ObjectWithDuration>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -251,7 +249,7 @@ class ObjectWithDurationRepository {
     return session.db.update<ObjectWithDuration>(
       rows,
       columns: columns?.call(ObjectWithDuration.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -264,7 +262,7 @@ class ObjectWithDurationRepository {
     return session.db.updateRow<ObjectWithDuration>(
       row,
       columns: columns?.call(ObjectWithDuration.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -275,7 +273,7 @@ class ObjectWithDurationRepository {
   }) async {
     return session.db.delete<ObjectWithDuration>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -286,7 +284,7 @@ class ObjectWithDurationRepository {
   }) async {
     return session.db.deleteRow<ObjectWithDuration>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -297,7 +295,7 @@ class ObjectWithDurationRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithDuration>(
       where: where(ObjectWithDuration.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -310,7 +308,7 @@ class ObjectWithDurationRepository {
     return session.db.count<ObjectWithDuration>(
       where: where?.call(ObjectWithDuration.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -281,7 +279,7 @@ class ObjectWithEnumRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class ObjectWithEnumRepository {
       orderByList: orderByList?.call(ObjectWithEnum.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -311,7 +309,7 @@ class ObjectWithEnumRepository {
   }) async {
     return session.db.findById<ObjectWithEnum>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -322,7 +320,7 @@ class ObjectWithEnumRepository {
   }) async {
     return session.db.insert<ObjectWithEnum>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -333,7 +331,7 @@ class ObjectWithEnumRepository {
   }) async {
     return session.db.insertRow<ObjectWithEnum>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -346,7 +344,7 @@ class ObjectWithEnumRepository {
     return session.db.update<ObjectWithEnum>(
       rows,
       columns: columns?.call(ObjectWithEnum.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -359,7 +357,7 @@ class ObjectWithEnumRepository {
     return session.db.updateRow<ObjectWithEnum>(
       row,
       columns: columns?.call(ObjectWithEnum.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -370,7 +368,7 @@ class ObjectWithEnumRepository {
   }) async {
     return session.db.delete<ObjectWithEnum>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -381,7 +379,7 @@ class ObjectWithEnumRepository {
   }) async {
     return session.db.deleteRow<ObjectWithEnum>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -392,7 +390,7 @@ class ObjectWithEnumRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithEnum>(
       where: where(ObjectWithEnum.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -405,7 +403,7 @@ class ObjectWithEnumRepository {
     return session.db.count<ObjectWithEnum>(
       where: where?.call(ObjectWithEnum.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -204,7 +202,7 @@ class ObjectWithIndexRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -223,7 +221,7 @@ class ObjectWithIndexRepository {
       orderByList: orderByList?.call(ObjectWithIndex.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -234,7 +232,7 @@ class ObjectWithIndexRepository {
   }) async {
     return session.db.findById<ObjectWithIndex>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -245,7 +243,7 @@ class ObjectWithIndexRepository {
   }) async {
     return session.db.insert<ObjectWithIndex>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -256,7 +254,7 @@ class ObjectWithIndexRepository {
   }) async {
     return session.db.insertRow<ObjectWithIndex>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -269,7 +267,7 @@ class ObjectWithIndexRepository {
     return session.db.update<ObjectWithIndex>(
       rows,
       columns: columns?.call(ObjectWithIndex.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -282,7 +280,7 @@ class ObjectWithIndexRepository {
     return session.db.updateRow<ObjectWithIndex>(
       row,
       columns: columns?.call(ObjectWithIndex.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -293,7 +291,7 @@ class ObjectWithIndexRepository {
   }) async {
     return session.db.delete<ObjectWithIndex>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -304,7 +302,7 @@ class ObjectWithIndexRepository {
   }) async {
     return session.db.deleteRow<ObjectWithIndex>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -315,7 +313,7 @@ class ObjectWithIndexRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithIndex>(
       where: where(ObjectWithIndex.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -328,7 +326,7 @@ class ObjectWithIndexRepository {
     return session.db.count<ObjectWithIndex>(
       where: where?.call(ObjectWithIndex.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -467,7 +465,7 @@ class ObjectWithObjectRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -486,7 +484,7 @@ class ObjectWithObjectRepository {
       orderByList: orderByList?.call(ObjectWithObject.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -497,7 +495,7 @@ class ObjectWithObjectRepository {
   }) async {
     return session.db.findById<ObjectWithObject>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -508,7 +506,7 @@ class ObjectWithObjectRepository {
   }) async {
     return session.db.insert<ObjectWithObject>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -519,7 +517,7 @@ class ObjectWithObjectRepository {
   }) async {
     return session.db.insertRow<ObjectWithObject>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -532,7 +530,7 @@ class ObjectWithObjectRepository {
     return session.db.update<ObjectWithObject>(
       rows,
       columns: columns?.call(ObjectWithObject.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -545,7 +543,7 @@ class ObjectWithObjectRepository {
     return session.db.updateRow<ObjectWithObject>(
       row,
       columns: columns?.call(ObjectWithObject.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -556,7 +554,7 @@ class ObjectWithObjectRepository {
   }) async {
     return session.db.delete<ObjectWithObject>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -567,7 +565,7 @@ class ObjectWithObjectRepository {
   }) async {
     return session.db.deleteRow<ObjectWithObject>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -578,7 +576,7 @@ class ObjectWithObjectRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithObject>(
       where: where(ObjectWithObject.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -591,7 +589,7 @@ class ObjectWithObjectRepository {
     return session.db.count<ObjectWithObject>(
       where: where?.call(ObjectWithObject.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -185,7 +183,7 @@ class ObjectWithParentRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -204,7 +202,7 @@ class ObjectWithParentRepository {
       orderByList: orderByList?.call(ObjectWithParent.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -215,7 +213,7 @@ class ObjectWithParentRepository {
   }) async {
     return session.db.findById<ObjectWithParent>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -226,7 +224,7 @@ class ObjectWithParentRepository {
   }) async {
     return session.db.insert<ObjectWithParent>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -237,7 +235,7 @@ class ObjectWithParentRepository {
   }) async {
     return session.db.insertRow<ObjectWithParent>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -250,7 +248,7 @@ class ObjectWithParentRepository {
     return session.db.update<ObjectWithParent>(
       rows,
       columns: columns?.call(ObjectWithParent.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -263,7 +261,7 @@ class ObjectWithParentRepository {
     return session.db.updateRow<ObjectWithParent>(
       row,
       columns: columns?.call(ObjectWithParent.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -274,7 +272,7 @@ class ObjectWithParentRepository {
   }) async {
     return session.db.delete<ObjectWithParent>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -285,7 +283,7 @@ class ObjectWithParentRepository {
   }) async {
     return session.db.deleteRow<ObjectWithParent>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -296,7 +294,7 @@ class ObjectWithParentRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithParent>(
       where: where(ObjectWithParent.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class ObjectWithParentRepository {
     return session.db.count<ObjectWithParent>(
       where: where?.call(ObjectWithParent.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -186,7 +184,7 @@ class ObjectWithSelfParentRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -205,7 +203,7 @@ class ObjectWithSelfParentRepository {
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -216,7 +214,7 @@ class ObjectWithSelfParentRepository {
   }) async {
     return session.db.findById<ObjectWithSelfParent>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -227,7 +225,7 @@ class ObjectWithSelfParentRepository {
   }) async {
     return session.db.insert<ObjectWithSelfParent>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -238,7 +236,7 @@ class ObjectWithSelfParentRepository {
   }) async {
     return session.db.insertRow<ObjectWithSelfParent>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -251,7 +249,7 @@ class ObjectWithSelfParentRepository {
     return session.db.update<ObjectWithSelfParent>(
       rows,
       columns: columns?.call(ObjectWithSelfParent.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -264,7 +262,7 @@ class ObjectWithSelfParentRepository {
     return session.db.updateRow<ObjectWithSelfParent>(
       row,
       columns: columns?.call(ObjectWithSelfParent.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -275,7 +273,7 @@ class ObjectWithSelfParentRepository {
   }) async {
     return session.db.delete<ObjectWithSelfParent>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -286,7 +284,7 @@ class ObjectWithSelfParentRepository {
   }) async {
     return session.db.deleteRow<ObjectWithSelfParent>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -297,7 +295,7 @@ class ObjectWithSelfParentRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithSelfParent>(
       where: where(ObjectWithSelfParent.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -310,7 +308,7 @@ class ObjectWithSelfParentRepository {
     return session.db.count<ObjectWithSelfParent>(
       where: where?.call(ObjectWithSelfParent.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -208,7 +206,7 @@ class ObjectWithUuidRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -227,7 +225,7 @@ class ObjectWithUuidRepository {
       orderByList: orderByList?.call(ObjectWithUuid.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -238,7 +236,7 @@ class ObjectWithUuidRepository {
   }) async {
     return session.db.findById<ObjectWithUuid>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -249,7 +247,7 @@ class ObjectWithUuidRepository {
   }) async {
     return session.db.insert<ObjectWithUuid>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -260,7 +258,7 @@ class ObjectWithUuidRepository {
   }) async {
     return session.db.insertRow<ObjectWithUuid>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -273,7 +271,7 @@ class ObjectWithUuidRepository {
     return session.db.update<ObjectWithUuid>(
       rows,
       columns: columns?.call(ObjectWithUuid.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -286,7 +284,7 @@ class ObjectWithUuidRepository {
     return session.db.updateRow<ObjectWithUuid>(
       row,
       columns: columns?.call(ObjectWithUuid.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -297,7 +295,7 @@ class ObjectWithUuidRepository {
   }) async {
     return session.db.delete<ObjectWithUuid>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class ObjectWithUuidRepository {
   }) async {
     return session.db.deleteRow<ObjectWithUuid>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -319,7 +317,7 @@ class ObjectWithUuidRepository {
   }) async {
     return session.db.deleteWhere<ObjectWithUuid>(
       where: where(ObjectWithUuid.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -332,7 +330,7 @@ class ObjectWithUuidRepository {
     return session.db.count<ObjectWithUuid>(
       where: where?.call(ObjectWithUuid.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'protocol.dart' as _i2;
@@ -252,7 +250,7 @@ class RelatedUniqueDataRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -273,7 +271,7 @@ class RelatedUniqueDataRepository {
       orderByList: orderByList?.call(RelatedUniqueData.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -286,7 +284,7 @@ class RelatedUniqueDataRepository {
   }) async {
     return session.db.findById<RelatedUniqueData>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
       include: include,
     );
   }
@@ -298,7 +296,7 @@ class RelatedUniqueDataRepository {
   }) async {
     return session.db.insert<RelatedUniqueData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -309,7 +307,7 @@ class RelatedUniqueDataRepository {
   }) async {
     return session.db.insertRow<RelatedUniqueData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -322,7 +320,7 @@ class RelatedUniqueDataRepository {
     return session.db.update<RelatedUniqueData>(
       rows,
       columns: columns?.call(RelatedUniqueData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -335,7 +333,7 @@ class RelatedUniqueDataRepository {
     return session.db.updateRow<RelatedUniqueData>(
       row,
       columns: columns?.call(RelatedUniqueData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -346,7 +344,7 @@ class RelatedUniqueDataRepository {
   }) async {
     return session.db.delete<RelatedUniqueData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -357,7 +355,7 @@ class RelatedUniqueDataRepository {
   }) async {
     return session.db.deleteRow<RelatedUniqueData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -368,7 +366,7 @@ class RelatedUniqueDataRepository {
   }) async {
     return session.db.deleteWhere<RelatedUniqueData>(
       where: where(RelatedUniqueData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -381,7 +379,7 @@ class RelatedUniqueDataRepository {
     return session.db.count<RelatedUniqueData>(
       where: where?.call(RelatedUniqueData.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }
@@ -407,7 +405,7 @@ class RelatedUniqueDataAttachRowRepository {
     await session.db.updateRow<RelatedUniqueData>(
       $relatedUniqueData,
       columns: [RelatedUniqueData.t.uniqueDataId],
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -184,7 +182,7 @@ class ScopeNoneFieldsRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -203,7 +201,7 @@ class ScopeNoneFieldsRepository {
       orderByList: orderByList?.call(ScopeNoneFields.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -214,7 +212,7 @@ class ScopeNoneFieldsRepository {
   }) async {
     return session.db.findById<ScopeNoneFields>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -225,7 +223,7 @@ class ScopeNoneFieldsRepository {
   }) async {
     return session.db.insert<ScopeNoneFields>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -236,7 +234,7 @@ class ScopeNoneFieldsRepository {
   }) async {
     return session.db.insertRow<ScopeNoneFields>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -249,7 +247,7 @@ class ScopeNoneFieldsRepository {
     return session.db.update<ScopeNoneFields>(
       rows,
       columns: columns?.call(ScopeNoneFields.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -262,7 +260,7 @@ class ScopeNoneFieldsRepository {
     return session.db.updateRow<ScopeNoneFields>(
       row,
       columns: columns?.call(ScopeNoneFields.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -273,7 +271,7 @@ class ScopeNoneFieldsRepository {
   }) async {
     return session.db.delete<ScopeNoneFields>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -284,7 +282,7 @@ class ScopeNoneFieldsRepository {
   }) async {
     return session.db.deleteRow<ScopeNoneFields>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -295,7 +293,7 @@ class ScopeNoneFieldsRepository {
   }) async {
     return session.db.deleteWhere<ScopeNoneFields>(
       where: where(ScopeNoneFields.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -308,7 +306,7 @@ class ScopeNoneFieldsRepository {
     return session.db.count<ScopeNoneFields>(
       where: where?.call(ScopeNoneFields.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -190,7 +188,7 @@ class SimpleDataRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -209,7 +207,7 @@ class SimpleDataRepository {
       orderByList: orderByList?.call(SimpleData.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -220,7 +218,7 @@ class SimpleDataRepository {
   }) async {
     return session.db.findById<SimpleData>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -231,7 +229,7 @@ class SimpleDataRepository {
   }) async {
     return session.db.insert<SimpleData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -242,7 +240,7 @@ class SimpleDataRepository {
   }) async {
     return session.db.insertRow<SimpleData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -255,7 +253,7 @@ class SimpleDataRepository {
     return session.db.update<SimpleData>(
       rows,
       columns: columns?.call(SimpleData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -268,7 +266,7 @@ class SimpleDataRepository {
     return session.db.updateRow<SimpleData>(
       row,
       columns: columns?.call(SimpleData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -279,7 +277,7 @@ class SimpleDataRepository {
   }) async {
     return session.db.delete<SimpleData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -290,7 +288,7 @@ class SimpleDataRepository {
   }) async {
     return session.db.deleteRow<SimpleData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -301,7 +299,7 @@ class SimpleDataRepository {
   }) async {
     return session.db.deleteWhere<SimpleData>(
       where: where(SimpleData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -314,7 +312,7 @@ class SimpleDataRepository {
     return session.db.count<SimpleData>(
       where: where?.call(SimpleData.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -189,7 +187,7 @@ class SimpleDateTimeRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -208,7 +206,7 @@ class SimpleDateTimeRepository {
       orderByList: orderByList?.call(SimpleDateTime.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -219,7 +217,7 @@ class SimpleDateTimeRepository {
   }) async {
     return session.db.findById<SimpleDateTime>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -230,7 +228,7 @@ class SimpleDateTimeRepository {
   }) async {
     return session.db.insert<SimpleDateTime>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -241,7 +239,7 @@ class SimpleDateTimeRepository {
   }) async {
     return session.db.insertRow<SimpleDateTime>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class SimpleDateTimeRepository {
     return session.db.update<SimpleDateTime>(
       rows,
       columns: columns?.call(SimpleDateTime.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -267,7 +265,7 @@ class SimpleDateTimeRepository {
     return session.db.updateRow<SimpleDateTime>(
       row,
       columns: columns?.call(SimpleDateTime.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -278,7 +276,7 @@ class SimpleDateTimeRepository {
   }) async {
     return session.db.delete<SimpleDateTime>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -289,7 +287,7 @@ class SimpleDateTimeRepository {
   }) async {
     return session.db.deleteRow<SimpleDateTime>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -300,7 +298,7 @@ class SimpleDateTimeRepository {
   }) async {
     return session.db.deleteWhere<SimpleDateTime>(
       where: where(SimpleDateTime.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class SimpleDateTimeRepository {
     return session.db.count<SimpleDateTime>(
       where: where?.call(SimpleDateTime.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
@@ -376,7 +374,7 @@ class TypesRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -395,7 +393,7 @@ class TypesRepository {
       orderByList: orderByList?.call(Types.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -406,7 +404,7 @@ class TypesRepository {
   }) async {
     return session.db.findById<Types>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -417,7 +415,7 @@ class TypesRepository {
   }) async {
     return session.db.insert<Types>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -428,7 +426,7 @@ class TypesRepository {
   }) async {
     return session.db.insertRow<Types>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -441,7 +439,7 @@ class TypesRepository {
     return session.db.update<Types>(
       rows,
       columns: columns?.call(Types.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -454,7 +452,7 @@ class TypesRepository {
     return session.db.updateRow<Types>(
       row,
       columns: columns?.call(Types.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -465,7 +463,7 @@ class TypesRepository {
   }) async {
     return session.db.delete<Types>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -476,7 +474,7 @@ class TypesRepository {
   }) async {
     return session.db.deleteRow<Types>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -487,7 +485,7 @@ class TypesRepository {
   }) async {
     return session.db.deleteWhere<Types>(
       where: where(Types.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -500,7 +498,7 @@ class TypesRepository {
     return session.db.count<Types>(
       where: where?.call(Types.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -8,8 +8,6 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-// ignore_for_file: invalid_use_of_visible_for_testing_member
-
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 
@@ -202,7 +200,7 @@ class UniqueDataRepository {
       orderDescending: orderDescending,
       limit: limit,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -221,7 +219,7 @@ class UniqueDataRepository {
       orderByList: orderByList?.call(UniqueData.t),
       orderDescending: orderDescending,
       offset: offset,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -232,7 +230,7 @@ class UniqueDataRepository {
   }) async {
     return session.db.findById<UniqueData>(
       id,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -243,7 +241,7 @@ class UniqueDataRepository {
   }) async {
     return session.db.insert<UniqueData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -254,7 +252,7 @@ class UniqueDataRepository {
   }) async {
     return session.db.insertRow<UniqueData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -267,7 +265,7 @@ class UniqueDataRepository {
     return session.db.update<UniqueData>(
       rows,
       columns: columns?.call(UniqueData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -280,7 +278,7 @@ class UniqueDataRepository {
     return session.db.updateRow<UniqueData>(
       row,
       columns: columns?.call(UniqueData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -291,7 +289,7 @@ class UniqueDataRepository {
   }) async {
     return session.db.delete<UniqueData>(
       rows,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -302,7 +300,7 @@ class UniqueDataRepository {
   }) async {
     return session.db.deleteRow<UniqueData>(
       row,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -313,7 +311,7 @@ class UniqueDataRepository {
   }) async {
     return session.db.deleteWhere<UniqueData>(
       where: where(UniqueData.t),
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 
@@ -326,7 +324,7 @@ class UniqueDataRepository {
     return session.db.count<UniqueData>(
       where: where?.call(UniqueData.t),
       limit: limit,
-      transaction: transaction ?? session.transaction,
+      transaction: transaction,
     );
   }
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -293,8 +293,7 @@ class BuildRepositoryClass {
             'orderDescending': refer('orderDescending'),
             'limit': refer('limit'),
             'offset': refer('offset'),
-            'transaction': refer('transaction')
-                .ifNullThen(refer('session').property('transaction')),
+            'transaction': refer('transaction'),
             if (objectRelationFields.isNotEmpty) 'include': refer('include'),
           }, [
             refer(className)
@@ -383,8 +382,7 @@ class BuildRepositoryClass {
               ),
               'orderDescending': refer('orderDescending'),
               'offset': refer('offset'),
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
               if (objectRelationFields.isNotEmpty) 'include': refer('include'),
             },
             [refer(className)],
@@ -437,8 +435,7 @@ class BuildRepositoryClass {
           .call(
             [refer('id')],
             {
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
               if (objectRelationFields.isNotEmpty) 'include': refer('include'),
             },
             [refer(className)],
@@ -480,8 +477,7 @@ class BuildRepositoryClass {
             .call([
               refer('rows')
             ], {
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -523,8 +519,7 @@ class BuildRepositoryClass {
             .call([
               refer('row')
             ], {
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -576,8 +571,7 @@ class BuildRepositoryClass {
               'columns': refer('columns').nullSafeProperty('call').call([
                 refer(className).property('t'),
               ]),
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -629,8 +623,7 @@ class BuildRepositoryClass {
               'columns': refer('columns').nullSafeProperty('call').call([
                 refer(className).property('t'),
               ]),
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -680,8 +673,7 @@ class BuildRepositoryClass {
             .call([
               refer('rows')
             ], {
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -725,8 +717,7 @@ class BuildRepositoryClass {
             .call([
               refer('row')
             ], {
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -781,8 +772,7 @@ class BuildRepositoryClass {
             .property('deleteWhere')
             .call([], {
               'where': refer('where').call([refer(className).property('t')]),
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -836,8 +826,7 @@ class BuildRepositoryClass {
                 [refer(className).property('t')],
               ),
               'limit': refer('limit'),
-              'transaction': refer('transaction')
-                  .ifNullThen(refer('session').property('transaction')),
+              'transaction': refer('transaction'),
             }, [
               refer(className)
             ])
@@ -1796,8 +1785,7 @@ class BuildRepositoryClass {
                   'columns': literalList(
                     [classReference.property('t').property(fieldName)],
                   ),
-                  'transaction': refer('transaction')
-                      .ifNullThen(refer('session').property('transaction')),
+                  'transaction': refer('transaction'),
                 }, [
                   classReference,
                 ])

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -72,8 +72,6 @@ class SerializableModelLibraryGenerator {
         ]);
 
         if (serverCode && tableName != null) {
-          libraryBuilder.ignoreForFile
-              .add('invalid_use_of_visible_for_testing_member');
           libraryBuilder.body.addAll([
             _buildModelTableClass(
               className,


### PR DESCRIPTION
## Description
The way we set up the transaction fallback to support the tests was actually overly complicated. It is better and more robust to only do this fallback at the source of truth. This also fixes the issue that unsafe queries was not included in the test transaction.

Closes #2874 

## Changes
- Moves transaction fallback to the database class instead

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.