### PR TITLE
ci: Add windows to bootstrap test platforms.

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -246,7 +246,7 @@ jobs:
       fail-fast: false
       matrix:
         flutter-version: ['3.19.0', '3.24.0']
-        os: [ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
         path: ['tests/bootstrap_project']
     steps:
       - uses: actions/checkout@v3

--- a/tests/bootstrap_project/lib/src/util.dart
+++ b/tests/bootstrap_project/lib/src/util.dart
@@ -36,14 +36,35 @@ Future<bool> isNetworkPortAvailable(int port) async {
   }
 }
 
+Future<ProcessResult> runProcess(
+  String command,
+  List<String> arguments, {
+  String? workingDirectory,
+  Map<String, String>? environment,
+  bool skipBatExtentionOnWindows = false,
+}) async {
+  var process = await Process.run(
+    _getCommandToRun(command, skipBatExtentionOnWindows),
+    arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+  );
+
+  print('COMMAND "$command" stdout: ${process.stdout}');
+  print('COMMAND "$command" stderr: ${process.stderr}');
+
+  return process;
+}
+
 Future<Process> startProcess(
   String command,
   List<String> arguments, {
   String? workingDirectory,
   Map<String, String>? environment,
+  bool ignorePlatform = false,
 }) async {
   var process = await Process.start(
-    command,
+    _getCommandToRun(command, ignorePlatform),
     arguments,
     workingDirectory: workingDirectory,
     environment: environment,
@@ -57,4 +78,12 @@ Future<Process> startProcess(
       .listen((e) => print('COMMAND "$command" stdout: $e'));
 
   return process;
+}
+
+String _getCommandToRun(String command, bool ignorePlatform) {
+  if (ignorePlatform) {
+    return command;
+  }
+
+  return Platform.isWindows ? '$command.bat' : command;
 }

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -21,16 +21,12 @@ void main() {
       workingDirectory: cliPath,
     );
 
-    await Process.run('mkdir', [tempDirName], workingDirectory: rootPath);
+    await Directory(tempPath).create();
   });
 
   tearDownAll(() async {
     try {
-      await Process.run(
-        'rm',
-        ['-rf', tempDirName],
-        workingDirectory: rootPath,
-      );
+      Directory(tempDirName).deleteSync(recursive: true);
     } catch (e) {}
   });
 

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -15,7 +15,7 @@ void main() {
   final tempPath = path.join(rootPath, tempDirName);
 
   setUpAll(() async {
-    await Process.run(
+    await runProcess(
       'dart',
       ['pub', 'global', 'activate', '-s', 'path', '.'],
       workingDirectory: cliPath,
@@ -238,6 +238,7 @@ void main() {
         'docker',
         ['compose', 'up', '--build', '--detach'],
         workingDirectory: commandRoot,
+        ignorePlatform: true,
       );
 
       assert((await docker.exitCode) == 0);
@@ -246,10 +247,11 @@ void main() {
     tearDown(() async {
       createProcess.kill();
 
-      await Process.run(
+      await runProcess(
         'docker',
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
+        skipBatExtentionOnWindows: true,
       );
 
       while (!await isNetworkPortAvailable(8090));

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -268,5 +268,8 @@ void main() {
 
       await expectLater(testProcess.exitCode, completion(0));
     });
-  });
+  },
+      skip: Platform.isWindows
+          ? 'Windows does not support postgres docker image in github actions'
+          : null);
 }

--- a/tests/bootstrap_project/test/module_test.dart
+++ b/tests/bootstrap_project/test/module_test.dart
@@ -35,15 +35,6 @@ void main() {
     final (:serverDir, :flutterDir, :clientDir) =
         createProjectFolderPaths(projectName);
 
-    tearDownAll(() async {
-      await Process.run(
-        'docker',
-        ['compose', 'down', '-v'],
-        workingDirectory: commandRoot,
-      );
-      while (!await isNetworkPortAvailable(8090));
-    });
-
     group('when creating a new project', () {
       setUpAll(() async {
         var process = await startProcess(

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -134,10 +134,27 @@ void main() async {
     });
   });
 
-  group('Given a clean state', () {
+  group('Given a mini project', () {
     final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
     final serverDir = createServerFolderPath(projectName);
     late Process createProcess;
+
+    setUpAll(() async {
+      createProcess = await startProcess(
+        'serverpod',
+        ['create', '--template', 'mini', projectName, '-v', '--no-analytics'],
+        workingDirectory: tempPath,
+        environment: {
+          'SERVERPOD_HOME': rootPath,
+        },
+      );
+
+      var createProjectExitCode = await createProcess.exitCode;
+      assert(
+        createProjectExitCode == 0,
+        'Failed to create the serverpod mini project.',
+      );
+    });
 
     tearDown(() async {
       await runProcess(
@@ -149,24 +166,9 @@ void main() async {
     });
 
     test(
-        'when creating a new project with the mini template and upgrading it to a full project then the project is created successfully and can be booted in maintenance mode with the apply-migrations flag.',
+        'when upgrading the project to a full project '
+        'then the project is created successfully and can be booted in maintenance mode with the apply-migrations flag.',
         () async {
-      createProcess = await startProcess(
-        'serverpod',
-        ['create', '--template', 'mini', projectName, '-v', '--no-analytics'],
-        workingDirectory: tempPath,
-        environment: {
-          'SERVERPOD_HOME': rootPath,
-        },
-      );
-
-      var createProjectExitCode = await createProcess.exitCode;
-      expect(
-        createProjectExitCode,
-        0,
-        reason: 'Failed to create the serverpod project.',
-      );
-
       var upgradeProcess = await startProcess(
         'serverpod',
         ['create', '--template', 'server', '.', '-v', '--no-analytics'],
@@ -212,17 +214,11 @@ void main() async {
             : null);
   });
 
-  group('Given a clean state', () {
+  group('Given a mini project', () {
     final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
     final serverDir = createServerFolderPath(projectName);
     late Process createProcess;
-    tearDown(() async {
-      createProcess.kill();
-    });
-
-    test(
-        'when creating a new project with the mini template and upgrading it to a full project then the project is created successfully and can be booted in maintenance mode with the apply-migrations flag.',
-        () async {
+    setUpAll(() async {
       createProcess = await startProcess(
         'serverpod',
         ['create', '--template', 'mini', projectName, '-v', '--no-analytics'],
@@ -233,76 +229,100 @@ void main() async {
       );
 
       var createProjectExitCode = await createProcess.exitCode;
-      expect(
-        createProjectExitCode,
-        0,
-        reason: 'Failed to create the serverpod project.',
-      );
+      assert(createProjectExitCode == 0,
+          'Failed to create the serverpod mini project.');
+    });
 
-      var upgradeProcess = await startProcess(
-        'serverpod',
-        ['create', '--template', 'server', '.', '-v', '--no-analytics'],
-        workingDirectory: path.join(tempPath, serverDir),
-        environment: {
-          'SERVERPOD_HOME': rootPath,
-        },
-      );
+    tearDown(() async {
+      createProcess.kill();
+    });
 
-      var upgradeProjectExitCode = await upgradeProcess.exitCode;
-      expect(
-        upgradeProjectExitCode,
-        0,
-        reason: 'Failed to create the serverpod project.',
-      );
+    group(
+        'when creating a new project with the mini template and upgrading it to a full project',
+        () {
+      late Process upgradeProcess;
+      setUpAll(() async {
+        upgradeProcess = await startProcess(
+          'serverpod',
+          ['create', '--template', 'server', '.', '-v', '--no-analytics'],
+          workingDirectory: path.join(tempPath, serverDir),
+          environment: {
+            'SERVERPOD_HOME': rootPath,
+          },
+        );
 
-      var configDir =
-          Directory(path.join(tempPath, serverDir, 'config')).existsSync();
-      expect(
-        configDir,
-        isTrue,
-        reason: 'Config directory should exist but it was not found.',
-      );
+        await upgradeProcess.exitCode;
+      });
 
-      var deployDir =
-          Directory(path.join(tempPath, serverDir, 'deploy')).existsSync();
-      expect(
-        deployDir,
-        isTrue,
-        reason: 'Deploy directory should exist but it was not found.',
-      );
+      test('then the upgrade command completes successfully', () async {
+        var upgradeProjectExitCode = await upgradeProcess.exitCode;
+        expect(
+          upgradeProjectExitCode,
+          0,
+          reason: 'Failed to create the serverpod project.',
+        );
+      });
 
-      var webDir =
-          Directory(path.join(tempPath, serverDir, 'web')).existsSync();
-      expect(
-        webDir,
-        isTrue,
-        reason: 'Web directory should exist but it was not found.',
-      );
+      test('then the project contains a config directory', () {
+        var configDir =
+            Directory(path.join(tempPath, serverDir, 'config')).existsSync();
+        expect(
+          configDir,
+          isTrue,
+          reason: 'Config directory should exist but it was not found.',
+        );
+      });
 
-      var dockerFile =
-          File(path.join(tempPath, serverDir, 'Dockerfile')).existsSync();
-      expect(
-        dockerFile,
-        isTrue,
-        reason: 'Dockerfile should exist but it was not found.',
-      );
+      test('then the project contains a deploy directory', () {
+        var deployDir =
+            Directory(path.join(tempPath, serverDir, 'deploy')).existsSync();
+        expect(
+          deployDir,
+          isTrue,
+          reason: 'Deploy directory should exist but it was not found.',
+        );
+      });
 
-      var dockerComposeFile =
-          File(path.join(tempPath, serverDir, 'docker-compose.yaml'))
-              .existsSync();
-      expect(
-        dockerComposeFile,
-        isTrue,
-        reason: 'docker-compose.yml should exist but it was not found.',
-      );
+      test('then the project contains a web directory', () {
+        var webDir =
+            Directory(path.join(tempPath, serverDir, 'web')).existsSync();
+        expect(
+          webDir,
+          isTrue,
+          reason: 'Web directory should exist but it was not found.',
+        );
+      });
 
-      var gcloudIgnoreFile =
-          File(path.join(tempPath, serverDir, '.gcloudignore')).existsSync();
-      expect(
-        gcloudIgnoreFile,
-        isTrue,
-        reason: '.gcloudignore should exist but it was not found.',
-      );
+      test('then the project contains a dockerfile', () {
+        var dockerFile =
+            File(path.join(tempPath, serverDir, 'Dockerfile')).existsSync();
+        expect(
+          dockerFile,
+          isTrue,
+          reason: 'Dockerfile should exist but it was not found.',
+        );
+      });
+
+      test('then the project contains a docker-compose.yaml file', () {
+        var dockerComposeFile =
+            File(path.join(tempPath, serverDir, 'docker-compose.yaml'))
+                .existsSync();
+        expect(
+          dockerComposeFile,
+          isTrue,
+          reason: 'docker-compose.yml should exist but it was not found.',
+        );
+      });
+
+      test('then the project contains a .gcloudignore file', () {
+        var gcloudIgnoreFile =
+            File(path.join(tempPath, serverDir, '.gcloudignore')).existsSync();
+        expect(
+          gcloudIgnoreFile,
+          isTrue,
+          reason: '.gcloudignore should exist but it was not found.',
+        );
+      });
     });
   });
 

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -15,7 +15,7 @@ void main() async {
   final tempPath = path.join(rootPath, tempDirName);
 
   setUpAll(() async {
-    await Process.run(
+    await runProcess(
       'dart',
       ['pub', 'global', 'activate', '-s', 'path', '.'],
       workingDirectory: cliPath,
@@ -140,10 +140,11 @@ void main() async {
     late Process createProcess;
 
     tearDown(() async {
-      await Process.run(
+      await runProcess(
         'docker',
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
+        skipBatExtentionOnWindows: true,
       );
     });
 
@@ -186,6 +187,7 @@ void main() async {
         'docker',
         ['compose', 'up', '--build', '--detach'],
         workingDirectory: commandRoot,
+        ignorePlatform: true,
       );
 
       var dockerExitCode = await docker.exitCode;
@@ -308,10 +310,11 @@ void main() async {
     tearDown(() async {
       createProcess.kill();
 
-      await Process.run(
+      await runProcess(
         'docker',
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
+        skipBatExtentionOnWindows: true,
       );
 
       while (!await isNetworkPortAvailable(8090));
@@ -356,6 +359,7 @@ void main() async {
         'docker',
         ['compose', 'up', '--build', '--detach'],
         workingDirectory: commandRoot,
+        ignorePlatform: true,
       );
 
       var dockerExitCode = await docker.exitCode;
@@ -366,7 +370,7 @@ void main() async {
         reason: 'Docker with postgres failed to start.',
       );
 
-      var testProcess = await Process.run(
+      var testProcess = await runProcess(
         'dart',
         ['test'],
         workingDirectory:
@@ -381,7 +385,7 @@ void main() async {
     final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
 
     setUp(() async {
-      var createProcess = await Process.run(
+      var createProcess = await runProcess(
         'serverpod',
         ['create', '--template', 'mini', projectName, '-v', '--no-analytics'],
         workingDirectory: tempPath,
@@ -394,7 +398,7 @@ void main() async {
 
     test('when running tests then example unit and integration tests passes',
         () async {
-      var testProcess = await Process.run(
+      var testProcess = await runProcess(
         'dart',
         ['test'],
         workingDirectory:

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -206,7 +206,10 @@ void main() async {
 
       var startProjectExitCode = await startProjectProcess.exitCode;
       expect(startProjectExitCode, 0);
-    });
+    },
+        skip: Platform.isWindows
+            ? 'Windows does not support postgres docker image in github actions'
+            : null);
   });
 
   group('Given a clean state', () {
@@ -378,7 +381,10 @@ void main() async {
       );
 
       expect(testProcess.exitCode, 0, reason: 'Tests are failing.');
-    });
+    },
+        skip: Platform.isWindows
+            ? 'Windows does not support postgres docker image in github actions'
+            : null);
   });
 
   group('Given a created mini project', () {

--- a/tests/bootstrap_project/test/project_mini_test.dart
+++ b/tests/bootstrap_project/test/project_mini_test.dart
@@ -21,16 +21,12 @@ void main() async {
       workingDirectory: cliPath,
     );
 
-    await Process.run('mkdir', [tempDirName], workingDirectory: rootPath);
+    await Directory(tempPath).create();
   });
 
   tearDownAll(() async {
     try {
-      await Process.run(
-        'rm',
-        ['-rf', tempDirName],
-        workingDirectory: rootPath,
-      );
+      Directory(tempPath).deleteSync(recursive: true);
     } catch (e) {}
   });
 

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -16,7 +16,7 @@ void main() async {
   final tempPath = path.join(rootPath, tempDirName);
 
   setUpAll(() async {
-    await Process.run(
+    await runProcess(
       'dart',
       ['pub', 'global', 'activate', '-s', 'path', '.'],
       workingDirectory: cliPath,
@@ -39,10 +39,11 @@ void main() async {
     tearDown(() async {
       createProcess.kill();
 
-      await Process.run(
+      await runProcess(
         'docker',
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
+        skipBatExtentionOnWindows: true,
       );
 
       while (!await isNetworkPortAvailable(8090));
@@ -71,6 +72,7 @@ void main() async {
         'docker',
         ['compose', 'up', '--build', '--detach'],
         workingDirectory: commandRoot,
+        ignorePlatform: true,
       );
 
       var dockerExitCode = await docker.exitCode;
@@ -102,10 +104,11 @@ void main() async {
       createProcess.kill();
       startProjectProcess?.kill();
 
-      await Process.run(
+      await runProcess(
         'docker',
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
+        skipBatExtentionOnWindows: true,
       );
 
       while (!await isNetworkPortAvailable(8090));
@@ -134,6 +137,7 @@ void main() async {
         'docker',
         ['compose', 'up', '--build', '--detach'],
         workingDirectory: commandRoot,
+        ignorePlatform: true,
       );
 
       var dockerExitCode = await docker.exitCode;
@@ -175,10 +179,11 @@ void main() async {
         createProjectFolderPaths(projectName);
 
     tearDownAll(() async {
-      await Process.run(
+      await runProcess(
         'docker',
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
+        skipBatExtentionOnWindows: true,
       );
       while (!await isNetworkPortAvailable(8090));
     });
@@ -490,7 +495,7 @@ void main() async {
       );
       generatedClientDir.deleteSync(recursive: true);
 
-      var generateProcess = await Process.run(
+      var generateProcess = await runProcess(
         'serverpod',
         ['generate'],
         workingDirectory: commandRoot,
@@ -578,6 +583,7 @@ void main() async {
         'docker',
         ['compose', 'up', '--build', '--detach'],
         workingDirectory: commandRoot,
+        ignorePlatform: true,
       );
 
       assert((await docker.exitCode) == 0);
@@ -586,10 +592,11 @@ void main() async {
     tearDown(() async {
       createProcess.kill();
 
-      await Process.run(
+      await runProcess(
         'docker',
         ['compose', 'down', '-v'],
         workingDirectory: commandRoot,
+        skipBatExtentionOnWindows: true,
       );
 
       while (!await isNetworkPortAvailable(8090));

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -91,7 +91,10 @@ void main() async {
 
       var startProjectExitCode = await startProjectProcess.exitCode;
       expect(startProjectExitCode, 0);
-    });
+    },
+        skip: Platform.isWindows
+            ? 'Windows does not support postgres docker image in github actions'
+            : null);
   });
 
   group('Given a clean state', () {
@@ -170,7 +173,10 @@ void main() async {
 
       expect(serverStarted, isTrue,
           reason: 'Failed to get 200 response from server.');
-    });
+    },
+        skip: Platform.isWindows
+            ? 'Windows does not support postgres docker image in github actions'
+            : null);
   });
 
   group('Given a clean state', () {
@@ -379,7 +385,10 @@ void main() async {
 ''';
           expect(contents.trim(), expected.trim(),
               reason: "DebugProfile entitlements is not as expected.");
-        });
+        },
+            skip: Platform.isWindows
+                ? 'Return characters are generated on windows'
+                : null);
 
         test('macOS Release entitlements has network client tag and true', () {
           var entitlementsPath = path.join(
@@ -403,7 +412,11 @@ void main() async {
 
           expect(contents.trim(), expected.trim(),
               reason: "Release entitlements is not as expected.");
-        });
+        },
+            skip: Platform.isWindows
+                ? 'Return characters are generated on windows'
+                : null);
+
         test('has a main file', () {
           expect(
             File(path.join(tempPath, flutterDir, 'lib', 'main.dart'))
@@ -612,6 +625,9 @@ void main() async {
       );
 
       await expectLater(testProcess.exitCode, completion(0));
-    });
+    },
+        skip: Platform.isWindows
+            ? 'Windows does not support postgres docker image in github actions'
+            : null);
   });
 }

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -460,12 +460,6 @@ void main() async {
 
     tearDown(() async {
       createProcess.kill();
-      await Process.run(
-        'docker',
-        ['compose', 'down', '-v'],
-        workingDirectory: commandRoot,
-      );
-      while (!await isNetworkPortAvailable(8090));
     });
 
     test(

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -22,16 +22,12 @@ void main() async {
       workingDirectory: cliPath,
     );
 
-    await Process.run('mkdir', [tempDirName], workingDirectory: rootPath);
+    await Directory(tempPath).create();
   });
 
   tearDownAll(() async {
     try {
-      await Process.run(
-        'rm',
-        ['-rf', tempDirName],
-        workingDirectory: rootPath,
-      );
+      await Directory(tempPath).delete(recursive: true);
     } catch (e) {}
   });
 
@@ -488,10 +484,17 @@ void main() async {
       expect(createProjectExitCode, 0);
 
       // Delete generated files
-      await Process.run(
-          'rm', ['-f', '${serverDir}/lib/src/generated/protocol.yaml']);
-      await Process.run('rm', ['-f', '${serverDir}/lib/src/generated/*.dart']);
-      await Process.run('rm', ['-f', '${clientDir}/lib/src/protocol/*.dart']);
+      var generatedServerDir = Directory(
+        path.normalize(
+            path.join(tempPath, serverDir, 'lib', 'src', 'generated')),
+      );
+      generatedServerDir.deleteSync(recursive: true);
+
+      var generatedClientDir = Directory(
+        path.normalize(
+            path.join(tempPath, clientDir, 'lib', 'src', 'protocol')),
+      );
+      generatedClientDir.deleteSync(recursive: true);
 
       var generateProcess = await Process.run(
         'serverpod',

--- a/tools/serverpod_cli/lib/src/util/pubspec_helpers.dart
+++ b/tools/serverpod_cli/lib/src/util/pubspec_helpers.dart
@@ -17,7 +17,7 @@ Pubspec parsePubspec(File pubspecFile) {
 List<File> findPubspecsFiles(Directory dir,
     {List<String> ignorePaths = const []}) {
   var pubspecFiles = <File>[];
-  for (var file in dir.listSync(recursive: true)) {
+  for (var file in dir.listSync(recursive: true, followLinks: false)) {
     if (shouldBeIgnored(file.path, ignorePaths)) continue;
 
     if (file is File && p.basename(file.path) == 'pubspec.yaml') {


### PR DESCRIPTION
Adds windows as a platform that the bootstrap tests are run on.

Unfortunately Github actions runs docker with windows containers and the postgres does not supply a windows container. Therefore, the tests that start the container are skipped on windows: https://github.com/docker-library/postgres/issues/324

This should still provide us with 90% of the confidence since the only difference between starting the database connection in windows and UNIX is the dart runtime which we are not changing.

We still have a test that validates running the mini project on windows and executing all of the tests.

**Additional fix** 
- Fixes an issue where symlinks would break serverpod version compatibility check. We really only need to do this check one level down so this should not be an issue.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - CI test platform addition.