### PR TITLE
fix: Use dart compatible paths for test tools imports.

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -1,5 +1,4 @@
 import 'package:code_builder/code_builder.dart';
-import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
 import 'package:serverpod_cli/src/config/serverpod_feature.dart';
@@ -36,14 +35,17 @@ class ServerTestToolsGenerator {
   }
 
   void _addPackageDirectives(LibraryBuilder library) {
-    var protocolPackageImportPath = 'package:${config.name}_server/${p.joinAll([
-          ...config.generatedServeModelPackagePathParts,
-          'protocol.dart'
-        ])}';
-    var endpointsPath = 'package:${config.name}_server/${p.joinAll([
-          ...config.generatedServeModelPackagePathParts,
-          'endpoints.dart'
-        ])}';
+    var protocolPackageImportPath = [
+      'package:${config.name}_server',
+      ...config.generatedServeModelPackagePathParts,
+      'protocol.dart',
+    ].join('/');
+
+    var endpointsPath = [
+      'package:${config.name}_server',
+      ...config.generatedServeModelPackagePathParts,
+      'endpoints.dart'
+    ].join('/');
 
     library.directives.addAll([
       Directive.import(protocolPackageImportPath),

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
@@ -148,6 +148,26 @@ void main() {
       },
       skip: testToolsFile == null,
     );
+
+    test('then import path towards project protocol is correct.', () {
+      var importPath = [
+        'package:example_project_server',
+        'src',
+        'generated',
+        'protocol.dart',
+      ].join('/');
+      expect(testToolsFile, contains("import '$importPath';"));
+    }, skip: testToolsFile == null);
+
+    test('then import path towards project endpoints is correct.', () {
+      var importPath = [
+        'package:example_project_server',
+        'src',
+        'generated',
+        'endpoints.dart',
+      ].join('/');
+      expect(testToolsFile, contains("import '$importPath';"));
+    }, skip: testToolsFile == null);
   });
 
   group(


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod/issues/2999

Fixes dart-compatible path imports for all platforms in the test tools.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - fixes an import issue.