### PR TITLE
fix: Relative imports sometimes generated with backward slashes on Windows

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/custom_allocators.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/custom_allocators.dart
@@ -14,10 +14,11 @@ class ImportCollector {
     }
 
     var absolutePath = p.join(p.dirname(currentPath), topNodePath);
-    return p.relative(
-      absolutePath,
-      from: p.dirname(basePath),
-    );
+    var relativePath = p.relative(absolutePath, from: p.dirname(basePath));
+
+    // If on Windows, top level paths could appear with backslashes and break
+    // the import clause, such as `import '..\protocol.dart' as _i1;`.
+    return relativePath.replaceAll('\\', '/');
   }
 
   int getOrCreateAlias(String topNodePath, String currentPath) {

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/custom_allocators.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/custom_allocators.dart
@@ -18,7 +18,7 @@ class ImportCollector {
 
     // If on Windows, top level paths could appear with backslashes and break
     // the import clause, such as `import '..\protocol.dart' as _i1;`.
-    return relativePath.replaceAll('\\', '/');
+    return p.split(relativePath).join('/');
   }
 
   int getOrCreateAlias(String topNodePath, String currentPath) {

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/imports_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/imports_test.dart
@@ -1,0 +1,94 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/serializable_entity_field_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/compilation_unit_helpers.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
+import 'package:test/test.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartClientCodeGenerator();
+
+void main() {
+  String getExpectedFilePath(String fileName, {List<String>? subDirParts}) =>
+      p.joinAll([
+        '..',
+        'example_project_client',
+        'lib',
+        'src',
+        'protocol',
+        ...?subDirParts,
+        '$fileName.dart',
+      ]);
+
+  group(
+      'Given a hierarchy with a sealed parent that has a model and a normal child, when generating code',
+      () {
+    var parent = ClassDefinitionBuilder()
+        .withSubDirParts(['subdir'])
+        .withClassName('Example')
+        .withFileName('example')
+        .withField(FieldDefinitionBuilder()
+            .withName('user')
+            .withType(
+              TypeDefinitionBuilder()
+                  .withClassName('User')
+                  .withUrl(defaultModuleAlias)
+                  .build(),
+            )
+            .build())
+        .withIsSealed(true)
+        .build();
+
+    var child = ClassDefinitionBuilder()
+        .withSubDirParts(['subdir'])
+        .withClassName('ExampleChild')
+        .withFileName('example_child')
+        .withSimpleField('age', 'int')
+        .withExtendsClass(parent)
+        .build();
+
+    var user = ClassDefinitionBuilder()
+        .withSubDirParts(['subdir'])
+        .withClassName('User')
+        .withFileName('user')
+        .withSimpleField('name', 'String')
+        .build();
+
+    parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+    var models = [
+      parent,
+      child,
+      user,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var parentCompilationUnit = parseString(
+      content: codeMap[getExpectedFilePath(
+        parent.fileName,
+        subDirParts: ['subdir'],
+      )]!,
+    ).unit;
+
+    test(
+        'then the ${parent.className} has a relative protocol import directive correctly generated',
+        () {
+      var protocolImport = CompilationUnitHelpers.tryFindImportDirective(
+        parentCompilationUnit,
+        uri: '../protocol.dart',
+      );
+
+      expect(protocolImport, isNotNull);
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/imports_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/imports_test.dart
@@ -1,0 +1,92 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/serializable_entity_field_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/type_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/compilation_unit_helpers.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
+import 'package:test/test.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  String getExpectedFilePath(String fileName, {List<String>? subDirParts}) =>
+      p.joinAll([
+        'lib',
+        'src',
+        'generated',
+        ...?subDirParts,
+        '$fileName.dart',
+      ]);
+
+  group(
+      'Given a hierarchy with a sealed parent that has a model and a normal child, when generating code',
+      () {
+    var parent = ClassDefinitionBuilder()
+        .withSubDirParts(['subdir'])
+        .withClassName('Example')
+        .withFileName('example')
+        .withField(FieldDefinitionBuilder()
+            .withName('user')
+            .withType(
+              TypeDefinitionBuilder()
+                  .withClassName('User')
+                  .withUrl(defaultModuleAlias)
+                  .build(),
+            )
+            .build())
+        .withIsSealed(true)
+        .build();
+
+    var child = ClassDefinitionBuilder()
+        .withSubDirParts(['subdir'])
+        .withClassName('ExampleChild')
+        .withFileName('example_child')
+        .withSimpleField('age', 'int')
+        .withExtendsClass(parent)
+        .build();
+
+    var user = ClassDefinitionBuilder()
+        .withSubDirParts(['subdir'])
+        .withClassName('User')
+        .withFileName('user')
+        .withSimpleField('name', 'String')
+        .build();
+
+    parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+    var models = [
+      parent,
+      child,
+      user,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var parentCompilationUnit = parseString(
+      content: codeMap[getExpectedFilePath(
+        parent.fileName,
+        subDirParts: ['subdir'],
+      )]!,
+    ).unit;
+
+    test(
+        'then the ${parent.className} has a relative protocol import directive correctly generated',
+        () {
+      var protocolImport = CompilationUnitHelpers.tryFindImportDirective(
+        parentCompilationUnit,
+        uri: '../protocol.dart',
+      );
+
+      expect(protocolImport, isNotNull);
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_class_test.dart
@@ -73,6 +73,15 @@ void main() {
         expect(parentClass, isNotNull);
       });
 
+      test('has a relative protocol import directive', () {
+        var protocolImport = CompilationUnitHelpers.tryFindImportDirective(
+          parentCompilationUnit,
+          uri: '../protocol.dart',
+        );
+
+        expect(protocolImport, isNotNull);
+      }, skip: 'The real code generation have this import, but not the test.');
+
       test('has a part directive with ${child.className} uri', () {
         var partDirective = CompilationUnitHelpers.tryFindPartDirective(
           parentCompilationUnit,

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_class_test.dart
@@ -73,15 +73,6 @@ void main() {
         expect(parentClass, isNotNull);
       });
 
-      test('has a relative protocol import directive', () {
-        var protocolImport = CompilationUnitHelpers.tryFindImportDirective(
-          parentCompilationUnit,
-          uri: '../protocol.dart',
-        );
-
-        expect(protocolImport, isNotNull);
-      }, skip: 'The real code generation have this import, but not the test.');
-
       test('has a part directive with ${child.className} uri', () {
         var partDirective = CompilationUnitHelpers.tryFindPartDirective(
           parentCompilationUnit,


### PR DESCRIPTION
Closes issue #3145.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes.