### PR TITLE
fix: Add `moduleAlias` checks for accurate class resolution

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -91,9 +91,10 @@ class ModelDependencyResolver {
       return;
     }
 
-    var enumDefinitionList = modelDefinitions
-        .whereType<EnumDefinition>()
-        .where((e) => e.className == typeDefinition.className);
+    var enumDefinitionList = modelDefinitions.whereType<EnumDefinition>().where(
+        (e) =>
+            e.className == typeDefinition.className &&
+            e.moduleAlias == typeDefinition.moduleAlias);
 
     if (enumDefinitionList.isEmpty) return;
 
@@ -111,7 +112,9 @@ class ModelDependencyResolver {
     var referenceClass = modelDefinitions
         .cast<SerializableModelDefinition?>()
         .firstWhere(
-            (model) => model?.className == fieldDefinition.type.className,
+            (model) =>
+                model?.className == fieldDefinition.type.className &&
+                model?.moduleAlias == fieldDefinition.type.moduleAlias,
             orElse: () => null);
 
     if (referenceClass is! ClassDefinition) return;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
@@ -1,0 +1,116 @@
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  test(
+      'Given multiple enums with the same name in different modules '
+      'when an enum is referenced '
+      'then the enum is resolved to the correct module', () {
+    var commonEnumName = 'CommonEnum';
+    var firstModuleAlias = 'module1';
+    var secondModuleAlias = 'module2';
+    var modelSources = [
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        enum: $commonEnumName
+        values:
+          - value1
+          - value2
+        ''',
+          )
+          .withFileName('common_enum.yaml')
+          .withModuleAlias(firstModuleAlias)
+          .build(),
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        enum: $commonEnumName
+        values:
+          - value1
+          - value2
+        ''',
+          )
+          .withFileName('common_enum.yaml')
+          .withModuleAlias(secondModuleAlias)
+          .build(),
+      ModelSourceBuilder().withYaml(
+        '''
+        class: Example
+        fields:
+          enumField: module:$secondModuleAlias:$commonEnumName
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var models =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+            .validateAll();
+
+    var model = models.last as ClassDefinition;
+    var enumField = model.fields.first;
+
+    expect(enumField.type.enumDefinition, isA<EnumDefinition>());
+
+    expect(enumField.type.enumDefinition?.moduleAlias, secondModuleAlias);
+  });
+
+  test(
+      'Given multiple classes with the same name in different modules '
+      'when a class has a relation to another class '
+      'then the relation is resolved to the correct module', () {
+    var commonClassName = 'CommonClass';
+    var firstModuleAlias = 'module1';
+    var secondModuleAlias = 'module2';
+    var modelSources = [
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        class: $commonClassName
+        table: common_class_$firstModuleAlias
+        fields:
+          name: String
+        ''',
+          )
+          .withFileName('common_class.yaml')
+          .withModuleAlias(firstModuleAlias)
+          .build(),
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        class: $commonClassName
+        table: common_class_$secondModuleAlias
+        fields:
+          name: String
+        ''',
+          )
+          .withFileName('common_class.yaml')
+          .withModuleAlias(secondModuleAlias)
+          .build(),
+      ModelSourceBuilder().withYaml(
+        '''
+        class: Example
+        table: example
+        fields:
+          objectRelation: module:$secondModuleAlias:$commonClassName?, relation
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var models =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+            .validateAll();
+
+    var model = models.last as ClassDefinition;
+    var fieldType = model.fields.last.relation as ObjectRelationDefinition;
+    expect(fieldType.parentTable, 'common_class_$secondModuleAlias');
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
@@ -9,221 +9,223 @@ import 'package:test/test.dart';
 void main() {
   var config = GeneratorConfigBuilder().build();
 
-  test(
-      'Given an enum with the same name defined in a module and then '
-      'the project (order matters) '
-      'when that enum is referenced '
-      'then the type is resolved to the correct module', () {
-    var commonEnumName = 'CommonEnum';
-    var firstModuleAlias = 'module1';
-    var modelSources = [
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+  group('Given an enum with the same name defined in', () {
+    test(
+        'a module and then the project (order matters) '
+        'when the project enum is referenced '
+        'then the type is resolved to the project enum', () {
+      var commonEnumName = 'CommonEnum';
+      var firstModuleAlias = 'module1';
+      var modelSources = [
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         enum: $commonEnumName
         values:
           - value1
           - value2
         ''',
-          )
-          .withFileName('common_enum.yaml')
-          .withModuleAlias(firstModuleAlias)
-          .build(),
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+            )
+            .withFileName('common_enum.yaml')
+            .withModuleAlias(firstModuleAlias)
+            .build(),
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         enum: $commonEnumName
         values:
           - value1
           - value2
         ''',
-          )
-          .withFileName('common_enum.yaml')
-          .withModuleAlias(defaultModuleAlias)
-          .build(),
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+            )
+            .withFileName('common_enum.yaml')
+            .withModuleAlias(defaultModuleAlias)
+            .build(),
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         class: Example
         fields:
           enumField: $commonEnumName
         ''',
-          )
-          .withModuleAlias(defaultModuleAlias)
-          .build(),
-    ];
+            )
+            .withModuleAlias(defaultModuleAlias)
+            .build(),
+      ];
 
-    var collector = CodeGenerationCollector();
-    var models =
-        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
-            .validateAll();
+      var collector = CodeGenerationCollector();
+      var models =
+          StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+              .validateAll();
 
-    var model = models.last as ClassDefinition;
-    var enumField = model.fields.first;
+      var model = models.last as ClassDefinition;
+      var enumField = model.fields.first;
 
-    expect(enumField.type.enumDefinition, isA<EnumDefinition>());
+      expect(enumField.type.enumDefinition, isA<EnumDefinition>());
 
-    expect(enumField.type.enumDefinition?.moduleAlias, defaultModuleAlias);
+      expect(enumField.type.enumDefinition?.moduleAlias, defaultModuleAlias);
+    });
+
+    test(
+        'different modules (order matters)'
+        'when the second module enum is referenced '
+        'then the type is resolved to the second module enum', () {
+      var commonEnumName = 'CommonEnum';
+      var firstModuleAlias = 'module1';
+      var secondModuleAlias = 'module2';
+      var modelSources = [
+        ModelSourceBuilder()
+            .withYaml(
+              '''
+        enum: $commonEnumName
+        values:
+          - value1
+          - value2
+        ''',
+            )
+            .withFileName('common_enum.yaml')
+            .withModuleAlias(firstModuleAlias)
+            .build(),
+        ModelSourceBuilder()
+            .withYaml(
+              '''
+        enum: $commonEnumName
+        values:
+          - value1
+          - value2
+        ''',
+            )
+            .withFileName('common_enum.yaml')
+            .withModuleAlias(secondModuleAlias)
+            .build(),
+        ModelSourceBuilder().withYaml(
+          '''
+        class: Example
+        fields:
+          enumField: module:$secondModuleAlias:$commonEnumName
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var models =
+          StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+              .validateAll();
+
+      var model = models.last as ClassDefinition;
+      var enumField = model.fields.first;
+
+      expect(enumField.type.enumDefinition, isA<EnumDefinition>());
+
+      expect(enumField.type.enumDefinition?.moduleAlias, secondModuleAlias);
+    });
   });
 
-  test(
-      'Given a class with the same name defined in a module and then '
-      'the project (order matters) '
-      'when that class is referenced in a relation '
-      'then the relation is resolved to the correct module', () {
-    var commonClassName = 'CommonClass';
-    var firstModuleAlias = 'module1';
-    var modelSources = [
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+  group('Given a class with the same name defined in', () {
+    test(
+        'a module and then the project (order matters) '
+        'when the project class is referenced in a relation '
+        'then the relation is resolved to the project class', () {
+      var commonClassName = 'CommonClass';
+      var firstModuleAlias = 'module1';
+      var modelSources = [
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         class: $commonClassName
         table: common_class_$firstModuleAlias
         fields:
           name: String
         ''',
-          )
-          .withFileName('common_class.yaml')
-          .withModuleAlias(firstModuleAlias)
-          .build(),
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+            )
+            .withFileName('common_class.yaml')
+            .withModuleAlias(firstModuleAlias)
+            .build(),
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         class: $commonClassName
         table: common_class_$defaultModuleAlias
         fields:
           name: String
         ''',
-          )
-          .withFileName('common_class.yaml')
-          .withModuleAlias(defaultModuleAlias)
-          .build(),
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+            )
+            .withFileName('common_class.yaml')
+            .withModuleAlias(defaultModuleAlias)
+            .build(),
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         class: Example
         table: example
         fields:
           objectRelation: $commonClassName?, relation
         ''',
-          )
-          .withModuleAlias(defaultModuleAlias)
-          .build(),
-    ];
+            )
+            .withModuleAlias(defaultModuleAlias)
+            .build(),
+      ];
 
-    var collector = CodeGenerationCollector();
-    var models =
-        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
-            .validateAll();
+      var collector = CodeGenerationCollector();
+      var models =
+          StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+              .validateAll();
 
-    var model = models.last as ClassDefinition;
-    var fieldType = model.fields.last.relation as ObjectRelationDefinition;
-    expect(fieldType.parentTable, 'common_class_$defaultModuleAlias');
-  });
+      var model = models.last as ClassDefinition;
+      var fieldType = model.fields.last.relation as ObjectRelationDefinition;
+      expect(fieldType.parentTable, 'common_class_$defaultModuleAlias');
+    });
 
-  test(
-      'Given an enum with the same name defined in different modules (order matters)'
-      'when that enum is referenced '
-      'then the type is resolved to the correct module', () {
-    var commonEnumName = 'CommonEnum';
-    var firstModuleAlias = 'module1';
-    var secondModuleAlias = 'module2';
-    var modelSources = [
-      ModelSourceBuilder()
-          .withYaml(
-            '''
-        enum: $commonEnumName
-        values:
-          - value1
-          - value2
-        ''',
-          )
-          .withFileName('common_enum.yaml')
-          .withModuleAlias(firstModuleAlias)
-          .build(),
-      ModelSourceBuilder()
-          .withYaml(
-            '''
-        enum: $commonEnumName
-        values:
-          - value1
-          - value2
-        ''',
-          )
-          .withFileName('common_enum.yaml')
-          .withModuleAlias(secondModuleAlias)
-          .build(),
-      ModelSourceBuilder().withYaml(
-        '''
-        class: Example
-        fields:
-          enumField: module:$secondModuleAlias:$commonEnumName
-        ''',
-      ).build(),
-    ];
-
-    var collector = CodeGenerationCollector();
-    var models =
-        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
-            .validateAll();
-
-    var model = models.last as ClassDefinition;
-    var enumField = model.fields.first;
-
-    expect(enumField.type.enumDefinition, isA<EnumDefinition>());
-
-    expect(enumField.type.enumDefinition?.moduleAlias, secondModuleAlias);
-  });
-
-  test(
-      'Given a class with the same name defined in different modules (order matters) '
-      'when that class is referenced in a relation '
-      'then the relation is resolved to the correct module', () {
-    var commonClassName = 'CommonClass';
-    var firstModuleAlias = 'module1';
-    var secondModuleAlias = 'module2';
-    var modelSources = [
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+    test(
+        'different modules (order matters)'
+        'when the second module class is referenced in a relation '
+        'then the relation is resolved to the second module class', () {
+      var commonClassName = 'CommonClass';
+      var firstModuleAlias = 'module1';
+      var secondModuleAlias = 'module2';
+      var modelSources = [
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         class: $commonClassName
         table: common_class_$firstModuleAlias
         fields:
           name: String
         ''',
-          )
-          .withFileName('common_class.yaml')
-          .withModuleAlias(firstModuleAlias)
-          .build(),
-      ModelSourceBuilder()
-          .withYaml(
-            '''
+            )
+            .withFileName('common_class.yaml')
+            .withModuleAlias(firstModuleAlias)
+            .build(),
+        ModelSourceBuilder()
+            .withYaml(
+              '''
         class: $commonClassName
         table: common_class_$secondModuleAlias
         fields:
           name: String
         ''',
-          )
-          .withFileName('common_class.yaml')
-          .withModuleAlias(secondModuleAlias)
-          .build(),
-      ModelSourceBuilder().withYaml(
-        '''
+            )
+            .withFileName('common_class.yaml')
+            .withModuleAlias(secondModuleAlias)
+            .build(),
+        ModelSourceBuilder().withYaml(
+          '''
         class: Example
         table: example
         fields:
           objectRelation: module:$secondModuleAlias:$commonClassName?, relation
         ''',
-      ).build(),
-    ];
+        ).build(),
+      ];
 
-    var collector = CodeGenerationCollector();
-    var models =
-        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
-            .validateAll();
+      var collector = CodeGenerationCollector();
+      var models =
+          StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+              .validateAll();
 
-    var model = models.last as ClassDefinition;
-    var fieldType = model.fields.last.relation as ObjectRelationDefinition;
-    expect(fieldType.parentTable, 'common_class_$secondModuleAlias');
+      var model = models.last as ClassDefinition;
+      var fieldType = model.fields.last.relation as ObjectRelationDefinition;
+      expect(fieldType.parentTable, 'common_class_$secondModuleAlias');
+    });
   });
 }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
@@ -3,15 +3,128 @@ import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
 import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
 import 'package:test/test.dart';
 
 void main() {
   var config = GeneratorConfigBuilder().build();
 
   test(
-      'Given multiple enums with the same name in different modules '
-      'when an enum is referenced '
-      'then the enum is resolved to the correct module', () {
+      'Given an enum with the same name defined in a module and then '
+      'the project (order matters) '
+      'when that enum is referenced '
+      'then the type is resolved to the correct module', () {
+    var commonEnumName = 'CommonEnum';
+    var firstModuleAlias = 'module1';
+    var modelSources = [
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        enum: $commonEnumName
+        values:
+          - value1
+          - value2
+        ''',
+          )
+          .withFileName('common_enum.yaml')
+          .withModuleAlias(firstModuleAlias)
+          .build(),
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        enum: $commonEnumName
+        values:
+          - value1
+          - value2
+        ''',
+          )
+          .withFileName('common_enum.yaml')
+          .withModuleAlias(defaultModuleAlias)
+          .build(),
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        class: Example
+        fields:
+          enumField: $commonEnumName
+        ''',
+          )
+          .withModuleAlias(defaultModuleAlias)
+          .build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var models =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+            .validateAll();
+
+    var model = models.last as ClassDefinition;
+    var enumField = model.fields.first;
+
+    expect(enumField.type.enumDefinition, isA<EnumDefinition>());
+
+    expect(enumField.type.enumDefinition?.moduleAlias, defaultModuleAlias);
+  });
+
+  test(
+      'Given a class with the same name defined in a module and then '
+      'the project (order matters) '
+      'when that class is referenced in a relation '
+      'then the relation is resolved to the correct module', () {
+    var commonClassName = 'CommonClass';
+    var firstModuleAlias = 'module1';
+    var modelSources = [
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        class: $commonClassName
+        table: common_class_$firstModuleAlias
+        fields:
+          name: String
+        ''',
+          )
+          .withFileName('common_class.yaml')
+          .withModuleAlias(firstModuleAlias)
+          .build(),
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        class: $commonClassName
+        table: common_class_$defaultModuleAlias
+        fields:
+          name: String
+        ''',
+          )
+          .withFileName('common_class.yaml')
+          .withModuleAlias(defaultModuleAlias)
+          .build(),
+      ModelSourceBuilder()
+          .withYaml(
+            '''
+        class: Example
+        table: example
+        fields:
+          objectRelation: $commonClassName?, relation
+        ''',
+          )
+          .withModuleAlias(defaultModuleAlias)
+          .build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var models =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+            .validateAll();
+
+    var model = models.last as ClassDefinition;
+    var fieldType = model.fields.last.relation as ObjectRelationDefinition;
+    expect(fieldType.parentTable, 'common_class_$defaultModuleAlias');
+  });
+
+  test(
+      'Given an enum with the same name defined in different modules (order matters)'
+      'when that enum is referenced '
+      'then the type is resolved to the correct module', () {
     var commonEnumName = 'CommonEnum';
     var firstModuleAlias = 'module1';
     var secondModuleAlias = 'module2';
@@ -63,8 +176,8 @@ void main() {
   });
 
   test(
-      'Given multiple classes with the same name in different modules '
-      'when a class has a relation to another class '
+      'Given a class with the same name defined in different modules (order matters) '
+      'when that class is referenced in a relation '
       'then the relation is resolved to the correct module', () {
     var commonClassName = 'CommonClass';
     var firstModuleAlias = 'module1';


### PR DESCRIPTION
###  Description:
This PR reviews all the places where class resolution is used. Added `moduleAlias` checks where needed to ensure correct behavior and left unchanged the places where the existing logic was already sufficient. Below is a breakdown of what was updated and what was not.

### 1. **Inheritance Resolution**
- **Unchanged**  
  The existing code already works correctly by checking only the `className`. Since we dont allow inheritance across modules, no changes were needed.
https://github.com/serverpod/serverpod/blob/0009d80b52417669e80dd0a728fc00dae409bcea/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart#L47


### 2. **Enum Resolution**
- **Modified**  
  We added `moduleAlias` checks because enums can have the same `className` in different modules. Both `className` and `moduleAlias` are now used to uniquely identify enums.
 https://github.com/serverpod/serverpod/blob/8ba5561eef83cce6af96587a91f85f199ce3c414/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart#L96-L97


### 3. **Object Relation Resolution**
- **Modified**  
  We added `moduleAlias` checks to ensure object relations are resolved correctly when there are classes with the same `className` in different modules.
 https://github.com/serverpod/serverpod/blob/8ba5561eef83cce6af96587a91f85f199ce3c414/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart#L116-L117


### 4. **List Relation Resolution**
- **Unchanged**  
  We dont allow list relations on modules. We already have this check:
https://github.com/serverpod/serverpod/blob/e1fae905d1fdba2d72e1920da20100baa23b96a3/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart#L1057-L1065
https://github.com/serverpod/serverpod/blob/0009d80b52417669e80dd0a728fc00dae409bcea/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart#L114


### 5. **Extra Class Restrictions**
- **Unchanged**  
  This code only checks if a `className` exists in `extraClasses`. Since no module ambiguity exists here, it didn’t need any changes.
https://github.com/serverpod/serverpod/blob/0009d80b52417669e80dd0a728fc00dae409bcea/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart#L172


### 6. **Custom Type Check**
- **Unchanged**  
  This function only checks if a type is in `extraClasses` by `className`. The existing logic was already correct, so no changes were made.
https://github.com/serverpod/serverpod/blob/0009d80b52417669e80dd0a728fc00dae409bcea/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart#L172


### 7. **Type Parsing for Extras**
- **Unchanged**  
  This part determines if a `className` exists in `extraClasses`. No changes were needed because the logic is simple and sufficient.
https://github.com/serverpod/serverpod/blob/0009d80b52417669e80dd0a728fc00dae409bcea/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart#L1415


### Closes: #3019

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._