### PR TITLE
fix: `LocalCache` returning `null` for expired keys instead of invoking `cacheMissHandler`

### DIFF
--- a/packages/serverpod/lib/src/cache/local_cache.dart
+++ b/packages/serverpod/lib/src/cache/local_cache.dart
@@ -97,7 +97,6 @@ class LocalCache extends Cache {
 
     if (entry != null) {
       if (entry.isExpired) {
-        // invalidate key and generate a new value below
         await invalidateKey(key);
       } else {
         return serializationManager.decode<T>(entry.serializedObject);

--- a/packages/serverpod/lib/src/cache/local_cache.dart
+++ b/packages/serverpod/lib/src/cache/local_cache.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:serverpod/src/cache/cache_miss_handler.dart';
 import 'package:serverpod_serialization/serverpod_serialization.dart';
@@ -10,6 +12,10 @@ class LocalCache extends Cache {
   final List<_KeyListKey> _keyList = <_KeyListKey>[];
   final Map<String, _CacheEntry> _entries = <String, _CacheEntry>{};
   final Map<String, Set<String>> _groups = <String, Set<String>>{};
+
+  /// New cache values currently being computed by a [CacheMissHandler]
+  // The future values in here must not be resolved (at which state the value should just be in the cache), but just pending
+  final _inProgressCacheValues = <String, Future<SerializableModel?>>{};
 
   /// Creates a new [LocalCache].
   LocalCache(super.maxEntries, super.serializationManager);
@@ -81,6 +87,10 @@ class LocalCache extends Cache {
   @override
   Future<T?> get<T extends SerializableModel>(
     String key, [
+    /// Handler to generate a new value in case there is no active value in the cache
+    ///
+    /// In case a value computation from a previous [get] call is already running, the caller will receive the value from
+    /// that call and the `cacheMissHandler` from this call will not be invoked.
     CacheMissHandler<T>? cacheMissHandler,
   ]) async {
     var entry = _entries[key];
@@ -94,10 +104,30 @@ class LocalCache extends Cache {
       }
     }
 
+    var pendingEntry = _inProgressCacheValues[key];
+    if (pendingEntry != null) {
+      return pendingEntry.then((v) => v as T);
+    }
+
     if (cacheMissHandler == null) return null;
 
-    var value = await cacheMissHandler.valueProvider();
-    if (value == null) return null;
+    T? value;
+    var completer = Completer<T?>();
+    try {
+      _inProgressCacheValues[key] = completer.future;
+
+      value = await cacheMissHandler.valueProvider();
+
+      completer.complete(value);
+
+      if (value == null) return null;
+    } catch (e, stackTrace) {
+      completer.completeError(e, stackTrace);
+
+      rethrow;
+    } finally {
+      unawaited(_inProgressCacheValues.remove(key));
+    }
 
     await put(
       key,

--- a/packages/serverpod/lib/src/cache/local_cache.dart
+++ b/packages/serverpod/lib/src/cache/local_cache.dart
@@ -105,7 +105,7 @@ class LocalCache extends Cache {
 
     var pendingEntry = _inProgressCacheValues[key];
     if (pendingEntry != null) {
-      return pendingEntry.then((v) => v as T);
+      return (await pendingEntry) as T;
     }
 
     if (cacheMissHandler == null) return null;

--- a/tests/serverpod_test_server/test/local_cache_test.dart
+++ b/tests/serverpod_test_server/test/local_cache_test.dart
@@ -8,55 +8,100 @@ import 'package:test/test.dart';
 const cacheMaxSize = 10;
 
 void main() {
-  var cache = LocalCache(cacheMaxSize, Protocol());
+  late LocalCache cache;
+  setUp(() {
+    cache = LocalCache(cacheMaxSize, Protocol());
+  });
 
   tearDown(() async => await cache.clear());
 
-  test('Put and get object', () async {
+  test(
+      'Given an entry was `put` to the cache, when it is accessed, then it can be read',
+      () async {
+    const key = 'entry';
+    var entry = SimpleData(num: 0);
+
+    await cache.put(key, entry);
+
+    var retrieved = await cache.get<SimpleData>(key);
+    expect(retrieved?.num, equals(0));
+  });
+
+  test(
+      'Given an entry was written to the cache, when the size is checked, then it will be 1',
+      () async {
     var entry = SimpleData(num: 0);
 
     await cache.put('entry', entry);
-    var retrieved = await cache.get<SimpleData>('entry');
-    expect(retrieved!.num, equals(0));
-
-    retrieved = await cache.get<SimpleData>('missing');
-    expect(retrieved, isNull);
-
-    retrieved = await cache.get<SimpleData>('entry');
-    expect(retrieved!.num, equals(0));
 
     expect(cache.localSize, equals(1));
   });
 
-  test('Put and get object with lifetime', () async {
+  test(
+      'Given an empty cache, when any item is accessed, then it will return `null`',
+      () async {
+    var retrieved = await cache.get<SimpleData>('missing');
+
+    expect(retrieved, isNull);
+  });
+
+  test(
+      'Given a cache entry with a lifetime, when it is accessed before it has expired, then the cache will return the item',
+      () async {
+    const key = 'entry_lifetime_1';
     var entry = SimpleData(num: 0);
 
-    await cache.put('entry', entry,
-        lifetime: const Duration(milliseconds: 100));
-    var retrieved = await cache.get<SimpleData>('entry');
-    expect(retrieved!.num, equals(0));
+    await cache.put(
+      key,
+      entry,
+      lifetime: const Duration(milliseconds: 100),
+    );
+
+    var retrieved = await cache.get<SimpleData>(key);
+    expect(retrieved?.num, equals(0));
+
+    expect(cache.localSize, equals(1));
+  });
+
+  test(
+      'Given a cache entry with a lifetime, when it is accessed after it has expired, then the cache will return `null`',
+      () async {
+    const key = 'entry_lifetime_2';
+    var entry = SimpleData(num: 0);
+
+    await cache.put(
+      key,
+      entry,
+      lifetime: const Duration(milliseconds: 100),
+    );
 
     await Future.delayed(const Duration(milliseconds: 110));
-    retrieved = await cache.get<SimpleData>('entry');
+
+    var retrieved = await cache.get<SimpleData>(key);
     expect(retrieved, isNull);
 
     expect(cache.localSize, equals(0));
   });
 
-  test('Put multiple with same key', () async {
+  test(
+      'Given a cache where multiple writes happened for the same key, when that key is accessed, then the latest value will be returned',
+      () async {
+    final key = 'multi_write';
     var entryA = SimpleData(num: 0);
     var entryB = SimpleData(num: 1);
 
-    await cache.put('entry', entryA);
-    await cache.put('entry', entryB);
+    await cache.put(key, entryA);
+    await cache.put(key, entryB);
 
-    var retrieved = await cache.get<SimpleData>('entry');
-    expect(retrieved!.num, equals(1));
+    var retrieved = await cache.get<SimpleData>(key);
+    expect(retrieved?.num, equals(1));
 
     expect(cache.localSize, equals(1));
   });
 
-  test('Cache overflow', () async {
+  test(
+      'Given a cache where more entries than it should hold are added, when its size is checked, then it will only contain the latest \$CACHE_SIZE items',
+      () async {
     var numEntries = cacheMaxSize * 2;
 
     for (var i = 0; i < numEntries; i++) {
@@ -73,7 +118,9 @@ void main() {
     expect(last!.num, equals(numEntries - 1));
   });
 
-  test('Invalidate keys', () async {
+  test(
+      'Given a cache with various items, when a single key is invalidated, then it will return `null` for that key while retaining all others',
+      () async {
     for (var i = 0; i < cacheMaxSize; i++) {
       var entry = SimpleData(num: i);
       await cache.put('entry:$i', entry);
@@ -91,7 +138,9 @@ void main() {
     expect(cache.localSize, equals(cacheMaxSize - 1));
   });
 
-  test('Invalidate group', () async {
+  test(
+      'Given a cache with items in 2 groups, when a single group is invalidated, then it will loose all items associated with that group',
+      () async {
     for (var i = 0; i < cacheMaxSize ~/ 2; i++) {
       var entry = SimpleData(num: i);
       await cache.put('entry:$i', entry, group: 'group:0');
@@ -147,18 +196,16 @@ void main() {
     expect(cache.localSize, equals(0));
   });
 
-  test('get object not in cache then null is returned', () async {
-    var retrieved = await cache.get<SimpleData>('invalidEntry');
-    expect(retrieved, isNull);
-  });
-
   test(
-      'get object which is expired in cache will call given `cacheMissHandler`',
+      'Given a cache with an expired item, when `get` is invoked with a `cacheMissHandler`, then the `cacheMissHandler` will be invoked and the newly create value returned',
       () async {
     final key = 'obj1';
 
-    await cache.put(key, SimpleData(num: 1),
-        lifetime: Duration(milliseconds: 100));
+    await cache.put(
+      key,
+      SimpleData(num: 1),
+      lifetime: Duration(milliseconds: 100),
+    );
 
     await Future.delayed(const Duration(milliseconds: 200));
 
@@ -174,7 +221,7 @@ void main() {
   });
 
   test(
-      'get `cacheMissHandler` will only be called once when multiple requests are made',
+      'Given an empty cache, when simultaneous `get`s are executed for the same key, then only the `cacheMissHandler` of the first request will be invoked',
       () async {
     final key = 'value_to_be_computed';
 
@@ -202,68 +249,50 @@ void main() {
     expect((await retrieved2Future)?.num, 100);
   });
 
-  group(
-      'get object not in cache when cache miss handler is specified to return object',
-      () {
+  test(
+      'Given an empty cache, when `get` is called with a `cacheMissHandler` returning an object, then that handler will be invoked to generate a new item to be stored in the cache and returned',
+      () async {
     const cacheKey = 'testKey';
-    SimpleData? retrieved;
-    setUp(() async {
-      retrieved = await cache.get(
-        cacheKey,
-        CacheMissHandler(() async => SimpleData(num: 1337)),
-      );
-    });
-    test('then object from cache miss handler is returned', () {
-      expect(retrieved?.num, equals(1337));
-    });
 
-    test('then cache miss handler value is retrievable from the cache',
-        () async {
-      var value = await cache.get<SimpleData>(cacheKey);
-      expect(value?.num, equals(1337));
-    });
+    var retrieved = await cache.get<SimpleData>(
+      cacheKey,
+      CacheMissHandler(() async => SimpleData(num: 1337)),
+    );
+
+    expect(retrieved?.num, equals(1337));
+
+    var value = await cache.get<SimpleData>(cacheKey);
+    expect(value?.num, equals(1337));
   });
 
-  group(
-      'get object not in cache when cache miss handler is specified to return null',
-      () {
+  test(
+      'Given an empty cache, when `get` is called with a `cacheMissHandler` returning null, then that handler will be invoked and `null` will be returned and nothing stored in the cache',
+      () async {
     const cacheKey = 'testKey';
-    SimpleData? retrieved;
-    setUp(() async {
-      retrieved = await cache.get(
-        cacheKey,
-        CacheMissHandler(() async => null),
-      );
-    });
-    test('then null is returned', () {
-      expect(retrieved, isNull);
-    });
 
-    test('then no value is set in cache', () async {
-      var value = await cache.get<SimpleData>(cacheKey);
-      expect(value, isNull);
-    });
+    var retrieved = await cache.get<SimpleData>(
+      cacheKey,
+      CacheMissHandler(() async => null),
+    );
+
+    expect(retrieved, isNull);
+
+    var value = await cache.get<SimpleData>(cacheKey);
+    expect(value, isNull);
+    expect(cache.localSize, equals(0));
   });
 
-  group('get object already in cache when cache miss handler is specified', () {
+  test(
+      'Given a cache containing an item with infinite lifetime, when that item is retrieved, then it will be returned and the `cacheMissHandler` will not be invoked',
+      () async {
     const cacheKey = 'testKey';
-    SimpleData? retrieved;
-    setUp(() async {
-      await cache.put(cacheKey, SimpleData(num: 1));
-      retrieved = await cache.get(
-        cacheKey,
-        CacheMissHandler(() async => SimpleData(num: 1337)),
-      );
-    });
 
-    test('then object already in cache is returned', () {
-      expect(retrieved?.num, equals(1));
-    });
+    await cache.put(cacheKey, SimpleData(num: 1));
+    var retrieved = await cache.get<SimpleData>(
+      cacheKey,
+      CacheMissHandler(() async => SimpleData(num: 1337)),
+    );
 
-    test('then object already in cache is still retrievable from the cache',
-        () async {
-      var value = await cache.get<SimpleData>(cacheKey);
-      expect(value?.num, equals(1));
-    });
+    expect(retrieved?.num, equals(1));
   });
 }

--- a/tests/serverpod_test_server/test/local_cache_test.dart
+++ b/tests/serverpod_test_server/test/local_cache_test.dart
@@ -150,6 +150,29 @@ void main() {
     expect(retrieved, isNull);
   });
 
+  test(
+      'get object which is expired in cache will call given `cacheMissHandler`',
+      () async {
+    final key = 'obj1';
+
+    await cache.put(
+      key,
+      SimpleData(num: 1),
+      // Object is expired from the start (but still gets added to the cache); we could also use a mocked "now" to have it expire on read
+      lifetime: Duration(minutes: -1),
+    );
+
+    final retrieved = await cache.get<SimpleData>(
+      key,
+      CacheMissHandler(
+        () async => SimpleData(num: 2),
+        lifetime: Duration(minutes: 10),
+      ),
+    );
+
+    expect(retrieved?.num, 2);
+  });
+
   group(
       'get object not in cache when cache miss handler is specified to return object',
       () {

--- a/tests/serverpod_test_server/test/local_cache_test.dart
+++ b/tests/serverpod_test_server/test/local_cache_test.dart
@@ -157,14 +157,13 @@ void main() {
       () async {
     final key = 'obj1';
 
-    await cache.put(
-      key,
-      SimpleData(num: 1),
-      // Object is expired from the start (but still gets added to the cache); we could also use a mocked "now" to have it expire on read
-      lifetime: Duration(minutes: -1),
-    );
+    await cache.put(key, SimpleData(num: 1),
+        lifetime: Duration(milliseconds: 100));
 
-    final retrieved = await cache.get<SimpleData>(
+    // Expire the newly added key
+    await Future.delayed(const Duration(milliseconds: 200));
+
+    var retrieved = await cache.get<SimpleData>(
       key,
       CacheMissHandler(
         () async => SimpleData(num: 2),

--- a/tests/serverpod_test_server/test/local_cache_test.dart
+++ b/tests/serverpod_test_server/test/local_cache_test.dart
@@ -160,7 +160,6 @@ void main() {
     await cache.put(key, SimpleData(num: 1),
         lifetime: Duration(milliseconds: 100));
 
-    // Expire the newly added key
     await Future.delayed(const Duration(milliseconds: 200));
 
     var retrieved = await cache.get<SimpleData>(

--- a/tests/serverpod_test_server/test/local_cache_test.dart
+++ b/tests/serverpod_test_server/test/local_cache_test.dart
@@ -59,8 +59,6 @@ void main() {
 
     var retrieved = await cache.get<SimpleData>(key);
     expect(retrieved?.num, equals(0));
-
-    expect(cache.localSize, equals(1));
   });
 
   test(
@@ -79,8 +77,6 @@ void main() {
 
     var retrieved = await cache.get<SimpleData>(key);
     expect(retrieved, isNull);
-
-    expect(cache.localSize, equals(0));
   });
 
   test(
@@ -95,8 +91,6 @@ void main() {
 
     var retrieved = await cache.get<SimpleData>(key);
     expect(retrieved?.num, equals(1));
-
-    expect(cache.localSize, equals(1));
   });
 
   test(
@@ -135,7 +129,14 @@ void main() {
     retrieved = await cache.get<SimpleData>('entry:$middleId');
     expect(retrieved, isNull);
 
-    expect(cache.localSize, equals(cacheMaxSize - 1));
+    for (var i = 0; i < cacheMaxSize; i++) {
+      if (i == middleId) {
+        continue;
+      }
+
+      retrieved = await cache.get<SimpleData>('entry:$i');
+      expect(retrieved, isNotNull);
+    }
   });
 
   test(
@@ -279,7 +280,6 @@ void main() {
 
     var value = await cache.get<SimpleData>(cacheKey);
     expect(value, isNull);
-    expect(cache.localSize, equals(0));
   });
 
   test(


### PR DESCRIPTION
Closes #2953

Additionally ensures only one `cacheMissHandler` for a given key is invoked, and that they won't be called in parallel for a given key. All `get`s will then resolve to the same value (or error).