### PR TITLE
chore: Add PATH and SERVERPOD_HOME to extension debug config.

### DIFF
--- a/tools/serverpod_vscode_extension/.vscode/launch.json
+++ b/tools/serverpod_vscode_extension/.vscode/launch.json
@@ -15,7 +15,11 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "${defaultBuildTask}",
+			"env": {
+				"PATH": "${env:PATH}",
+				"SERVERPOD_HOME": "${env:SERVERPOD_HOME}"
+			  }
 		},
 		{
 			"name": "Extension Tests",


### PR DESCRIPTION
VSCode no longer seems to inherit the environment that a launch configuration is run from, resulting in the `PATH` and `ENV` being empty.

This PR adds a copy of the `PATH` and the required `SERVERPOD_HOME` env variable to ensure the extension can be debugged.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.