### PR TITLE
fix: Replaced null assert with error check in web_widget

### DIFF
--- a/packages/serverpod/lib/src/relic/web_widget.dart
+++ b/packages/serverpod/lib/src/relic/web_widget.dart
@@ -29,9 +29,11 @@ class Widget extends AbstractWidget {
   Widget({
     required this.name,
   }) {
-    assert(templates[name] != null,
-        'Template $name.html missing for $runtimeType');
-    template = templates[name]!;
+    var cachedTemplate = templates[name];
+    if (cachedTemplate == null) {
+      throw StateError('Template $name.html missing for $runtimeType');
+    }
+    template = cachedTemplate;
   }
 
   @override


### PR DESCRIPTION
Replaces null assert with error check and proper error message in web_widget.dart.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a