### PR TITLE
chore: Bump code builder dependency

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   archive: ^3.3.7
   args: ^2.4.0
   ci: ^0.1.0
-  code_builder: ^4.4.0
+  code_builder: ^4.5.0
   dart_style: ^2.3.0
   http: '>=1.0.0 <2.0.0'
   intl: ^0.19.0

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   archive: ^3.3.7
   args: ^2.4.0
   ci: ^0.1.0
-  code_builder: ^4.4.0
+  code_builder: ^4.5.0
   dart_style: ^2.3.0
   http: '>=1.0.0 <2.0.0'
   intl: ^0.19.0


### PR DESCRIPTION
Bumps the code builder dependency to min version `4.5.0` so that class modifiers are supported.

This is required to support sealed classes.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - internal change for Serverpod.