### PR TITLE
fix: Use valid dart import paths for endpoints on all platforms. 

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -764,10 +764,13 @@ class LibraryGenerator {
       p.joinAll([...config.generatedServeModelPathParts]);
 
   String _endpointPath(EndpointDefinition endpoint) {
-    return p.relative(
+    var relativePath = p.relative(
       endpoint.filePath,
       from: _buildGeneratedDirectoryPath(),
     );
+
+    // Replace backslashes with forward slashes to make it work on Windows.
+    return p.split(relativePath).join('/');
   }
 
   Code _buildEndpointLookupMap(List<EndpointDefinition> endpoints) {

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/endpoints_test.dart
@@ -342,11 +342,11 @@ void main() {
     var endpointsFile = codeMap[expectedFileName];
 
     test('then import path is correct.', () {
-      var importPath = path.joinAll([
+      var importPath = [
         '..',
         '..',
         'my_endpoint.dart',
-      ]);
+      ].join('/');
       expect(endpointsFile, contains("import '$importPath' as "));
     });
   });


### PR DESCRIPTION
Closes: #2990 

Fixes an issue where we would build a platform dependent import path for the import path in the dart files.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - fixes an issue introduced with the previous release.