### PR TITLE
fix: Generator crashes when encountering field with `List, relation` missing the generic type argument

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -1,11 +1,10 @@
 import 'dart:math';
 
-import 'package:super_string/super_string.dart';
-
 import 'package:serverpod_cli/src/analyzer/models/checker/analyze_checker.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:super_string/super_string.dart';
 
 class ModelDependencyResolver {
   /// Resolves dependencies between models, this method mutates the input.
@@ -342,6 +341,12 @@ class ModelDependencyResolver {
   ) {
     var relation = fieldDefinition.relation;
     if (relation is! UnresolvedListRelationDefinition) {
+      return;
+    }
+
+    if (fieldDefinition.type.generics.isEmpty) {
+      // Having other than 1 generics on a list type is an error, but we can not throw that here without breaking all parsing.
+      // The appropriate check is being done in `restrictions.dart` (`_validateFieldDataType`)
       return;
     }
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
@@ -637,6 +637,37 @@ fields:
     });
   });
 
+  group('Given a class with a relation missing the target type', () {
+    var models = [
+      ModelSourceBuilder().withYaml(
+        '''
+        class: Basket
+        fields:
+          items: List, relation
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(
+      config,
+      models,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+
+    test('no classes were generated', () {
+      expect(definitions, isEmpty);
+    });
+
+    test('An error for the missing type is emitted.', () {
+      expect(
+        collector.errors.map((e) => e.message),
+        contains(matches('List type must have one generic type defined')),
+      );
+    });
+  });
+
   group('Given a class with a List json field without a relation', () {
     var models = [
       ModelSourceBuilder().withYaml(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_keyword_test.dart
@@ -637,7 +637,9 @@ fields:
     });
   });
 
-  group('Given a class with a relation missing the target type', () {
+  test(
+      'Given a class with a `List` relation missing the target type, when the analyzer is invoked, then it will return an error pointing to the false definition and not generate any classes',
+      () {
     var models = [
       ModelSourceBuilder().withYaml(
         '''
@@ -656,16 +658,12 @@ fields:
     );
     var definitions = analyzer.validateAll();
 
-    test('no classes were generated', () {
-      expect(definitions, isEmpty);
-    });
+    expect(definitions, isEmpty);
 
-    test('An error for the missing type is emitted.', () {
-      expect(
-        collector.errors.map((e) => e.message),
-        contains(matches('List type must have one generic type defined')),
-      );
-    });
+    expect(
+      collector.errors.map((e) => e.message),
+      contains(matches('List type must have one generic type defined')),
+    );
   });
 
   group('Given a class with a List json field without a relation', () {


### PR DESCRIPTION


Closes #2972



At first I thought to implement it on a lower level, e.g. not even allowing to generate an invalid `TypeDefinition` (e.g. when it's a `List` but does not have any (1!) generics specified). But that just leads to a low-level crash like the one in the linked issue.

So instead we have to stop the processing early in the error case, and then rely on the analyzer to spot that condition (as well) and prevent the code generation.