### PR TITLE
chore: Add template for documentation issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,34 @@
+name: Documentation request
+description: Request a correction, clarification, or addition to the documentation.
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please use this template to help us improve the documentation. Be as specific and clear as possible!
+
+  - type: textarea
+    id: issue-summary
+    attributes:
+      label: Summary of the issue
+      description: Describe the documentation correction or the proposed addition. Please add references to relevant documentation sections if applicable.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: experience
+    attributes:
+      label: How experienced are you with this library?
+      multiple: false
+      description: This helps us understand where in the user journey this issue might arise.
+      options:
+        - Beginner - Just getting started with this library
+        - Intermediate - Familiar with the basics or have used it in a few projects
+        - Expert - Experienced and comfortable with using this library in complex projects
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Are you interested in working on a PR for this?
+      options:
+        - label: I want to work on this


### PR DESCRIPTION
Adds a template for filing documentation issues.

The new template appears in the list like so:

<img width="819" alt="Screenshot 2025-01-21 at 15 48 27" src="https://github.com/user-attachments/assets/85a2699d-96fc-4c31-abce-9bb488e759d2" />

And looks like this once opened:

<img width="1025" alt="Screenshot 2025-01-21 at 15 49 30" src="https://github.com/user-attachments/assets/44cc4d77-cd58-4a6d-aabc-f597ef850b0d" />

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.