### PR TITLE
fix: remove debug print messages for failed client calls

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -499,12 +499,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     } catch (e, s) {
       onFailedCall?.call(callContext, e, s);
 
-      if (logFailedCalls) {
-        // ignore: avoid_print
-        print('Failed call: $endpoint.$method');
-        // ignore: avoid_print
-        print('$e');
-      }
       rethrow;
     }
   }

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -137,9 +137,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
   /// The [SerializationManager] used to serialize objects sent to the server.
   final SerializationManager serializationManager;
 
-  /// If true, the client will log any failed calls to stdout.
-  final bool logFailedCalls;
-
   /// Optional [AuthenticationKeyManager] if the client needs to sign the user
   /// in.
   final AuthenticationKeyManager? authenticationKeyManager;
@@ -214,7 +211,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     this.serializationManager, {
     dynamic securityContext,
     required this.authenticationKeyManager,
-    this.logFailedCalls = true,
     required Duration? streamingConnectionTimeout,
     required Duration? connectionTimeout,
     this.onFailedCall,


### PR DESCRIPTION
## Description
- Removes debug prints for failed client calls, as it doesn't make any sense.
- Closes https://github.com/serverpod/serverpod/issues/1557.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.
