### PR TITLE
feat: Support free endpoint definition placement

### DIFF
--- a/packages/serverpod/lib/src/cloud_storage/public_endpoint.dart
+++ b/packages/serverpod/lib/src/cloud_storage/public_endpoint.dart
@@ -4,10 +4,12 @@ import 'dart:typed_data';
 import 'package:path/path.dart' as p;
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/generated/cloud_storage_direct_upload.dart';
+import 'package:serverpod_shared/annotations.dart';
 
 const _endpointName = 'serverpod_cloud_storage';
 
 /// Endpoint for the default public [DatabaseCloudStorage].
+@ignoreEndpoint
 class CloudStoragePublicEndpoint extends Endpoint {
   @override
   bool get sendByteDataAsRaw => true;

--- a/packages/serverpod_shared/lib/annotations.dart
+++ b/packages/serverpod_shared/lib/annotations.dart
@@ -1,0 +1,1 @@
+export 'src/annotations.dart';

--- a/packages/serverpod_shared/lib/serverpod_shared.dart
+++ b/packages/serverpod_shared/lib/serverpod_shared.dart
@@ -1,7 +1,7 @@
 export 'src/certificates.dart';
 export 'src/config.dart';
 export 'src/constants.dart';
-export 'src/migration_exceptions.dart';
 export 'src/method_streaming_exceptions.dart';
+export 'src/migration_exceptions.dart';
 export 'src/password_manager.dart';
 export 'src/util.dart';

--- a/packages/serverpod_shared/lib/src/annotations.dart
+++ b/packages/serverpod_shared/lib/src/annotations.dart
@@ -1,0 +1,20 @@
+/// Used to annotate endpoints that should be ignored by the Serverpod code
+/// analyzer.
+///
+/// If an endpoint class is annotated with this annotation:
+/// - No client code to call the endpoint will ge generated.
+/// - No server code to handle requests towards the endpoint will be generated.
+const ignoreEndpoint = _IgnoreEndpoint();
+
+/// Names of annotations used by the Serverpod framework.
+abstract final class ServerpodAnnotationClassNames {
+  /// Name of the ignore endpoint annotation class.
+  /// Needs to be synchronized with the [_ignoreEndpoint] annotation.
+  static const String ignoreEndpoint = '_IgnoreEndpoint';
+}
+
+/// Name of the class needs to be synchronized with the
+/// [ServerpodAnnotationClassNames.ignoreEndpoint] constant.
+class _IgnoreEndpoint {
+  const _IgnoreEndpoint();
+}

--- a/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
@@ -372,6 +372,188 @@ class TestEndpoint extends Endpoint {
   });
 
   group(
+      'Given an endpoint file in the "lib/src" folder that is changed when generate watch is active',
+      () {
+    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (serverDir, _, _) = createProjectFolderPaths(projectName);
+
+    late Process createProcess;
+    Process? generateWatch;
+    KeywordSearchInStream generateStreamSearch = KeywordSearchInStream(
+      keywords: generateWatchCompletionKeywords,
+    );
+    setUp(() async {
+      // Create project
+      createProcess = await Process.start(
+        'serverpod',
+        ['create', projectName, '-v', '--no-analytics'],
+        workingDirectory: tempPath,
+        environment: {
+          'SERVERPOD_HOME': rootPath,
+        },
+      );
+
+      createProcess.stdout.transform(const Utf8Decoder()).listen(print);
+      createProcess.stderr.transform(const Utf8Decoder()).listen(print);
+
+      var createProjectExitCode = await createProcess.exitCode;
+      assert(
+        createProjectExitCode == 0,
+        'Failed to create the serverpod project.',
+      );
+    });
+
+    tearDown(() async {
+      createProcess.kill();
+      generateWatch?.kill();
+      generateStreamSearch.cancel();
+
+      await Process.run(
+        'docker',
+        ['compose', 'down', '-v'],
+        workingDirectory: commandRoot,
+      );
+
+      while (!await isNetworkPortAvailable(8090)) {}
+    });
+
+    test('then endpoint dispatcher is generated and updated as expected.',
+        () async {
+      // Start generate watch
+      generateWatch = await Process.start(
+        'serverpod',
+        ['generate', '--watch', '-v', '--no-analytics'],
+        workingDirectory: path.join(tempPath, serverDir),
+        environment: {
+          'SERVERPOD_HOME': rootPath,
+        },
+      );
+
+      generateWatch!.stdout
+          .transform(const Utf8Decoder())
+          .transform(const LineSplitter())
+          .listen(generateStreamSearch.onData);
+      generateWatch!.stderr
+          .transform(const Utf8Decoder())
+          .transform(const LineSplitter())
+          .listen(print);
+
+      await expectLater(
+        generateStreamSearch.keywordFound,
+        completion(isTrue),
+        reason:
+            'Initial code generation did not complete before timeout was reached.',
+      );
+      // This delay is required to ensure that the generate watch is
+      // ready to receive file changes after the initial generation.
+      await Future.delayed(const Duration(seconds: 1));
+
+      // Add endpoint file
+      var endpointFile = File(createProjectDartFilePath(
+        tmpFolder: tempPath,
+        serverDir: serverDir,
+        fileName: 'test_endpoint',
+      ));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class TestEndpoint extends Endpoint {
+  Future<String> testEndpointMethod(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+
+''', flush: true);
+
+      await expectLater(
+        generateStreamSearch.keywordFound,
+        completion(isTrue),
+        reason:
+            'Incremental code generation did not complete before timeout was reached.',
+      );
+
+      // Validate endpoint client methods are generated
+      var endpointDispatcherFile = File(createServerEndpointDispatcherFilePath(
+        tempPath,
+        serverDir,
+      ));
+      expect(
+        endpointDispatcherFile.existsSync(),
+        isTrue,
+        reason: 'Endpoint dispatcher file not found.',
+      );
+      var endpointDispatcherFileContents =
+          endpointDispatcherFile.readAsStringSync();
+      expect(
+        endpointDispatcherFileContents,
+        contains('TestEndpoint'),
+        reason:
+            'Endpoint dispatcher file did not contain added endpoint class.',
+      );
+      expect(
+        endpointDispatcherFileContents,
+        contains('testEndpointMethod'),
+        reason:
+            'Endpoint dispatcher file did not contain the test endpoint method.',
+      );
+
+      // Update endpoint file
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class TestEndpoint extends Endpoint {
+  Future<String> testEndpointMethod(Session session, String name) async {
+    return 'Hello \$name';
+  }
+
+  Future<String> newTestEndpointMethod(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+
+''', flush: true);
+
+      await expectLater(
+        generateStreamSearch.keywordFound,
+        completion(isTrue),
+        reason:
+            'Incremental code generation did not complete before timeout was reached.',
+      );
+
+      // Validate that endpoint changes are reflected in endpoint dispatcher
+      endpointDispatcherFileContents =
+          endpointDispatcherFile.readAsStringSync();
+      expect(
+        endpointDispatcherFileContents,
+        contains('newTestEndpointMethod'),
+        reason:
+            'Endpoint dispatcher file did not contain the new endpoint method.',
+      );
+
+      // Remove endpoint file
+      endpointFile.deleteSync();
+
+      await expectLater(
+        generateStreamSearch.keywordFound,
+        completion(isTrue),
+        reason:
+            'Incremental code generation did not complete before timeout was reached.',
+      );
+
+      // Validate that endpoint is removed from endpoint dispatcher
+      endpointDispatcherFileContents =
+          endpointDispatcherFile.readAsStringSync();
+      expect(
+        endpointDispatcherFileContents,
+        isNot(contains('TestEndpoint')),
+        reason:
+            'Endpoint dispatcher still contained removed endpoint in "lib/src".',
+      );
+    });
+  });
+
+  group(
       'Given a serializable model used in an endpoint that is moved to a subfolder when generate watch is active',
       () {
     var (projectName, commandRoot) = createRandomProjectName(tempPath);
@@ -530,6 +712,142 @@ fields:
             'import \'package:${projectName}_client/src/protocol/$subFolderName/$entityFileName\''),
         reason:
             'Could not find import for moved entity file in client endpoint dispatcher.',
+      );
+    });
+  });
+
+  group('Given a generated file that is changed when generate watch is active',
+      () {
+    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (serverDir, _, clientDir) = createProjectFolderPaths(projectName);
+
+    late Process createProcess;
+    Process? generateWatch;
+    KeywordSearchInStream generateStreamSearch = KeywordSearchInStream(
+      keywords: generateWatchCompletionKeywords,
+    );
+    setUp(() async {
+      // Create project
+      createProcess = await Process.start(
+        'serverpod',
+        ['create', projectName, '-v', '--no-analytics'],
+        workingDirectory: tempPath,
+        environment: {
+          'SERVERPOD_HOME': rootPath,
+        },
+      );
+
+      createProcess.stdout.transform(const Utf8Decoder()).listen(print);
+      createProcess.stderr.transform(const Utf8Decoder()).listen(print);
+
+      var createProjectExitCode = await createProcess.exitCode;
+      assert(
+        createProjectExitCode == 0,
+        'Failed to create the serverpod project.',
+      );
+    });
+
+    tearDown(() async {
+      createProcess.kill();
+      generateWatch?.kill();
+      generateStreamSearch.cancel();
+
+      await Process.run(
+        'docker',
+        ['compose', 'down', '-v'],
+        workingDirectory: commandRoot,
+      );
+
+      while (!await isNetworkPortAvailable(8090)) {}
+    });
+
+    test('then generator is not triggered.', () async {
+      // Start generate watch
+      generateWatch = await Process.start(
+        'serverpod',
+        ['generate', '--watch', '-v', '--no-analytics'],
+        workingDirectory: path.join(tempPath, serverDir),
+        environment: {
+          'SERVERPOD_HOME': rootPath,
+        },
+      );
+
+      generateStreamSearch = KeywordSearchInStream(
+        keywords: generateWatchCompletionKeywords,
+      );
+      generateWatch!.stdout
+          .transform(const Utf8Decoder())
+          .transform(const LineSplitter())
+          .listen(generateStreamSearch.onData);
+      generateWatch!.stderr
+          .transform(const Utf8Decoder())
+          .transform(const LineSplitter())
+          .listen(print);
+
+      await expectLater(
+        generateStreamSearch.keywordFound,
+        completion(isTrue),
+        reason:
+            'Initial code generation did not complete before timeout was reached.',
+      );
+      // This delay is required to ensure that the generate watch is
+      // ready to receive file changes after the initial generation.
+      await Future.delayed(const Duration(seconds: 1));
+
+      // Add model file
+      var protocolFileName = 'test_entity';
+      var protocolFile = File(createProtocolFilePath(
+        tempPath,
+        serverDir,
+        protocolFileName,
+      ));
+      protocolFile.createSync(recursive: true);
+      protocolFile.writeAsStringSync('''
+class: TestEntity
+fields:
+  name: String
+''', flush: true);
+
+      await expectLater(
+        generateStreamSearch.keywordFound,
+        completion(isTrue),
+        reason:
+            'Incremental code generation did not complete before timeout was reached.',
+      );
+
+      // Validate that entity file is generated
+      var entityFileName = '$protocolFileName.dart';
+      var entityDirectory =
+          Directory(createClientModelDirectoryPath(tempPath, clientDir));
+      var entityFiles = entityDirectory.listSync();
+      expect(
+        entityFiles.map((e) => path.basename(e.path)),
+        contains(entityFileName),
+        reason: 'Entity file not found.',
+      );
+
+      // Read generated file
+      var entityFile = entityFiles.firstWhereOrNull(
+        (e) => path.basename(e.path) == entityFileName,
+      );
+      expect(
+        entityFile,
+        isA<File>(),
+        reason: 'Entity file did not have expected type.',
+      );
+
+      // Modify generated file
+      var entityFileContents = (entityFile as File).readAsStringSync();
+      var modifiedEntityFileContents = '''$entityFileContents
+\n// Modified
+      ''';
+      entityFile.writeAsStringSync(modifiedEntityFileContents, flush: true);
+
+      await expectLater(
+        generateStreamSearch.keywordFound,
+        completion(isFalse),
+        reason:
+            'Incremental code generation was triggered when generated file was modified.',
       );
     });
   });

--- a/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
@@ -267,10 +267,11 @@ fields:
       await Future.delayed(const Duration(seconds: 1));
 
       // Add endpoint file
-      var endpointFile = File(createEndpointFilePath(
-        tempPath,
-        serverDir,
-        'test_endpoint',
+      var endpointFile = File(createProjectDartFilePath(
+        tmpFolder: tempPath,
+        serverDir: serverDir,
+        pathParts: ['endpoints'],
+        fileName: 'test_endpoint',
       ));
       endpointFile.createSync(recursive: true);
       endpointFile.writeAsStringSync('''
@@ -409,10 +410,11 @@ class TestEndpoint extends Endpoint {
     });
     test('then client endpoint dispatcher is updated as expected.', () async {
       // Add endpoint file
-      var endpointFile = File(createEndpointFilePath(
-        tempPath,
-        serverDir,
-        'test_endpoint',
+      var endpointFile = File(createProjectDartFilePath(
+        tmpFolder: tempPath,
+        serverDir: serverDir,
+        pathParts: ['endpoints'],
+        fileName: 'test_endpoint',
       ));
       endpointFile.createSync(recursive: true);
       endpointFile.writeAsStringSync('''
@@ -582,19 +584,20 @@ String createProtocolFilePath(
   );
 }
 
-String createEndpointFilePath(
-  String tmpFolder,
-  String serverDir,
-  String fileName,
-) {
-  return path.join(
+String createProjectDartFilePath({
+  required String tmpFolder,
+  required String serverDir,
+  required String fileName,
+  List<String>? pathParts,
+}) {
+  return path.joinAll([
     tmpFolder,
     serverDir,
     'lib',
     'src',
-    'endpoints',
+    ...?pathParts,
     '$fileName.dart',
-  );
+  ]);
 }
 
 String createServerEndpointDispatcherFilePath(

--- a/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
@@ -43,7 +43,6 @@ void main() async {
       keywords: generateWatchCompletionKeywords,
     );
     setUp(() async {
-      // Create project
       createProcess = await Process.start(
         'serverpod',
         ['create', projectName, '-v', '--no-analytics'],
@@ -71,7 +70,6 @@ void main() async {
 
     test('then the entity files are generated and updated as expected.',
         () async {
-      // Start generate watch
       generateWatch = await Process.start(
         'serverpod',
         ['generate', '--watch', '-v', '--no-analytics'],
@@ -103,7 +101,6 @@ void main() async {
       // ready to receive file changes after the initial generation.
       await Future.delayed(const Duration(seconds: 1));
 
-      // Add model file
       var protocolFileName = 'test_entity';
       var protocolFile = File(createProtocolFilePath(
         tempPath,
@@ -180,7 +177,6 @@ fields:
         reason: 'Entity file did not contain the added field.',
       );
 
-      // Remove model file
       protocolFile.deleteSync();
       await expectLater(
         generateStreamSearch.keywordFound,
@@ -189,7 +185,6 @@ fields:
             'Incremental code generation did not complete before timeout was reached.',
       );
 
-      // Validate file is removed
       entityFiles = entityDirectory.listSync();
       expect(
         entityFiles.map((e) => path.basename(e.path)),
@@ -210,7 +205,6 @@ fields:
       keywords: generateWatchCompletionKeywords,
     );
     setUp(() async {
-      // Create project
       createProcess = await Process.start(
         'serverpod',
         ['create', projectName, '-v', '--no-analytics'],
@@ -237,7 +231,6 @@ fields:
     });
     test('then endpoint dispatcher is generated and updated as expected.',
         () async {
-      // Start generate watch
       generateWatch = await Process.start(
         'serverpod',
         ['generate', '--watch', '-v', '--no-analytics'],
@@ -266,7 +259,6 @@ fields:
       // ready to receive file changes after the initial generation.
       await Future.delayed(const Duration(seconds: 1));
 
-      // Add endpoint file
       var endpointFile = File(createProjectDartFilePath(
         tmpFolder: tempPath,
         serverDir: serverDir,
@@ -350,7 +342,6 @@ class TestEndpoint extends Endpoint {
             'Endpoint dispatcher file did not contain the new endpoint method.',
       );
 
-      // Remove endpoint file
       endpointFile.deleteSync();
 
       await expectLater(
@@ -383,7 +374,6 @@ class TestEndpoint extends Endpoint {
       keywords: generateWatchCompletionKeywords,
     );
     setUp(() async {
-      // Create project
       createProcess = await Process.start(
         'serverpod',
         ['create', projectName, '-v', '--no-analytics'],
@@ -407,19 +397,10 @@ class TestEndpoint extends Endpoint {
       createProcess.kill();
       generateWatch?.kill();
       generateStreamSearch.cancel();
-
-      await Process.run(
-        'docker',
-        ['compose', 'down', '-v'],
-        workingDirectory: commandRoot,
-      );
-
-      while (!await isNetworkPortAvailable(8090)) {}
     });
 
     test('then endpoint dispatcher is generated and updated as expected.',
         () async {
-      // Start generate watch
       generateWatch = await Process.start(
         'serverpod',
         ['generate', '--watch', '-v', '--no-analytics'],
@@ -448,7 +429,6 @@ class TestEndpoint extends Endpoint {
       // ready to receive file changes after the initial generation.
       await Future.delayed(const Duration(seconds: 1));
 
-      // Add endpoint file
       var endpointFile = File(createProjectDartFilePath(
         tmpFolder: tempPath,
         serverDir: serverDir,
@@ -531,7 +511,6 @@ class TestEndpoint extends Endpoint {
             'Endpoint dispatcher file did not contain the new endpoint method.',
       );
 
-      // Remove endpoint file
       endpointFile.deleteSync();
 
       await expectLater(
@@ -565,7 +544,6 @@ class TestEndpoint extends Endpoint {
       keywords: generateWatchCompletionKeywords,
     );
     setUp(() async {
-      // Create project
       createProcess = await Process.start(
         'serverpod',
         ['create', projectName, '-v', '--no-analytics'],
@@ -591,7 +569,6 @@ class TestEndpoint extends Endpoint {
       generateStreamSearch.cancel();
     });
     test('then client endpoint dispatcher is updated as expected.', () async {
-      // Add endpoint file
       var endpointFile = File(createProjectDartFilePath(
         tmpFolder: tempPath,
         serverDir: serverDir,
@@ -610,7 +587,6 @@ class TestEndpoint extends Endpoint {
 }
 ''', flush: true);
 
-      // Add model file
       var protocolFileName = 'test_entity';
       var protocolFile = File(createProtocolFilePath(
         tempPath,
@@ -624,7 +600,6 @@ fields:
   name: String
 ''', flush: true);
 
-      // Start generate watch
       generateWatch = await Process.start(
         'serverpod',
         ['generate', '--watch', '-v', '--no-analytics'],
@@ -727,7 +702,6 @@ fields:
       keywords: generateWatchCompletionKeywords,
     );
     setUp(() async {
-      // Create project
       createProcess = await Process.start(
         'serverpod',
         ['create', projectName, '-v', '--no-analytics'],
@@ -751,18 +725,9 @@ fields:
       createProcess.kill();
       generateWatch?.kill();
       generateStreamSearch.cancel();
-
-      await Process.run(
-        'docker',
-        ['compose', 'down', '-v'],
-        workingDirectory: commandRoot,
-      );
-
-      while (!await isNetworkPortAvailable(8090)) {}
     });
 
     test('then generator is not triggered.', () async {
-      // Start generate watch
       generateWatch = await Process.start(
         'serverpod',
         ['generate', '--watch', '-v', '--no-analytics'],
@@ -794,7 +759,6 @@ fields:
       // ready to receive file changes after the initial generation.
       await Future.delayed(const Duration(seconds: 1));
 
-      // Add model file
       var protocolFileName = 'test_entity';
       var protocolFile = File(createProtocolFilePath(
         tempPath,
@@ -944,14 +908,4 @@ String createClientEndpointDispatcherFilePath(
     'protocol',
     'client.dart',
   );
-}
-
-Future<bool> isNetworkPortAvailable(int port) async {
-  try {
-    var socket = await ServerSocket.bind(InternetAddress.anyIPv4, port);
-    await socket.close();
-    return true;
-  } catch (e) {
-    return false;
-  }
 }

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -2392,6 +2392,20 @@ class EndpointAuthenticatedTestTools extends _i1.EndpointRef {
       );
 }
 
+/// {@category Endpoint}
+class EndpointMyFeature extends _i1.EndpointRef {
+  EndpointMyFeature(_i1.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'myFeature';
+
+  _i2.Future<String> myFeatureMethod() => caller.callServerEndpoint<String>(
+        'myFeature',
+        'myFeatureMethod',
+        {},
+      );
+}
+
 class Modules {
   Modules(Client client) {
     auth = _i3.Caller(client);
@@ -2470,6 +2484,7 @@ class Client extends _i1.ServerpodClientShared {
     subDirTest = EndpointSubDirTest(this);
     testTools = EndpointTestTools(this);
     authenticatedTestTools = EndpointAuthenticatedTestTools(this);
+    myFeature = EndpointMyFeature(this);
     modules = Modules(this);
   }
 
@@ -2554,6 +2569,8 @@ class Client extends _i1.ServerpodClientShared {
 
   late final EndpointAuthenticatedTestTools authenticatedTestTools;
 
+  late final EndpointMyFeature myFeature;
+
   late final Modules modules;
 
   @override
@@ -2598,6 +2615,7 @@ class Client extends _i1.ServerpodClientShared {
         'subDirTest': subDirTest,
         'testTools': testTools,
         'authenticatedTestTools': authenticatedTestTools,
+        'myFeature': myFeature,
       };
 
   @override

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -45,23 +45,24 @@ import '../endpoints/streaming_logging.dart' as _i33;
 import '../endpoints/subDir/subSubDir/subsubdir_test_endpoint.dart' as _i34;
 import '../endpoints/subDir/subdir_test_endpoint.dart' as _i35;
 import '../endpoints/test_tools.dart' as _i36;
-import 'dart:typed_data' as _i37;
-import 'package:uuid/uuid_value.dart' as _i38;
-import 'package:serverpod_test_server/src/custom_classes.dart' as _i39;
-import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i40;
-import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i41;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i42;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i43;
+import '../my_feature/endpoints/my_feature_endpoint.dart' as _i37;
+import 'dart:typed_data' as _i38;
+import 'package:uuid/uuid_value.dart' as _i39;
+import 'package:serverpod_test_server/src/custom_classes.dart' as _i40;
+import 'package:serverpod_test_shared/src/external_custom_class.dart' as _i41;
+import 'package:serverpod_test_shared/src/freezed_custom_class.dart' as _i42;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i43;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i44;
 import 'package:serverpod_test_server/src/generated/object_with_enum.dart'
-    as _i44;
-import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i45;
-import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+import 'package:serverpod_test_server/src/generated/object_with_object.dart'
     as _i46;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i47;
+import 'package:serverpod_test_server/src/generated/object_field_scopes.dart'
+    as _i47;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i48;
 import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
-    as _i48;
-import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i49;
+    as _i49;
+import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i50;
 
 class Endpoints extends _i1.EndpointDispatch {
   @override
@@ -306,6 +307,12 @@ class Endpoints extends _i1.EndpointDispatch {
         ..initialize(
           server,
           'authenticatedTestTools',
+          null,
+        ),
+      'myFeature': _i37.MyFeatureEndpoint()
+        ..initialize(
+          server,
+          'myFeature',
           null,
         ),
     };
@@ -575,7 +582,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i37.ByteData?>(),
+              type: _i1.getType<_i38.ByteData?>(),
               nullable: true,
             )
           },
@@ -611,7 +618,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i38.UuidValue?>(),
+              type: _i1.getType<_i39.UuidValue?>(),
               nullable: true,
             )
           },
@@ -650,7 +657,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'byteData': _i1.ParameterDescription(
               name: 'byteData',
-              type: _i1.getType<_i37.ByteData>(),
+              type: _i1.getType<_i38.ByteData>(),
               nullable: false,
             ),
           },
@@ -795,7 +802,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'byteData': _i1.ParameterDescription(
               name: 'byteData',
-              type: _i1.getType<_i37.ByteData>(),
+              type: _i1.getType<_i38.ByteData>(),
               nullable: false,
             ),
           },
@@ -952,7 +959,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i39.CustomClass>(),
+              type: _i1.getType<_i40.CustomClass>(),
               nullable: false,
             )
           },
@@ -971,7 +978,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i39.CustomClass?>(),
+              type: _i1.getType<_i40.CustomClass?>(),
               nullable: true,
             )
           },
@@ -990,7 +997,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i39.CustomClass2>(),
+              type: _i1.getType<_i40.CustomClass2>(),
               nullable: false,
             )
           },
@@ -1009,7 +1016,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i39.CustomClass2?>(),
+              type: _i1.getType<_i40.CustomClass2?>(),
               nullable: true,
             )
           },
@@ -1028,7 +1035,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i40.ExternalCustomClass>(),
+              type: _i1.getType<_i41.ExternalCustomClass>(),
               nullable: false,
             )
           },
@@ -1047,7 +1054,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i40.ExternalCustomClass?>(),
+              type: _i1.getType<_i41.ExternalCustomClass?>(),
               nullable: true,
             )
           },
@@ -1066,7 +1073,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i41.FreezedCustomClass>(),
+              type: _i1.getType<_i42.FreezedCustomClass>(),
               nullable: false,
             )
           },
@@ -1085,7 +1092,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i41.FreezedCustomClass?>(),
+              type: _i1.getType<_i42.FreezedCustomClass?>(),
               nullable: true,
             )
           },
@@ -1276,7 +1283,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i42.SimpleData>(),
+              type: _i1.getType<_i43.SimpleData>(),
               nullable: false,
             )
           },
@@ -1295,7 +1302,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i42.SimpleData>(),
+              type: _i1.getType<_i43.SimpleData>(),
               nullable: false,
             )
           },
@@ -1314,7 +1321,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i42.SimpleData>(),
+              type: _i1.getType<_i43.SimpleData>(),
               nullable: false,
             )
           },
@@ -1353,7 +1360,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i43.Types>(),
+              type: _i1.getType<_i44.Types>(),
               nullable: false,
             )
           },
@@ -1371,7 +1378,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'value': _i1.ParameterDescription(
               name: 'value',
-              type: _i1.getType<_i43.Types>(),
+              type: _i1.getType<_i44.Types>(),
               nullable: false,
             )
           },
@@ -1446,7 +1453,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i44.ObjectWithEnum>(),
+              type: _i1.getType<_i45.ObjectWithEnum>(),
               nullable: false,
             )
           },
@@ -1484,7 +1491,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i45.ObjectWithObject>(),
+              type: _i1.getType<_i46.ObjectWithObject>(),
               nullable: false,
             )
           },
@@ -1863,7 +1870,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i46.ObjectFieldScopes>(),
+              type: _i1.getType<_i47.ObjectFieldScopes>(),
               nullable: false,
             )
           },
@@ -1898,7 +1905,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i42.SimpleData?>(),
+              type: _i1.getType<_i43.SimpleData?>(),
               nullable: true,
             )
           },
@@ -2208,7 +2215,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i37.ByteData>>(),
+              type: _i1.getType<List<_i38.ByteData>>(),
               nullable: false,
             )
           },
@@ -2227,7 +2234,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i37.ByteData?>>(),
+              type: _i1.getType<List<_i38.ByteData?>>(),
               nullable: false,
             )
           },
@@ -2246,7 +2253,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i42.SimpleData>>(),
+              type: _i1.getType<List<_i43.SimpleData>>(),
               nullable: false,
             )
           },
@@ -2265,7 +2272,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i42.SimpleData?>>(),
+              type: _i1.getType<List<_i43.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -2284,7 +2291,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i42.SimpleData>?>(),
+              type: _i1.getType<List<_i43.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -2303,7 +2310,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'list': _i1.ParameterDescription(
               name: 'list',
-              type: _i1.getType<List<_i42.SimpleData?>?>(),
+              type: _i1.getType<List<_i43.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -2761,7 +2768,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<_i47.TestEnum, int>>(),
+              type: _i1.getType<Map<_i48.TestEnum, int>>(),
               nullable: false,
             )
           },
@@ -2780,7 +2787,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i47.TestEnum>>(),
+              type: _i1.getType<Map<String, _i48.TestEnum>>(),
               nullable: false,
             )
           },
@@ -2951,7 +2958,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i37.ByteData>>(),
+              type: _i1.getType<Map<String, _i38.ByteData>>(),
               nullable: false,
             )
           },
@@ -2970,7 +2977,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i37.ByteData?>>(),
+              type: _i1.getType<Map<String, _i38.ByteData?>>(),
               nullable: false,
             )
           },
@@ -2989,7 +2996,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i42.SimpleData>>(),
+              type: _i1.getType<Map<String, _i43.SimpleData>>(),
               nullable: false,
             )
           },
@@ -3008,7 +3015,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i42.SimpleData?>>(),
+              type: _i1.getType<Map<String, _i43.SimpleData?>>(),
               nullable: false,
             )
           },
@@ -3027,7 +3034,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i42.SimpleData>?>(),
+              type: _i1.getType<Map<String, _i43.SimpleData>?>(),
               nullable: true,
             )
           },
@@ -3046,7 +3053,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'map': _i1.ParameterDescription(
               name: 'map',
-              type: _i1.getType<Map<String, _i42.SimpleData?>?>(),
+              type: _i1.getType<Map<String, _i43.SimpleData?>?>(),
               nullable: true,
             )
           },
@@ -3796,7 +3803,7 @@ class Endpoints extends _i1.EndpointDispatch {
           name: 'simpleInOutDataStream',
           params: {},
           streamParams: {
-            'simpleDataStream': _i1.StreamParameterDescription<_i42.SimpleData>(
+            'simpleDataStream': _i1.StreamParameterDescription<_i43.SimpleData>(
               name: 'simpleDataStream',
               nullable: false,
             )
@@ -3810,7 +3817,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['methodStreaming'] as _i23.MethodStreaming)
                   .simpleInOutDataStream(
             session,
-            streamParams['simpleDataStream']!.cast<_i42.SimpleData>(),
+            streamParams['simpleDataStream']!.cast<_i43.SimpleData>(),
           ),
         ),
         'delayedStreamResponse': _i1.MethodStreamConnector(
@@ -4202,7 +4209,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'object': _i1.ParameterDescription(
               name: 'object',
-              type: _i1.getType<_i48.ModuleClass>(),
+              type: _i1.getType<_i49.ModuleClass>(),
               nullable: false,
             )
           },
@@ -4338,7 +4345,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i42.SimpleData>(),
+              type: _i1.getType<_i43.SimpleData>(),
               nullable: false,
             ),
           },
@@ -4362,7 +4369,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i42.SimpleData>(),
+              type: _i1.getType<_i43.SimpleData>(),
               nullable: false,
             ),
           },
@@ -4451,7 +4458,7 @@ class Endpoints extends _i1.EndpointDispatch {
             ),
             'data': _i1.ParameterDescription(
               name: 'data',
-              type: _i1.getType<_i42.SimpleData>(),
+              type: _i1.getType<_i43.SimpleData>(),
               nullable: false,
             ),
           },
@@ -4797,7 +4804,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleData': _i1.ParameterDescription(
               name: 'simpleData',
-              type: _i1.getType<_i42.SimpleData>(),
+              type: _i1.getType<_i43.SimpleData>(),
               nullable: false,
             )
           },
@@ -4815,7 +4822,7 @@ class Endpoints extends _i1.EndpointDispatch {
           params: {
             'simpleDatas': _i1.ParameterDescription(
               name: 'simpleDatas',
-              type: _i1.getType<List<_i42.SimpleData>>(),
+              type: _i1.getType<List<_i43.SimpleData>>(),
               nullable: false,
             )
           },
@@ -4921,7 +4928,7 @@ class Endpoints extends _i1.EndpointDispatch {
           name: 'returnsSimpleDataListFromInputStream',
           params: {},
           streamParams: {
-            'simpleDatas': _i1.StreamParameterDescription<_i42.SimpleData>(
+            'simpleDatas': _i1.StreamParameterDescription<_i43.SimpleData>(
               name: 'simpleDatas',
               nullable: false,
             )
@@ -4935,7 +4942,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsSimpleDataListFromInputStream(
             session,
-            streamParams['simpleDatas']!.cast<_i42.SimpleData>(),
+            streamParams['simpleDatas']!.cast<_i43.SimpleData>(),
           ),
         ),
         'returnsStreamFromInputStream': _i1.MethodStreamConnector(
@@ -4963,7 +4970,7 @@ class Endpoints extends _i1.EndpointDispatch {
           name: 'returnsSimpleDataStreamFromInputStream',
           params: {},
           streamParams: {
-            'simpleDatas': _i1.StreamParameterDescription<_i42.SimpleData>(
+            'simpleDatas': _i1.StreamParameterDescription<_i43.SimpleData>(
               name: 'simpleDatas',
               nullable: false,
             )
@@ -4977,7 +4984,7 @@ class Endpoints extends _i1.EndpointDispatch {
               (endpoints['testTools'] as _i36.TestToolsEndpoint)
                   .returnsSimpleDataStreamFromInputStream(
             session,
-            streamParams['simpleDatas']!.cast<_i42.SimpleData>(),
+            streamParams['simpleDatas']!.cast<_i43.SimpleData>(),
           ),
         ),
         'postNumberToSharedStreamAndReturnStream': _i1.MethodStreamConnector(
@@ -5125,8 +5132,24 @@ class Endpoints extends _i1.EndpointDispatch {
         ),
       },
     );
-    modules['serverpod_auth'] = _i49.Endpoints()..initializeEndpoints(server);
-    modules['serverpod_test_module'] = _i48.Endpoints()
+    connectors['myFeature'] = _i1.EndpointConnector(
+      name: 'myFeature',
+      endpoint: endpoints['myFeature']!,
+      methodConnectors: {
+        'myFeatureMethod': _i1.MethodConnector(
+          name: 'myFeatureMethod',
+          params: {},
+          call: (
+            _i1.Session session,
+            Map<String, dynamic> params,
+          ) async =>
+              (endpoints['myFeature'] as _i37.MyFeatureEndpoint)
+                  .myFeatureMethod(session),
+        )
+      },
+    );
+    modules['serverpod_auth'] = _i50.Endpoints()..initializeEndpoints(server);
+    modules['serverpod_test_module'] = _i49.Endpoints()
       ..initializeEndpoints(server);
   }
 }

--- a/tests/serverpod_test_server/lib/src/generated/protocol.yaml
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.yaml
@@ -292,3 +292,5 @@ authenticatedTestTools:
   - returnsStream:
   - returnsListFromInputStream:
   - intEchoStream:
+myFeature:
+  - myFeatureMethod:

--- a/tests/serverpod_test_server/lib/src/my_feature/endpoints/my_feature_endpoint.dart
+++ b/tests/serverpod_test_server/lib/src/my_feature/endpoints/my_feature_endpoint.dart
@@ -1,0 +1,7 @@
+import 'package:serverpod/serverpod.dart';
+
+class MyFeatureEndpoint extends Endpoint {
+  Future<String> myFeatureMethod(Session session) async {
+    return 'Hello, world!';
+  }
+}

--- a/tests/serverpod_test_server/test_e2e/endpoint_test.dart
+++ b/tests/serverpod_test_server/test_e2e/endpoint_test.dart
@@ -1,0 +1,19 @@
+import 'package:serverpod_test_client/serverpod_test_client.dart';
+import 'package:serverpod_test_server/test_util/config.dart';
+import 'package:serverpod_test_server/test_util/test_key_manager.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var client = Client(
+    serverUrl,
+    authenticationKeyManager: TestAuthKeyManager(),
+  );
+
+  group('Given an endpoint that is defined outside of the endpoint directory',
+      () {
+    test('when calling the endpoint then call is successful', () async {
+      var response = client.myFeature.myFeatureMethod();
+      await expectLater(response, completion('Hello, world!'));
+    });
+  });
+}

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -200,6 +200,8 @@ class TestEndpoints {
   late final _TestToolsEndpoint testTools;
 
   late final _AuthenticatedTestToolsEndpoint authenticatedTestTools;
+
+  late final _MyFeatureEndpoint myFeature;
 }
 
 class _InternalTestEndpoints extends TestEndpoints
@@ -366,6 +368,10 @@ class _InternalTestEndpoints extends TestEndpoints
       serializationManager,
     );
     authenticatedTestTools = _AuthenticatedTestToolsEndpoint(
+      endpoints,
+      serializationManager,
+    );
+    myFeature = _MyFeatureEndpoint(
       endpoints,
       serializationManager,
     );
@@ -8250,5 +8256,43 @@ class _AuthenticatedTestToolsEndpoint {
       _localTestStreamManager.outputStreamController,
     );
     return _localTestStreamManager.outputStreamController.stream;
+  }
+}
+
+class _MyFeatureEndpoint {
+  _MyFeatureEndpoint(
+    this._endpointDispatch,
+    this._serializationManager,
+  );
+
+  final _i2.EndpointDispatch _endpointDispatch;
+
+  final _i2.SerializationManager _serializationManager;
+
+  _i3.Future<String> myFeatureMethod(
+      _i1.TestSessionBuilder sessionBuilder) async {
+    return _i1.callAwaitableFunctionAndHandleExceptions(() async {
+      var _localUniqueSession =
+          (sessionBuilder as _i1.InternalTestSessionBuilder).internalBuild(
+        endpoint: 'myFeature',
+        method: 'myFeatureMethod',
+      );
+      try {
+        var _localCallContext = await _endpointDispatch.getMethodCallContext(
+          createSessionCallback: (_) => _localUniqueSession,
+          endpointPath: 'myFeature',
+          methodName: 'myFeatureMethod',
+          parameters: _i1.testObjectToJson({}),
+          serializationManager: _serializationManager,
+        );
+        var _localReturnValue = await (_localCallContext.method.call(
+          _localUniqueSession,
+          _localCallContext.arguments,
+        ) as _i3.Future<String>);
+        return _localReturnValue;
+      } finally {
+        await _localUniqueSession.close();
+      }
+    });
   }
 }

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_class_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoint_analyzers/endpoint_class_analyzer.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/dart/element_extensions.dart';
+import 'package:serverpod_shared/annotations.dart';
 
 abstract class EndpointClassAnalyzer {
   /// Parses an [ClassElement] into a [EndpointDefinition].
@@ -33,6 +34,13 @@ abstract class EndpointClassAnalyzer {
   /// be validated and parsed.
   static bool isEndpointClass(ClassElement element) {
     if (element.supertype?.element.name != 'Endpoint') return false;
+    bool markedAsIgnored = element.metadata.any((annotation) {
+      var constant = annotation.computeConstantValue();
+      var type = constant?.type;
+      var typeName = type?.element?.name;
+      return typeName == ServerpodAnnotationClassNames.ignoreEndpoint;
+    });
+    if (markedAsIgnored) return false;
 
     return true;
   }

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -57,9 +57,8 @@ class GenerateCommand extends ServerpodCommand {
       }
     }
 
-    var endpointDirectory =
-        Directory(path.joinAll(config.endpointsSourcePathParts));
-    var endpointsAnalyzer = EndpointsAnalyzer(endpointDirectory);
+    var libDirectory = Directory(path.joinAll(config.libSourcePathParts));
+    var endpointsAnalyzer = EndpointsAnalyzer(libDirectory);
 
     var yamlModels = await ModelHelper.loadProjectYamlModelsFromDisk(config);
     var modelAnalyzer = StatefulAnalyzer(config, yamlModels, (uri, collector) {

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -116,10 +116,6 @@ class GeneratorConfig {
   List<String> get modelSourcePathParts =>
       [...serverPackageDirectoryPathParts, ...relativeModelSourcePathParts];
 
-  /// Path parts to the endpoints directory of the server package.
-  List<String> get endpointsSourcePathParts =>
-      [...serverPackageDirectoryPathParts, 'lib', 'src', 'endpoints'];
-
   /// The internal package path parts of the directory, where the generated code is stored in the
   /// server package.
   List<String> get generatedServeModelPackagePathParts => ['src', 'generated'];
@@ -429,7 +425,6 @@ class GeneratorConfig {
     var str = '''type: $type
 sourceProtocol: ${p.joinAll(protocolSourcePathParts)}
 sourceModel: ${p.joinAll(modelSourcePathParts)}
-sourceEndpoints: ${p.joinAll(endpointsSourcePathParts)}
 generatedClientDart: ${p.joinAll(generatedDartClientModelPathParts)}
 generatedServerModel: ${p.joinAll(generatedServeModelPathParts)}
 ''';

--- a/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
@@ -88,23 +88,22 @@ Future<bool> performGenerateContinuously({
 Stream<WatchEvent> _setupAllWatchedDirectories(GeneratorConfig config) {
   var watchers = <DirectoryWatcher>[];
 
-  var protocolPath = p.joinAll(config.protocolSourcePathParts);
-  var modelPath = p.joinAll(config.modelSourcePathParts);
-  var endpointPath = p.joinAll(config.endpointsSourcePathParts);
+  var libPath = p.joinAll(config.libSourcePathParts);
 
-  if (_directoryPathExists(protocolPath)) {
-    watchers.add(DirectoryWatcher(p.joinAll(config.protocolSourcePathParts)));
+  if (_directoryPathExists(libPath)) {
+    watchers.add(DirectoryWatcher(libPath));
   }
 
-  if (_directoryPathExists(modelPath)) {
-    watchers.add(DirectoryWatcher(p.joinAll(config.modelSourcePathParts)));
+  bool notInGeneratedDirectory(WatchEvent e) {
+    var generatedFile = e.path.contains(
+      p.joinAll(config.generatedServeModelPackagePathParts),
+    );
+
+    return !generatedFile;
   }
 
-  if (_directoryPathExists(endpointPath)) {
-    watchers.add(DirectoryWatcher(p.joinAll(config.endpointsSourcePathParts)));
-  }
-
-  return StreamGroup.merge(watchers.map((w) => w.events));
+  return StreamGroup.merge(watchers.map((w) => w.events))
+      .where(notInGeneratedDirectory);
 }
 
 bool _directoryPathExists(String path) {

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_ignore_annotation_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_ignore_annotation_test.dart
@@ -62,6 +62,43 @@ class ExampleEndpoint extends Endpoint {
     });
   });
 
+  group('Given endpoint with a random annotation when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_shared/annotations.dart';
+
+const myAnnotation = 'myAnnotation';
+
+@myAnnotation
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created.', () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+  });
+
   group(
       'Given two endpoints in the same file where one has IgnoreEndpoint annotation when analyzed',
       () {

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_ignore_annotation_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/endpoint_ignore_annotation_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/dart/endpoints_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/endpoint_validation_helpers.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+const pathToServerpodRoot = '../../../../../../../..';
+var testProjectDirectory = Directory(path.joinAll([
+  'test',
+  'integration',
+  'analyzer',
+  'dart',
+  'endpoint_validation',
+  const Uuid().v4(),
+]));
+
+void main() {
+  setUpAll(() async {
+    await createTestEnvironment(testProjectDirectory, pathToServerpodRoot);
+  });
+
+  tearDownAll(() {
+    testProjectDirectory.deleteSync(recursive: true);
+  });
+
+  group('Given endpoint with IgnoreEndpoint annotation when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_shared/annotations.dart';
+
+@ignoreEndpoint
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then no endpoint definition is created.', () {
+      expect(endpointDefinitions, isEmpty);
+    });
+  });
+
+  group(
+      'Given two endpoints in the same file where one has IgnoreEndpoint annotation when analyzed',
+      () {
+    var collector = CodeGenerationCollector();
+    var testDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late List<EndpointDefinition> endpointDefinitions;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile = File(path.join(testDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_shared/annotations.dart';
+
+@ignoreEndpoint
+class FirstExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+
+class SecondExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(testDirectory);
+      endpointDefinitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then endpoint definition is created for the non-marked endpoint.',
+        () {
+      expect(endpointDefinitions, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
Adds support for placing endpoint files anywhere in the project.


This PR also introduces a new annotation that allows developers to exclude endpoint definitions from being generated by the project.

Part of: #964 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - This is implemented as a new feature to the framework.