### PR TITLE
Fix: Convert generated import paths to use forward slashes on Windows

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -36,14 +36,15 @@ class ServerTestToolsGenerator {
   }
 
   void _addPackageDirectives(LibraryBuilder library) {
-    var protocolPackageImportPath = 'package:${config.name}_server/${p.joinAll([
-          ...config.generatedServeModelPackagePathParts,
-          'protocol.dart'
-        ])}';
-    var endpointsPath = 'package:${config.name}_server/${p.joinAll([
-          ...config.generatedServeModelPackagePathParts,
-          'endpoints.dart'
-        ])}';
+    var protocolPackageImportPath =
+        'package:${config.name}_server/${p.split(p.joinAll([
+                  ...config.generatedServeModelPackagePathParts,
+                  'protocol.dart'
+                ])).join('/')}';
+    var endpointsPath = 'package:${config.name}_server/${p.split(p.joinAll([
+              ...config.generatedServeModelPackagePathParts,
+              'endpoints.dart'
+            ])).join('/')}';
 
     library.directives.addAll([
       Directive.import(protocolPackageImportPath),


### PR DESCRIPTION
Convert paths to use forward slashes for package imports to work correctly on all platforms

Fixed an issue where generated import paths in server_test_tools_generator.dart were using backslashes on Windows platforms, causing invalid import statements. Modified the path handling to consistently use forward slashes for package imports across all platforms.

Fixes #2999 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None
