### PR TITLE
feat: Improved Serverpod startup and stream lifecycle events logging

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -291,11 +291,17 @@ class Serverpod {
     this.httpResponseHeaders = _defaultHttpResponseHeaders,
     this.httpOptionsResponseHeaders = _defaultHttpOptionsResponseHeaders,
   }) {
+    stdout.writeln(
+      'SERVERPOD version: $serverpodVersion, dart: ${Platform.version}, time: ${DateTime.now().toUtc()}',
+    );
+
     _instance = this;
     _internalSerializationManager = internal.Protocol();
 
     // Read command line arguments.
     commandLineArgs = CommandLineArgs(args);
+    stdout.writeln(commandLineArgs.toString());
+
     _runMode = commandLineArgs.runMode;
     serverId = commandLineArgs.serverId;
 
@@ -310,6 +316,8 @@ class Serverpod {
           serverId,
           _passwords,
         );
+    logVerbose(this.config.toString());
+
     Features(this.config);
 
     // Create a temporary log manager with default settings, until we have
@@ -397,12 +405,7 @@ class Serverpod {
       _webServer = WebServer(serverpod: this);
     }
 
-    // Print version and runtime arguments.
-    stdout.writeln(
-      'SERVERPOD version: $serverpodVersion, dart: ${Platform.version}, time: ${DateTime.now().toUtc()}',
-    );
-    stdout.writeln(commandLineArgs.toString());
-    logVerbose(this.config.toString());
+    stdout.writeln('SERVERPOD initialized, time: ${DateTime.now().toUtc()}');
   }
 
   int _exitCode = 0;

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -212,6 +212,9 @@ abstract class Session implements DatabaseAccessor {
   /// Returns the duration this session has been open.
   Duration get duration => DateTime.now().difference(_startTime);
 
+  /// Returns true if this session is closed.
+  bool get isClosed => _closed;
+
   /// Closes the session. This method should only be called if you have
   /// manually created a the [Session] e.g. by calling [createSession] on
   /// [Serverpod]. Closing the session finalizes and writes logs to the

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -212,9 +212,6 @@ abstract class Session implements DatabaseAccessor {
   /// Returns the duration this session has been open.
   Duration get duration => DateTime.now().difference(_startTime);
 
-  /// Returns true if this session is closed.
-  bool get isClosed => _closed;
-
   /// Closes the session. This method should only be called if you have
   /// manually created a the [Session] e.g. by calling [createSession] on
   /// [Serverpod]. Closing the session finalizes and writes logs to the

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
@@ -343,15 +343,9 @@ class MethodStreamManager {
       /// or a request from the client.
       if (isCancelled) return;
       isCancelled = true;
-      var logMessage =
+      session.serverpod.logVerbose(
           'Cancelling method output stream for ${methodStreamCallContext.fullEndpointPath}.'
-          '${methodStreamCallContext.method.name}, id $methodStreamId';
-      if (session.isClosed) {
-        methodStreamCallContext.endpoint.pod
-            .logVerbose('$logMessage (session already closed)');
-      } else {
-        session.log(logMessage, level: LogLevel.debug);
-      }
+          '${methodStreamCallContext.method.name}, id $methodStreamId');
       await revokedAuthenticationHandler?.destroy(session);
       await _closeOutboundStream(methodStreamCallContext, methodStreamId);
       await session.close();
@@ -448,15 +442,9 @@ class MethodStreamManager {
     for (var streamParam in callContext.inputStreams) {
       var parameterName = streamParam.name;
       var controller = StreamController(onCancel: () async {
-        var logMessage =
+        session.serverpod.logVerbose(
             'Cancelling method input stream for ${callContext.fullEndpointPath}.'
-            '${callContext.method.name}.$parameterName, id $methodStreamId';
-        if (session.isClosed) {
-          callContext.endpoint.pod
-              .logVerbose('$logMessage (session already closed)');
-        } else {
-          session.log(logMessage, level: LogLevel.debug);
-        }
+            '${callContext.method.name}.$parameterName, id $methodStreamId');
         var context = _inputStreamContexts.remove(_buildStreamKey(
           endpoint: callContext.fullEndpointPath,
           method: callContext.method.name,

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/helpers/method_stream_manager.dart
@@ -343,9 +343,15 @@ class MethodStreamManager {
       /// or a request from the client.
       if (isCancelled) return;
       isCancelled = true;
-      session.log(
-          'Cancelling method output stream for ${session.endpoint}.${session.method}, id $methodStreamId',
-          level: LogLevel.debug);
+      var logMessage =
+          'Cancelling method output stream for ${methodStreamCallContext.fullEndpointPath}.'
+          '${methodStreamCallContext.method.name}, id $methodStreamId';
+      if (session.isClosed) {
+        methodStreamCallContext.endpoint.pod
+            .logVerbose('$logMessage (session already closed)');
+      } else {
+        session.log(logMessage, level: LogLevel.debug);
+      }
       await revokedAuthenticationHandler?.destroy(session);
       await _closeOutboundStream(methodStreamCallContext, methodStreamId);
       await session.close();

--- a/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
+++ b/packages/serverpod/lib/src/server/websocket_request_handlers/method_websocket_request_handler.dart
@@ -36,7 +36,13 @@ class MethodWebsocketRequestHandler {
         }
 
         switch (message) {
-          case OpenMethodStreamCommand():
+          case OpenMethodStreamCommand(
+              endpoint: var endpoint,
+              method: var method,
+              connectionId: var connectionId,
+            ):
+            server.serverpod.logVerbose(
+                'Open method stream command for $endpoint.$method, id $connectionId');
             webSocket.tryAdd(
               await _handleOpenMethodStreamCommand(
                 server,
@@ -46,7 +52,13 @@ class MethodWebsocketRequestHandler {
               ),
             );
             break;
-          case OpenMethodStreamResponse():
+          case OpenMethodStreamResponse(
+              endpoint: var endpoint,
+              method: var method,
+              connectionId: var connectionId,
+            ):
+            server.serverpod.logVerbose(
+                'Open method stream response for $endpoint.$method, id $connectionId');
             break;
           case MethodStreamMessage():
             _dispatchMethodStreamMessage(
@@ -56,7 +68,13 @@ class MethodWebsocketRequestHandler {
               methodStreamManager,
             );
             break;
-          case CloseMethodStreamCommand():
+          case CloseMethodStreamCommand(
+              endpoint: var endpoint,
+              method: var method,
+              connectionId: var connectionId,
+            ):
+            server.serverpod.logVerbose(
+                'Close method stream command for $endpoint.$method, id $connectionId');
             await methodStreamManager.closeStream(
               endpoint: message.endpoint,
               method: message.method,
@@ -87,13 +105,18 @@ class MethodWebsocketRequestHandler {
         }
       }
     } catch (e, stackTrace) {
-      if (server.serverpod.runtimeSettings.logMalformedCalls) {
+      if (e is! UnknownMessageException ||
+          server.serverpod.runtimeSettings.logMalformedCalls) {
         stderr.writeln(
-            '${DateTime.now().toUtc()} Method stream websocket error.');
-        stderr.writeln('$e');
+            '${DateTime.now().toUtc()} Method stream websocket error: $e');
         stderr.writeln('$stackTrace');
       }
     } finally {
+      server.serverpod.logVerbose(
+        'Closing method stream websocket while '
+        '${methodStreamManager.openOutputStreamCount} out-streams and '
+        '${methodStreamManager.openInputStreamCount} in-streams still open.',
+      );
       await methodStreamManager.closeAllStreams();
       // Send a close message to the client.
       await webSocket.close();


### PR DESCRIPTION
Improved Serverpod initialization log messages, and added verbose logging of method streams lifecycle events.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a