### PR TITLE
Make `Route.getBody` handle `application/json` content type body

### DIFF
--- a/packages/serverpod/lib/src/relic/web_server.dart
+++ b/packages/serverpod/lib/src/relic/web_server.dart
@@ -240,13 +240,17 @@ abstract class Route {
   // types of responses too. Or at least clarify the naming of the method.
 
   /// Returns the body of the request, assuming it is standard URL encoded form
-  /// post request.
-  static Future<Map<String, String>> getBody(HttpRequest request) async {
+  /// post request or JSON.
+  static Future<Map<String, dynamic>> getBody(HttpRequest request) async {
     var body = await _readBody(request);
 
     var params = <String, String>{};
 
     if (body != null) {
+      if (request.headers.contentType.toString() == 'application/json') {
+        return jsonDecode(body) as Map<String, dynamic>;
+      }
+
       var encodedParams = body.split('&');
       for (var encodedParam in encodedParams) {
         var comps = encodedParam.split('=');


### PR DESCRIPTION
I'm currently developing a backend where I need to build a webhook endpoint that adheres to a specific contract that sends POST messages with an `application/json` content type. For this, I saw on the #2140 discussion that there is the experimental `webserver`, but the body parsing is limited.

Currently, the `Route.getBody` method only handles `application/x-www-form-urlencoded` body types. This PR allows the method to also parse `application/json` types, which are broadly used. Although this change is far from the major abstraction proposed on #2495, it aims to temporarily improve the coverage of a very common use case while the #2008 improvements are still ongoing.

I understand that the `relic` package is one of the main focuses right now and this change is on its experimental version, so I will also understand if approving this PR makes no much sense for the timeline. Anyway, it is pleasure to contribute.

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] ~I added new tests to check the change I am making.~
  _(Because (1) the webserver is still experimental, (2) there are nearly no tests for the `relic` module and (3) the change consists in a very simple 3-line addition, it seemed to me that there was no reason to include a test. But I may be wrong.)_
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

## Breaking changes

The only breaking change would be the typing change of the `getBody` return, from `Map<String, String>` to `Map<String, dynamic>`. However, this method is not used inside the `serverpod` code itself. The change may only break external code during compile time if there are variables strictly typed to expect `Map<String, String>`.