### PR TITLE
ci: Add melos and melos lint job for project

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -50,10 +50,11 @@ jobs:
 
   dart_analyze_latest:
     name: dart analyze latest
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         flutter-version: ['3.27.0']
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -68,10 +69,11 @@ jobs:
 
   dart_analyze_downgrade:
     name: dart analyze downgrade
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         flutter-version: ['3.19.0', '3.27.0']
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -48,22 +48,6 @@ jobs:
       - name: Run lint
         run: melos lint_strict
 
-  dart_analyze_downgrade:
-    name: dart analyze downgrade
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        flutter-version: ['3.19.0', '3.27.0']
-    steps:
-      - uses: actions/checkout@v3
-      - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ matrix.flutter-version }}
-      - name: Install dependencies
-        run: bash util/pub_get_all --downgrade
-      - name: Analyze
-        run: bash util/run_tests_analyze --allow-warnings
-
   dart_analyze_latest:
     name: dart analyze latest
     runs-on: ubuntu-latest
@@ -75,10 +59,32 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
-      - name: Install dependencies
-        run: bash util/pub_get_all
-      - name: Analyze
-        run: bash util/run_tests_analyze --allow-infos
+      - name: Install melos
+        run: dart pub global activate melos
+      - name: Bootstrap
+        run: melos bootstrap
+      - name: Run lint
+        run: melos lint
+
+  dart_analyze_downgrade:
+    name: dart analyze downgrade
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flutter-version: ['3.19.0', '3.27.0']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ matrix.flutter-version }}
+      - name: Install melos
+        run: dart pub global activate melos
+      - name: Bootstrap
+        run: melos bootstrap
+      - name: Downgrade dependencies
+        run: melos downgrade
+      - name: Run lint
+        run: melos lint_loose
 
   serverpod_generate:
     name: serverpod generate

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -30,19 +30,23 @@ jobs:
 
   dart_analyze:
     name: dart analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         flutter-version: ['3.19.0']
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ matrix.flutter-version }}
-      - name: Install dependencies
-        run: bash util/pub_get_all
-      - name: Analyze
-        run: bash util/run_tests_analyze
+      - name: Install melos
+        run: dart pub global activate melos
+      - name: Bootstrap
+        run: melos bootstrap
+      - name: Run lint
+        run: melos lint_strict
 
   dart_analyze_downgrade:
     name: dart analyze downgrade

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0']
+        flutter-version: ['3.19.0', '3.27.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -79,22 +79,6 @@ jobs:
         run: bash util/pub_get_all
       - name: Analyze
         run: bash util/run_tests_analyze --allow-infos
-
-  dart_analyze_latest_downgrade:
-    name: dart analyze latest downgrade
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        flutter-version: ['3.27.0']
-    steps:
-      - uses: actions/checkout@v3
-      - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ matrix.flutter-version }}
-      - name: Install dependencies
-        run: bash util/pub_get_all --downgrade
-      - name: Analyze
-        run: bash util/run_tests_analyze --allow-warnings
 
   serverpod_generate:
     name: serverpod generate

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ doc/api/
 *.ipr
 *.iws
 
+**/pubspec_overrides.yaml
+
 
 .DS_Store
 .atom/

--- a/melos.yaml
+++ b/melos.yaml
@@ -15,3 +15,9 @@ scripts:
     run: melos analyze --no-fatal-warnings
   lint_strict:
     run: melos analyze --fatal-infos --fatal-warnings
+  downgrade_flutter:
+    run: melos exec --flutter -c 1 -- flutter pub downgrade
+  downgrade_dart:
+    run: melos exec --no-flutter -c 1 -- dart pub downgrade
+  downgrade:
+    run: melos downgrade_flutter && melos downgrade_dart

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,0 +1,17 @@
+name: serverpod
+
+packages:
+  - examples/**
+  - integrations/*
+  - modules/*
+  - packages/*
+  - tests/*
+  - tools/*
+
+scripts:
+  lint:
+    run: melos analyze --fatal-warnings
+  lint_loose:
+    run: melos analyze --no-fatal-warnings
+  lint_strict:
+    run: melos analyze --fatal-infos --fatal-warnings

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,6 @@
+name: serverpod
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+dev_dependencies:
+  melos: ^6.1.0

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -31,8 +31,8 @@ void main() {
   });
 
   group('Given a clean state', () {
-    var (:commandRoot, :projectName) = createRandomProjectName(tempPath);
-    final (:serverDir, :flutterDir, :clientDir) =
+    var (commandRoot: _, :projectName) = createRandomProjectName(tempPath);
+    final (:serverDir, flutterDir: _, :clientDir) =
         createProjectFolderPaths(projectName);
 
     group('when creating a new project', () {

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -66,7 +66,7 @@ void main() async {
   });
 
   group('Given a clean state', () {
-    final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
+    final (:projectName, commandRoot: _) = createRandomProjectName(tempPath);
 
     late Process createProcess;
 
@@ -215,7 +215,7 @@ void main() async {
   });
 
   group('Given a mini project', () {
-    final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
+    final (:projectName, commandRoot: _) = createRandomProjectName(tempPath);
     final serverDir = createServerFolderPath(projectName);
     late Process createProcess;
     setUpAll(() async {
@@ -408,7 +408,7 @@ void main() async {
   });
 
   group('Given a created mini project', () {
-    final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
+    final (:projectName, commandRoot: _) = createRandomProjectName(tempPath);
 
     setUp(() async {
       var createProcess = await runProcess(

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -471,7 +471,7 @@ void main() async {
 
   group('Given a clean state', () {
     final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
-    final (:serverDir, :flutterDir, :clientDir) =
+    final (:serverDir, flutterDir: _, :clientDir) =
         createProjectFolderPaths(projectName);
 
     late Process createProcess;

--- a/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
@@ -34,7 +34,7 @@ void main() async {
   });
 
   group('Given a model file that is changed when generate watch is active', () {
-    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (projectName, _) = createRandomProjectName(tempPath);
     var (serverDir, _, clientDir) = createProjectFolderPaths(projectName);
 
     late Process createProcess;
@@ -197,7 +197,7 @@ fields:
   group(
       'Given a model file in the "lib/src/ directory that is changed when generate watch is active',
       () {
-    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (projectName, _) = createRandomProjectName(tempPath);
     var (serverDir, _, clientDir) = createProjectFolderPaths(projectName);
 
     late Process createProcess;
@@ -359,7 +359,7 @@ fields:
 
   group('Given an endpoint file that is changed when generate watch is active',
       () {
-    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (projectName, _) = createRandomProjectName(tempPath);
     var (serverDir, _, _) = createProjectFolderPaths(projectName);
 
     late Process createProcess;
@@ -528,7 +528,7 @@ class TestEndpoint extends Endpoint {
   group(
       'Given an endpoint file in the "lib/src" folder that is changed when generate watch is active',
       () {
-    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (projectName, _) = createRandomProjectName(tempPath);
     var (serverDir, _, _) = createProjectFolderPaths(projectName);
 
     late Process createProcess;
@@ -698,7 +698,7 @@ class TestEndpoint extends Endpoint {
   group(
       'Given a serializable model used in an endpoint that is moved to a subfolder when generate watch is active',
       () {
-    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (projectName, _) = createRandomProjectName(tempPath);
     var (serverDir, _, clientDir) = createProjectFolderPaths(projectName);
 
     late Process createProcess;
@@ -856,7 +856,7 @@ fields:
 
   group('Given a generated file that is changed when generate watch is active',
       () {
-    var (projectName, commandRoot) = createRandomProjectName(tempPath);
+    var (projectName, _) = createRandomProjectName(tempPath);
     var (serverDir, _, clientDir) = createProjectFolderPaths(projectName);
 
     late Process createProcess;


### PR DESCRIPTION
# Changes

- Adds melos to the root of the project
  - With lint command with the 3 options, normal, strict and loose, normal allows info but not warning, loose allows warnings, strict fails on all.
  - With downgrade command to install the oldest dependencies.
- Add lint job with melos across all projects
- Add CI job to run the new melos command on linux and windows machines

Melos also comes with the benefit of the `bootstrap` command e.g. installing dependencies. I think it is a good idea to transition all our commands to melos instead of bash scripts. Much easier to understand and work with and we can make them platform-agnostic which is a huge plus.

But I think we can convert one script at a time rather than bundle them in a big PR.

Related issue: #2990 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
none