### PR TITLE
test: Add database operations tests.

### DIFF
--- a/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_operations_test.dart
@@ -418,7 +418,7 @@ void main() {
   });
 
   withServerpod(
-    'Given rollbackDatabase is not disabled ',
+    'Given rollbackDatabase is not disabled (transaction active) ',
     rollbackDatabase: RollbackDatabase.afterEach,
     (sessionBuilder, _) {
       var session = sessionBuilder.build();
@@ -508,6 +508,191 @@ void main() {
 
         expect(simpleDatas, hasLength(3));
         expect(simpleDatas.map((s) => s.num), containsAll([1, 2, 3]));
+      });
+
+      group('when calling database operation insertRow', () {
+        setUp(() async {
+          await SimpleData.db.insertRow(
+            session,
+            SimpleData(num: 123),
+          );
+        });
+
+        test('then should have inserted row', () async {
+          var simpleDatas = await SimpleData.db.find(session);
+          expect(simpleDatas.length, 1);
+          expect(simpleDatas.first.num, 123);
+        });
+      });
+
+      group('when calling database operation insert', () {
+        setUp(() async {
+          await SimpleData.db.insert(
+            session,
+            [
+              SimpleData(num: 1),
+              SimpleData(num: 2),
+            ],
+          );
+        });
+
+        test('then should have inserted rows', () async {
+          var simpleDatas = await SimpleData.db.find(session);
+          expect(simpleDatas.length, 2);
+          expect(simpleDatas.map((s) => s.num), containsAll([1, 2]));
+        });
+      });
+
+      group('and SimpleDatas exist', () {
+        late List<SimpleData> insertedSimpleDatas;
+        late SimpleData insertedSimpleData1;
+
+        setUp(() async {
+          insertedSimpleDatas = await SimpleData.db.insert(
+            session,
+            [
+              SimpleData(num: 1),
+              SimpleData(num: 2),
+            ],
+          );
+          insertedSimpleData1 =
+              insertedSimpleDatas.firstWhere((s) => s.num == 1);
+        });
+
+        test(
+            'when calling database operation updateRow '
+            'then should update row', () async {
+          insertedSimpleData1.num = 10;
+          var updatedSimpleData =
+              await SimpleData.db.updateRow(session, insertedSimpleData1);
+          expect(updatedSimpleData.num, 10);
+        });
+
+        test(
+            'when calling database operation update '
+            'then should update rows', () async {
+          var simpleDatas = await SimpleData.db.update(
+            session,
+            insertedSimpleDatas.map((s) => s..num = s.num + 10).toList(),
+          );
+          expect(simpleDatas.map((s) => s.num), containsAll([11, 12]));
+        });
+
+        test(
+            'when calling database operation findById'
+            'then should find the saved row by id', () async {
+          var simpleData = await SimpleData.db.findById(
+            session,
+            insertedSimpleData1.id!,
+          );
+          expect(simpleData, isNotNull);
+          expect(simpleData?.num, 1);
+        });
+
+        test(
+            'when calling database operation findFirstRow'
+            'then should be possible to find first row', () async {
+          var simpleData = await SimpleData.db.findFirstRow(session);
+
+          expect(simpleData, isNotNull);
+          expect(simpleData?.num, 1);
+        });
+
+        test(
+            'when calling database operation find '
+            'then should be possible to find all rows', () async {
+          var simpleDatas = await SimpleData.db.find(session);
+          expect(simpleDatas.length, 2);
+        });
+
+        test(
+            'when calling database operation deleteRow '
+            'then should delete rows', () async {
+          await SimpleData.db.deleteRow(session, insertedSimpleData1);
+          var simpleDatas = await SimpleData.db.find(session);
+          expect(simpleDatas.length, 1);
+          expect(simpleDatas.first.num, 2);
+        });
+
+        test(
+            'when calling database operation deleteWhere'
+            'then rows should be deleted', () async {
+          await SimpleData.db.deleteWhere(
+            session,
+            where: (t) => t.num.equals(1),
+          );
+
+          var simpleDatas = await SimpleData.db.find(session);
+
+          expect(simpleDatas.length, 1);
+          expect(simpleDatas.first.num, 2);
+        });
+
+        test(
+            'when calling database operation delete '
+            'then rows should be deleted', () async {
+          await SimpleData.db.delete(
+            session,
+            insertedSimpleDatas,
+          );
+
+          var simpleDatas = await SimpleData.db.find(session);
+          expect(simpleDatas.length, 0);
+        });
+
+        test(
+            'when calling database operation count'
+            'then rows should be counted', () async {
+          var count = await SimpleData.db.count(session);
+          expect(count, 2);
+        });
+
+        test(
+            'when calling database operation unsafeQuery with select statement '
+            'then should find inserted row', () async {
+          var result = await session.db.unsafeQuery(
+            'SELECT num from simple_data where num = @num',
+            parameters: QueryParameters.named({'num': 2}),
+          );
+          expect(result.length, 1);
+          expect(result.first.first, 2);
+        });
+
+        test(
+            'when calling database operation unsafeExecute with delete statement '
+            'then should delete row', () async {
+          var rowsAffected = await session.db.unsafeExecute(
+            'DELETE FROM simple_data WHERE num = @num',
+            parameters: QueryParameters.named({'num': 2}),
+          );
+
+          expect(rowsAffected, 1);
+        });
+
+        test(
+            'when calling database operation unsafeSimpleQuery with select statement '
+            'then should find inserted row', () async {
+          var result = await session.db.unsafeSimpleQuery(
+            'SELECT num from simple_data',
+          );
+          expect(result.length, 2);
+          expect(
+              result,
+              containsAll([
+                [1],
+                [2],
+              ]));
+        });
+
+        test(
+            'when calling database operation unsafeSimpleExecute with delete statement '
+            'then should delete row', () async {
+          var rowsAffected = await session.db.unsafeSimpleExecute(
+            'DELETE FROM simple_data WHERE num = 2',
+          );
+
+          expect(rowsAffected, 1);
+        });
       });
     },
   );


### PR DESCRIPTION
## Description 
To ensure that the test transaction are correctly passed on to database calls in `packages/serverpod/lib/src/database/database.dart`, this PR adds a simple test for each available method.

There are already other tests to verify that database calls are performed inside a transaction and are correctly rolled back. So it's enough here to prove that the database calls can observe changes made by another call (e.g. insert/find).

## Changes
- Adds more database operations tests

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.