### PR TITLE
Remove obsolete test 

### DIFF
--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/sealed_class_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:path/path.dart' as p;
@@ -1014,25 +1012,5 @@ void main() {
         );
       });
     });
-  });
-
-  test(
-      'CompilationUnit.directives[i].uri.stringValue returns relative path without separators on Windows.',
-      () {
-    var content = Platform.isWindows
-        ? "part 'sub_dir\\example_child.dart';"
-        : "part 'sub_dir/example_child.dart';";
-
-    var unit = parseString(content: content).unit;
-
-    var directive = unit.directives.whereType<PartDirective>().first;
-
-    var directiveStringValue = directive.uri.stringValue;
-
-    var expectedPath = Platform.isWindows
-        ? 'sub_direxample_child.dart'
-        : 'sub_dir/example_child.dart';
-
-    expect(directiveStringValue == expectedPath, isTrue);
   });
 }


### PR DESCRIPTION
This PR removes the test I used to reproduce the [separator sdk bug](https://github.com/dart-lang/sdk/issues/59629) we discovered. As it is no longer needed it can be removed

no related issues

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes as just a test and an unused import are removed