### PR TITLE
fix: Return same uri when extracting path from model outside of allowed directory.

### DIFF
--- a/tools/serverpod_cli/lib/src/util/model_helper.dart
+++ b/tools/serverpod_cli/lib/src/util/model_helper.dart
@@ -112,7 +112,11 @@ class ModelHelper {
       return extractPathFromModelRoot(config.protocolSourcePathParts, uri);
     }
 
-    return extractPathFromModelRoot(config.modelSourcePathParts, uri);
+    if (isWithin(joinAll(config.modelSourcePathParts), uri.path)) {
+      return extractPathFromModelRoot(config.modelSourcePathParts, uri);
+    }
+
+    return split(uri.path);
   }
 
   static List<String> extractPathFromModelRoot(

--- a/tools/serverpod_cli/test/integration/util/model_helper_test.dart
+++ b/tools/serverpod_cli/test/integration/util/model_helper_test.dart
@@ -26,8 +26,8 @@ void main() {
   group('Test path extraction - extractPathFromConfig.', () {
     var serverRootDir = Directory(join(
       'test',
-      'integration'
-          'util',
+      'integration',
+      'util',
       'test_assets',
       'protocol_helper',
       'has_serverpod_server_project',
@@ -39,8 +39,8 @@ void main() {
         () {
       var modelFile = File(join(
         'test',
-        'integration'
-            'util',
+        'integration',
+        'util',
         'test_assets',
         'protocol_helper',
         'has_serverpod_server_project',
@@ -66,6 +66,7 @@ void main() {
         () {
       var modelFile = File(join(
         'test',
+        'integration',
         'util',
         'test_assets',
         'protocol_helper',
@@ -94,6 +95,7 @@ void main() {
         () {
       var modelFile = File(join(
         'test',
+        'integration',
         'util',
         'test_assets',
         'protocol_helper',
@@ -101,7 +103,7 @@ void main() {
         'test_server',
         'lib',
         'src',
-        'model',
+        'models',
         'nested',
         'folder',
         'test.yaml',
@@ -123,8 +125,8 @@ void main() {
         () {
       var modelFile = File(join(
         'test',
-        'integration'
-            'util',
+        'integration',
+        'util',
         'test_assets',
         'protocol_helper',
         'has_serverpod_server_project',
@@ -137,8 +139,8 @@ void main() {
 
       var rootPath = [
         'test',
-        'integration'
-            'util',
+        'integration',
+        'util',
         'test_assets',
         'protocol_helper',
         'has_serverpod_server_project',

--- a/tools/serverpod_cli/test/integration/util/model_helper_test.dart
+++ b/tools/serverpod_cli/test/integration/util/model_helper_test.dart
@@ -118,7 +118,34 @@ void main() {
 
       expect(pathParts, ['nested', 'folder']);
     });
+
+    test(
+        'Given a model with a path outside of the protocol or models folder, then parts list contains all the path parts',
+        () {
+      var filePathParts = [
+        'test',
+        'integration',
+        'util',
+        'test_assets',
+        'protocol_helper',
+        'has_serverpod_server_project',
+        'test_server',
+        'lib',
+        'src',
+      ];
+      var modelFile = File(joinAll(filePathParts));
+
+      var config = createGeneratorConfig(split(serverRootDir.path));
+
+      var pathParts = ModelHelper.extractPathFromConfig(
+        config,
+        modelFile.uri,
+      );
+
+      expect(pathParts, filePathParts);
+    });
   });
+
   group('Test path extraction - extractPathFromModelRoot.', () {
     test(
         'Given a model path directly inside the model folder, then the parts list is empty.',


### PR DESCRIPTION
Found some false positives in our tests and "completed" the implementation so that a valid response is always returned.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._