### PR TITLE
fix: Removed deprecated version tag in docker compose files

### DIFF
--- a/examples/auth_example/auth_example_server/docker-compose.yaml
+++ b/examples/auth_example/auth_example_server/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   postgres:
     image: postgres:16.3

--- a/examples/chat/chat_server/docker-compose.yaml
+++ b/examples/chat/chat_server/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   postgres:
     image: postgres:16.3

--- a/templates/serverpod_templates/modulename_server/docker-compose.yaml
+++ b/templates/serverpod_templates/modulename_server/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   # Test services
   postgres_test:

--- a/templates/serverpod_templates/projectname_server_upgrade/docker-compose.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   # Development services
   postgres:

--- a/tests/docker/tests_e2e_migrations/docker-compose.yml
+++ b/tests/docker/tests_e2e_migrations/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   serverpod_test_server:
     build:

--- a/tests/docker/tests_flutter/docker-compose.yml
+++ b/tests/docker/tests_flutter/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   serverpod_test_server:
     build:

--- a/tests/docker/tests_integration/docker-compose.yml
+++ b/tests/docker/tests_integration/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   serverpod_test_server:
     build:


### PR DESCRIPTION
Removed deprecated version tag in the docker compose files.

Closes #2210 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a