### PR TITLE
fix: Enable logging for tests and ensure session is always closed 

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -175,19 +175,22 @@ class _AdminEndpoint {
         endpoint: 'admin',
         method: 'getUserInfo',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'admin',
-        methodName: 'getUserInfo',
-        parameters: _i1.testObjectToJson({'userId': userId}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i4.UserInfo?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'admin',
+          methodName: 'getUserInfo',
+          parameters: _i1.testObjectToJson({'userId': userId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i4.UserInfo?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -201,19 +204,22 @@ class _AdminEndpoint {
         endpoint: 'admin',
         method: 'blockUser',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'admin',
-        methodName: 'blockUser',
-        parameters: _i1.testObjectToJson({'userId': userId}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'admin',
+          methodName: 'blockUser',
+          parameters: _i1.testObjectToJson({'userId': userId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -227,19 +233,22 @@ class _AdminEndpoint {
         endpoint: 'admin',
         method: 'unblockUser',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'admin',
-        methodName: 'unblockUser',
-        parameters: _i1.testObjectToJson({'userId': userId}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'admin',
+          methodName: 'unblockUser',
+          parameters: _i1.testObjectToJson({'userId': userId}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -264,19 +273,22 @@ class _AppleEndpoint {
         endpoint: 'apple',
         method: 'authenticate',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'apple',
-        methodName: 'authenticate',
-        parameters: _i1.testObjectToJson({'authInfo': authInfo}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.AuthenticationResponse>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'apple',
+          methodName: 'authenticate',
+          parameters: _i1.testObjectToJson({'authInfo': authInfo}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.AuthenticationResponse>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -302,22 +314,25 @@ class _EmailEndpoint {
         endpoint: 'email',
         method: 'authenticate',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'email',
-        methodName: 'authenticate',
-        parameters: _i1.testObjectToJson({
-          'email': email,
-          'password': password,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.AuthenticationResponse>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'email',
+          methodName: 'authenticate',
+          parameters: _i1.testObjectToJson({
+            'email': email,
+            'password': password,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.AuthenticationResponse>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -332,22 +347,25 @@ class _EmailEndpoint {
         endpoint: 'email',
         method: 'changePassword',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'email',
-        methodName: 'changePassword',
-        parameters: _i1.testObjectToJson({
-          'oldPassword': oldPassword,
-          'newPassword': newPassword,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'email',
+          methodName: 'changePassword',
+          parameters: _i1.testObjectToJson({
+            'oldPassword': oldPassword,
+            'newPassword': newPassword,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -361,19 +379,22 @@ class _EmailEndpoint {
         endpoint: 'email',
         method: 'initiatePasswordReset',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'email',
-        methodName: 'initiatePasswordReset',
-        parameters: _i1.testObjectToJson({'email': email}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'email',
+          methodName: 'initiatePasswordReset',
+          parameters: _i1.testObjectToJson({'email': email}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -388,22 +409,25 @@ class _EmailEndpoint {
         endpoint: 'email',
         method: 'resetPassword',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'email',
-        methodName: 'resetPassword',
-        parameters: _i1.testObjectToJson({
-          'verificationCode': verificationCode,
-          'password': password,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'email',
+          methodName: 'resetPassword',
+          parameters: _i1.testObjectToJson({
+            'verificationCode': verificationCode,
+            'password': password,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -419,23 +443,26 @@ class _EmailEndpoint {
         endpoint: 'email',
         method: 'createAccountRequest',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'email',
-        methodName: 'createAccountRequest',
-        parameters: _i1.testObjectToJson({
-          'userName': userName,
-          'email': email,
-          'password': password,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'email',
+          methodName: 'createAccountRequest',
+          parameters: _i1.testObjectToJson({
+            'userName': userName,
+            'email': email,
+            'password': password,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -450,22 +477,25 @@ class _EmailEndpoint {
         endpoint: 'email',
         method: 'createAccount',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'email',
-        methodName: 'createAccount',
-        parameters: _i1.testObjectToJson({
-          'email': email,
-          'verificationCode': verificationCode,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i4.UserInfo?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'email',
+          methodName: 'createAccount',
+          parameters: _i1.testObjectToJson({
+            'email': email,
+            'verificationCode': verificationCode,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i4.UserInfo?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -490,19 +520,22 @@ class _FirebaseEndpoint {
         endpoint: 'firebase',
         method: 'authenticate',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'firebase',
-        methodName: 'authenticate',
-        parameters: _i1.testObjectToJson({'idToken': idToken}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.AuthenticationResponse>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'firebase',
+          methodName: 'authenticate',
+          parameters: _i1.testObjectToJson({'idToken': idToken}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.AuthenticationResponse>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -528,22 +561,25 @@ class _GoogleEndpoint {
         endpoint: 'google',
         method: 'authenticateWithServerAuthCode',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'google',
-        methodName: 'authenticateWithServerAuthCode',
-        parameters: _i1.testObjectToJson({
-          'authenticationCode': authenticationCode,
-          'redirectUri': redirectUri,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.AuthenticationResponse>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'google',
+          methodName: 'authenticateWithServerAuthCode',
+          parameters: _i1.testObjectToJson({
+            'authenticationCode': authenticationCode,
+            'redirectUri': redirectUri,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.AuthenticationResponse>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -557,19 +593,22 @@ class _GoogleEndpoint {
         endpoint: 'google',
         method: 'authenticateWithIdToken',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'google',
-        methodName: 'authenticateWithIdToken',
-        parameters: _i1.testObjectToJson({'idToken': idToken}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.AuthenticationResponse>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'google',
+          methodName: 'authenticateWithIdToken',
+          parameters: _i1.testObjectToJson({'idToken': idToken}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.AuthenticationResponse>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -591,19 +630,22 @@ class _StatusEndpoint {
         endpoint: 'status',
         method: 'isSignedIn',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'status',
-        methodName: 'isSignedIn',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'status',
+          methodName: 'isSignedIn',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -614,19 +656,22 @@ class _StatusEndpoint {
         endpoint: 'status',
         method: 'signOut',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'status',
-        methodName: 'signOut',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'status',
+          methodName: 'signOut',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -637,19 +682,22 @@ class _StatusEndpoint {
         endpoint: 'status',
         method: 'signOutDevice',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'status',
-        methodName: 'signOutDevice',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'status',
+          methodName: 'signOutDevice',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -661,19 +709,22 @@ class _StatusEndpoint {
         endpoint: 'status',
         method: 'signOutAllDevices',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'status',
-        methodName: 'signOutAllDevices',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'status',
+          methodName: 'signOutAllDevices',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -685,19 +736,22 @@ class _StatusEndpoint {
         endpoint: 'status',
         method: 'getUserInfo',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'status',
-        methodName: 'getUserInfo',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i4.UserInfo?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'status',
+          methodName: 'getUserInfo',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i4.UserInfo?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -709,19 +763,22 @@ class _StatusEndpoint {
         endpoint: 'status',
         method: 'getUserSettingsConfig',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'status',
-        methodName: 'getUserSettingsConfig',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i7.UserSettingsConfig>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'status',
+          methodName: 'getUserSettingsConfig',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i7.UserSettingsConfig>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -744,19 +801,22 @@ class _UserEndpoint {
         endpoint: 'user',
         method: 'removeUserImage',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'user',
-        methodName: 'removeUserImage',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'user',
+          methodName: 'removeUserImage',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -770,19 +830,22 @@ class _UserEndpoint {
         endpoint: 'user',
         method: 'setUserImage',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'user',
-        methodName: 'setUserImage',
-        parameters: _i1.testObjectToJson({'image': image}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'user',
+          methodName: 'setUserImage',
+          parameters: _i1.testObjectToJson({'image': image}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -796,19 +859,22 @@ class _UserEndpoint {
         endpoint: 'user',
         method: 'changeUserName',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'user',
-        methodName: 'changeUserName',
-        parameters: _i1.testObjectToJson({'userName': userName}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'user',
+          methodName: 'changeUserName',
+          parameters: _i1.testObjectToJson({'userName': userName}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -822,19 +888,22 @@ class _UserEndpoint {
         endpoint: 'user',
         method: 'changeFullName',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'user',
-        methodName: 'changeFullName',
-        parameters: _i1.testObjectToJson({'fullName': fullName}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'user',
+          methodName: 'changeFullName',
+          parameters: _i1.testObjectToJson({'fullName': fullName}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }

--- a/templates/serverpod_templates/modulename_server/config/test.yaml
+++ b/templates/serverpod_templates/modulename_server/config/test.yaml
@@ -40,3 +40,7 @@ redis:
   enabled: false
   host: localhost
   port: 9091
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/templates/serverpod_templates/modulename_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/templates/serverpod_templates/modulename_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -131,19 +131,22 @@ class _ModuleEndpoint {
         endpoint: 'module',
         method: 'hello',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'module',
-        methodName: 'hello',
-        parameters: _i1.testObjectToJson({'name': name}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'module',
+          methodName: 'hello',
+          parameters: _i1.testObjectToJson({'name': name}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }

--- a/templates/serverpod_templates/projectname_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/templates/serverpod_templates/projectname_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -110,19 +110,22 @@ class _ExampleEndpoint {
         endpoint: 'example',
         method: 'hello',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'example',
-        methodName: 'hello',
-        parameters: _i1.testObjectToJson({'name': name}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'example',
+          methodName: 'hello',
+          parameters: _i1.testObjectToJson({'name': name}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }

--- a/templates/serverpod_templates/projectname_server_upgrade/config/test.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/config/test.yaml
@@ -40,3 +40,7 @@ redis:
   enabled: false
   host: localhost
   port: 9091
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/templates/serverpod_templates/projectname_server_upgrade/test/integration/test_tools/serverpod_test_tools.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/test/integration/test_tools/serverpod_test_tools.dart
@@ -131,19 +131,22 @@ class _ExampleEndpoint {
         endpoint: 'example',
         method: 'hello',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'example',
-        methodName: 'hello',
-        parameters: _i1.testObjectToJson({'name': name}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'example',
+          methodName: 'hello',
+          parameters: _i1.testObjectToJson({'name': name}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2344,10 +2344,10 @@ class EndpointTestTools extends _i1.EndpointRef {
         {},
       );
 
-  _i2.Stream<int> addWillCloseListenerToSessionInStreamMethodAndThrow() =>
+  _i2.Stream<int> addWillCloseListenerToSessionIntStreamMethodAndThrow() =>
       caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
         'testTools',
-        'addWillCloseListenerToSessionInStreamMethodAndThrow',
+        'addWillCloseListenerToSessionIntStreamMethodAndThrow',
         {},
         {},
       );

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2330,6 +2330,27 @@ class EndpointTestTools extends _i1.EndpointRef {
         'echoSimpleDatas',
         {'simpleDatas': simpleDatas},
       );
+
+  _i2.Future<void> logMessageWithSession() => caller.callServerEndpoint<void>(
+        'testTools',
+        'logMessageWithSession',
+        {},
+      );
+
+  _i2.Future<void> addWillCloseListenerToSessionAndThrow() =>
+      caller.callServerEndpoint<void>(
+        'testTools',
+        'addWillCloseListenerToSessionAndThrow',
+        {},
+      );
+
+  _i2.Stream<int> addWillCloseListenerToSessionInStreamMethodAndThrow() =>
+      caller.callStreamingServerEndpoint<_i2.Stream<int>, int>(
+        'testTools',
+        'addWillCloseListenerToSessionInStreamMethodAndThrow',
+        {},
+        {},
+      );
 }
 
 /// {@category Endpoint}

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -139,19 +139,22 @@ class _ModuleEndpoint {
         endpoint: 'module',
         method: 'hello',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'module',
-        methodName: 'hello',
-        parameters: _i1.testObjectToJson({'name': name}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'module',
+          methodName: 'hello',
+          parameters: _i1.testObjectToJson({'name': name}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -165,19 +168,22 @@ class _ModuleEndpoint {
         endpoint: 'module',
         method: 'modifyModuleObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'module',
-        methodName: 'modifyModuleObject',
-        parameters: _i1.testObjectToJson({'object': object}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i4.ModuleClass>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'module',
+          methodName: 'modifyModuleObject',
+          parameters: _i1.testObjectToJson({'object': object}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i4.ModuleClass>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -200,19 +206,22 @@ class _StreamingEndpoint {
         endpoint: 'streaming',
         method: 'wasStreamOpenCalled',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'streaming',
-        methodName: 'wasStreamOpenCalled',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'streaming',
+          methodName: 'wasStreamOpenCalled',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -224,19 +233,22 @@ class _StreamingEndpoint {
         endpoint: 'streaming',
         method: 'wasStreamClosedCalled',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'streaming',
-        methodName: 'wasStreamClosedCalled',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'streaming',
+          methodName: 'wasStreamClosedCalled',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 

--- a/tests/serverpod_test_server/config/test.yaml
+++ b/tests/serverpod_test_server/config/test.yaml
@@ -28,3 +28,7 @@ redis:
   enabled: true
   host: redis
   port: 6379
+
+sessionLogs:
+  persistentEnabled: true
+  consoleEnabled: true

--- a/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_test_server/src/generated/protocol.dart';
 
@@ -185,21 +187,21 @@ class TestToolsEndpoint extends Endpoint {
     session.log('test session log in endpoint');
   }
 
-  static bool willCloseListenerCalled = false;
+  static Completer<void> willCloseListenerCalled = Completer();
 
   Future<void> addWillCloseListenerToSessionAndThrow(Session session) async {
     session.addWillCloseListener((Session s) {
-      willCloseListenerCalled = true;
+      willCloseListenerCalled.complete();
     });
 
     throw Exception();
   }
 
-  Stream<int> addWillCloseListenerToSessionInStreamMethodAndThrow(
+  Stream<int> addWillCloseListenerToSessionIntStreamMethodAndThrow(
     Session session,
   ) {
     session.addWillCloseListener((Session s) {
-      willCloseListenerCalled = true;
+      willCloseListenerCalled.complete();
     });
 
     throw Exception();

--- a/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
@@ -185,6 +185,25 @@ class TestToolsEndpoint extends Endpoint {
     session.log('test session log in endpoint');
   }
 
+  static bool willCloseListenerCalled = false;
+
+  Future<void> addWillCloseListenerToSessionAndThrow(Session session) async {
+    session.addWillCloseListener((Session s) {
+      willCloseListenerCalled = true;
+    });
+
+    throw Exception();
+  }
+
+  Stream<int> addWillCloseListenerToSessionInStreamMethodAndThrow(
+    Session session,
+  ) {
+    session.addWillCloseListener((Session s) {
+      willCloseListenerCalled = true;
+    });
+
+    throw Exception();
+  }
 }
 
 class AuthenticatedTestToolsEndpoint extends Endpoint {

--- a/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
@@ -187,11 +187,11 @@ class TestToolsEndpoint extends Endpoint {
     session.log('test session log in endpoint');
   }
 
-  static Completer<void> willCloseListenerCalled = Completer();
+  static Completer<void>? willCloseListenerCalled;
 
   Future<void> addWillCloseListenerToSessionAndThrow(Session session) async {
     session.addWillCloseListener((Session s) {
-      willCloseListenerCalled.complete();
+      willCloseListenerCalled?.complete();
     });
 
     throw Exception();
@@ -201,7 +201,7 @@ class TestToolsEndpoint extends Endpoint {
     Session session,
   ) {
     session.addWillCloseListener((Session s) {
-      willCloseListenerCalled.complete();
+      willCloseListenerCalled?.complete();
     });
 
     throw Exception();

--- a/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/test_tools.dart
@@ -180,6 +180,11 @@ class TestToolsEndpoint extends Endpoint {
   ) async {
     return simpleDatas;
   }
+
+  Future<void> logMessageWithSession(Session session) async {
+    session.log('test session log in endpoint');
+  }
+
 }
 
 class AuthenticatedTestToolsEndpoint extends Endpoint {

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -5015,9 +5015,9 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .listenForNumbersOnSharedStream(session),
         ),
-        'addWillCloseListenerToSessionInStreamMethodAndThrow':
+        'addWillCloseListenerToSessionIntStreamMethodAndThrow':
             _i1.MethodStreamConnector(
-          name: 'addWillCloseListenerToSessionInStreamMethodAndThrow',
+          name: 'addWillCloseListenerToSessionIntStreamMethodAndThrow',
           params: {},
           streamParams: {},
           returnType: _i1.MethodStreamReturnType.streamType,
@@ -5027,7 +5027,8 @@ class Endpoints extends _i1.EndpointDispatch {
             Map<String, Stream> streamParams,
           ) =>
               (endpoints['testTools'] as _i36.TestToolsEndpoint)
-                  .addWillCloseListenerToSessionInStreamMethodAndThrow(session),
+                  .addWillCloseListenerToSessionIntStreamMethodAndThrow(
+                      session),
         ),
       },
     );

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -4829,6 +4829,26 @@ class Endpoints extends _i1.EndpointDispatch {
             params['simpleDatas'],
           ),
         ),
+        'logMessageWithSession': _i1.MethodConnector(
+          name: 'logMessageWithSession',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
+                  .logMessageWithSession(session),
+        ),
+        'addWillCloseListenerToSessionAndThrow': _i1.MethodConnector(
+          name: 'addWillCloseListenerToSessionAndThrow',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
+                  .addWillCloseListenerToSessionAndThrow(session),
+        ),
         'returnsSessionIdFromStream': _i1.MethodStreamConnector(
           name: 'returnsSessionIdFromStream',
           params: {},
@@ -4994,6 +5014,20 @@ class Endpoints extends _i1.EndpointDispatch {
           ) =>
               (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .listenForNumbersOnSharedStream(session),
+        ),
+        'addWillCloseListenerToSessionInStreamMethodAndThrow':
+            _i1.MethodStreamConnector(
+          name: 'addWillCloseListenerToSessionInStreamMethodAndThrow',
+          params: {},
+          streamParams: {},
+          returnType: _i1.MethodStreamReturnType.streamType,
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+            Map<String, Stream> streamParams,
+          ) =>
+              (endpoints['testTools'] as _i36.TestToolsEndpoint)
+                  .addWillCloseListenerToSessionInStreamMethodAndThrow(session),
         ),
       },
     );

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -284,6 +284,9 @@ testTools:
   - createSimpleDatasInParallelTransactionCalls:
   - echoSimpleData:
   - echoSimpleDatas:
+  - logMessageWithSession:
+  - addWillCloseListenerToSessionAndThrow:
+  - addWillCloseListenerToSessionInStreamMethodAndThrow:
 authenticatedTestTools:
   - returnsString:
   - returnsStream:

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -286,7 +286,7 @@ testTools:
   - echoSimpleDatas:
   - logMessageWithSession:
   - addWillCloseListenerToSessionAndThrow:
-  - addWillCloseListenerToSessionInStreamMethodAndThrow:
+  - addWillCloseListenerToSessionIntStreamMethodAndThrow:
 authenticatedTestTools:
   - returnsString:
   - returnsStream:

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -8088,7 +8088,7 @@ class _TestToolsEndpoint {
     });
   }
 
-  _i3.Stream<int> addWillCloseListenerToSessionInStreamMethodAndThrow(
+  _i3.Stream<int> addWillCloseListenerToSessionIntStreamMethodAndThrow(
       _i1.TestSessionBuilder sessionBuilder) {
     var _localTestStreamManager = _i1.TestStreamManager<int>();
     _i1.callStreamFunctionAndHandleExceptions(
@@ -8096,13 +8096,13 @@ class _TestToolsEndpoint {
         var _localUniqueSession =
             (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
           endpoint: 'testTools',
-          method: 'addWillCloseListenerToSessionInStreamMethodAndThrow',
+          method: 'addWillCloseListenerToSessionIntStreamMethodAndThrow',
         );
         var _localCallContext =
             await _endpointDispatch.getMethodStreamCallContext(
           createSessionCallback: (_) => _localUniqueSession,
           endpointPath: 'testTools',
-          methodName: 'addWillCloseListenerToSessionInStreamMethodAndThrow',
+          methodName: 'addWillCloseListenerToSessionIntStreamMethodAndThrow',
           arguments: {},
           requestedInputStreams: [],
           serializationManager: _serializationManager,

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -393,22 +393,25 @@ class _AsyncTasksEndpoint {
         endpoint: 'asyncTasks',
         method: 'insertRowToSimpleDataAfterDelay',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'asyncTasks',
-        methodName: 'insertRowToSimpleDataAfterDelay',
-        parameters: _i1.testObjectToJson({
-          'num': num,
-          'seconds': seconds,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'asyncTasks',
+          methodName: 'insertRowToSimpleDataAfterDelay',
+          parameters: _i1.testObjectToJson({
+            'num': num,
+            'seconds': seconds,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -422,19 +425,22 @@ class _AsyncTasksEndpoint {
         endpoint: 'asyncTasks',
         method: 'throwExceptionAfterDelay',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'asyncTasks',
-        methodName: 'throwExceptionAfterDelay',
-        parameters: _i1.testObjectToJson({'seconds': seconds}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'asyncTasks',
+          methodName: 'throwExceptionAfterDelay',
+          parameters: _i1.testObjectToJson({'seconds': seconds}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -456,19 +462,22 @@ class _AuthenticationEndpoint {
         endpoint: 'authentication',
         method: 'removeAllUsers',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'authentication',
-        methodName: 'removeAllUsers',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'authentication',
+          methodName: 'removeAllUsers',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -479,19 +488,22 @@ class _AuthenticationEndpoint {
         endpoint: 'authentication',
         method: 'countUsers',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'authentication',
-        methodName: 'countUsers',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'authentication',
+          methodName: 'countUsers',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -506,22 +518,25 @@ class _AuthenticationEndpoint {
         endpoint: 'authentication',
         method: 'createUser',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'authentication',
-        methodName: 'createUser',
-        parameters: _i1.testObjectToJson({
-          'email': email,
-          'password': password,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'authentication',
+          methodName: 'createUser',
+          parameters: _i1.testObjectToJson({
+            'email': email,
+            'password': password,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -537,23 +552,26 @@ class _AuthenticationEndpoint {
         endpoint: 'authentication',
         method: 'authenticate',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'authentication',
-        methodName: 'authenticate',
-        parameters: _i1.testObjectToJson({
-          'email': email,
-          'password': password,
-          'scopes': scopes,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i4.AuthenticationResponse>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'authentication',
+          methodName: 'authenticate',
+          parameters: _i1.testObjectToJson({
+            'email': email,
+            'password': password,
+            'scopes': scopes,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i4.AuthenticationResponse>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -564,19 +582,22 @@ class _AuthenticationEndpoint {
         endpoint: 'authentication',
         method: 'signOut',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'authentication',
-        methodName: 'signOut',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'authentication',
+          methodName: 'signOut',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -591,22 +612,25 @@ class _AuthenticationEndpoint {
         endpoint: 'authentication',
         method: 'updateScopes',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'authentication',
-        methodName: 'updateScopes',
-        parameters: _i1.testObjectToJson({
-          'userId': userId,
-          'scopes': scopes,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'authentication',
+          methodName: 'updateScopes',
+          parameters: _i1.testObjectToJson({
+            'userId': userId,
+            'scopes': scopes,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -631,19 +655,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testInt',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testInt',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testInt',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -657,19 +684,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testDouble',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testDouble',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<double?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testDouble',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<double?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -683,19 +713,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testBool',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testBool',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testBool',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -709,19 +742,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testDateTime',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testDateTime',
-        parameters: _i1.testObjectToJson({'dateTime': dateTime}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<DateTime?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testDateTime',
+          parameters: _i1.testObjectToJson({'dateTime': dateTime}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<DateTime?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -735,19 +771,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testString',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testString',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testString',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -761,19 +800,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testByteData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testByteData',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.ByteData?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testByteData',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.ByteData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -787,19 +829,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testDuration',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testDuration',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Duration?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testDuration',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Duration?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -813,19 +858,22 @@ class _BasicTypesEndpoint {
         endpoint: 'basicTypes',
         method: 'testUuid',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicTypes',
-        methodName: 'testUuid',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i6.UuidValue?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicTypes',
+          methodName: 'testUuid',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i6.UuidValue?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -847,19 +895,22 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'reset',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'reset',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'reset',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -874,22 +925,25 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'storePublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'storePublicFile',
-        parameters: _i1.testObjectToJson({
-          'path': path,
-          'byteData': byteData,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'storePublicFile',
+          parameters: _i1.testObjectToJson({
+            'path': path,
+            'byteData': byteData,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -903,19 +957,22 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'retrievePublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'retrievePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.ByteData?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'retrievePublicFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.ByteData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -929,19 +986,22 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'existsPublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'existsPublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'existsPublicFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -955,19 +1015,22 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'deletePublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'deletePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'deletePublicFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -981,19 +1044,22 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'getPublicUrlForFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'getPublicUrlForFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'getPublicUrlForFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1007,19 +1073,22 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'getDirectFilePostUrl',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'getDirectFilePostUrl',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'getDirectFilePostUrl',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1033,19 +1102,22 @@ class _CloudStorageEndpoint {
         endpoint: 'cloudStorage',
         method: 'verifyDirectFileUpload',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'cloudStorage',
-        methodName: 'verifyDirectFileUpload',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'cloudStorage',
+          methodName: 'verifyDirectFileUpload',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -1071,22 +1143,25 @@ class _S3CloudStorageEndpoint {
         endpoint: 's3CloudStorage',
         method: 'storePublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 's3CloudStorage',
-        methodName: 'storePublicFile',
-        parameters: _i1.testObjectToJson({
-          'path': path,
-          'byteData': byteData,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 's3CloudStorage',
+          methodName: 'storePublicFile',
+          parameters: _i1.testObjectToJson({
+            'path': path,
+            'byteData': byteData,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1100,19 +1175,22 @@ class _S3CloudStorageEndpoint {
         endpoint: 's3CloudStorage',
         method: 'retrievePublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 's3CloudStorage',
-        methodName: 'retrievePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i5.ByteData?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 's3CloudStorage',
+          methodName: 'retrievePublicFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i5.ByteData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1126,19 +1204,22 @@ class _S3CloudStorageEndpoint {
         endpoint: 's3CloudStorage',
         method: 'existsPublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 's3CloudStorage',
-        methodName: 'existsPublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 's3CloudStorage',
+          methodName: 'existsPublicFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1152,19 +1233,22 @@ class _S3CloudStorageEndpoint {
         endpoint: 's3CloudStorage',
         method: 'deletePublicFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 's3CloudStorage',
-        methodName: 'deletePublicFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 's3CloudStorage',
+          methodName: 'deletePublicFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1178,19 +1262,22 @@ class _S3CloudStorageEndpoint {
         endpoint: 's3CloudStorage',
         method: 'getPublicUrlForFile',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 's3CloudStorage',
-        methodName: 'getPublicUrlForFile',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 's3CloudStorage',
+          methodName: 'getPublicUrlForFile',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1204,19 +1291,22 @@ class _S3CloudStorageEndpoint {
         endpoint: 's3CloudStorage',
         method: 'getDirectFilePostUrl',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 's3CloudStorage',
-        methodName: 'getDirectFilePostUrl',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 's3CloudStorage',
+          methodName: 'getDirectFilePostUrl',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1230,19 +1320,22 @@ class _S3CloudStorageEndpoint {
         endpoint: 's3CloudStorage',
         method: 'verifyDirectFileUpload',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 's3CloudStorage',
-        methodName: 'verifyDirectFileUpload',
-        parameters: _i1.testObjectToJson({'path': path}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 's3CloudStorage',
+          methodName: 'verifyDirectFileUpload',
+          parameters: _i1.testObjectToJson({'path': path}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -1265,19 +1358,22 @@ class _CustomClassProtocolEndpoint {
         endpoint: 'customClassProtocol',
         method: 'getProtocolField',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customClassProtocol',
-        methodName: 'getProtocolField',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i7.ProtocolCustomClass>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customClassProtocol',
+          methodName: 'getProtocolField',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i7.ProtocolCustomClass>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -1302,19 +1398,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnCustomClass',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnCustomClass',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i8.CustomClass>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnCustomClass',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i8.CustomClass>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1328,19 +1427,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnCustomClassNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnCustomClassNullable',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i8.CustomClass?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnCustomClassNullable',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i8.CustomClass?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1354,19 +1456,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnCustomClass2',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnCustomClass2',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i8.CustomClass2>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnCustomClass2',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i8.CustomClass2>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1380,19 +1485,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnCustomClass2Nullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnCustomClass2Nullable',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i8.CustomClass2?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnCustomClass2Nullable',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i8.CustomClass2?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1406,19 +1514,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnExternalCustomClass',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnExternalCustomClass',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i9.ExternalCustomClass>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnExternalCustomClass',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i9.ExternalCustomClass>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1432,19 +1543,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnExternalCustomClassNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnExternalCustomClassNullable',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i9.ExternalCustomClass?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnExternalCustomClassNullable',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i9.ExternalCustomClass?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1458,19 +1572,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnFreezedCustomClass',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnFreezedCustomClass',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i10.FreezedCustomClass>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnFreezedCustomClass',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i10.FreezedCustomClass>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1484,19 +1601,22 @@ class _CustomTypesEndpoint {
         endpoint: 'customTypes',
         method: 'returnFreezedCustomClassNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'customTypes',
-        methodName: 'returnFreezedCustomClassNullable',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i10.FreezedCustomClass?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'customTypes',
+          methodName: 'returnFreezedCustomClassNullable',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i10.FreezedCustomClass?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -1519,19 +1639,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'deleteAllSimpleTestData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'deleteAllSimpleTestData',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'deleteAllSimpleTestData',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1545,19 +1668,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'deleteSimpleTestDataLessThan',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'deleteSimpleTestDataLessThan',
-        parameters: _i1.testObjectToJson({'num': num}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'deleteSimpleTestDataLessThan',
+          parameters: _i1.testObjectToJson({'num': num}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1571,19 +1697,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'findAndDeleteSimpleTestData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'findAndDeleteSimpleTestData',
-        parameters: _i1.testObjectToJson({'num': num}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'findAndDeleteSimpleTestData',
+          parameters: _i1.testObjectToJson({'num': num}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1597,19 +1726,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'createSimpleTestData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'createSimpleTestData',
-        parameters: _i1.testObjectToJson({'numRows': numRows}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'createSimpleTestData',
+          parameters: _i1.testObjectToJson({'numRows': numRows}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1624,22 +1756,25 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'findSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'findSimpleData',
-        parameters: _i1.testObjectToJson({
-          'limit': limit,
-          'offset': offset,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i11.SimpleData>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'findSimpleData',
+          parameters: _i1.testObjectToJson({
+            'limit': limit,
+            'offset': offset,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i11.SimpleData>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1653,19 +1788,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'findFirstRowSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'findFirstRowSimpleData',
-        parameters: _i1.testObjectToJson({'num': num}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i11.SimpleData?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'findFirstRowSimpleData',
+          parameters: _i1.testObjectToJson({'num': num}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1679,19 +1817,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'findByIdSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'findByIdSimpleData',
-        parameters: _i1.testObjectToJson({'id': id}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i11.SimpleData?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'findByIdSimpleData',
+          parameters: _i1.testObjectToJson({'id': id}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1708,24 +1849,27 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'findSimpleDataRowsLessThan',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'findSimpleDataRowsLessThan',
-        parameters: _i1.testObjectToJson({
-          'num': num,
-          'offset': offset,
-          'limit': limit,
-          'descending': descending,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i12.SimpleDataList?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'findSimpleDataRowsLessThan',
+          parameters: _i1.testObjectToJson({
+            'num': num,
+            'offset': offset,
+            'limit': limit,
+            'descending': descending,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i12.SimpleDataList?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1739,19 +1883,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'insertRowSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'insertRowSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i11.SimpleData>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'insertRowSimpleData',
+          parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1765,19 +1912,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'updateRowSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'updateRowSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i11.SimpleData>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'updateRowSimpleData',
+          parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1791,19 +1941,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'deleteRowSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'deleteRowSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'deleteRowSimpleData',
+          parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1815,19 +1968,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'deleteWhereSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'deleteWhereSimpleData',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<int>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'deleteWhereSimpleData',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<int>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1838,19 +1994,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'countSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'countSimpleData',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'countSimpleData',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1864,19 +2023,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'insertTypes',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'insertTypes',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i13.Types>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'insertTypes',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i13.Types>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1890,19 +2052,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'updateTypes',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'updateTypes',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i13.Types>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'updateTypes',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i13.Types>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1913,19 +2078,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'countTypesRows',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'countTypesRows',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'countTypesRows',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1937,19 +2105,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'deleteAllInTypes',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'deleteAllInTypes',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<int>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'deleteAllInTypes',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<int>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1963,19 +2134,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'getTypes',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'getTypes',
-        parameters: _i1.testObjectToJson({'id': id}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i13.Types?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'getTypes',
+          parameters: _i1.testObjectToJson({'id': id}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i13.Types?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -1989,19 +2163,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'getTypesRawQuery',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'getTypesRawQuery',
-        parameters: _i1.testObjectToJson({'id': id}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'getTypesRawQuery',
+          parameters: _i1.testObjectToJson({'id': id}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2015,19 +2192,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'storeObjectWithEnum',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'storeObjectWithEnum',
-        parameters: _i1.testObjectToJson({'object': object}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i14.ObjectWithEnum>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'storeObjectWithEnum',
+          parameters: _i1.testObjectToJson({'object': object}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i14.ObjectWithEnum>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2041,19 +2221,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'getObjectWithEnum',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'getObjectWithEnum',
-        parameters: _i1.testObjectToJson({'id': id}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i14.ObjectWithEnum?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'getObjectWithEnum',
+          parameters: _i1.testObjectToJson({'id': id}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i14.ObjectWithEnum?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2067,19 +2250,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'storeObjectWithObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'storeObjectWithObject',
-        parameters: _i1.testObjectToJson({'object': object}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i15.ObjectWithObject>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'storeObjectWithObject',
+          parameters: _i1.testObjectToJson({'object': object}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i15.ObjectWithObject>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2093,19 +2279,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'getObjectWithObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'getObjectWithObject',
-        parameters: _i1.testObjectToJson({'id': id}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i15.ObjectWithObject?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'getObjectWithObject',
+          parameters: _i1.testObjectToJson({'id': id}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i15.ObjectWithObject?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2116,19 +2305,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'deleteAll',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'deleteAll',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'deleteAll',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2140,19 +2332,22 @@ class _BasicDatabase {
         endpoint: 'basicDatabase',
         method: 'testByteDataStore',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'basicDatabase',
-        methodName: 'testByteDataStore',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'basicDatabase',
+          methodName: 'testByteDataStore',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2177,19 +2372,22 @@ class _TransactionsDatabaseEndpoint {
         endpoint: 'transactionsDatabase',
         method: 'removeRow',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'transactionsDatabase',
-        methodName: 'removeRow',
-        parameters: _i1.testObjectToJson({'num': num}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'transactionsDatabase',
+          methodName: 'removeRow',
+          parameters: _i1.testObjectToJson({'num': num}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2205,23 +2403,26 @@ class _TransactionsDatabaseEndpoint {
         endpoint: 'transactionsDatabase',
         method: 'updateInsertDelete',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'transactionsDatabase',
-        methodName: 'updateInsertDelete',
-        parameters: _i1.testObjectToJson({
-          'numUpdate': numUpdate,
-          'numInsert': numInsert,
-          'numDelete': numDelete,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'transactionsDatabase',
+          methodName: 'updateInsertDelete',
+          parameters: _i1.testObjectToJson({
+            'numUpdate': numUpdate,
+            'numInsert': numInsert,
+            'numDelete': numDelete,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2246,19 +2447,22 @@ class _DeprecationEndpoint {
         endpoint: 'deprecation',
         method: 'setGlobalDouble',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'deprecation',
-        methodName: 'setGlobalDouble',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'deprecation',
+          methodName: 'setGlobalDouble',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2270,19 +2474,22 @@ class _DeprecationEndpoint {
         endpoint: 'deprecation',
         method: 'getGlobalDouble',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'deprecation',
-        methodName: 'getGlobalDouble',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<double>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'deprecation',
+          methodName: 'getGlobalDouble',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<double>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2305,19 +2512,22 @@ class _EchoRequestEndpoint {
         endpoint: 'echoRequest',
         method: 'echoAuthenticationKey',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'echoRequest',
-        methodName: 'echoAuthenticationKey',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'echoRequest',
+          methodName: 'echoAuthenticationKey',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2331,19 +2541,22 @@ class _EchoRequestEndpoint {
         endpoint: 'echoRequest',
         method: 'echoHttpHeader',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'echoRequest',
-        methodName: 'echoHttpHeader',
-        parameters: _i1.testObjectToJson({'headerName': headerName}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<String>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'echoRequest',
+          methodName: 'echoHttpHeader',
+          parameters: _i1.testObjectToJson({'headerName': headerName}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<String>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2369,22 +2582,25 @@ class _EmailAuthTestMethods {
         endpoint: 'emailAuthTestMethods',
         method: 'findVerificationCode',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'emailAuthTestMethods',
-        methodName: 'findVerificationCode',
-        parameters: _i1.testObjectToJson({
-          'userName': userName,
-          'email': email,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'emailAuthTestMethods',
+          methodName: 'findVerificationCode',
+          parameters: _i1.testObjectToJson({
+            'userName': userName,
+            'email': email,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2398,19 +2614,22 @@ class _EmailAuthTestMethods {
         endpoint: 'emailAuthTestMethods',
         method: 'findResetCode',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'emailAuthTestMethods',
-        methodName: 'findResetCode',
-        parameters: _i1.testObjectToJson({'email': email}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'emailAuthTestMethods',
+          methodName: 'findResetCode',
+          parameters: _i1.testObjectToJson({'email': email}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2421,19 +2640,22 @@ class _EmailAuthTestMethods {
         endpoint: 'emailAuthTestMethods',
         method: 'tearDown',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'emailAuthTestMethods',
-        methodName: 'tearDown',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'emailAuthTestMethods',
+          methodName: 'tearDown',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2449,23 +2671,26 @@ class _EmailAuthTestMethods {
         endpoint: 'emailAuthTestMethods',
         method: 'createUser',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'emailAuthTestMethods',
-        methodName: 'createUser',
-        parameters: _i1.testObjectToJson({
-          'userName': userName,
-          'email': email,
-          'password': password,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'emailAuthTestMethods',
+          methodName: 'createUser',
+          parameters: _i1.testObjectToJson({
+            'userName': userName,
+            'email': email,
+            'password': password,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2488,19 +2713,22 @@ class _ExceptionTestEndpoint {
         endpoint: 'exceptionTest',
         method: 'throwNormalException',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'exceptionTest',
-        methodName: 'throwNormalException',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'exceptionTest',
+          methodName: 'throwNormalException',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2512,19 +2740,22 @@ class _ExceptionTestEndpoint {
         endpoint: 'exceptionTest',
         method: 'throwExceptionWithData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'exceptionTest',
-        methodName: 'throwExceptionWithData',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'exceptionTest',
+          methodName: 'throwExceptionWithData',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2536,19 +2767,22 @@ class _ExceptionTestEndpoint {
         endpoint: 'exceptionTest',
         method: 'workingWithoutException',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'exceptionTest',
-        methodName: 'workingWithoutException',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'exceptionTest',
+          methodName: 'workingWithoutException',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2570,19 +2804,22 @@ class _FailedCallsEndpoint {
         endpoint: 'failedCalls',
         method: 'failedCall',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'failedCalls',
-        methodName: 'failedCall',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'failedCalls',
+          methodName: 'failedCall',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2594,19 +2831,22 @@ class _FailedCallsEndpoint {
         endpoint: 'failedCalls',
         method: 'failedDatabaseQuery',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'failedCalls',
-        methodName: 'failedDatabaseQuery',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'failedCalls',
+          methodName: 'failedDatabaseQuery',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2618,19 +2858,22 @@ class _FailedCallsEndpoint {
         endpoint: 'failedCalls',
         method: 'failedDatabaseQueryCaughtException',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'failedCalls',
-        methodName: 'failedDatabaseQueryCaughtException',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'failedCalls',
+          methodName: 'failedDatabaseQueryCaughtException',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2641,19 +2884,22 @@ class _FailedCallsEndpoint {
         endpoint: 'failedCalls',
         method: 'slowCall',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'failedCalls',
-        methodName: 'slowCall',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'failedCalls',
+          methodName: 'slowCall',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2665,19 +2911,22 @@ class _FailedCallsEndpoint {
         endpoint: 'failedCalls',
         method: 'caughtException',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'failedCalls',
-        methodName: 'caughtException',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'failedCalls',
+          methodName: 'caughtException',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2702,19 +2951,22 @@ class _FieldScopesEndpoint {
         endpoint: 'fieldScopes',
         method: 'storeObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'fieldScopes',
-        methodName: 'storeObject',
-        parameters: _i1.testObjectToJson({'object': object}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'fieldScopes',
+          methodName: 'storeObject',
+          parameters: _i1.testObjectToJson({'object': object}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2726,19 +2978,22 @@ class _FieldScopesEndpoint {
         endpoint: 'fieldScopes',
         method: 'retrieveObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'fieldScopes',
-        methodName: 'retrieveObject',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i16.ObjectFieldScopes?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'fieldScopes',
+          methodName: 'retrieveObject',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i16.ObjectFieldScopes?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2763,19 +3018,22 @@ class _FutureCallsEndpoint {
         endpoint: 'futureCalls',
         method: 'makeFutureCall',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'futureCalls',
-        methodName: 'makeFutureCall',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'futureCalls',
+          methodName: 'makeFutureCall',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -2800,19 +3058,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnIntList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnIntList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<int>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnIntList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<int>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2826,19 +3087,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnIntListList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnIntListList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<List<int>>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnIntListList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<List<int>>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2852,19 +3116,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnIntListNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnIntListNullable',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<int>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnIntListNullable',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<int>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2878,19 +3145,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnIntListNullableList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnIntListNullableList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<List<int>?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnIntListNullableList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<List<int>?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2904,19 +3174,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnIntListListNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnIntListListNullable',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<List<int>>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnIntListListNullable',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<List<int>>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2930,19 +3203,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnIntListNullableInts',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnIntListNullableInts',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<int?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnIntListNullableInts',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<int?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2956,19 +3232,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnNullableIntListNullableInts',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnNullableIntListNullableInts',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<int?>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnNullableIntListNullableInts',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<int?>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -2982,19 +3261,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnDoubleList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnDoubleList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<double>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnDoubleList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<double>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3008,19 +3290,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnDoubleListNullableDoubles',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnDoubleListNullableDoubles',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<double?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnDoubleListNullableDoubles',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<double?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3034,19 +3319,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnBoolList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnBoolList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<bool>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnBoolList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<bool>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3060,19 +3348,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnBoolListNullableBools',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnBoolListNullableBools',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<bool?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnBoolListNullableBools',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<bool?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3086,19 +3377,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnStringList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnStringList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<String>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnStringList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<String>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3112,19 +3406,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnStringListNullableStrings',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnStringListNullableStrings',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<String?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnStringListNullableStrings',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<String?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3138,19 +3435,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnDateTimeList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnDateTimeList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<DateTime>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnDateTimeList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<DateTime>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3164,19 +3464,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnDateTimeListNullableDateTimes',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnDateTimeListNullableDateTimes',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<DateTime?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnDateTimeListNullableDateTimes',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<DateTime?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3190,19 +3493,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnByteDataList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnByteDataList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i5.ByteData>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnByteDataList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i5.ByteData>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3216,19 +3522,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnByteDataListNullableByteDatas',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnByteDataListNullableByteDatas',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i5.ByteData?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnByteDataListNullableByteDatas',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i5.ByteData?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3242,19 +3551,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnSimpleDataList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnSimpleDataList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i11.SimpleData>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnSimpleDataList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i11.SimpleData>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3268,19 +3580,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnSimpleDataListNullableSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnSimpleDataListNullableSimpleData',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i11.SimpleData?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnSimpleDataListNullableSimpleData',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i11.SimpleData?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3294,19 +3609,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnSimpleDataListNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnSimpleDataListNullable',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i11.SimpleData>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnSimpleDataListNullable',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i11.SimpleData>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3321,19 +3639,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnNullableSimpleDataListNullableSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnNullableSimpleDataListNullableSimpleData',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i11.SimpleData?>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnNullableSimpleDataListNullableSimpleData',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i11.SimpleData?>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3347,19 +3668,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnDurationList',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnDurationList',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<Duration>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnDurationList',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<Duration>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3373,19 +3697,22 @@ class _ListParametersEndpoint {
         endpoint: 'listParameters',
         method: 'returnDurationListNullableDurations',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'listParameters',
-        methodName: 'returnDurationListNullableDurations',
-        parameters: _i1.testObjectToJson({'list': list}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<Duration?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'listParameters',
+          methodName: 'returnDurationListNullableDurations',
+          parameters: _i1.testObjectToJson({'list': list}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<Duration?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -3410,19 +3737,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'slowQueryMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'slowQueryMethod',
-        parameters: _i1.testObjectToJson({'seconds': seconds}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'slowQueryMethod',
+          parameters: _i1.testObjectToJson({'seconds': seconds}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3436,19 +3766,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'queryMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'queryMethod',
-        parameters: _i1.testObjectToJson({'queries': queries}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'queryMethod',
+          parameters: _i1.testObjectToJson({'queries': queries}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3460,19 +3793,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'failedQueryMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'failedQueryMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'failedQueryMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3486,19 +3822,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'slowMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'slowMethod',
-        parameters: _i1.testObjectToJson({'delayMillis': delayMillis}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'slowMethod',
+          parameters: _i1.testObjectToJson({'delayMillis': delayMillis}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3509,19 +3848,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'failingMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'failingMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'failingMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3532,19 +3874,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'emptyMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'emptyMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'emptyMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3559,22 +3904,25 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'log',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'log',
-        parameters: _i1.testObjectToJson({
-          'message': message,
-          'logLevels': logLevels,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'log',
+          parameters: _i1.testObjectToJson({
+            'message': message,
+            'logLevels': logLevels,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3588,19 +3936,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'logInfo',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'logInfo',
-        parameters: _i1.testObjectToJson({'message': message}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'logInfo',
+          parameters: _i1.testObjectToJson({'message': message}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3616,23 +3967,26 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'logDebugAndInfoAndError',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'logDebugAndInfoAndError',
-        parameters: _i1.testObjectToJson({
-          'debug': debug,
-          'info': info,
-          'error': error,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'logDebugAndInfoAndError',
+          parameters: _i1.testObjectToJson({
+            'debug': debug,
+            'info': info,
+            'error': error,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3643,19 +3997,22 @@ class _LoggingEndpoint {
         endpoint: 'logging',
         method: 'twoQueries',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'logging',
-        methodName: 'twoQueries',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'logging',
+          methodName: 'twoQueries',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3819,19 +4176,22 @@ class _LoggingDisabledEndpoint {
         endpoint: 'loggingDisabled',
         method: 'logInfo',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'loggingDisabled',
-        methodName: 'logInfo',
-        parameters: _i1.testObjectToJson({'message': message}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'loggingDisabled',
+          methodName: 'logInfo',
+          parameters: _i1.testObjectToJson({'message': message}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -3856,19 +4216,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnIntMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, int>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnIntMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, int>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3882,19 +4245,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnIntMapNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnIntMapNullable',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, int>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnIntMapNullable',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, int>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3908,19 +4274,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnNestedIntMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnNestedIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, Map<String, int>>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnNestedIntMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, Map<String, int>>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3934,19 +4303,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnIntMapNullableInts',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnIntMapNullableInts',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, int?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnIntMapNullableInts',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, int?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3960,19 +4332,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnNullableIntMapNullableInts',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnNullableIntMapNullableInts',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, int?>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnNullableIntMapNullableInts',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, int?>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -3986,19 +4361,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnIntIntMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnIntIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<int, int>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnIntIntMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<int, int>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4012,19 +4390,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnEnumIntMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnEnumIntMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<_i17.TestEnum, int>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnEnumIntMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<_i17.TestEnum, int>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4038,19 +4419,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnEnumMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnEnumMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, _i17.TestEnum>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnEnumMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, _i17.TestEnum>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4064,19 +4448,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnDoubleMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnDoubleMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, double>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnDoubleMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, double>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4090,19 +4477,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnDoubleMapNullableDoubles',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnDoubleMapNullableDoubles',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, double?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnDoubleMapNullableDoubles',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, double?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4116,19 +4506,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnBoolMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnBoolMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, bool>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnBoolMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, bool>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4142,19 +4535,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnBoolMapNullableBools',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnBoolMapNullableBools',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, bool?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnBoolMapNullableBools',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, bool?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4168,19 +4564,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnStringMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnStringMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, String>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnStringMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, String>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4194,19 +4593,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnStringMapNullableStrings',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnStringMapNullableStrings',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, String?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnStringMapNullableStrings',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, String?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4220,19 +4622,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnDateTimeMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnDateTimeMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, DateTime>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnDateTimeMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, DateTime>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4246,19 +4651,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnDateTimeMapNullableDateTimes',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnDateTimeMapNullableDateTimes',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, DateTime?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnDateTimeMapNullableDateTimes',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, DateTime?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4272,19 +4680,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnByteDataMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnByteDataMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, _i5.ByteData>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnByteDataMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, _i5.ByteData>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4298,19 +4709,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnByteDataMapNullableByteDatas',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnByteDataMapNullableByteDatas',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, _i5.ByteData?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnByteDataMapNullableByteDatas',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, _i5.ByteData?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4324,19 +4738,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnSimpleDataMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnSimpleDataMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, _i11.SimpleData>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnSimpleDataMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, _i11.SimpleData>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4351,19 +4768,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnSimpleDataMapNullableSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnSimpleDataMapNullableSimpleData',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, _i11.SimpleData?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnSimpleDataMapNullableSimpleData',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, _i11.SimpleData?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4377,19 +4797,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnSimpleDataMapNullable',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnSimpleDataMapNullable',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, _i11.SimpleData>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnSimpleDataMapNullable',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, _i11.SimpleData>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4404,19 +4827,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnNullableSimpleDataMapNullableSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnNullableSimpleDataMapNullableSimpleData',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, _i11.SimpleData?>?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnNullableSimpleDataMapNullableSimpleData',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, _i11.SimpleData?>?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4430,19 +4856,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnDurationMap',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnDurationMap',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, Duration>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnDurationMap',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, Duration>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4456,19 +4885,22 @@ class _MapParametersEndpoint {
         endpoint: 'mapParameters',
         method: 'returnDurationMapNullableDurations',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'mapParameters',
-        methodName: 'returnDurationMapNullableDurations',
-        parameters: _i1.testObjectToJson({'map': map}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<Map<String, Duration?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'mapParameters',
+          methodName: 'returnDurationMapNullableDurations',
+          parameters: _i1.testObjectToJson({'map': map}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<Map<String, Duration?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -4493,19 +4925,22 @@ class _MethodSignaturePermutationsEndpoint {
         endpoint: 'methodSignaturePermutations',
         method: 'echoPositionalArg',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodSignaturePermutations',
-        methodName: 'echoPositionalArg',
-        parameters: _i1.testObjectToJson({'string': string}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodSignaturePermutations',
+          methodName: 'echoPositionalArg',
+          parameters: _i1.testObjectToJson({'string': string}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4519,19 +4954,22 @@ class _MethodSignaturePermutationsEndpoint {
         endpoint: 'methodSignaturePermutations',
         method: 'echoNamedArg',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodSignaturePermutations',
-        methodName: 'echoNamedArg',
-        parameters: _i1.testObjectToJson({'string': string}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodSignaturePermutations',
+          methodName: 'echoNamedArg',
+          parameters: _i1.testObjectToJson({'string': string}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4545,19 +4983,22 @@ class _MethodSignaturePermutationsEndpoint {
         endpoint: 'methodSignaturePermutations',
         method: 'echoNullableNamedArg',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodSignaturePermutations',
-        methodName: 'echoNullableNamedArg',
-        parameters: _i1.testObjectToJson({'string': string}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodSignaturePermutations',
+          methodName: 'echoNullableNamedArg',
+          parameters: _i1.testObjectToJson({'string': string}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4571,19 +5012,22 @@ class _MethodSignaturePermutationsEndpoint {
         endpoint: 'methodSignaturePermutations',
         method: 'echoOptionalArg',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodSignaturePermutations',
-        methodName: 'echoOptionalArg',
-        parameters: _i1.testObjectToJson({'string': string}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodSignaturePermutations',
+          methodName: 'echoOptionalArg',
+          parameters: _i1.testObjectToJson({'string': string}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4598,22 +5042,25 @@ class _MethodSignaturePermutationsEndpoint {
         endpoint: 'methodSignaturePermutations',
         method: 'echoPositionalAndNamedArgs',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodSignaturePermutations',
-        methodName: 'echoPositionalAndNamedArgs',
-        parameters: _i1.testObjectToJson({
-          'string1': string1,
-          'string2': string2,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<String?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodSignaturePermutations',
+          methodName: 'echoPositionalAndNamedArgs',
+          parameters: _i1.testObjectToJson({
+            'string1': string1,
+            'string2': string2,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<String?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4628,22 +5075,25 @@ class _MethodSignaturePermutationsEndpoint {
         endpoint: 'methodSignaturePermutations',
         method: 'echoPositionalAndNullableNamedArgs',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodSignaturePermutations',
-        methodName: 'echoPositionalAndNullableNamedArgs',
-        parameters: _i1.testObjectToJson({
-          'string1': string1,
-          'string2': string2,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<String?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodSignaturePermutations',
+          methodName: 'echoPositionalAndNullableNamedArgs',
+          parameters: _i1.testObjectToJson({
+            'string1': string1,
+            'string2': string2,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<String?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4658,22 +5108,25 @@ class _MethodSignaturePermutationsEndpoint {
         endpoint: 'methodSignaturePermutations',
         method: 'echoPositionalAndOptionalArgs',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodSignaturePermutations',
-        methodName: 'echoPositionalAndOptionalArgs',
-        parameters: _i1.testObjectToJson({
-          'string1': string1,
-          'string2': string2,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<String?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodSignaturePermutations',
+          methodName: 'echoPositionalAndOptionalArgs',
+          parameters: _i1.testObjectToJson({
+            'string1': string1,
+            'string2': string2,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<String?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4881,19 +5334,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'methodCallEndpoint',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'methodCallEndpoint',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'methodCallEndpoint',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -4994,19 +5450,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'wasBroadcastStreamCanceled',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'wasBroadcastStreamCanceled',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'wasBroadcastStreamCanceled',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -5018,19 +5477,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'wasSessionWillCloseListenerCalled',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'wasSessionWillCloseListenerCalled',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'wasSessionWillCloseListenerCalled',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -5424,19 +5886,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'simpleEndpoint',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'simpleEndpoint',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'simpleEndpoint',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -5450,19 +5915,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'intParameter',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'intParameter',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'intParameter',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -5476,19 +5944,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'doubleInputValue',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'doubleInputValue',
-        parameters: _i1.testObjectToJson({'value': value}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'doubleInputValue',
+          parameters: _i1.testObjectToJson({'value': value}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -5502,19 +5973,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'delayedResponse',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'delayedResponse',
-        parameters: _i1.testObjectToJson({'delay': delay}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'delayedResponse',
+          parameters: _i1.testObjectToJson({'delay': delay}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -5620,19 +6094,22 @@ class _MethodStreaming {
         endpoint: 'methodStreaming',
         method: 'completeAllDelayedResponses',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'methodStreaming',
-        methodName: 'completeAllDelayedResponses',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'methodStreaming',
+          methodName: 'completeAllDelayedResponses',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6146,19 +6623,22 @@ class _ModuleSerializationEndpoint {
         endpoint: 'moduleSerialization',
         method: 'serializeModuleObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'moduleSerialization',
-        methodName: 'serializeModuleObject',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'moduleSerialization',
+          methodName: 'serializeModuleObject',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6172,19 +6652,22 @@ class _ModuleSerializationEndpoint {
         endpoint: 'moduleSerialization',
         method: 'modifyModuleObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'moduleSerialization',
-        methodName: 'modifyModuleObject',
-        parameters: _i1.testObjectToJson({'object': object}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i18.ModuleClass>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'moduleSerialization',
+          methodName: 'modifyModuleObject',
+          parameters: _i1.testObjectToJson({'object': object}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i18.ModuleClass>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6196,19 +6679,22 @@ class _ModuleSerializationEndpoint {
         endpoint: 'moduleSerialization',
         method: 'serializeNestedModuleObject',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'moduleSerialization',
-        methodName: 'serializeNestedModuleObject',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i19.ModuleDatatype>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'moduleSerialization',
+          methodName: 'serializeNestedModuleObject',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i19.ModuleDatatype>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6236,24 +6722,27 @@ class _NamedParametersEndpoint {
         endpoint: 'namedParameters',
         method: 'namedParametersMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'namedParameters',
-        methodName: 'namedParametersMethod',
-        parameters: _i1.testObjectToJson({
-          'namedInt': namedInt,
-          'intWithDefaultValue': intWithDefaultValue,
-          'nullableInt': nullableInt,
-          'nullableIntWithDefaultValue': nullableIntWithDefaultValue,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'namedParameters',
+          methodName: 'namedParametersMethod',
+          parameters: _i1.testObjectToJson({
+            'namedInt': namedInt,
+            'intWithDefaultValue': intWithDefaultValue,
+            'nullableInt': nullableInt,
+            'nullableIntWithDefaultValue': nullableIntWithDefaultValue,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6268,22 +6757,25 @@ class _NamedParametersEndpoint {
         endpoint: 'namedParameters',
         method: 'namedParametersMethodEqualInts',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'namedParameters',
-        methodName: 'namedParametersMethodEqualInts',
-        parameters: _i1.testObjectToJson({
-          'namedInt': namedInt,
-          'nullableInt': nullableInt,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'namedParameters',
+          methodName: 'namedParametersMethodEqualInts',
+          parameters: _i1.testObjectToJson({
+            'namedInt': namedInt,
+            'nullableInt': nullableInt,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6308,19 +6800,22 @@ class _OptionalParametersEndpoint {
         endpoint: 'optionalParameters',
         method: 'returnOptionalInt',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'optionalParameters',
-        methodName: 'returnOptionalInt',
-        parameters: _i1.testObjectToJson({'optionalInt': optionalInt}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'optionalParameters',
+          methodName: 'returnOptionalInt',
+          parameters: _i1.testObjectToJson({'optionalInt': optionalInt}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6346,22 +6841,25 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'setSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'setSimpleData',
-        parameters: _i1.testObjectToJson({
-          'key': key,
-          'data': data,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'setSimpleData',
+          parameters: _i1.testObjectToJson({
+            'key': key,
+            'data': data,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6376,22 +6874,25 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'setSimpleDataWithLifetime',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'setSimpleDataWithLifetime',
-        parameters: _i1.testObjectToJson({
-          'key': key,
-          'data': data,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'setSimpleDataWithLifetime',
+          parameters: _i1.testObjectToJson({
+            'key': key,
+            'data': data,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6405,19 +6906,22 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'getSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'getSimpleData',
-        parameters: _i1.testObjectToJson({'key': key}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i11.SimpleData?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'getSimpleData',
+          parameters: _i1.testObjectToJson({'key': key}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6431,19 +6935,22 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'deleteSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'deleteSimpleData',
-        parameters: _i1.testObjectToJson({'key': key}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'deleteSimpleData',
+          parameters: _i1.testObjectToJson({'key': key}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6455,19 +6962,22 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'resetMessageCentralTest',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'resetMessageCentralTest',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'resetMessageCentralTest',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6481,19 +6991,22 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'listenToChannel',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'listenToChannel',
-        parameters: _i1.testObjectToJson({'channel': channel}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i11.SimpleData?>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'listenToChannel',
+          parameters: _i1.testObjectToJson({'channel': channel}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData?>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6508,22 +7021,25 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'postToChannel',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'postToChannel',
-        parameters: _i1.testObjectToJson({
-          'channel': channel,
-          'data': data,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'postToChannel',
+          parameters: _i1.testObjectToJson({
+            'channel': channel,
+            'data': data,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6535,19 +7051,22 @@ class _RedisEndpoint {
         endpoint: 'redis',
         method: 'countSubscribedChannels',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'redis',
-        methodName: 'countSubscribedChannels',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'redis',
+          methodName: 'countSubscribedChannels',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6570,19 +7089,22 @@ class _ServerOnlyScopedFieldModelEndpoint {
         endpoint: 'serverOnlyScopedFieldModel',
         method: 'getScopeServerOnlyField',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'serverOnlyScopedFieldModel',
-        methodName: 'getScopeServerOnlyField',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i20.ScopeServerOnlyField>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'serverOnlyScopedFieldModel',
+          methodName: 'getScopeServerOnlyField',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i20.ScopeServerOnlyField>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6605,19 +7127,22 @@ class _ServerOnlyScopedFieldChildModelEndpoint {
         endpoint: 'serverOnlyScopedFieldChildModel',
         method: 'getProtocolField',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'serverOnlyScopedFieldChildModel',
-        methodName: 'getProtocolField',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i21.ScopeServerOnlyFieldChild>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'serverOnlyScopedFieldChildModel',
+          methodName: 'getProtocolField',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i21.ScopeServerOnlyFieldChild>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6639,19 +7164,22 @@ class _SignInRequiredEndpoint {
         endpoint: 'signInRequired',
         method: 'testMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'signInRequired',
-        methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'signInRequired',
+          methodName: 'testMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6673,19 +7201,22 @@ class _AdminScopeRequiredEndpoint {
         endpoint: 'adminScopeRequired',
         method: 'testMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'adminScopeRequired',
-        methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<bool>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'adminScopeRequired',
+          methodName: 'testMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<bool>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6711,22 +7242,25 @@ class _SimpleEndpoint {
         endpoint: 'simple',
         method: 'setGlobalInt',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'simple',
-        methodName: 'setGlobalInt',
-        parameters: _i1.testObjectToJson({
-          'value': value,
-          'secondValue': secondValue,
-        }),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'simple',
+          methodName: 'setGlobalInt',
+          parameters: _i1.testObjectToJson({
+            'value': value,
+            'secondValue': secondValue,
+          }),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6737,19 +7271,22 @@ class _SimpleEndpoint {
         endpoint: 'simple',
         method: 'addToGlobalInt',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'simple',
-        methodName: 'addToGlobalInt',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'simple',
+          methodName: 'addToGlobalInt',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6760,19 +7297,22 @@ class _SimpleEndpoint {
         endpoint: 'simple',
         method: 'getGlobalInt',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'simple',
-        methodName: 'getGlobalInt',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<int>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'simple',
+          methodName: 'getGlobalInt',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<int>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6786,19 +7326,22 @@ class _SimpleEndpoint {
         endpoint: 'simple',
         method: 'hello',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'simple',
-        methodName: 'hello',
-        parameters: _i1.testObjectToJson({'name': name}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'simple',
+          methodName: 'hello',
+          parameters: _i1.testObjectToJson({'name': name}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6834,19 +7377,22 @@ class _SubSubDirTestEndpoint {
         endpoint: 'subSubDirTest',
         method: 'testMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'subSubDirTest',
-        methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'subSubDirTest',
+          methodName: 'testMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6868,19 +7414,22 @@ class _SubDirTestEndpoint {
         endpoint: 'subDirTest',
         method: 'testMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'subDirTest',
-        methodName: 'testMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'subDirTest',
+          methodName: 'testMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 }
@@ -6903,19 +7452,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'returnsSessionId',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'returnsSessionId',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i6.UuidValue>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'returnsSessionId',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i6.UuidValue>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -6927,19 +7479,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'returnsSessionEndpointAndMethod',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'returnsSessionEndpointAndMethod',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<String?>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'returnsSessionEndpointAndMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<String?>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7013,19 +7568,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'returnsString',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'returnsString',
-        parameters: _i1.testObjectToJson({'string': string}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'returnsString',
+          parameters: _i1.testObjectToJson({'string': string}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7196,19 +7754,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'postNumberToSharedStream',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'postNumberToSharedStream',
-        parameters: _i1.testObjectToJson({'number': number}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'postNumberToSharedStream',
+          parameters: _i1.testObjectToJson({'number': number}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7284,19 +7845,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'createSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'createSimpleData',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'createSimpleData',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7308,19 +7872,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'getAllSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'getAllSimpleData',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i11.SimpleData>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'getAllSimpleData',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i11.SimpleData>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7334,19 +7901,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'createSimpleDatasInsideTransactions',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'createSimpleDatasInsideTransactions',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'createSimpleDatasInsideTransactions',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7360,19 +7930,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'createSimpleDataAndThrowInsideTransaction',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'createSimpleDataAndThrowInsideTransaction',
-        parameters: _i1.testObjectToJson({'data': data}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'createSimpleDataAndThrowInsideTransaction',
+          parameters: _i1.testObjectToJson({'data': data}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7384,19 +7957,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'createSimpleDatasInParallelTransactionCalls',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'createSimpleDatasInParallelTransactionCalls',
-        parameters: _i1.testObjectToJson({}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<void>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'createSimpleDatasInParallelTransactionCalls',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7410,19 +7986,22 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'echoSimpleData',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'echoSimpleData',
-        parameters: _i1.testObjectToJson({'simpleData': simpleData}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<_i11.SimpleData>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'echoSimpleData',
+          parameters: _i1.testObjectToJson({'simpleData': simpleData}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<_i11.SimpleData>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 
@@ -7436,20 +8015,107 @@ class _TestToolsEndpoint {
         endpoint: 'testTools',
         method: 'echoSimpleDatas',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'testTools',
-        methodName: 'echoSimpleDatas',
-        parameters: _i1.testObjectToJson({'simpleDatas': simpleDatas}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<List<_i11.SimpleData>>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'echoSimpleDatas',
+          parameters: _i1.testObjectToJson({'simpleDatas': simpleDatas}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<List<_i11.SimpleData>>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
+  }
+
+  _i3.Future<void> logMessageWithSession(
+      _i1.TestSessionBuilder sessionBuilder) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'logMessageWithSession',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'logMessageWithSession',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Future<void> addWillCloseListenerToSessionAndThrow(
+      _i1.TestSessionBuilder sessionBuilder) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'testTools',
+        method: 'addWillCloseListenerToSessionAndThrow',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'addWillCloseListenerToSessionAndThrow',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<void>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
+  }
+
+  _i3.Stream<int> addWillCloseListenerToSessionInStreamMethodAndThrow(
+      _i1.TestSessionBuilder sessionBuilder) {
+    var _localTestStreamManager = _i1.TestStreamManager<int>();
+    _i1.callStreamFunctionAndHandleExceptions(
+      () async {
+        var _localUniqueSession =
+            (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+          endpoint: 'testTools',
+          method: 'addWillCloseListenerToSessionInStreamMethodAndThrow',
+        );
+        var _localCallContext =
+            await _endpointDispatch.getMethodStreamCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'testTools',
+          methodName: 'addWillCloseListenerToSessionInStreamMethodAndThrow',
+          arguments: {},
+          requestedInputStreams: [],
+          serializationManager: _serializationManager,
+        );
+        await _localTestStreamManager.callStreamMethod(
+          _localCallContext,
+          _localUniqueSession,
+          {},
+        );
+      },
+      _localTestStreamManager.outputStreamController,
+    );
+    return _localTestStreamManager.outputStreamController.stream;
   }
 }
 
@@ -7473,19 +8139,22 @@ class _AuthenticatedTestToolsEndpoint {
         endpoint: 'authenticatedTestTools',
         method: 'returnsString',
       );
-      var _localCallContext = await _endpointDispatch.getMethodCallContext(
-        createSessionCallback: (_) => _localUniqueSession,
-        endpointPath: 'authenticatedTestTools',
-        methodName: 'returnsString',
-        parameters: _i1.testObjectToJson({'string': string}),
-        serializationManager: _serializationManager,
-      );
-      var _localReturnValue = await (_localCallContext.method.call(
-        _localUniqueSession,
-        _localCallContext.arguments,
-      ) as _i3.Future<String>);
-      await _localUniqueSession.close();
-      return _localReturnValue;
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'authenticatedTestTools',
+          methodName: 'returnsString',
+          parameters: _i1.testObjectToJson({'string': string}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
     });
   }
 

--- a/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:serverpod/serverpod.dart';
@@ -65,7 +66,7 @@ void main() {
         });
 
         tearDown(() async {
-          TestToolsEndpoint.willCloseListenerCalled = false;
+          TestToolsEndpoint.willCloseListenerCalled = Completer();
         });
 
         test(
@@ -75,7 +76,10 @@ void main() {
             await future;
           } catch (_) {}
 
-          expect(TestToolsEndpoint.willCloseListenerCalled, isTrue);
+          await expectLater(
+            TestToolsEndpoint.willCloseListenerCalled,
+            completes,
+          );
         });
       });
     },
@@ -119,14 +123,14 @@ void main() {
 
         setUp(() async {
           stream = endpoints.testTools
-              .addWillCloseListenerToSessionInStreamMethodAndThrow(
+              .addWillCloseListenerToSessionIntStreamMethodAndThrow(
                   sessionBuilder.copyWith(
             enableLogging: true,
           ));
         });
 
         tearDown(() async {
-          TestToolsEndpoint.willCloseListenerCalled = false;
+          TestToolsEndpoint.willCloseListenerCalled = Completer();
         });
 
         test(
@@ -137,7 +141,10 @@ void main() {
           } catch (_) {}
           await flushEventQueue();
 
-          expect(TestToolsEndpoint.willCloseListenerCalled, isTrue);
+          await expectLater(
+            TestToolsEndpoint.willCloseListenerCalled,
+            completes,
+          );
         });
       });
     },

--- a/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
@@ -53,6 +53,31 @@ void main() {
         expect(stdout.output,
             contains('"message":"test session log in endpoint"'));
       });
+
+      group('when method throws an exception', () {
+        late Future future;
+
+        setUp(() async {
+          future = endpoints.testTools
+              .addWillCloseListenerToSessionAndThrow(sessionBuilder.copyWith(
+            enableLogging: true,
+          ));
+        });
+
+        tearDown(() async {
+          TestToolsEndpoint.willCloseListenerCalled = false;
+        });
+
+        test(
+            'then the session is closed so that the `willCloseListener` is called',
+            () async {
+          try {
+            await future;
+          } catch (_) {}
+
+          expect(TestToolsEndpoint.willCloseListenerCalled, isTrue);
+        });
+      });
     },
   );
 
@@ -87,6 +112,33 @@ void main() {
 
         expect(endpoint, 'testTools');
         expect(method, 'returnsSessionEndpointAndMethodFromStream');
+      });
+
+      group('when method throws an exception', () {
+        late Stream stream;
+
+        setUp(() async {
+          stream = endpoints.testTools
+              .addWillCloseListenerToSessionInStreamMethodAndThrow(
+                  sessionBuilder.copyWith(
+            enableLogging: true,
+          ));
+        });
+
+        tearDown(() async {
+          TestToolsEndpoint.willCloseListenerCalled = false;
+        });
+
+        test(
+            'then the session is closed so that the `willCloseListener` is called',
+            () async {
+          try {
+            await stream.take(1);
+          } catch (_) {}
+          await flushEventQueue();
+
+          expect(TestToolsEndpoint.willCloseListenerCalled, isTrue);
+        });
       });
     },
   );

--- a/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
@@ -59,6 +59,7 @@ void main() {
         late Future future;
 
         setUp(() async {
+          TestToolsEndpoint.willCloseListenerCalled = Completer();
           future = endpoints.testTools
               .addWillCloseListenerToSessionAndThrow(sessionBuilder.copyWith(
             enableLogging: true,
@@ -66,7 +67,7 @@ void main() {
         });
 
         tearDown(() async {
-          TestToolsEndpoint.willCloseListenerCalled = Completer();
+          TestToolsEndpoint.willCloseListenerCalled = null;
         });
 
         test(
@@ -77,7 +78,7 @@ void main() {
           } catch (_) {}
 
           await expectLater(
-            TestToolsEndpoint.willCloseListenerCalled.future,
+            TestToolsEndpoint.willCloseListenerCalled?.future,
             completes,
           );
         });
@@ -122,6 +123,7 @@ void main() {
         late Stream stream;
 
         setUp(() async {
+          TestToolsEndpoint.willCloseListenerCalled = Completer();
           stream = endpoints.testTools
               .addWillCloseListenerToSessionIntStreamMethodAndThrow(
                   sessionBuilder.copyWith(
@@ -130,7 +132,7 @@ void main() {
         });
 
         tearDown(() async {
-          TestToolsEndpoint.willCloseListenerCalled = Completer();
+          TestToolsEndpoint.willCloseListenerCalled = null;
         });
 
         test(
@@ -142,7 +144,7 @@ void main() {
           await flushEventQueue();
 
           await expectLater(
-            TestToolsEndpoint.willCloseListenerCalled.future,
+            TestToolsEndpoint.willCloseListenerCalled?.future,
             completes,
           );
         });

--- a/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
@@ -77,7 +77,7 @@ void main() {
           } catch (_) {}
 
           await expectLater(
-            TestToolsEndpoint.willCloseListenerCalled,
+            TestToolsEndpoint.willCloseListenerCalled.future,
             completes,
           );
         });
@@ -142,7 +142,7 @@ void main() {
           await flushEventQueue();
 
           await expectLater(
-            TestToolsEndpoint.willCloseListenerCalled,
+            TestToolsEndpoint.willCloseListenerCalled.future,
             completes,
           );
         });

--- a/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/session_correctness_test.dart
@@ -1,4 +1,8 @@
+import 'dart:io';
+
 import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/endpoints/test_tools.dart';
+import 'package:serverpod_test_server/test_util/mock_stdout.dart';
 import 'package:test/test.dart';
 
 import 'serverpod_test_tools.dart';
@@ -30,6 +34,24 @@ void main() {
             .returnsSessionEndpointAndMethod(sessionBuilder);
         expect(endpoint, 'testTools');
         expect(method, 'returnsSessionEndpointAndMethod');
+      });
+
+      test('when method logs to session then can be observered in stdout',
+          () async {
+        var stdout = MockStdout();
+        await IOOverrides.runZoned(
+          () async {
+            await endpoints.testTools
+                .logMessageWithSession(sessionBuilder.copyWith(
+              enableLogging: true,
+            ));
+          },
+          stdout: () => stdout,
+          stderr: () => stdout,
+        );
+
+        expect(stdout.output,
+            contains('"message":"test session log in endpoint"'));
       });
     },
   );

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -179,6 +179,7 @@ class ServerTestToolsGenerator {
                 'method': literalString(method.name),
               }))
               .statement,
+          const Code('try {'),
           refer('var _localCallContext')
               .assign(refer('_endpointDispatch')
                   .awaited
@@ -213,12 +214,14 @@ class ServerTestToolsGenerator {
                     .awaited,
               )
               .statement,
+          refer('_localReturnValue').returned.statement,
+          const Code('} finally {'),
           refer('_localUniqueSession')
               .property('close')
               .call([])
               .awaited
               .statement,
-          refer('_localReturnValue').returned.statement,
+          const Code('}'),
         ])
         ..returns,
     ).closure;


### PR DESCRIPTION
## Description
- Closes #2941 
- Enables logging for run mode `test`. This is not a very nice and sustainable solution, but there are no good solution with a reasonable effort I think. Please let me know if you think there is a better way to solve this.
- Fixes a bug where sessions weren't closed if an exception was thrown in future returning endpoints
- Fixes a bug where sessions weren't closed for any case in stream returning endpoints

NB: All sessions _were_ closed in the test frameworks' `tearDownAll`, but this is too late for the test user to make any assertions.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.