### PR TITLE
fix: Fix unnecessary_library_name warnings #2901

### DIFF
--- a/examples/auth_example/auth_example_client/lib/src/protocol/protocol.dart
+++ b/examples/auth_example/auth_example_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'example.dart' as _i2;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i3;

--- a/examples/auth_example/auth_example_server/lib/src/generated/protocol.dart
+++ b/examples/auth_example/auth_example_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i3;

--- a/examples/chat/chat_client/lib/src/protocol/protocol.dart
+++ b/examples/chat/chat_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'channel.dart' as _i2;
 import 'package:chat_client/src/protocol/channel.dart' as _i3;

--- a/examples/chat/chat_server/lib/src/generated/protocol.dart
+++ b/examples/chat/chat_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i3;

--- a/integrations/serverpod_cloud_storage_gcp/lib/serverpod_cloud_storage_gcp.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/serverpod_cloud_storage_gcp.dart
@@ -1,6 +1,6 @@
 /// Support for doing something awesome.
 ///
 /// More dartdocs go here.
-library serverpod_cloud_storage_gcp;
+library;
 
 export 'src/cloud_storage/google_cloud_storage.dart';

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result.dart
@@ -1,5 +1,3 @@
-library list_bucket_result;
-
 import 'dart:convert';
 
 import 'package:built_collection/built_collection.dart';

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result.g.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: library_private_types_in_public_api, no_leading_underscores_for_local_identifiers, use_string_in_part_of_directives
 
-part of list_bucket_result;
+part of 'list_bucket_result.dart';
 
 // **************************************************************************
 // BuiltValueGenerator

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result_contents.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result_contents.dart
@@ -1,5 +1,3 @@
-library list_bucket_result_contents;
-
 import 'dart:convert';
 
 import 'package:built_value/built_value.dart';

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result_contents.g.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_client/model/list_bucket_result_contents.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: library_private_types_in_public_api, no_leading_underscores_for_local_identifiers, use_string_in_part_of_directives
 
-part of list_bucket_result_contents;
+part of 'list_bucket_result_contents.dart';
 
 // **************************************************************************
 // BuiltValueGenerator

--- a/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -1,5 +1,3 @@
-library aws_s3_upload;
-
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';

--- a/integrations/serverpod_cloud_storage_s3/lib/serverpod_cloud_storage_s3.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/serverpod_cloud_storage_s3.dart
@@ -1,6 +1,6 @@
 /// Support for doing something awesome.
 ///
 /// More dartdocs go here.
-library serverpod_cloud_storage_s3;
+library;
 
 export 'src/cloud_storage.dart/s3_cloud_storage.dart';

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result.dart
@@ -1,5 +1,3 @@
-library list_bucket_result;
-
 import 'dart:convert';
 
 import 'package:built_collection/built_collection.dart';

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result.g.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: library_private_types_in_public_api, no_leading_underscores_for_local_identifiers, use_string_in_part_of_directives
 
-part of list_bucket_result;
+part of 'list_bucket_result.dart';
 
 // **************************************************************************
 // BuiltValueGenerator

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result_contents.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result_contents.dart
@@ -1,5 +1,3 @@
-library list_bucket_result_contents;
-
 import 'dart:convert';
 
 import 'package:built_value/built_value.dart';

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result_contents.g.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_client/model/list_bucket_result_contents.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: library_private_types_in_public_api, no_leading_underscores_for_local_identifiers, use_string_in_part_of_directives
 
-part of list_bucket_result_contents;
+part of 'list_bucket_result_contents.dart';
 
 // **************************************************************************
 // BuiltValueGenerator

--- a/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
+++ b/integrations/serverpod_cloud_storage_s3/lib/src/aws_s3_upload/aws_s3_upload.dart
@@ -1,5 +1,3 @@
-library aws_s3_upload;
-
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';

--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/lib/serverpod_auth_apple_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/lib/serverpod_auth_apple_flutter.dart
@@ -1,5 +1,3 @@
-library serverpod_auth_apple_flutter;
-
 export 'src/signin_button.dart';
 export 'src/auth.dart';
 export 'package:serverpod_auth_shared_flutter/serverpod_auth_shared_flutter.dart';

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'apple_auth_info.dart' as _i2;
 import 'auth_key.dart' as _i3;

--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/serverpod_auth_email_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/serverpod_auth_email_flutter.dart
@@ -1,4 +1,2 @@
-library serverpod_auth_email_flutter;
-
 export 'src/signin_button.dart';
 export 'src/auth.dart';

--- a/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/serverpod_auth_firebase_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_firebase_flutter/lib/serverpod_auth_firebase_flutter.dart
@@ -1,4 +1,2 @@
-library serverpod_auth_firebase_flutter;
-
 export 'src/auth.dart';
 export 'src/signin_button.dart';

--- a/modules/serverpod_auth/serverpod_auth_google_flutter/lib/serverpod_auth_google_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_google_flutter/lib/serverpod_auth_google_flutter.dart
@@ -1,5 +1,3 @@
-library serverpod_auth_google_flutter;
-
 export 'src/auth.dart';
 export 'src/signin_button.dart';
 export 'package:serverpod_auth_shared_flutter/serverpod_auth_shared_flutter.dart';

--- a/modules/serverpod_auth/serverpod_auth_server/lib/module.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/module.dart
@@ -1,5 +1,3 @@
-library protocol;
-
 export 'src/business/config.dart';
 export 'src/business/email_auth.dart';
 export 'src/business/google_auth.dart';

--- a/modules/serverpod_auth/serverpod_auth_server/lib/serverpod_auth_server.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/serverpod_auth_server.dart
@@ -1,5 +1,3 @@
-library protocol;
-
 export 'src/business/authentication_handler.dart';
 export 'src/business/user_authentication.dart';
 export 'src/business/config.dart';

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'apple_auth_info.dart' as _i3;

--- a/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/serverpod_auth_shared_flutter.dart
+++ b/modules/serverpod_auth/serverpod_auth_shared_flutter/lib/serverpod_auth_shared_flutter.dart
@@ -1,5 +1,3 @@
-library serverpod_auth_shared_flutter;
-
 export 'src/authentication_key_manager.dart';
 export 'src/circular_user_image.dart';
 export 'src/image_uploader.dart';

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'chat_join_channel.dart' as _i2;
 import 'chat_join_channel_failed.dart' as _i3;

--- a/modules/serverpod_chat/serverpod_chat_flutter/lib/serverpod_chat_flutter.dart
+++ b/modules/serverpod_chat/serverpod_chat_flutter/lib/serverpod_chat_flutter.dart
@@ -1,5 +1,3 @@
-library serverpod_chat_flutter;
-
 export 'src/chat_controller.dart';
 export 'src/chat_dispatch.dart';
 export 'src/chat_input.dart';

--- a/modules/serverpod_chat/serverpod_chat_server/lib/module.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/module.dart
@@ -1,5 +1,3 @@
-library protocol;
-
 export 'src/business/config.dart';
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';

--- a/modules/serverpod_chat/serverpod_chat_server/lib/serverpod_chat_server.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/serverpod_chat_server.dart
@@ -1,5 +1,3 @@
-library protocol;
-
 export 'src/business/config.dart';
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i3;

--- a/packages/serverpod/lib/database.dart
+++ b/packages/serverpod/lib/database.dart
@@ -1,5 +1,3 @@
-library database;
-
 export 'src/database/concepts/columns.dart';
 export 'src/database/concepts/database_result.dart';
 export 'src/database/concepts/expressions.dart';

--- a/packages/serverpod/lib/server.dart
+++ b/packages/serverpod/lib/server.dart
@@ -1,5 +1,3 @@
-library server;
-
 export 'src/authentication/authentication_info.dart';
 export 'src/authentication/scope.dart';
 export 'src/generated/server_health_metric.dart';

--- a/packages/serverpod/lib/serverpod.dart
+++ b/packages/serverpod/lib/serverpod.dart
@@ -1,3 +1,5 @@
+library serverpod;
+
 // Config
 export 'package:serverpod_shared/src/config.dart';
 

--- a/packages/serverpod/lib/serverpod.dart
+++ b/packages/serverpod/lib/serverpod.dart
@@ -1,5 +1,3 @@
-library serverpod;
-
 // Config
 export 'package:serverpod_shared/src/config.dart';
 

--- a/packages/serverpod/lib/serverpod_internal.dart
+++ b/packages/serverpod/lib/serverpod_internal.dart
@@ -1,5 +1,5 @@
 // This library should only be imported by Serverpod packages
-library serverpod_internal;
+library;
 
 // ignore: invalid_export_of_internal_element
 export 'src/server/websocket_request_handlers/helpers/method_stream_manager.dart';

--- a/packages/serverpod/lib/src/generated/protocol.dart
+++ b/packages/serverpod/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'authentication/revoked_authentication_auth_id.dart' as _i3;

--- a/packages/serverpod_client/lib/serverpod_client.dart
+++ b/packages/serverpod_client/lib/serverpod_client.dart
@@ -1,5 +1,3 @@
-library serverpod_client;
-
 export 'package:serverpod_serialization/serverpod_serialization.dart';
 export 'src/auth_key_manager.dart';
 export 'src/connectivity_monitor.dart';

--- a/packages/serverpod_flutter/lib/serverpod_flutter.dart
+++ b/packages/serverpod_flutter/lib/serverpod_flutter.dart
@@ -1,4 +1,2 @@
-library serverpod_flutter;
-
 export 'src/flutter_connectivity_monitor.dart';
 export 'src/localhost_web.dart' if (dart.library.io) 'src/localhost_io.dart';

--- a/packages/serverpod_serialization/lib/serverpod_serialization.dart
+++ b/packages/serverpod_serialization/lib/serverpod_serialization.dart
@@ -1,5 +1,3 @@
-library serverpod_serialization;
-
 export 'package:uuid/uuid.dart';
 
 export 'src/auth_encoding.dart';

--- a/packages/serverpod_serialization/lib/src/auth_encoding.dart
+++ b/packages/serverpod_serialization/lib/src/auth_encoding.dart
@@ -1,5 +1,5 @@
 /// Serverpod's default authentication key encoding and decoding.
-library serverpod_serialization.auth_encoding;
+library;
 
 import 'dart:convert';
 

--- a/packages/serverpod_service_client/lib/serverpod_service_client.dart
+++ b/packages/serverpod_service_client/lib/serverpod_service_client.dart
@@ -1,7 +1,7 @@
 /// Support for doing something awesome.
 ///
 /// More dartdocs go here.
-library serverpod_service_client;
+library;
 
 export 'src/protocol/protocol.dart';
 export 'src/service_key_manager.dart';

--- a/packages/serverpod_service_client/lib/src/protocol/protocol.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'cache_info.dart' as _i2;
 import 'caches_info.dart' as _i3;

--- a/packages/serverpod_shared/lib/serverpod_shared.dart
+++ b/packages/serverpod_shared/lib/serverpod_shared.dart
@@ -1,5 +1,3 @@
-library serverpod_shared;
-
 export 'src/certificates.dart';
 export 'src/config.dart';
 export 'src/constants.dart';

--- a/packages/serverpod_test/lib/serverpod_test.dart
+++ b/packages/serverpod_test/lib/serverpod_test.dart
@@ -1,5 +1,3 @@
-library serverpod_test;
-
 export 'src/with_serverpod.dart';
 export 'src/test_session_builder.dart';
 export 'src/util.dart';

--- a/packages/serverpod_test/lib/serverpod_test_public_exports.dart
+++ b/packages/serverpod_test/lib/serverpod_test_public_exports.dart
@@ -1,5 +1,3 @@
-library serverpod_test;
-
 // ATTENTION: This file should never be imported directly.
 // It is used to re-export the public parts of the test tools
 // in the generated test tools file.

--- a/templates/serverpod_templates/modulename_client/lib/src/protocol/protocol.dart
+++ b/templates/serverpod_templates/modulename_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'module_class.dart' as _i2;
 export 'module_class.dart';

--- a/templates/serverpod_templates/modulename_server/lib/modulename_server.dart
+++ b/templates/serverpod_templates/modulename_server/lib/modulename_server.dart
@@ -1,4 +1,2 @@
-library protocol;
-
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';

--- a/templates/serverpod_templates/modulename_server/lib/src/generated/protocol.dart
+++ b/templates/serverpod_templates/modulename_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'module_class.dart' as _i3;

--- a/templates/serverpod_templates/projectname_client/lib/src/protocol/protocol.dart
+++ b/templates/serverpod_templates/projectname_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'example.dart' as _i2;
 export 'example.dart';

--- a/templates/serverpod_templates/projectname_server/lib/src/generated/protocol.dart
+++ b/templates/serverpod_templates/projectname_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'example.dart' as _i3;

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'defaults/boolean/bool_default.dart' as _i2;
 import 'defaults/boolean/bool_default_mix.dart' as _i3;

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'module_class.dart' as _i2;
 export 'module_class.dart';

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/serverpod_test_module_server.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/serverpod_test_module_server.dart
@@ -1,4 +1,2 @@
-library protocol;
-
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'module_class.dart' as _i3;

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -8,8 +8,7 @@
 // ignore_for_file: type_literal_in_constant_pattern
 // ignore_for_file: use_super_parameters
 
-library protocol; // ignore_for_file: no_leading_underscores_for_library_prefixes
-
+// ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod/protocol.dart' as _i2;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i3;

--- a/tests/serverpod_test_shared/lib/serverpod_test_shared.dart
+++ b/tests/serverpod_test_shared/lib/serverpod_test_shared.dart
@@ -1,4 +1,2 @@
-library serverpod_test_shared;
-
 export 'src/external_custom_class.dart';
 export 'src/freezed_custom_class.dart';

--- a/tools/serverpod_cli/lib/analyzer.dart
+++ b/tools/serverpod_cli/lib/analyzer.dart
@@ -1,5 +1,5 @@
 /// Tools for analyzing the protocol files of a Serverpod project.
-library analyzer;
+library;
 
 export 'src/analyzer/protocol_definition.dart' show ProtocolDefinition;
 export 'src/config/config.dart' show GeneratorConfig, PackageType;

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -25,8 +25,6 @@ class LibraryGenerator {
   Library generateProtocol() {
     var library = LibraryBuilder();
 
-    library.name = 'protocol';
-
     var models = protocolDefinition.models
         .where((model) => serverCode || !model.serverOnly)
         .toList();


### PR DESCRIPTION
Fixes unnecessary_library_name warnings.
Since Dart 3.4, naming a dart source library is discouraged by the analyzer rule unnecessary_library_name.
https://dart.dev/tools/linter-rules/unnecessary_library_name

Closes #2901

> NOTE: This PR fixes all except one last 'unnecessary_library_name' problem from the analyzer. The reason we keep one is that dart analyzer has a bug where it crashes and fails the test in package/serverpod if it finds zero problems. See bug report:

https://github.com/dart-lang/linter/issues/5113

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a