### PR TITLE
chore: bump vm_service dependency range

### DIFF
--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0
-  vm_service: ">=13.0.0 <15.0.0"
+  vm_service: ">=13.0.0 <16.0.0"
   yaml: ^3.1.1
   serverpod_shared: 2.2.0
   serverpod_serialization: 2.2.0

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   retry: ^3.1.1
   synchronized: ^3.1.0
   system_resources: ^1.6.0
-  vm_service: ">=13.0.0 <15.0.0"
+  vm_service: ">=13.0.0 <16.0.0"
   yaml: ^3.1.1
   serverpod_shared: SERVERPOD_VERSION
   serverpod_serialization: SERVERPOD_VERSION


### PR DESCRIPTION
A new major version of vm_service was released so this PR bumps the range to allow the new version from `">=13.0.0 <15.0.0"` to `">=13.0.0 <16.0.0"`

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple widening of the dependency range.