### PR TITLE
fix(dockerfile): Add missing copy step for protocol.yaml

### DIFF
--- a/templates/serverpod_templates/projectname_server/Dockerfile
+++ b/templates/serverpod_templates/projectname_server/Dockerfile
@@ -1,27 +1,39 @@
+# Build stage
 FROM dart:3.3.0 AS build
-
 WORKDIR /app
 COPY . .
 
+# Install dependencies and compile the server executable
 RUN dart pub get
 RUN dart compile exe bin/main.dart -o bin/server
 
+# Final stage
 FROM alpine:latest
 
+# Environment variables
 ENV runmode=production
 ENV serverid=default
 ENV logging=normal
 ENV role=monolith
 
+# Copy runtime dependencies
 COPY --from=build /runtime/ /
+
+# Copy compiled server executable
 COPY --from=build /app/bin/server server
-COPY --from=build /app/confi[g]/ config/
-COPY --from=build /app/we[b]/ web/
-COPY --from=build /app/migration[s]/ migrations/
 
+# Copy configuration files and resources
+COPY --from=build /app/config/ config/
+COPY --from=build /app/web/ web/
+COPY --from=build /app/migrations/ migrations/
 
+# This file is required to enable the endpoint log filter in Insights.
+COPY --from=build /app/lib/src/generated/protocol.yaml lib/src/generated/protocol.yaml
+
+# Expose ports
 EXPOSE 8080
 EXPOSE 8081
 EXPOSE 8082
 
+# Define the entrypoint command
 ENTRYPOINT ./server --mode=$runmode --server-id=$serverid --logging=$logging --role=$role


### PR DESCRIPTION
### Changes:
- Adds a missing step to copy `protocol.yaml` from the build stage to the final stage in the Dockerfile, essential for enabling log filtering in the Insights server.  
- Groups related commands in the Dockerfile for better readability and organization.

### Screenshot:
![Screenshot 2025-01-20 at 10 30 00 AM](https://github.com/user-attachments/assets/891821cb-0264-4a38-ae7f-7e4bb2e272b0)

Closes: #3031

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._