### PR TITLE
chore: Bump pub_api_client dependency.

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   watcher: ^1.0.2
   analyzer: ^6.0.0
   path: ^1.8.2
-  pub_api_client: ^2.4.0
+  pub_api_client: '>=2.4.0 <4.0.0'
   uuid: ^4.1.0
   yaml: ^3.1.1
   serverpod_shared: SERVERPOD_VERSION

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   watcher: ^1.0.2
   analyzer: ^6.0.0
   path: ^1.8.2
-  pub_api_client: ^2.4.0
+  pub_api_client: '>=2.4.0 <4.0.0'
   uuid: ^4.1.0
   yaml: ^3.1.1
   serverpod_shared: 2.3.0-beta.1


### PR DESCRIPTION
Bumps the dependency range for pub_api_client from `'^2.4.0'` to `'>=2.4.0 <4.0.0'`

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - new versions should be compatible with the code currently in place.