### PR TITLE
chore: Bump archive dependency

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: DART_VERSION
 
 dependencies:
-  archive: ^3.3.7
+  archive: '>=3.3.7 <5.0.0'
   args: ^2.4.0
   ci: ^0.1.0
   code_builder: ^4.5.0

--- a/tools/serverpod_cli/lib/src/downloads/resource_manager.dart
+++ b/tools/serverpod_cli/lib/src/downloads/resource_manager.dart
@@ -114,6 +114,10 @@ class ResourceManager {
     // var outFile = File(p.join(versionedDir.path, 'serverpod_templates.tar.gz'));
     // outFile.writeAsBytesSync(data);
 
+    // Const constructor was introduced in version 4.0.0 of archive package.
+    // At the time this was written, that version was 2 days old and we don't
+    // want to force a constraint on the package for this.
+    // ignore: prefer_const_constructors
     var unzipped = GZipDecoder().decodeBytes(data);
     var archive = TarDecoder().decodeBytes(unzipped);
 

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  archive: ^3.3.7
+  archive: '>=3.3.7 <5.0.0'
   args: ^2.4.0
   ci: ^0.1.0
   code_builder: ^4.5.0


### PR DESCRIPTION
Widens the archive dependency range to allow the newly released `4.0.1` version.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple dependency range bump with no implications.