### PR TITLE
feat: Add validation for relations with serverOnly scope to ensure they are optional

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/checker/analyze_checker.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/checker/analyze_checker.dart
@@ -19,6 +19,11 @@ class AnalyzeChecker {
     return node.containsKey(Keyword.optional);
   }
 
+  static bool isFieldDefined(dynamic node) {
+    if (node is! YamlMap) return false;
+    return node.containsKey(Keyword.field);
+  }
+
   static List<SerializableModelFieldDefinition> filterRelationByName(
     ClassDefinition classDefinition,
     ClassDefinition foreignClass,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -748,6 +748,14 @@ class Restrictions {
       ));
     }
 
+    var isServerOnly = field.scope == ModelFieldScopeDefinition.serverOnly;
+    if (isServerOnly && !AnalyzeChecker.isOptionalDefined(content)) {
+      errors.add(SourceSpanSeverityException(
+        'The relation with scope "${field.scope.name}" requires the relation to be optional.',
+        span,
+      ));
+    }
+
     return errors;
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -748,12 +748,15 @@ class Restrictions {
       ));
     }
 
-    var isServerOnly = field.scope == ModelFieldScopeDefinition.serverOnly;
-    if (isServerOnly && !AnalyzeChecker.isOptionalDefined(content)) {
-      errors.add(SourceSpanSeverityException(
-        'The relation with scope "${field.scope.name}" requires the relation to be optional.',
-        span,
-      ));
+    if (!AnalyzeChecker.isFieldDefined(content)) {
+      var isOptional = AnalyzeChecker.isOptionalDefined(content);
+      var isServerOnly = field.scope == ModelFieldScopeDefinition.serverOnly;
+      if (isServerOnly && !isOptional) {
+        errors.add(SourceSpanSeverityException(
+          'The relation with scope "${field.scope.name}" requires the relation to be optional.',
+          span,
+        ));
+      }
     }
 
     return errors;

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
@@ -121,6 +121,9 @@ class ClassYamlDefinition {
                     Keyword.optional,
                     keyRestriction: restrictions.validateOptionalKey,
                     valueRestriction: BooleanValueRestriction().validate,
+                    mutuallyExclusiveKeys: {
+                      Keyword.field,
+                    },
                   ),
                   ValidateNode(
                     Keyword.name,

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_relation_scope_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_relation_scope_test.dart
@@ -1,0 +1,147 @@
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  var parentClassModel = ModelSourceBuilder()
+      .withYaml(
+        '''
+        class: ParentClass
+        table: parent
+        fields:
+          name: String
+        ''',
+      )
+      .withFileName('parent_class')
+      .build();
+
+  group('Given a class with a non-optional relation and "serverOnly" scope',
+      () {
+    test(
+      'when analyzed then an error is generated for an object relation',
+      () {
+        var models = [
+          parentClassModel,
+          ModelSourceBuilder()
+              .withYaml(
+                '''
+                class: Example
+                table: example
+                fields:
+                  parentClass: ParentClass?, relation, scope=serverOnly
+                ''',
+              )
+              .withFileName('example_class')
+              .build(),
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var error = collector.errors.first as SourceSpanSeverityException;
+        expect(error.severity, SourceSpanSeverity.error);
+        expect(
+          error.message,
+          'The relation with scope "serverOnly" requires the relation to be optional.',
+        );
+      },
+    );
+
+    test(
+      'when analyzed then an error is generated for a foreign key relation',
+      () {
+        var models = [
+          parentClassModel,
+          ModelSourceBuilder()
+              .withYaml(
+                '''
+                class: Example
+                table: example
+                fields:
+                  relationId: int
+                  parentClass: ParentClass?, relation(field=relationId), scope=serverOnly
+                ''',
+              )
+              .withFileName('example_class')
+              .build(),
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var error = collector.errors.first as SourceSpanSeverityException;
+        expect(error.severity, SourceSpanSeverity.error);
+        expect(
+          error.message,
+          'The relation with scope "serverOnly" requires the relation to be optional.',
+        );
+      },
+    );
+  });
+
+  group('Given a class with an optional relation and "serverOnly" scope', () {
+    test(
+      'when analyzed then no errors are generated for an object relation',
+      () {
+        var models = [
+          parentClassModel,
+          ModelSourceBuilder()
+              .withYaml(
+                '''
+                class: Example
+                table: example
+                fields:
+                  parentClass: ParentClass?, relation(optional), scope=serverOnly
+                ''',
+              )
+              .withFileName('example_class')
+              .build(),
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isEmpty);
+      },
+    );
+
+    test(
+      'when analyzed then no errors are generated for a foreign key relation',
+      () {
+        var models = [
+          parentClassModel,
+          ModelSourceBuilder()
+              .withYaml(
+                '''
+                class: Example
+                table: example
+                fields:
+                  relationId: int
+                  parentClass: ParentClass?, relation(optional, field=relationId), scope=serverOnly
+                ''',
+              )
+              .withFileName('example_class')
+              .build(),
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(config, models, onErrorsCollector(collector))
+            .validateAll();
+
+        expect(collector.errors, isEmpty);
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_manual_field_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_manual_field_test.dart
@@ -298,6 +298,46 @@ fields:
   });
 
   group(
+    'Given a class with an optional relation pointing to a field ',
+    () {
+      var models = [
+        ModelSourceBuilder()
+            .withYaml(
+              '''
+                class: Example
+                table: example
+                fields:
+                  manualId: int
+                  relationObject: Example?, relation(optional, field=manualId), scope=serverOnly
+                ''',
+            )
+            .withFileName('example_class')
+            .build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, models, onErrorsCollector(collector))
+          .validateAll();
+
+      var errors = collector.errors;
+
+      test('then an error was collected.', () {
+        expect(errors, isNotEmpty);
+      });
+
+      test(
+          'then the error message reports that the "optional" property '
+          'is mutually exclusive with the "field" property.', () {
+        var error = errors.first;
+        expect(
+          error.message,
+          'The "optional" property is mutually exclusive with the "field" property.',
+        );
+      });
+    },
+  );
+
+  group(
       'Given two classes with a named relation with a defined field name that holds the relation',
       () {
     var models = [


### PR DESCRIPTION
### Description
This PR introduces validation to ensure that relations with the `serverOnly` scope are explicitly marked as optional. Without this validation, the analyzer fails to detect invalid model definitions, leading to runtime exceptions during deserialization.

Previously, if a relation with the `serverOnly` scope was not marked as optional, the generated `fromJson` method would expect the foreign key column to be present, even though it is absent in the client model. This mismatch caused runtime errors when the class was passed as a parameter to an endpoint.

### Example
**Invalid Definition:**
```yaml
class: Example
table: example
fields:
  name: String
  user: User?, relation, scope=serverOnly
```

**Valid Definition:**
```yaml
class: Example
table: example
fields:
  name: String
  user: User?, relation(optional), scope=serverOnly
```


Closes: #3104 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._