### PR TITLE
fix: Remove redundant file collection from code generation

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
+++ b/tools/serverpod_cli/lib/src/generator/code_generation_collector.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:source_span/source_span.dart';
@@ -9,9 +7,6 @@ class CodeGenerationCollector extends CodeAnalysisCollector {
   /// All the errors reported.
   @override
   final List<SourceSpanException> errors = [];
-
-  /// All the generated files reported.
-  final Set<File> generatedFiles = {};
 
   @override
   void addError(SourceSpanException error) {
@@ -72,15 +67,5 @@ class CodeGenerationCollector extends CodeAnalysisCollector {
   @override
   void clearErrors() {
     errors.clear();
-  }
-
-  /// Report a generated file.
-  void addGeneratedFile(File file) {
-    generatedFiles.add(file);
-  }
-
-  /// Clear the list of generated files.
-  void clearGeneratedFiles() {
-    generatedFiles.clear();
   }
 }

--- a/tools/serverpod_cli/lib/src/generator/generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator.dart
@@ -34,7 +34,6 @@ Future<bool> performGenerate({
       await ServerpodCodeGenerator.generateSerializableModels(
     models: models,
     config: config,
-    collector: collector,
   );
 
   if (collector.hasSeverErrors) {
@@ -72,7 +71,6 @@ Future<bool> performGenerate({
       await ServerpodCodeGenerator.generateProtocolDefinition(
     protocolDefinition: protocolDefinition,
     config: config,
-    collector: collector,
   );
 
   if (collector.hasSeverErrors) {

--- a/tools/serverpod_cli/lib/src/generator/generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator.dart
@@ -49,16 +49,16 @@ Future<bool> performGenerate({
     changedFiles.add(changedFilePath);
   }
 
+  var endpointAnalyzerCollector = CodeGenerationCollector();
   var endpoints = await endpointsAnalyzer.analyze(
-    collector: collector,
+    collector: endpointAnalyzerCollector,
     changedFiles: changedFiles,
   );
 
-  if (collector.hasSeverErrors) {
+  if (endpointAnalyzerCollector.hasSeverErrors) {
     success = false;
   }
-  collector.printErrors();
-  collector.clearErrors();
+  endpointAnalyzerCollector.printErrors();
 
   log.debug('Generating the protocol.');
 

--- a/tools/serverpod_cli/lib/src/generator/generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator.dart
@@ -12,7 +12,6 @@ Future<bool> performGenerate({
   required EndpointsAnalyzer endpointsAnalyzer,
   String? changedFilePath,
 }) async {
-  var collector = CodeGenerationCollector();
   bool success = true;
 
   log.debug('Analyzing serializable models in the protocol directory.');
@@ -35,12 +34,6 @@ Future<bool> performGenerate({
     models: models,
     config: config,
   );
-
-  if (collector.hasSeverErrors) {
-    success = false;
-  }
-  collector.printErrors();
-  collector.clearErrors();
 
   log.debug('Analyzing the endpoints.');
 
@@ -72,12 +65,6 @@ Future<bool> performGenerate({
     protocolDefinition: protocolDefinition,
     config: config,
   );
-
-  if (collector.hasSeverErrors) {
-    success = false;
-  }
-  collector.printErrors();
-  collector.clearErrors();
 
   log.debug('Cleaning old files.');
 

--- a/tools/serverpod_cli/lib/src/generator/serverpod_code_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/serverpod_code_generator.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
-import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/generator/code_generator.dart';
 import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
@@ -26,9 +25,7 @@ abstract class ServerpodCodeGenerator {
   static Future<List<String>> generateSerializableModels({
     required List<SerializableModelDefinition> models,
     required GeneratorConfig config,
-    required CodeGenerationCollector collector,
   }) async {
-    collector.generatedFiles.clear();
     var allFiles = {
       for (var generator in _generators)
         ...generator.generateSerializableModelsCode(
@@ -42,8 +39,6 @@ abstract class ServerpodCodeGenerator {
         var out = File(file.key);
         await out.create(recursive: true);
         await out.writeAsString(file.value, flush: true);
-
-        collector.addGeneratedFile(out);
       } catch (e, stackTrace) {
         log.error('Failed to generate ${file.key}!');
         printInternalError(e, stackTrace);
@@ -60,9 +55,7 @@ abstract class ServerpodCodeGenerator {
   static Future<List<String>> generateProtocolDefinition({
     required ProtocolDefinition protocolDefinition,
     required GeneratorConfig config,
-    required CodeGenerationCollector collector,
   }) async {
-    collector.generatedFiles.clear();
     var allFiles = {
       for (var generator in _generators)
         ...generator.generateProtocolCode(
@@ -76,8 +69,6 @@ abstract class ServerpodCodeGenerator {
         var out = File(file.key);
         await out.create(recursive: true);
         await out.writeAsString(file.value, flush: true);
-
-        collector.addGeneratedFile(out);
       } catch (e, stackTrace) {
         log.error('Failed to generate ${file.key}');
         printInternalError(e, stackTrace);


### PR DESCRIPTION
Removes a the redundant file collection feature from our code generation collector.

The files generated are already returned by the affected methods.

Also scoped down the error gathering to only target the endpoints analyzer since that was the only real user of the collector.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - changes to internal classes not intended for developers to use.