### PR TITLE
fix: Set explicit return type in test tools code.

### DIFF
--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -21,7 +21,7 @@ import 'package:serverpod_test_module_server/src/generated/endpoints.dart';
 export 'package:serverpod_test/serverpod_test_public_exports.dart';
 
 @_i1.isTestGroup
-withServerpod(
+void withServerpod(
   String testGroupName,
   _i1.TestClosure<TestEndpoints> testClosure, {
   String? runMode,
@@ -55,7 +55,7 @@ class TestEndpoints {
 class _InternalTestEndpoints extends TestEndpoints
     implements _i1.InternalTestEndpoints {
   @override
-  initialize(
+  void initialize(
     _i2.SerializationManager serializationManager,
     _i2.EndpointDispatch endpoints,
   ) {

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -45,7 +45,7 @@ import 'package:serverpod_test_server/src/generated/endpoints.dart';
 export 'package:serverpod_test/serverpod_test_public_exports.dart';
 
 @_i1.isTestGroup
-withServerpod(
+void withServerpod(
   String testGroupName,
   _i1.TestClosure<TestEndpoints> testClosure, {
   String? runMode,
@@ -156,7 +156,7 @@ class TestEndpoints {
 class _InternalTestEndpoints extends TestEndpoints
     implements _i1.InternalTestEndpoints {
   @override
-  initialize(
+  void initialize(
     _i2.SerializationManager serializationManager,
     _i2.EndpointDispatch endpoints,
   ) {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -345,6 +345,7 @@ class ServerTestToolsGenerator {
           (methodBuilder) {
             methodBuilder
               ..name = 'initialize'
+              ..returns = refer('void')
               ..annotations.add(refer('override'))
               ..requiredParameters.add(
                 Parameter(
@@ -384,6 +385,7 @@ class ServerTestToolsGenerator {
     return Method((methodBuilder) {
       methodBuilder
         ..name = 'withServerpod'
+        ..returns = refer('void')
         ..annotations.add(refer('isTestGroup', serverpodTestUrl))
         ..requiredParameters.addAll([
           Parameter((p) => p

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
@@ -66,7 +66,7 @@ void main() {
             testToolsFile,
             matches(
               r'@_i\d\.isTestGroup\n'
-              r'withServerpod\(\n'
+              r'void withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  String\? runMode,\n'
@@ -138,7 +138,7 @@ void main() {
             testToolsFile,
             matches(
               r'@_i\d\.isTestGroup\n'
-              r'withServerpod\(\n'
+              r'void withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  String\? runMode,\n'
@@ -183,7 +183,7 @@ void main() {
             testToolsFile,
             matches(
               r'@_i\d\.isTestGroup\n'
-              r'withServerpod\(\n'
+              r'void withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  String\? runMode,\n'
@@ -263,7 +263,7 @@ void main() {
             testToolsFile,
             matches(
               r'@_i\d\.isTestGroup\n'
-              r'withServerpod\(\n'
+              r'void withServerpod\(\n'
               r'  String testGroupName,\n'
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  String\? runMode,\n'


### PR DESCRIPTION
## Changes
- Sets an explicit return type in the generated test tools code to prevent linter warnings in newer dart versions

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.