### PR TITLE
fix: Only assign project model definitions to project models.

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/types.dart
+++ b/tools/serverpod_cli/lib/src/generator/types.dart
@@ -435,8 +435,10 @@ class TypeDefinition {
   TypeDefinition applyProtocolReferences(
     List<SerializableModelDefinition> classDefinitions,
   ) {
-    var modelDefinition =
-        classDefinitions.where((c) => c.className == className).firstOrNull;
+    var modelDefinition = classDefinitions
+        .where((c) => c.className == className)
+        .where((c) => c.moduleAlias == defaultModuleAlias)
+        .firstOrNull;
     bool isProjectModel =
         url == defaultModuleAlias || (url == null && modelDefinition != null);
     return TypeDefinition(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_datatype_test.dart
@@ -119,6 +119,69 @@ fields:
       });
     });
 
+    group(
+        'Given a class with a field containing a model first defined in a module and then the project (order matters)',
+        () {
+      var containedClassName = 'User';
+      var testClassName = 'Example';
+      var models = [
+        ModelSourceBuilder()
+            .withFileName('user.spy.yaml')
+            .withModuleAlias('module')
+            .withYaml(
+          '''
+class: $containedClassName
+fields:
+  nickname: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('user.spy.yaml').withYaml(
+          '''
+class: $containedClassName
+fields:
+  nickname: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withYaml(
+          '''
+class: $testClassName
+fields:
+  user: User 
+          ''',
+        ).build()
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer analyzer = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      );
+      var definitions = analyzer.validateAll();
+
+      test('then no errors was generated', () {
+        expect(collector.errors, isEmpty);
+      });
+
+      var testClassDefinition = definitions
+          .whereType<ClassDefinition>()
+          .where((e) => e.className == testClassName)
+          .firstOrNull;
+
+      test('then field projectModelDefinition type is the project model', () {
+        expect(
+          testClassDefinition
+              ?.fields.first.type.projectModelDefinition?.moduleAlias,
+          'protocol',
+        );
+
+        expect(
+          testClassDefinition?.fields.first.type.className,
+          containedClassName,
+        );
+      });
+    });
+
     group('Given a class with a field with a module type', () {
       var models = [
         ModelSourceBuilder().withModuleAlias('auth').withYaml(


### PR DESCRIPTION
Implements a stricter check to ensure that the projectModelDefinition field is only assigned to a model that is part of the project.

If this check is missing, an invalid reference might be generated. This could happened if there was a class name collision with a Serverpod model.

One such example was a project with a `Filter` model, which was used as a field in another model. When the project was loaded, the Serverpod definitions of the `filter`model were loaded first, so it was assigned as the 'projectModelDefinition` value.

This fix should also be applied to the `Stable-2.2` branch.

Created an issue to fix this "potential" issue in the other places as well: https://github.com/serverpod/serverpod/issues/3019

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Simple bugfix.