### PR TITLE
chore: Bump intl dependency.

### DIFF
--- a/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^8.0.0
-  intl: ^0.19.0
+  intl: '>=0.19.0 <0.21.0'
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: 2.2.0-beta.1

--- a/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_chat/serverpod_chat_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   file_picker: ^8.0.0
-  intl: ^0.19.0
+  intl: '>=0.19.0 <0.21.0'
   url_launcher: ^6.1.10
   path: ^1.8.2
   serverpod_auth_client: SERVERPOD_VERSION

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   code_builder: ^4.5.0
   dart_style: ^2.3.0
   http: '>=1.0.0 <2.0.0'
-  intl: ^0.19.0
+  intl: '>=0.19.0 <0.21.0'
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   code_builder: ^4.5.0
   dart_style: ^2.3.0
   http: '>=1.0.0 <2.0.0'
-  intl: ^0.19.0
+  intl: '>=0.19.0 <0.21.0'
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0


### PR DESCRIPTION
Bumps the `intl` dependency from `^0.19.0` to `'>=0.19.0 <0.21.0'`

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - range allows old version of the same package.