### PR TITLE
fix: Improve error description on generated file collision

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -104,7 +104,7 @@ class SerializableModelAnalyzer {
     Uri sourceUri,
     CodeAnalysisCollector collector,
     SerializableModelDefinition? model,
-    List<({String documentPath, SerializableModelDefinition model})> models,
+    ParsedModelsCollection parsedModels,
   ) {
     var yamlErrors = ErrorCollector();
     YamlMap? document = _loadYamlMap(yaml, sourceUri, yamlErrors);
@@ -141,9 +141,7 @@ class SerializableModelAnalyzer {
       documentType: definitionType,
       documentContents: documentContents,
       documentDefinition: model,
-      // TODO: move instance creation of EntityRelations to StatefulAnalyzer
-      // to resolve n-squared time complexity.
-      parsedModels: ParsedModelsCollection(models),
+      parsedModels: parsedModels,
     );
 
     var generateCollisionErrors = validateDuplicateFileName(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -104,7 +104,7 @@ class SerializableModelAnalyzer {
     Uri sourceUri,
     CodeAnalysisCollector collector,
     SerializableModelDefinition? model,
-    List<SerializableModelDefinition> models,
+    List<({String documentPath, SerializableModelDefinition model})> models,
   ) {
     var yamlErrors = ErrorCollector();
     YamlMap? document = _loadYamlMap(yaml, sourceUri, yamlErrors);

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -119,7 +119,11 @@ class StatefulAnalyzer {
   void _validateAllModels() {
     var modelsToValidate = _modelStates.values
         .where((state) => state.source.moduleAlias == defaultModuleAlias);
-    var models = _models;
+    var models = _modelStates.values
+        .map((state) =>
+            (documentPath: state.source.yamlSourceUri.path, model: state.model))
+        .whereType<({String documentPath, SerializableModelDefinition model})>()
+        .toList();
 
     for (var state in modelsToValidate) {
       var collector = CodeGenerationCollector();

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/validation/model_relations.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 
@@ -119,11 +120,13 @@ class StatefulAnalyzer {
   void _validateAllModels() {
     var modelsToValidate = _modelStates.values
         .where((state) => state.source.moduleAlias == defaultModuleAlias);
-    var models = _modelStates.values
+    var modelsWithDocumentPath = _modelStates.values
         .map((state) =>
             (documentPath: state.source.yamlSourceUri.path, model: state.model))
-        .whereType<({String documentPath, SerializableModelDefinition model})>()
+        .whereType<ModelWithDocumentPath>()
         .toList();
+
+    var parsedModels = ParsedModelsCollection(modelsWithDocumentPath);
 
     for (var state in modelsToValidate) {
       var collector = CodeGenerationCollector();
@@ -133,7 +136,7 @@ class StatefulAnalyzer {
         state.source.yamlSourceUri,
         collector,
         state.model,
-        models,
+        parsedModels,
       );
 
       if (collector.hasSeverErrors) {

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/model_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/model_relations.dart
@@ -11,7 +11,7 @@ class ParsedModelsCollection {
   late final Map<String, List<SerializableModelDefinition>> indexNames;
   late final Map<String,
           List<({String documentPath, SerializableModelDefinition model})>>
-      filePaths;
+      generatedFilePaths;
 
   ParsedModelsCollection(
     List<({String documentPath, SerializableModelDefinition model})>
@@ -22,7 +22,7 @@ class ParsedModelsCollection {
     classNames = _createClassNameMap(models);
     tableNames = _createTableNameMap(models);
     indexNames = _createIndexNameMap(models);
-    filePaths = _createFilePathMap(modelWithPath);
+    generatedFilePaths = _createGenerateFilePathMap(modelWithPath);
   }
 
   Set<String> get moduleNames => modules;
@@ -86,7 +86,7 @@ class ParsedModelsCollection {
   }
 
   Map<String, List<({String documentPath, SerializableModelDefinition model})>>
-      _createFilePathMap(
+      _createGenerateFilePathMap(
     List<({String documentPath, SerializableModelDefinition model})> models,
   ) {
     Map<String,
@@ -95,7 +95,7 @@ class ParsedModelsCollection {
     for (var (:documentPath, :model)
         in models.where((e) => e.model.moduleAlias == defaultModuleAlias)) {
       filePaths.update(
-        _buildFilePath(model),
+        _buildGeneratedFilePath(model),
         (value) => value..add((documentPath: documentPath, model: model)),
         ifAbsent: () => [(documentPath: documentPath, model: model)],
       );
@@ -104,21 +104,24 @@ class ParsedModelsCollection {
     return filePaths;
   }
 
-  String _buildFilePath(SerializableModelDefinition model) {
+  String _buildGeneratedFilePath(SerializableModelDefinition model) {
     return path.joinAll([...model.subDirParts, '${model.fileName}.dart']);
   }
 
   bool isFilePathUnique(
     SerializableModelDefinition classDefinition,
   ) {
-    return filePaths[_buildFilePath(classDefinition)]?.length == 1;
+    return generatedFilePaths[_buildGeneratedFilePath(classDefinition)]
+            ?.length ==
+        1;
   }
 
-  ({String documentPath, SerializableModelDefinition model})? findByFilePath(
+  ({String documentPath, SerializableModelDefinition model})?
+      findByGeneratedFilePath(
     SerializableModelDefinition model, {
     SerializableModelDefinition? ignore,
   }) {
-    var entries = filePaths[_buildFilePath(model)];
+    var entries = generatedFilePaths[_buildGeneratedFilePath(model)];
     var filteredEntries = entries?.where((e) => e.model != ignore).toList();
     return filteredEntries?.firstOrNull;
   }

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/model_relations.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/model_relations.dart
@@ -3,15 +3,18 @@ import 'package:serverpod_cli/src/analyzer/models/checker/analyze_checker.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 
+typedef ModelWithDocumentPath = ({
+  String documentPath,
+  SerializableModelDefinition model
+});
+
 /// A collection of all parsed models, and their potential collisions.
 class ParsedModelsCollection {
   late final Set<String> modules;
   late final Map<String, List<SerializableModelDefinition>> classNames;
   late final Map<String, List<SerializableModelDefinition>> tableNames;
   late final Map<String, List<SerializableModelDefinition>> indexNames;
-  late final Map<String,
-          List<({String documentPath, SerializableModelDefinition model})>>
-      generatedFilePaths;
+  late final Map<String, List<ModelWithDocumentPath>> generatedFilePaths;
 
   ParsedModelsCollection(
     List<({String documentPath, SerializableModelDefinition model})>
@@ -85,13 +88,10 @@ class ParsedModelsCollection {
     return indexNames;
   }
 
-  Map<String, List<({String documentPath, SerializableModelDefinition model})>>
-      _createGenerateFilePathMap(
-    List<({String documentPath, SerializableModelDefinition model})> models,
+  Map<String, List<ModelWithDocumentPath>> _createGenerateFilePathMap(
+    List<ModelWithDocumentPath> models,
   ) {
-    Map<String,
-            List<({String documentPath, SerializableModelDefinition model})>>
-        filePaths = {};
+    Map<String, List<ModelWithDocumentPath>> filePaths = {};
     for (var (:documentPath, :model)
         in models.where((e) => e.model.moduleAlias == defaultModuleAlias)) {
       filePaths.update(
@@ -116,8 +116,7 @@ class ParsedModelsCollection {
         1;
   }
 
-  ({String documentPath, SerializableModelDefinition model})?
-      findByGeneratedFilePath(
+  ModelWithDocumentPath? findByGeneratedFilePath(
     SerializableModelDefinition model, {
     SerializableModelDefinition? ignore,
   }) {

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/model_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/model_validator.dart
@@ -56,16 +56,18 @@ List<SourceSpanSeverityException> validateDuplicateFileName(
     return [];
   }
 
-  var result = parsedModels.findByFilePath(
+  var result = parsedModels.findByGeneratedFilePath(
     modelDefinition,
     ignore: modelDefinition,
   );
   if (result == null) return [];
 
-  var (:documentPath, model: otherClass) = result;
+  var (documentPath: otherDocumentPath, model: _) = result;
+
   return [
     SourceSpanSeverityException(
-      'File collision with "${otherClass.className}" was detected for the generated model, please provide a unique path or filename for the model.',
+      'File path collision detected: This model and "$otherDocumentPath" would generate files at the same location. '
+      'Please modify the path or filename to ensure each model generates to a unique location.',
       documentContents.span,
     )
   ];

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/model_validator.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/model_validator.dart
@@ -47,23 +47,28 @@ List<SourceSpanSeverityException> validateDuplicateFileName(
   YamlMap documentContents,
   Restrictions restrictions,
 ) {
-  var model = restrictions.documentDefinition;
+  var modelDefinition = restrictions.documentDefinition;
   var parsedModels = restrictions.parsedModels;
 
-  if (model == null) return [];
+  if (modelDefinition == null) return [];
 
-  if (!parsedModels.isFilePathUnique(model)) {
-    var otherClass = parsedModels.findByFilePath(model, ignore: model);
-
-    return [
-      SourceSpanSeverityException(
-        'File collision with "${otherClass.className}" was detected for the generated model, please provide a unique path or filename for the model.',
-        documentContents.span,
-      )
-    ];
+  if (parsedModels.isFilePathUnique(modelDefinition)) {
+    return [];
   }
 
-  return [];
+  var result = parsedModels.findByFilePath(
+    modelDefinition,
+    ignore: modelDefinition,
+  );
+  if (result == null) return [];
+
+  var (:documentPath, model: otherClass) = result;
+  return [
+    SourceSpanSeverityException(
+      'File collision with "${otherClass.className}" was detected for the generated model, please provide a unique path or filename for the model.',
+      documentContents.span,
+    )
+  ];
 }
 
 /// Recursively validates a yaml document against a set of [ValidateNode]s.

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/file_name_conflicts_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/file_name_conflicts_test.dart
@@ -51,7 +51,7 @@ void main() {
       var error = collector.errors.first;
       expect(
         error.message,
-        'File collision with "MySecondModel" was detected for the generated model, please provide a unique path or filename for the model.',
+        'File path collision detected: This model and "module/protocol/lib/src/protocol/example.yaml" would generate files at the same location. Please modify the path or filename to ensure each model generates to a unique location.',
       );
     });
   });


### PR DESCRIPTION
Improves the error message displayed when a generated file collision is detected.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple improvement to the error message.