### PR TITLE
fix: Use statefull analyzers in generator

### DIFF
--- a/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
@@ -67,14 +67,6 @@ void main() async {
       createProcess.kill();
       generateWatch?.kill();
       generateStreamSearch.cancel();
-
-      await Process.run(
-        'docker',
-        ['compose', 'down', '-v'],
-        workingDirectory: commandRoot,
-      );
-
-      while (!await isNetworkPortAvailable(8090)) {}
     });
 
     test('then the entity files are generated and updated as expected.',
@@ -242,14 +234,6 @@ fields:
       createProcess.kill();
       generateWatch?.kill();
       generateStreamSearch.cancel();
-
-      await Process.run(
-        'docker',
-        ['compose', 'down', '-v'],
-        workingDirectory: commandRoot,
-      );
-
-      while (!await isNetworkPortAvailable(8090)) {}
     });
     test('then endpoint dispatcher is generated and updated as expected.',
         () async {
@@ -422,14 +406,6 @@ class TestEndpoint extends Endpoint {
       createProcess.kill();
       generateWatch?.kill();
       generateStreamSearch.cancel();
-
-      await Process.run(
-        'docker',
-        ['compose', 'down', '-v'],
-        workingDirectory: commandRoot,
-      );
-
-      while (!await isNetworkPortAvailable(8090)) {}
     });
     test('then client endpoint dispatcher is updated as expected.', () async {
       // Add endpoint file

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -27,6 +27,8 @@ class EndpointsAnalyzer {
           resourceProvider: PhysicalResourceProvider.INSTANCE,
         );
 
+  Set<EndpointDefinition> _endpointDefinitions = {};
+
   /// Analyze all files in the [AnalysisContextCollection].
   /// Use [changedFiles] to mark files, that need reloading.
   Future<List<EndpointDefinition>> analyze({
@@ -95,6 +97,7 @@ class EndpointsAnalyzer {
       ));
     }
 
+    _endpointDefinitions = endpointDefs.toSet();
     return endpointDefs;
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -11,12 +11,15 @@ import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_class_analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_method_analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/endpoint_analyzers/endpoint_parameter_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 
 import 'definitions.dart';
 
 /// Analyzes dart files for the protocol specification.
 class EndpointsAnalyzer {
   final AnalysisContextCollection collection;
+
+  final String absoluteIncludedPaths;
 
   /// Create a new [EndpointsAnalyzer], containing a
   /// [AnalysisContextCollection] that analyzes all dart files in the
@@ -25,12 +28,34 @@ class EndpointsAnalyzer {
       : collection = AnalysisContextCollection(
           includedPaths: [directory.absolute.path],
           resourceProvider: PhysicalResourceProvider.INSTANCE,
-        );
+        ),
+        absoluteIncludedPaths = directory.absolute.path;
 
   Set<EndpointDefinition> _endpointDefinitions = {};
 
+  /// Inform the analyzer that the provided [filePaths] have been updated.
+  ///
+  /// This will trigger a re-analysis of the files and return true if the
+  /// updated files should trigger a code generation.
+  Future<bool> updateFileContexts(Set<String> filePaths) async {
+    await _refreshContextForFiles(filePaths);
+
+    var oldDefinitions = _endpointDefinitions;
+    await analyze(collector: CodeGenerationCollector());
+
+    var shared = _endpointDefinitions.intersection(oldDefinitions);
+    if (shared.length != oldDefinitions.length) {
+      return true;
+    }
+
+    return filePaths.any((e) => _isEndpointFile(File(e)));
+  }
+
   /// Analyze all files in the [AnalysisContextCollection].
-  /// Use [changedFiles] to mark files, that need reloading.
+  ///
+  /// [changedFiles] is an optional list of files that should have their context
+  /// refreshed before analysis. This is useful when only a subset of files have
+  /// changed since [updateFileContexts] was last called.
   Future<List<EndpointDefinition>> analyze({
     required CodeAnalysisCollector collector,
     Set<String>? changedFiles,
@@ -174,6 +199,17 @@ class EndpointsAnalyzer {
       }
       await context.applyPendingFileChanges();
     }
+  }
+
+  bool _isEndpointFile(File file) {
+    if (!file.absolute.path.startsWith(absoluteIncludedPaths)) return false;
+    if (!file.path.endsWith('.dart')) return false;
+    if (!file.existsSync()) return false;
+
+    var contents = file.readAsStringSync();
+    if (!contents.contains('extends Endpoint')) return false;
+
+    return true;
   }
 
   Map<String, List<SourceSpanSeverityException>> _validateLibrary(

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -13,6 +13,11 @@ class StatefulAnalyzer {
   final Map<String, _ModelState> _modelStates = {};
   List<SerializableModelDefinition> _models = [];
 
+  /// Returns true if any of the models have severe errors.
+  bool get hasSeverErrors => _modelStates.values.any(
+        (state) => CodeAnalysisCollector.containsSeverErrors(state.errors),
+      );
+
   Function(Uri, CodeGenerationCollector)? _onErrorsChangedNotifier;
 
   StatefulAnalyzer(

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -5,11 +5,13 @@ import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 
 import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generated/version.dart';
 import 'package:serverpod_cli/src/generator/generator.dart';
 import 'package:serverpod_cli/src/generator/generator_continuous.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/serverpod_packages_version_check/serverpod_packages_version_check.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 class GenerateCommand extends ServerpodCommand {
@@ -59,11 +61,17 @@ class GenerateCommand extends ServerpodCommand {
         Directory(path.joinAll(config.endpointsSourcePathParts));
     var endpointsAnalyzer = EndpointsAnalyzer(endpointDirectory);
 
+    var protocols = await ModelHelper.loadProjectYamlModelsFromDisk(config);
+    var modelAnalyzer = StatefulAnalyzer(config, protocols, (uri, collector) {
+      collector.printErrors();
+    });
+
     bool success = true;
     if (watch) {
       success = await performGenerateContinuously(
         config: config,
         endpointsAnalyzer: endpointsAnalyzer,
+        modelAnalyzer: modelAnalyzer,
       );
     } else {
       success = await log.progress(
@@ -71,6 +79,7 @@ class GenerateCommand extends ServerpodCommand {
         () => performGenerate(
           config: config,
           endpointsAnalyzer: endpointsAnalyzer,
+          modelAnalyzer: modelAnalyzer,
         ),
       );
     }

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -61,8 +61,8 @@ class GenerateCommand extends ServerpodCommand {
         Directory(path.joinAll(config.endpointsSourcePathParts));
     var endpointsAnalyzer = EndpointsAnalyzer(endpointDirectory);
 
-    var protocols = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-    var modelAnalyzer = StatefulAnalyzer(config, protocols, (uri, collector) {
+    var yamlModels = await ModelHelper.loadProjectYamlModelsFromDisk(config);
+    var modelAnalyzer = StatefulAnalyzer(config, yamlModels, (uri, collector) {
       collector.printErrors();
     });
 

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -101,13 +101,20 @@ class GeneratorConfig {
   List<String> get libSourcePathParts =>
       [...serverPackageDirectoryPathParts, 'lib'];
 
+  /// Relative path parts to the protocol directory
+  List<String> get relativeProtocolSourcePathParts =>
+      ['lib', 'src', 'protocol'];
+
   /// Path parts to the protocol directory of the server package.
   List<String> get protocolSourcePathParts =>
-      [...serverPackageDirectoryPathParts, 'lib', 'src', 'protocol'];
+      [...serverPackageDirectoryPathParts, ...relativeProtocolSourcePathParts];
+
+  /// Relative path parts to the model directory
+  List<String> get relativeModelSourcePathParts => ['lib', 'src', 'models'];
 
   /// Path parts to the model directory of the server package.
   List<String> get modelSourcePathParts =>
-      [...serverPackageDirectoryPathParts, 'lib', 'src', 'models'];
+      [...serverPackageDirectoryPathParts, ...relativeModelSourcePathParts];
 
   /// Path parts to the endpoints directory of the server package.
   List<String> get endpointsSourcePathParts =>

--- a/tools/serverpod_cli/lib/src/generator/generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator.dart
@@ -10,7 +10,6 @@ Future<bool> performGenerate({
   bool dartFormat = true,
   required GeneratorConfig config,
   required EndpointsAnalyzer endpointsAnalyzer,
-  String? changedFilePath,
 }) async {
   bool success = true;
 
@@ -37,15 +36,10 @@ Future<bool> performGenerate({
 
   log.debug('Analyzing the endpoints.');
 
-  var changedFiles = generatedModelFiles.toSet();
-  if (changedFilePath != null) {
-    changedFiles.add(changedFilePath);
-  }
-
   var endpointAnalyzerCollector = CodeGenerationCollector();
   var endpoints = await endpointsAnalyzer.analyze(
     collector: endpointAnalyzerCollector,
-    changedFiles: changedFiles,
+    changedFiles: generatedModelFiles.toSet(),
   );
 
   if (endpointAnalyzerCollector.hasSeverErrors) {

--- a/tools/serverpod_cli/lib/src/generator/generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator.dart
@@ -2,7 +2,6 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/generator/serverpod_code_generator.dart';
-import 'package:serverpod_cli/src/util/model_helper.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 /// Analyze the server package and generate the code.
@@ -10,21 +9,14 @@ Future<bool> performGenerate({
   bool dartFormat = true,
   required GeneratorConfig config,
   required EndpointsAnalyzer endpointsAnalyzer,
+  required StatefulAnalyzer modelAnalyzer,
 }) async {
   bool success = true;
 
   log.debug('Analyzing serializable models in the protocol directory.');
-  var protocols = await ModelHelper.loadProjectYamlModelsFromDisk(config);
 
-  var analyzer = StatefulAnalyzer(config, protocols, (uri, collector) {
-    collector.printErrors();
-
-    if (collector.hasSeverErrors) {
-      success = false;
-    }
-  });
-
-  var models = analyzer.validateAll();
+  var models = modelAnalyzer.validateAll();
+  success &= !modelAnalyzer.hasSeverErrors;
 
   log.debug('Generating files for serializable models.');
 
@@ -42,9 +34,7 @@ Future<bool> performGenerate({
     changedFiles: generatedModelFiles.toSet(),
   );
 
-  if (endpointAnalyzerCollector.hasSeverErrors) {
-    success = false;
-  }
+  success &= !endpointAnalyzerCollector.hasSeverErrors;
   endpointAnalyzerCollector.printErrors();
 
   log.debug('Generating the protocol.');

--- a/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
@@ -34,7 +34,7 @@ Future<bool> performGenerateContinuously({
   var modelSourcePath = p.joinAll(config.modelSourcePathParts);
   var protocolSourcePath = p.joinAll(config.protocolSourcePathParts);
 
-  Timer? generateDispatch;
+  Timer? debouncedGenerate;
   await for (WatchEvent event in watchers) {
     log.debug('File changed: $event');
 
@@ -65,8 +65,8 @@ Future<bool> performGenerateContinuously({
 
     if (!shouldGenerate) continue;
 
-    generateDispatch?.cancel();
-    generateDispatch = Timer(const Duration(milliseconds: 500), () async {
+    debouncedGenerate?.cancel();
+    debouncedGenerate = Timer(const Duration(milliseconds: 500), () async {
       log.info(
         DateFormat('MMM dd - HH:mm:ss:SS').format(DateTime.now()),
         newParagraph: true,

--- a/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
@@ -32,10 +32,11 @@ Future<bool> performGenerateContinuously({
       newParagraph: true,
     );
     log.info('File changed: $event');
+
+    await endpointsAnalyzer.updateFileContexts({event.path});
     success = await _performSafeGenerate(
       config: config,
       endpointsAnalyzer: endpointsAnalyzer,
-      changedFilePath: event.path,
       completionMessage: 'Incremental code generation complete.',
     );
   }
@@ -73,7 +74,6 @@ bool _directoryPathExists(String path) {
 Future<bool> _performSafeGenerate({
   required GeneratorConfig config,
   required EndpointsAnalyzer endpointsAnalyzer,
-  String? changedFilePath,
   required String completionMessage,
 }) async {
   var success = false;
@@ -83,7 +83,6 @@ Future<bool> _performSafeGenerate({
         () => performGenerate(
               config: config,
               endpointsAnalyzer: endpointsAnalyzer,
-              changedFilePath: changedFilePath,
             ));
     log.info(completionMessage);
   } catch (e) {

--- a/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
+++ b/tools/serverpod_cli/lib/src/generator/generator_continuous.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:async/async.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:watcher/watcher.dart';
 
@@ -14,6 +16,7 @@ import 'generator.dart';
 Future<bool> performGenerateContinuously({
   required GeneratorConfig config,
   required EndpointsAnalyzer endpointsAnalyzer,
+  required StatefulAnalyzer modelAnalyzer,
 }) async {
   log.debug('Starting up continuous generator');
 
@@ -22,21 +25,53 @@ Future<bool> performGenerateContinuously({
   var success = await _performSafeGenerate(
     config: config,
     endpointsAnalyzer: endpointsAnalyzer,
+    modelAnalyzer: modelAnalyzer,
     completionMessage:
         'Initial code generation complete. Listening for changes.',
   );
 
+  var modelSourcePath = p.joinAll(config.modelSourcePathParts);
+  var protocolSourcePath = p.joinAll(config.protocolSourcePathParts);
   await for (WatchEvent event in watchers) {
+    log.debug('File changed: $event');
+
+    var shouldGenerate =
+        await endpointsAnalyzer.updateFileContexts({event.path});
+
+    if (ModelHelper.isModelFile(
+      event.path,
+      modelSourcePath,
+      protocolSourcePath,
+    )) {
+      shouldGenerate = true;
+      var modelUri = Uri.parse(p.absolute(event.path));
+      switch (event.type) {
+        case ChangeType.ADD:
+        case ChangeType.MODIFY:
+          var yaml = File(event.path).readAsStringSync();
+          modelAnalyzer.addYamlModel(ModelSource(
+            defaultModuleAlias,
+            yaml,
+            modelUri,
+            ModelHelper.extractPathFromConfig(config, Uri.parse(event.path)),
+          ));
+        case ChangeType.REMOVE:
+          modelAnalyzer.removeYamlModel(modelUri);
+      }
+    }
+
+    if (!shouldGenerate) continue;
+
     log.info(
       DateFormat('MMM dd - HH:mm:ss:SS').format(DateTime.now()),
       newParagraph: true,
     );
     log.info('File changed: $event');
 
-    await endpointsAnalyzer.updateFileContexts({event.path});
     success = await _performSafeGenerate(
       config: config,
       endpointsAnalyzer: endpointsAnalyzer,
+      modelAnalyzer: modelAnalyzer,
       completionMessage: 'Incremental code generation complete.',
     );
   }
@@ -74,16 +109,19 @@ bool _directoryPathExists(String path) {
 Future<bool> _performSafeGenerate({
   required GeneratorConfig config,
   required EndpointsAnalyzer endpointsAnalyzer,
+  required StatefulAnalyzer modelAnalyzer,
   required String completionMessage,
 }) async {
   var success = false;
   try {
     success = await log.progress(
-        'Generating code',
-        () => performGenerate(
-              config: config,
-              endpointsAnalyzer: endpointsAnalyzer,
-            ));
+      'Generating code',
+      () => performGenerate(
+        config: config,
+        endpointsAnalyzer: endpointsAnalyzer,
+        modelAnalyzer: modelAnalyzer,
+      ),
+    );
     log.info(completionMessage);
   } catch (e) {
     if (e is Error) {

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/stateful_analyzer_test.dart
@@ -122,6 +122,20 @@ fields:
   });
 
   test(
+      'Given a model with a severe error (invalid syntax), when validating all, then hasSeverErrors returns true',
+      () {
+    var yamlSource = ModelSourceBuilder().withYaml('''''').build();
+
+    var statefulAnalyzer = StatefulAnalyzer(
+      config,
+      [yamlSource],
+    );
+
+    statefulAnalyzer.validateAll();
+    expect(statefulAnalyzer.hasSeverErrors, true);
+  });
+
+  test(
       'Given a model with multi line invalid yaml syntax when validating all then error is reported.',
       () {
     var invalidSource = ModelSourceBuilder().withYaml(

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -42,7 +42,6 @@ void main() {
         'then false is returned.', () async {
       var emptyFile = File(path.join(trackedDirectory.path, 'empty_file.dart'));
       emptyFile.createSync(recursive: true);
-      // Empty file
       emptyFile.writeAsStringSync('');
 
       await expectLater(

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -1,0 +1,289 @@
+import 'dart:io';
+
+import 'package:serverpod_cli/src/analyzer/dart/endpoints_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/endpoint_validation_helpers.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+const pathToServerpodRoot = '../../../../../../../..';
+var testProjectDirectory = Directory(path.joinAll([
+  'test',
+  'integration',
+  'analyzer',
+  'dart',
+  'endpoint_validation',
+  const Uuid().v4(),
+]));
+
+void main() {
+  setUpAll(() async {
+    await createTestEnvironment(testProjectDirectory, pathToServerpodRoot);
+  });
+
+  tearDownAll(() {
+    testProjectDirectory.deleteSync(recursive: true);
+  });
+
+  group('Given an empty tracked and analyzed directory', () {
+    var trackedDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      analyzer = EndpointsAnalyzer(trackedDirectory);
+      await analyzer.analyze(collector: CodeGenerationCollector());
+    });
+
+    test(
+        'when the file context is updated with a file without an endpoint '
+        'definition in the tracked directory'
+        'then false is returned.', () async {
+      var emptyFile = File(path.join(trackedDirectory.path, 'empty_file.dart'));
+      emptyFile.createSync(recursive: true);
+      // Empty file
+      emptyFile.writeAsStringSync('');
+
+      await expectLater(
+        analyzer.updateFileContexts({emptyFile.path}),
+        completion(false),
+      );
+    });
+
+    test(
+        'when the file context is updated with an endpoint file outside '
+        'of the tracked directory '
+        'then false is returned.', () async {
+      var endpointFile =
+          File(path.join(testProjectDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+
+      await expectLater(
+        analyzer.updateFileContexts({endpointFile.path}),
+        completion(false),
+      );
+    });
+
+    test(
+        'when the file context is updated with a new endpoint file in the '
+        'tracked directory '
+        'then true is returned.', () async {
+      var endpointFile =
+          File(path.join(trackedDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+
+      await expectLater(
+        analyzer.updateFileContexts({endpointFile.path}),
+        completion(true),
+      );
+    });
+  });
+  group('Given a tracked and analyzed directory with valid endpoint file', () {
+    var trackedDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late File endpointFile;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      endpointFile = File(path.join(trackedDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(trackedDirectory);
+      await analyzer.analyze(collector: CodeGenerationCollector());
+    });
+
+    test(
+        'when the file context is updated with the removal of the tracked '
+        'endpoint file '
+        'then true is returned.', () async {
+      endpointFile.deleteSync();
+
+      await expectLater(
+        analyzer.updateFileContexts({endpointFile.path}),
+        completion(true),
+      );
+    });
+
+    test(
+        'when the file context is updated with the update of the endpoint '
+        'file in the tracked folder '
+        'then true is returned.', () async {
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> goodbye(Session session, String name) async {
+    return 'Goodbye \$name';
+  }
+}
+''');
+
+      await expectLater(
+        analyzer.updateFileContexts({endpointFile.path}),
+        completion(true),
+      );
+    });
+  });
+
+  group('Given a tracked and analyzed directory with valid non-endpoint file',
+      () {
+    var trackedDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late File trackedFile;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      trackedFile = File(path.join(trackedDirectory.path, 'tracked.dart'));
+      trackedFile.createSync(recursive: true);
+      trackedFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleClass {
+  Future<String> hello(String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      analyzer = EndpointsAnalyzer(trackedDirectory);
+      await analyzer.analyze(collector: CodeGenerationCollector());
+    });
+
+    test(
+        'when the file context is updated with an endpoint definition added '
+        'to the tracked file '
+        'then true is returned.', () async {
+      trackedFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+
+      await expectLater(
+        analyzer.updateFileContexts({trackedFile.path}),
+        completion(true),
+      );
+    });
+  });
+
+  group(
+      'Given a tracked and analyzed directory with invalid dart endpoint file',
+      () {
+    var trackedDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late File endpointFile;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      endpointFile = File(path.join(trackedDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      // Class is missing closing brackets
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+
+
+''');
+      analyzer = EndpointsAnalyzer(trackedDirectory);
+      await analyzer.analyze(collector: CodeGenerationCollector());
+    });
+
+    test(
+        'when the file context is updated with a valid endpoint definition '
+        'added to the tracked file '
+        'then true is returned.', () async {
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+
+      await expectLater(
+        analyzer.updateFileContexts({endpointFile.path}),
+        completion(true),
+      );
+    });
+  });
+
+  group(
+      'Given a tracked and analyzed endpoint file that depends on an invalid dart file',
+      () {
+    var trackedDirectory =
+        Directory(path.join(testProjectDirectory.path, const Uuid().v4()));
+
+    late File invalidDartFile;
+    late EndpointsAnalyzer analyzer;
+    setUpAll(() async {
+      var endpointFile =
+          File(path.join(trackedDirectory.path, 'endpoint.dart'));
+      endpointFile.createSync(recursive: true);
+      endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+import 'invalid_dart.dart';
+
+class ExampleClass extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+}
+''');
+      invalidDartFile =
+          File(path.join(trackedDirectory.path, 'invalid_dart.dart'));
+      invalidDartFile.createSync(recursive: true);
+      // Class is missing closing brackets
+      invalidDartFile.writeAsStringSync('''
+class MyClass {
+''');
+      analyzer = EndpointsAnalyzer(trackedDirectory);
+      await analyzer.analyze(collector: CodeGenerationCollector());
+    });
+
+    test(
+        'when the file context is updated with a fix for the invalid dart file '
+        'then true is returned.', () async {
+      invalidDartFile.writeAsStringSync('''
+class MyClass {}
+''');
+
+      await expectLater(
+        analyzer.updateFileContexts({invalidDartFile.path}),
+        completion(true),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Uses stateful analyzers to analyze both endpoints and model files in the generator.

This PR is a preparation for supporting endpoint and model files located anywhere in the project that is tracked here  https://github.com/serverpod/serverpod/issues/964

This PR also introduces additional filtering on the watched files to only trigger a regeneration when either an endpoint or a model file is updated. This will be a necessary change once we listen to all files in the project directory to prevent unnecessary regenerations for other file changes.

A small delay was added to generate files so that multiple changes are batched together. For example, when a file is moved from one folder to another, this creates an `add` and a `remove` event, which could introduce an invalid state if they are processed separately. We already have tests that validate this in the e2e generate watch tests.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - the changes in this PR should preserve the current generated behavior.