### PR TITLE
fix: Fix print message for database exceptions.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/postgres_exceptions.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/postgres_exceptions.dart
@@ -1,6 +1,6 @@
 part of 'database_connection.dart';
 
-final class _PgDatabaseQueryException implements DatabaseQueryException {
+final class _PgDatabaseQueryException extends DatabaseQueryException {
   @override
   final String message;
   @override
@@ -47,24 +47,21 @@ final class _PgDatabaseQueryException implements DatabaseQueryException {
   }
 }
 
-final class _PgDatabaseInsertRowException
-    implements DatabaseInsertRowException {
+final class _PgDatabaseInsertRowException extends DatabaseInsertRowException {
   @override
   final String message;
 
   _PgDatabaseInsertRowException(this.message);
 }
 
-final class _PgDatabaseUpdateRowException
-    implements DatabaseUpdateRowException {
+final class _PgDatabaseUpdateRowException extends DatabaseUpdateRowException {
   @override
   final String message;
 
   _PgDatabaseUpdateRowException(this.message);
 }
 
-final class _PgDatabaseDeleteRowException
-    implements DatabaseDeleteRowException {
+final class _PgDatabaseDeleteRowException extends DatabaseDeleteRowException {
   @override
   final String message;
 

--- a/packages/serverpod/lib/src/database/concepts/exceptions.dart
+++ b/packages/serverpod/lib/src/database/concepts/exceptions.dart
@@ -1,5 +1,5 @@
 /// Exception thrown when an error occurs in the database.
-abstract interface class DatabaseException implements Exception {
+abstract base class DatabaseException implements Exception {
   /// Returns the message of the exception.
   String get message;
 
@@ -8,7 +8,7 @@ abstract interface class DatabaseException implements Exception {
 }
 
 /// Exception thrown when an exception occurs during a database query.
-abstract interface class DatabaseQueryException implements DatabaseException {
+abstract base class DatabaseQueryException implements DatabaseException {
   /// Returns the error code of the exception.
   String? get code;
 
@@ -47,22 +47,19 @@ abstract interface class DatabaseQueryException implements DatabaseException {
 }
 
 /// Exception thrown when an insert row operation fails.
-abstract interface class DatabaseInsertRowException
-    implements DatabaseException {
+abstract base class DatabaseInsertRowException implements DatabaseException {
   @override
   String toString() => 'DatabaseInsertRowException: $message';
 }
 
 /// Exception thrown when an update row operation fails.
-abstract interface class DatabaseUpdateRowException
-    implements DatabaseException {
+abstract base class DatabaseUpdateRowException implements DatabaseException {
   @override
   String toString() => 'DatabaseUpdateRowException: $message';
 }
 
 /// Exception thrown when a delete row operation fails.
-abstract interface class DatabaseDeleteRowException
-    implements DatabaseException {
+abstract base class DatabaseDeleteRowException implements DatabaseException {
   @override
   String toString() => 'DatabaseDeleteRowException: $message';
 }


### PR DESCRIPTION
Closes: #3075 

Typed database exceptions were recently introduced, but they did not correctly inherit the `toString` method defined in the base class.

This PR fixes that by using `base` class and extending the class rather than implementing it.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - the class should not be implemented by users outside of the library.