### PR TITLE
feat: Support for SERVERPOD_DEPLOY_TAGS

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -294,6 +294,10 @@ class Serverpod {
     stdout.writeln(
       'SERVERPOD version: $serverpodVersion, dart: ${Platform.version}, time: ${DateTime.now().toUtc()}',
     );
+    var deployTags = Platform.environment['SERVERPOD_DEPLOY_TAGS'];
+    if (deployTags != null) {
+      stdout.writeln('SERVERPOD deploy tags: $deployTags');
+    }
 
     _instance = this;
     _internalSerializationManager = internal.Protocol();


### PR DESCRIPTION
Adding awareness of the optional environment variable SERVERPOD_DEPLOY_TAGS, which a deployment environment can use to provide metadata to the serverpod process in tags format. 

For example:
```bash
SERVERPOD_DEPLOY_TAGS="buildNumber=42,provider=GCP"
```

Upon start, Serverpod will log the content:

```
SERVERPOD deploy tags: buildNumber=42,provider=GCP
```

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a