### PR TITLE
Add doc comments to generated `copyWith` methods

### DIFF
--- a/examples/auth_example/auth_example_client/lib/src/protocol/example.dart
+++ b/examples/auth_example/auth_example_client/lib/src/protocol/example.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class Example implements _i1.SerializableModel {
   Example._({
@@ -33,6 +34,9 @@ abstract class Example implements _i1.SerializableModel {
 
   int data;
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Example copyWith({
     String? name,
     int? data,
@@ -60,6 +64,9 @@ class _ExampleImpl extends Example {
           data: data,
         );
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Example copyWith({
     String? name,

--- a/examples/auth_example/auth_example_server/lib/src/generated/example.dart
+++ b/examples/auth_example/auth_example_server/lib/src/generated/example.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class Example
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -34,6 +35,9 @@ abstract class Example
 
   int data;
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Example copyWith({
     String? name,
     int? data,
@@ -69,6 +73,9 @@ class _ExampleImpl extends Example {
           data: data,
         );
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Example copyWith({
     String? name,

--- a/examples/chat/chat_client/lib/src/protocol/channel.dart
+++ b/examples/chat/chat_client/lib/src/protocol/channel.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a chat channel.
 abstract class Channel implements _i1.SerializableModel {
@@ -44,6 +45,9 @@ abstract class Channel implements _i1.SerializableModel {
   /// The id of the channel.
   String channel;
 
+  /// Returns a shallow copy of this [Channel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Channel copyWith({
     int? id,
     String? name,
@@ -77,6 +81,9 @@ class _ChannelImpl extends Channel {
           channel: channel,
         );
 
+  /// Returns a shallow copy of this [Channel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Channel copyWith({
     Object? id = _Undefined,

--- a/examples/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/chat/chat_server/lib/src/generated/channel.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a chat channel.
 abstract class Channel implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -49,6 +50,9 @@ abstract class Channel implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Channel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Channel copyWith({
     int? id,
     String? name,
@@ -115,6 +119,9 @@ class _ChannelImpl extends Channel {
           channel: channel,
         );
 
+  /// Returns a shallow copy of this [Channel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Channel copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/apple_auth_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/apple_auth_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Authentication info for Sign in with Apple.
 abstract class AppleAuthInfo implements _i1.SerializableModel {
@@ -60,6 +61,9 @@ abstract class AppleAuthInfo implements _i1.SerializableModel {
   /// Authorization code associated with the sign in.
   String authorizationCode;
 
+  /// Returns a shallow copy of this [AppleAuthInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AppleAuthInfo copyWith({
     String? userIdentifier,
     String? email,
@@ -105,6 +109,9 @@ class _AppleAuthInfoImpl extends AppleAuthInfo {
           authorizationCode: authorizationCode,
         );
 
+  /// Returns a shallow copy of this [AppleAuthInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AppleAuthInfo copyWith({
     String? userIdentifier,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/auth_key.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/auth_key.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Provides a method of access for a user to authenticate with the server.
 abstract class AuthKey implements _i1.SerializableModel {
@@ -65,6 +66,9 @@ abstract class AuthKey implements _i1.SerializableModel {
   /// or different social logins.
   String method;
 
+  /// Returns a shallow copy of this [AuthKey]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AuthKey copyWith({
     int? id,
     int? userId,
@@ -110,6 +114,9 @@ class _AuthKeyImpl extends AuthKey {
           method: method,
         );
 
+  /// Returns a shallow copy of this [AuthKey]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AuthKey copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_response.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/authentication_response.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'user_info.dart' as _i2;
 import 'authentication_fail_reason.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Provides a response to an authentication attempt.
 abstract class AuthenticationResponse implements _i1.SerializableModel {
@@ -65,6 +66,9 @@ abstract class AuthenticationResponse implements _i1.SerializableModel {
   /// failed.
   _i3.AuthenticationFailReason? failReason;
 
+  /// Returns a shallow copy of this [AuthenticationResponse]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AuthenticationResponse copyWith({
     bool? success,
     String? key,
@@ -106,6 +110,9 @@ class _AuthenticationResponseImpl extends AuthenticationResponse {
           failReason: failReason,
         );
 
+  /// Returns a shallow copy of this [AuthenticationResponse]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AuthenticationResponse copyWith({
     bool? success,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_auth.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for a sign in with email.
 abstract class EmailAuth implements _i1.SerializableModel {
@@ -50,6 +51,9 @@ abstract class EmailAuth implements _i1.SerializableModel {
   /// The hashed password of the user.
   String hash;
 
+  /// Returns a shallow copy of this [EmailAuth]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailAuth copyWith({
     int? id,
     int? userId,
@@ -87,6 +91,9 @@ class _EmailAuthImpl extends EmailAuth {
           hash: hash,
         );
 
+  /// Returns a shallow copy of this [EmailAuth]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailAuth copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_create_account_request.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A request for creating an email signin. Created during the sign up process
 /// to keep track of the user's details and verification code.
@@ -58,6 +59,9 @@ abstract class EmailCreateAccountRequest implements _i1.SerializableModel {
   /// The verification code sent to the user.
   String verificationCode;
 
+  /// Returns a shallow copy of this [EmailCreateAccountRequest]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailCreateAccountRequest copyWith({
     int? id,
     String? userName,
@@ -99,6 +103,9 @@ class _EmailCreateAccountRequestImpl extends EmailCreateAccountRequest {
           verificationCode: verificationCode,
         );
 
+  /// Returns a shallow copy of this [EmailCreateAccountRequest]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailCreateAccountRequest copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_failed_sign_in.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database table for tracking failed email sign-ins. Saves IP-address, time,
 /// and email to be prevent brute force attacks.
@@ -51,6 +52,9 @@ abstract class EmailFailedSignIn implements _i1.SerializableModel {
   /// The IP address of the sign in attempt.
   String ipAddress;
 
+  /// Returns a shallow copy of this [EmailFailedSignIn]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailFailedSignIn copyWith({
     int? id,
     String? email,
@@ -88,6 +92,9 @@ class _EmailFailedSignInImpl extends EmailFailedSignIn {
           ipAddress: ipAddress,
         );
 
+  /// Returns a shallow copy of this [EmailFailedSignIn]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailFailedSignIn copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_password_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_password_reset.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about an email password reset.
 abstract class EmailPasswordReset implements _i1.SerializableModel {
@@ -36,6 +37,9 @@ abstract class EmailPasswordReset implements _i1.SerializableModel {
   /// The email of the user.
   String email;
 
+  /// Returns a shallow copy of this [EmailPasswordReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailPasswordReset copyWith({
     String? userName,
     String? email,
@@ -65,6 +69,9 @@ class _EmailPasswordResetImpl extends EmailPasswordReset {
           email: email,
         );
 
+  /// Returns a shallow copy of this [EmailPasswordReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailPasswordReset copyWith({
     Object? userName = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/email_reset.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for an email reset.
 abstract class EmailReset implements _i1.SerializableModel {
@@ -51,6 +52,9 @@ abstract class EmailReset implements _i1.SerializableModel {
   /// The expiration time for the password reset.
   DateTime expiration;
 
+  /// Returns a shallow copy of this [EmailReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailReset copyWith({
     int? id,
     int? userId,
@@ -88,6 +92,9 @@ class _EmailResetImpl extends EmailReset {
           expiration: expiration,
         );
 
+  /// Returns a shallow copy of this [EmailReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailReset copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/google_refresh_token.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for a Google refresh token.
 abstract class GoogleRefreshToken implements _i1.SerializableModel {
@@ -44,6 +45,9 @@ abstract class GoogleRefreshToken implements _i1.SerializableModel {
   /// The token itself.
   String refreshToken;
 
+  /// Returns a shallow copy of this [GoogleRefreshToken]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   GoogleRefreshToken copyWith({
     int? id,
     int? userId,
@@ -77,6 +81,9 @@ class _GoogleRefreshTokenImpl extends GoogleRefreshToken {
           refreshToken: refreshToken,
         );
 
+  /// Returns a shallow copy of this [GoogleRefreshToken]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   GoogleRefreshToken copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_image.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for a user image.
 abstract class UserImage implements _i1.SerializableModel {
@@ -50,6 +51,9 @@ abstract class UserImage implements _i1.SerializableModel {
   /// The URL to the image.
   String url;
 
+  /// Returns a shallow copy of this [UserImage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserImage copyWith({
     int? id,
     int? userId,
@@ -87,6 +91,9 @@ class _UserImageImpl extends UserImage {
           url: url,
         );
 
+  /// Returns a shallow copy of this [UserImage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserImage copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a user. The [UserInfo] should only be shared with the user
 /// itself as it may contain sensitive information, such as the users email.
@@ -87,6 +88,9 @@ abstract class UserInfo implements _i1.SerializableModel {
   /// True if the user is blocked from signing in.
   bool blocked;
 
+  /// Returns a shallow copy of this [UserInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserInfo copyWith({
     int? id,
     String? userIdentifier,
@@ -144,6 +148,9 @@ class _UserInfoImpl extends UserInfo {
           blocked: blocked,
         );
 
+  /// Returns a shallow copy of this [UserInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserInfo copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_info_public.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a user that can safely be publicly accessible.
 abstract class UserInfoPublic implements _i1.SerializableModel {
@@ -54,6 +55,9 @@ abstract class UserInfoPublic implements _i1.SerializableModel {
   /// URL to the user's avatar.
   String? imageUrl;
 
+  /// Returns a shallow copy of this [UserInfoPublic]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserInfoPublic copyWith({
     int? id,
     String? userName,
@@ -95,6 +99,9 @@ class _UserInfoPublicImpl extends UserInfoPublic {
           imageUrl: imageUrl,
         );
 
+  /// Returns a shallow copy of this [UserInfoPublic]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserInfoPublic copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_settings_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_client/lib/src/protocol/user_settings_config.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// User settings.
 abstract class UserSettingsConfig implements _i1.SerializableModel {
@@ -54,6 +55,9 @@ abstract class UserSettingsConfig implements _i1.SerializableModel {
   /// True if the user should be able to upload a new user image.
   bool canEditUserImage;
 
+  /// Returns a shallow copy of this [UserSettingsConfig]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserSettingsConfig copyWith({
     bool? canSeeUserName,
     bool? canSeeFullName,
@@ -93,6 +97,9 @@ class _UserSettingsConfigImpl extends UserSettingsConfig {
           canEditUserImage: canEditUserImage,
         );
 
+  /// Returns a shallow copy of this [UserSettingsConfig]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserSettingsConfig copyWith({
     bool? canSeeUserName,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/apple_auth_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/apple_auth_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Authentication info for Sign in with Apple.
 abstract class AppleAuthInfo
@@ -61,6 +62,9 @@ abstract class AppleAuthInfo
   /// Authorization code associated with the sign in.
   String authorizationCode;
 
+  /// Returns a shallow copy of this [AppleAuthInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AppleAuthInfo copyWith({
     String? userIdentifier,
     String? email,
@@ -118,6 +122,9 @@ class _AppleAuthInfoImpl extends AppleAuthInfo {
           authorizationCode: authorizationCode,
         );
 
+  /// Returns a shallow copy of this [AppleAuthInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AppleAuthInfo copyWith({
     String? userIdentifier,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Provides a method of access for a user to authenticate with the server.
 abstract class AuthKey implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -70,6 +71,9 @@ abstract class AuthKey implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [AuthKey]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AuthKey copyWith({
     int? id,
     int? userId,
@@ -151,6 +155,9 @@ class _AuthKeyImpl extends AuthKey {
           method: method,
         );
 
+  /// Returns a shallow copy of this [AuthKey]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AuthKey copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/authentication_response.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'user_info.dart' as _i2;
 import 'authentication_fail_reason.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Provides a response to an authentication attempt.
 abstract class AuthenticationResponse
@@ -66,6 +67,9 @@ abstract class AuthenticationResponse
   /// failed.
   _i3.AuthenticationFailReason? failReason;
 
+  /// Returns a shallow copy of this [AuthenticationResponse]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AuthenticationResponse copyWith({
     bool? success,
     String? key,
@@ -118,6 +122,9 @@ class _AuthenticationResponseImpl extends AuthenticationResponse {
           failReason: failReason,
         );
 
+  /// Returns a shallow copy of this [AuthenticationResponse]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AuthenticationResponse copyWith({
     bool? success,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for a sign in with email.
 abstract class EmailAuth implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -55,6 +56,9 @@ abstract class EmailAuth implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EmailAuth]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailAuth copyWith({
     int? id,
     int? userId,
@@ -126,6 +130,9 @@ class _EmailAuthImpl extends EmailAuth {
           hash: hash,
         );
 
+  /// Returns a shallow copy of this [EmailAuth]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailAuth copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A request for creating an email signin. Created during the sign up process
 /// to keep track of the user's details and verification code.
@@ -64,6 +65,9 @@ abstract class EmailCreateAccountRequest
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EmailCreateAccountRequest]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailCreateAccountRequest copyWith({
     int? id,
     String? userName,
@@ -140,6 +144,9 @@ class _EmailCreateAccountRequestImpl extends EmailCreateAccountRequest {
           verificationCode: verificationCode,
         );
 
+  /// Returns a shallow copy of this [EmailCreateAccountRequest]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailCreateAccountRequest copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database table for tracking failed email sign-ins. Saves IP-address, time,
 /// and email to be prevent brute force attacks.
@@ -57,6 +58,9 @@ abstract class EmailFailedSignIn
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EmailFailedSignIn]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailFailedSignIn copyWith({
     int? id,
     String? email,
@@ -128,6 +132,9 @@ class _EmailFailedSignInImpl extends EmailFailedSignIn {
           ipAddress: ipAddress,
         );
 
+  /// Returns a shallow copy of this [EmailFailedSignIn]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailFailedSignIn copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_password_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_password_reset.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about an email password reset.
 abstract class EmailPasswordReset
@@ -37,6 +38,9 @@ abstract class EmailPasswordReset
   /// The email of the user.
   String email;
 
+  /// Returns a shallow copy of this [EmailPasswordReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailPasswordReset copyWith({
     String? userName,
     String? email,
@@ -74,6 +78,9 @@ class _EmailPasswordResetImpl extends EmailPasswordReset {
           email: email,
         );
 
+  /// Returns a shallow copy of this [EmailPasswordReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailPasswordReset copyWith({
     Object? userName = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for an email reset.
 abstract class EmailReset implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -56,6 +57,9 @@ abstract class EmailReset implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EmailReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmailReset copyWith({
     int? id,
     int? userId,
@@ -127,6 +131,9 @@ class _EmailResetImpl extends EmailReset {
           expiration: expiration,
         );
 
+  /// Returns a shallow copy of this [EmailReset]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmailReset copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for a Google refresh token.
 abstract class GoogleRefreshToken
@@ -50,6 +51,9 @@ abstract class GoogleRefreshToken
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [GoogleRefreshToken]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   GoogleRefreshToken copyWith({
     int? id,
     int? userId,
@@ -116,6 +120,9 @@ class _GoogleRefreshTokenImpl extends GoogleRefreshToken {
           refreshToken: refreshToken,
         );
 
+  /// Returns a shallow copy of this [GoogleRefreshToken]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   GoogleRefreshToken copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database bindings for a user image.
 abstract class UserImage implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -55,6 +56,9 @@ abstract class UserImage implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UserImage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserImage copyWith({
     int? id,
     int? userId,
@@ -126,6 +130,9 @@ class _UserImageImpl extends UserImage {
           url: url,
         );
 
+  /// Returns a shallow copy of this [UserImage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserImage copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a user. The [UserInfo] should only be shared with the user
 /// itself as it may contain sensitive information, such as the users email.
@@ -92,6 +93,9 @@ abstract class UserInfo implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UserInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserInfo copyWith({
     int? id,
     String? userIdentifier,
@@ -188,6 +192,9 @@ class _UserInfoImpl extends UserInfo {
           blocked: blocked,
         );
 
+  /// Returns a shallow copy of this [UserInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserInfo copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info_public.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a user that can safely be publicly accessible.
 abstract class UserInfoPublic
@@ -55,6 +56,9 @@ abstract class UserInfoPublic
   /// URL to the user's avatar.
   String? imageUrl;
 
+  /// Returns a shallow copy of this [UserInfoPublic]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserInfoPublic copyWith({
     int? id,
     String? userName,
@@ -107,6 +111,9 @@ class _UserInfoPublicImpl extends UserInfoPublic {
           imageUrl: imageUrl,
         );
 
+  /// Returns a shallow copy of this [UserInfoPublic]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserInfoPublic copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_settings_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_server/lib/src/generated/user_settings_config.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// User settings.
 abstract class UserSettingsConfig
@@ -55,6 +56,9 @@ abstract class UserSettingsConfig
   /// True if the user should be able to upload a new user image.
   bool canEditUserImage;
 
+  /// Returns a shallow copy of this [UserSettingsConfig]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserSettingsConfig copyWith({
     bool? canSeeUserName,
     bool? canSeeFullName,
@@ -105,6 +109,9 @@ class _UserSettingsConfigImpl extends UserSettingsConfig {
           canEditUserImage: canEditUserImage,
         );
 
+  /// Returns a shallow copy of this [UserSettingsConfig]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserSettingsConfig copyWith({
     bool? canSeeUserName,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_join_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_join_channel.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A message indicating an attempt to join a channel.
 abstract class ChatJoinChannel implements _i1.SerializableModel {
@@ -36,6 +37,9 @@ abstract class ChatJoinChannel implements _i1.SerializableModel {
   /// The name of the user.
   String? userName;
 
+  /// Returns a shallow copy of this [ChatJoinChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatJoinChannel copyWith({
     String? channel,
     String? userName,
@@ -65,6 +69,9 @@ class _ChatJoinChannelImpl extends ChatJoinChannel {
           userName: userName,
         );
 
+  /// Returns a shallow copy of this [ChatJoinChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatJoinChannel copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_join_channel_failed.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_join_channel_failed.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message being sent if a user failed to join a channel.
 abstract class ChatJoinChannelFailed implements _i1.SerializableModel {
@@ -37,6 +38,9 @@ abstract class ChatJoinChannelFailed implements _i1.SerializableModel {
   /// The reason of failure.
   String reason;
 
+  /// Returns a shallow copy of this [ChatJoinChannelFailed]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatJoinChannelFailed copyWith({
     String? channel,
     String? reason,
@@ -64,6 +68,9 @@ class _ChatJoinChannelFailedImpl extends ChatJoinChannelFailed {
           reason: reason,
         );
 
+  /// Returns a shallow copy of this [ChatJoinChannelFailed]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatJoinChannelFailed copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_joined_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_joined_channel.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'chat_message_chunk.dart' as _i2;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// A message passed to a user when it joins a channel.
 abstract class ChatJoinedChannel implements _i1.SerializableModel {
@@ -52,6 +53,9 @@ abstract class ChatJoinedChannel implements _i1.SerializableModel {
   /// The user info of the user who joined the channel.
   _i3.UserInfo userInfo;
 
+  /// Returns a shallow copy of this [ChatJoinedChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatJoinedChannel copyWith({
     String? channel,
     _i2.ChatMessageChunk? initialMessageChunk,
@@ -87,6 +91,9 @@ class _ChatJoinedChannelImpl extends ChatJoinedChannel {
           userInfo: userInfo,
         );
 
+  /// Returns a shallow copy of this [ChatJoinedChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatJoinedChannel copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_leave_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_leave_channel.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Indicates that a user wants to leave a channel.
 abstract class ChatLeaveChannel implements _i1.SerializableModel {
@@ -24,6 +25,9 @@ abstract class ChatLeaveChannel implements _i1.SerializableModel {
   /// The name of the channel to leave.
   String channel;
 
+  /// Returns a shallow copy of this [ChatLeaveChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatLeaveChannel copyWith({String? channel});
   @override
   Map<String, dynamic> toJson() {
@@ -39,6 +43,9 @@ abstract class ChatLeaveChannel implements _i1.SerializableModel {
 class _ChatLeaveChannelImpl extends ChatLeaveChannel {
   _ChatLeaveChannelImpl({required String channel}) : super._(channel: channel);
 
+  /// Returns a shallow copy of this [ChatLeaveChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatLeaveChannel copyWith({String? channel}) {
     return ChatLeaveChannel(channel: channel ?? this.channel);

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i2;
 import 'chat_message_attachment.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// A chat message.
 abstract class ChatMessage implements _i1.SerializableModel {
@@ -94,6 +95,9 @@ abstract class ChatMessage implements _i1.SerializableModel {
   /// List of attachments associated with this message.
   List<_i3.ChatMessageAttachment>? attachments;
 
+  /// Returns a shallow copy of this [ChatMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessage copyWith({
     int? id,
     String? channel,
@@ -156,6 +160,9 @@ class _ChatMessageImpl extends ChatMessage {
           attachments: attachments,
         );
 
+  /// Returns a shallow copy of this [ChatMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessage copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// An attachment to a chat message. Typically an image or a file.
 abstract class ChatMessageAttachment implements _i1.SerializableModel {
@@ -61,6 +62,9 @@ abstract class ChatMessageAttachment implements _i1.SerializableModel {
   /// The height of the image preview, if available.
   int? previewHeight;
 
+  /// Returns a shallow copy of this [ChatMessageAttachment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessageAttachment copyWith({
     String? fileName,
     String? url,
@@ -106,6 +110,9 @@ class _ChatMessageAttachmentImpl extends ChatMessageAttachment {
           previewHeight: previewHeight,
         );
 
+  /// Returns a shallow copy of this [ChatMessageAttachment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessageAttachment copyWith({
     String? fileName,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment_upload_description.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_attachment_upload_description.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A description for uploading an attachment.
 abstract class ChatMessageAttachmentUploadDescription
@@ -39,6 +40,9 @@ abstract class ChatMessageAttachmentUploadDescription
   /// the upload.
   String uploadDescription;
 
+  /// Returns a shallow copy of this [ChatMessageAttachmentUploadDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessageAttachmentUploadDescription copyWith({
     String? filePath,
     String? uploadDescription,
@@ -67,6 +71,9 @@ class _ChatMessageAttachmentUploadDescriptionImpl
           uploadDescription: uploadDescription,
         );
 
+  /// Returns a shallow copy of this [ChatMessageAttachmentUploadDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessageAttachmentUploadDescription copyWith({
     String? filePath,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_chunk.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'chat_message.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A chunk of chat messages.
 abstract class ChatMessageChunk implements _i1.SerializableModel {
@@ -45,6 +46,9 @@ abstract class ChatMessageChunk implements _i1.SerializableModel {
   /// True if there are more chat messages to fetch from this channel.
   bool hasOlderMessages;
 
+  /// Returns a shallow copy of this [ChatMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessageChunk copyWith({
     String? channel,
     List<_i2.ChatMessage>? messages,
@@ -76,6 +80,9 @@ class _ChatMessageChunkImpl extends ChatMessageChunk {
           hasOlderMessages: hasOlderMessages,
         );
 
+  /// Returns a shallow copy of this [ChatMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessageChunk copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_message_post.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'chat_message_attachment.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A chat message post request.
 abstract class ChatMessagePost implements _i1.SerializableModel {
@@ -52,6 +53,9 @@ abstract class ChatMessagePost implements _i1.SerializableModel {
   /// List of attachments associated with this message.
   List<_i2.ChatMessageAttachment>? attachments;
 
+  /// Returns a shallow copy of this [ChatMessagePost]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessagePost copyWith({
     String? channel,
     String? message,
@@ -90,6 +94,9 @@ class _ChatMessagePostImpl extends ChatMessagePost {
           attachments: attachments,
         );
 
+  /// Returns a shallow copy of this [ChatMessagePost]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessagePost copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_read_message.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message to notify the server that messages have been read.
 abstract class ChatReadMessage implements _i1.SerializableModel {
@@ -50,6 +51,9 @@ abstract class ChatReadMessage implements _i1.SerializableModel {
   /// The id of the last read message.
   int lastReadMessageId;
 
+  /// Returns a shallow copy of this [ChatReadMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatReadMessage copyWith({
     int? id,
     String? channel,
@@ -87,6 +91,9 @@ class _ChatReadMessageImpl extends ChatReadMessage {
           lastReadMessageId: lastReadMessageId,
         );
 
+  /// Returns a shallow copy of this [ChatReadMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatReadMessage copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_request_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_client/lib/src/protocol/chat_request_message_chunk.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message to request a new chunk of messages from the server.
 abstract class ChatRequestMessageChunk implements _i1.SerializableModel {
@@ -37,6 +38,9 @@ abstract class ChatRequestMessageChunk implements _i1.SerializableModel {
   /// The id of the last read message.
   int lastMessageId;
 
+  /// Returns a shallow copy of this [ChatRequestMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatRequestMessageChunk copyWith({
     String? channel,
     int? lastMessageId,
@@ -64,6 +68,9 @@ class _ChatRequestMessageChunkImpl extends ChatRequestMessageChunk {
           lastMessageId: lastMessageId,
         );
 
+  /// Returns a shallow copy of this [ChatRequestMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatRequestMessageChunk copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_join_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_join_channel.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A message indicating an attempt to join a channel.
 abstract class ChatJoinChannel
@@ -37,6 +38,9 @@ abstract class ChatJoinChannel
   /// The name of the user.
   String? userName;
 
+  /// Returns a shallow copy of this [ChatJoinChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatJoinChannel copyWith({
     String? channel,
     String? userName,
@@ -74,6 +78,9 @@ class _ChatJoinChannelImpl extends ChatJoinChannel {
           userName: userName,
         );
 
+  /// Returns a shallow copy of this [ChatJoinChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatJoinChannel copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_join_channel_failed.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_join_channel_failed.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message being sent if a user failed to join a channel.
 abstract class ChatJoinChannelFailed
@@ -38,6 +39,9 @@ abstract class ChatJoinChannelFailed
   /// The reason of failure.
   String reason;
 
+  /// Returns a shallow copy of this [ChatJoinChannelFailed]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatJoinChannelFailed copyWith({
     String? channel,
     String? reason,
@@ -73,6 +77,9 @@ class _ChatJoinChannelFailedImpl extends ChatJoinChannelFailed {
           reason: reason,
         );
 
+  /// Returns a shallow copy of this [ChatJoinChannelFailed]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatJoinChannelFailed copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_joined_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_joined_channel.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'chat_message_chunk.dart' as _i2;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// A message passed to a user when it joins a channel.
 abstract class ChatJoinedChannel
@@ -53,6 +54,9 @@ abstract class ChatJoinedChannel
   /// The user info of the user who joined the channel.
   _i3.UserInfo userInfo;
 
+  /// Returns a shallow copy of this [ChatJoinedChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatJoinedChannel copyWith({
     String? channel,
     _i2.ChatMessageChunk? initialMessageChunk,
@@ -98,6 +102,9 @@ class _ChatJoinedChannelImpl extends ChatJoinedChannel {
           userInfo: userInfo,
         );
 
+  /// Returns a shallow copy of this [ChatJoinedChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatJoinedChannel copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_leave_channel.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_leave_channel.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Indicates that a user wants to leave a channel.
 abstract class ChatLeaveChannel
@@ -25,6 +26,9 @@ abstract class ChatLeaveChannel
   /// The name of the channel to leave.
   String channel;
 
+  /// Returns a shallow copy of this [ChatLeaveChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatLeaveChannel copyWith({String? channel});
   @override
   Map<String, dynamic> toJson() {
@@ -45,6 +49,9 @@ abstract class ChatLeaveChannel
 class _ChatLeaveChannelImpl extends ChatLeaveChannel {
   _ChatLeaveChannelImpl({required String channel}) : super._(channel: channel);
 
+  /// Returns a shallow copy of this [ChatLeaveChannel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatLeaveChannel copyWith({String? channel}) {
     return ChatLeaveChannel(channel: channel ?? this.channel);

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
 import 'chat_message_attachment.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// A chat message.
 abstract class ChatMessage implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -99,6 +100,9 @@ abstract class ChatMessage implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ChatMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessage copyWith({
     int? id,
     String? channel,
@@ -203,6 +207,9 @@ class _ChatMessageImpl extends ChatMessage {
           attachments: attachments,
         );
 
+  /// Returns a shallow copy of this [ChatMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessage copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// An attachment to a chat message. Typically an image or a file.
 abstract class ChatMessageAttachment
@@ -62,6 +63,9 @@ abstract class ChatMessageAttachment
   /// The height of the image preview, if available.
   int? previewHeight;
 
+  /// Returns a shallow copy of this [ChatMessageAttachment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessageAttachment copyWith({
     String? fileName,
     String? url,
@@ -119,6 +123,9 @@ class _ChatMessageAttachmentImpl extends ChatMessageAttachment {
           previewHeight: previewHeight,
         );
 
+  /// Returns a shallow copy of this [ChatMessageAttachment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessageAttachment copyWith({
     String? fileName,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment_upload_description.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_attachment_upload_description.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A description for uploading an attachment.
 abstract class ChatMessageAttachmentUploadDescription
@@ -39,6 +40,9 @@ abstract class ChatMessageAttachmentUploadDescription
   /// the upload.
   String uploadDescription;
 
+  /// Returns a shallow copy of this [ChatMessageAttachmentUploadDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessageAttachmentUploadDescription copyWith({
     String? filePath,
     String? uploadDescription,
@@ -75,6 +79,9 @@ class _ChatMessageAttachmentUploadDescriptionImpl
           uploadDescription: uploadDescription,
         );
 
+  /// Returns a shallow copy of this [ChatMessageAttachmentUploadDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessageAttachmentUploadDescription copyWith({
     String? filePath,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_chunk.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'chat_message.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A chunk of chat messages.
 abstract class ChatMessageChunk
@@ -46,6 +47,9 @@ abstract class ChatMessageChunk
   /// True if there are more chat messages to fetch from this channel.
   bool hasOlderMessages;
 
+  /// Returns a shallow copy of this [ChatMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessageChunk copyWith({
     String? channel,
     List<_i2.ChatMessage>? messages,
@@ -86,6 +90,9 @@ class _ChatMessageChunkImpl extends ChatMessageChunk {
           hasOlderMessages: hasOlderMessages,
         );
 
+  /// Returns a shallow copy of this [ChatMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessageChunk copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message_post.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'chat_message_attachment.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A chat message post request.
 abstract class ChatMessagePost
@@ -53,6 +54,9 @@ abstract class ChatMessagePost
   /// List of attachments associated with this message.
   List<_i2.ChatMessageAttachment>? attachments;
 
+  /// Returns a shallow copy of this [ChatMessagePost]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatMessagePost copyWith({
     String? channel,
     String? message,
@@ -103,6 +107,9 @@ class _ChatMessagePostImpl extends ChatMessagePost {
           attachments: attachments,
         );
 
+  /// Returns a shallow copy of this [ChatMessagePost]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatMessagePost copyWith({
     String? channel,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message to notify the server that messages have been read.
 abstract class ChatReadMessage
@@ -56,6 +57,9 @@ abstract class ChatReadMessage
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ChatReadMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatReadMessage copyWith({
     int? id,
     String? channel,
@@ -127,6 +131,9 @@ class _ChatReadMessageImpl extends ChatReadMessage {
           lastReadMessageId: lastReadMessageId,
         );
 
+  /// Returns a shallow copy of this [ChatReadMessage]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatReadMessage copyWith({
     Object? id = _Undefined,

--- a/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_request_message_chunk.dart
+++ b/modules/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_request_message_chunk.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message to request a new chunk of messages from the server.
 abstract class ChatRequestMessageChunk
@@ -38,6 +39,9 @@ abstract class ChatRequestMessageChunk
   /// The id of the last read message.
   int lastMessageId;
 
+  /// Returns a shallow copy of this [ChatRequestMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ChatRequestMessageChunk copyWith({
     String? channel,
     int? lastMessageId,
@@ -73,6 +77,9 @@ class _ChatRequestMessageChunkImpl extends ChatRequestMessageChunk {
           lastMessageId: lastMessageId,
         );
 
+  /// Returns a shallow copy of this [ChatRequestMessageChunk]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChatRequestMessageChunk copyWith({
     String? channel,

--- a/packages/serverpod/lib/src/generated/authentication/revoked_authentication_auth_id.dart
+++ b/packages/serverpod/lib/src/generated/authentication/revoked_authentication_auth_id.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message sent when an authentication key id is revoked.
 abstract class RevokedAuthenticationAuthId
@@ -27,6 +28,9 @@ abstract class RevokedAuthenticationAuthId
 
   String authId;
 
+  /// Returns a shallow copy of this [RevokedAuthenticationAuthId]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RevokedAuthenticationAuthId copyWith({String? authId});
   @override
   Map<String, dynamic> toJson() {
@@ -48,6 +52,9 @@ class _RevokedAuthenticationAuthIdImpl extends RevokedAuthenticationAuthId {
   _RevokedAuthenticationAuthIdImpl({required String authId})
       : super._(authId: authId);
 
+  /// Returns a shallow copy of this [RevokedAuthenticationAuthId]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RevokedAuthenticationAuthId copyWith({String? authId}) {
     return RevokedAuthenticationAuthId(authId: authId ?? this.authId);

--- a/packages/serverpod/lib/src/generated/authentication/revoked_authentication_scope.dart
+++ b/packages/serverpod/lib/src/generated/authentication/revoked_authentication_scope.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message sent when authentication scopes for a user are revoked.
 abstract class RevokedAuthenticationScope
@@ -29,6 +30,9 @@ abstract class RevokedAuthenticationScope
 
   List<String> scopes;
 
+  /// Returns a shallow copy of this [RevokedAuthenticationScope]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RevokedAuthenticationScope copyWith({List<String>? scopes});
   @override
   Map<String, dynamic> toJson() {
@@ -50,6 +54,9 @@ class _RevokedAuthenticationScopeImpl extends RevokedAuthenticationScope {
   _RevokedAuthenticationScopeImpl({required List<String> scopes})
       : super._(scopes: scopes);
 
+  /// Returns a shallow copy of this [RevokedAuthenticationScope]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RevokedAuthenticationScope copyWith({List<String>? scopes}) {
     return RevokedAuthenticationScope(

--- a/packages/serverpod/lib/src/generated/authentication/revoked_authentication_user.dart
+++ b/packages/serverpod/lib/src/generated/authentication/revoked_authentication_user.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Message sent when all authentication for a user is revoked.
 abstract class RevokedAuthenticationUser
@@ -23,6 +24,9 @@ abstract class RevokedAuthenticationUser
     return RevokedAuthenticationUser();
   }
 
+  /// Returns a shallow copy of this [RevokedAuthenticationUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RevokedAuthenticationUser copyWith();
   @override
   Map<String, dynamic> toJson() {
@@ -43,6 +47,9 @@ abstract class RevokedAuthenticationUser
 class _RevokedAuthenticationUserImpl extends RevokedAuthenticationUser {
   _RevokedAuthenticationUserImpl() : super._();
 
+  /// Returns a shallow copy of this [RevokedAuthenticationUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RevokedAuthenticationUser copyWith() {
     return RevokedAuthenticationUser();

--- a/packages/serverpod/lib/src/generated/cache_info.dart
+++ b/packages/serverpod/lib/src/generated/cache_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Provides high level information about a cache.
 abstract class CacheInfo
@@ -45,6 +46,9 @@ abstract class CacheInfo
   /// Optional list of keys used by the cache.
   List<String>? keys;
 
+  /// Returns a shallow copy of this [CacheInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CacheInfo copyWith({
     int? numEntries,
     int? maxEntries,
@@ -87,6 +91,9 @@ class _CacheInfoImpl extends CacheInfo {
           keys: keys,
         );
 
+  /// Returns a shallow copy of this [CacheInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CacheInfo copyWith({
     int? numEntries,

--- a/packages/serverpod/lib/src/generated/caches_info.dart
+++ b/packages/serverpod/lib/src/generated/caches_info.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'cache_info.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// High level information about the caches.
 abstract class CachesInfo
@@ -47,6 +48,9 @@ abstract class CachesInfo
   /// Information about the global cache.
   _i2.CacheInfo global;
 
+  /// Returns a shallow copy of this [CachesInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CachesInfo copyWith({
     _i2.CacheInfo? local,
     _i2.CacheInfo? localPrio,
@@ -87,6 +91,9 @@ class _CachesInfoImpl extends CachesInfo {
           global: global,
         );
 
+  /// Returns a shallow copy of this [CachesInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CachesInfo copyWith({
     _i2.CacheInfo? local,

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:meta/meta.dart';
 
 /// An entry in the database for an uploaded file.
 abstract class CloudStorageEntry
@@ -79,6 +80,9 @@ abstract class CloudStorageEntry
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [CloudStorageEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CloudStorageEntry copyWith({
     int? id,
     String? storageId,
@@ -165,6 +169,9 @@ class _CloudStorageEntryImpl extends CloudStorageEntry {
           verified: verified,
         );
 
+  /// Returns a shallow copy of this [CloudStorageEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CloudStorageEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Connects a table for handling uploading of files.
 abstract class CloudStorageDirectUploadEntry
@@ -64,6 +65,9 @@ abstract class CloudStorageDirectUploadEntry
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [CloudStorageDirectUploadEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CloudStorageDirectUploadEntry copyWith({
     int? id,
     String? storageId,
@@ -140,6 +144,9 @@ class _CloudStorageDirectUploadEntryImpl extends CloudStorageDirectUploadEntry {
           authKey: authKey,
         );
 
+  /// Returns a shallow copy of this [CloudStorageDirectUploadEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CloudStorageDirectUploadEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/cluster_info.dart
+++ b/packages/serverpod/lib/src/generated/cluster_info.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'cluster_server_info.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Information about a cluster of servers.
 abstract class ClusterInfo
@@ -31,6 +32,9 @@ abstract class ClusterInfo
   /// List of servers in the cluster.
   List<_i2.ClusterServerInfo> servers;
 
+  /// Returns a shallow copy of this [ClusterInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers});
   @override
   Map<String, dynamic> toJson() {
@@ -54,6 +58,9 @@ class _ClusterInfoImpl extends ClusterInfo {
   _ClusterInfoImpl({required List<_i2.ClusterServerInfo> servers})
       : super._(servers: servers);
 
+  /// Returns a shallow copy of this [ClusterInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers}) {
     return ClusterInfo(

--- a/packages/serverpod/lib/src/generated/cluster_server_info.dart
+++ b/packages/serverpod/lib/src/generated/cluster_server_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a single server in a cluster.
 abstract class ClusterServerInfo
@@ -26,6 +27,9 @@ abstract class ClusterServerInfo
   /// The id of the server.
   String serverId;
 
+  /// Returns a shallow copy of this [ClusterServerInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ClusterServerInfo copyWith({String? serverId});
   @override
   Map<String, dynamic> toJson() {
@@ -47,6 +51,9 @@ class _ClusterServerInfoImpl extends ClusterServerInfo {
   _ClusterServerInfoImpl({required String serverId})
       : super._(serverId: serverId);
 
+  /// Returns a shallow copy of this [ClusterServerInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ClusterServerInfo copyWith({String? serverId}) {
     return ClusterServerInfo(serverId: serverId ?? this.serverId);

--- a/packages/serverpod/lib/src/generated/database/bulk_data.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/table_definition.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class BulkData
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -36,6 +37,9 @@ abstract class BulkData
 
   String data;
 
+  /// Returns a shallow copy of this [BulkData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkData copyWith({
     _i2.TableDefinition? tableDefinition,
     String? data,
@@ -71,6 +75,9 @@ class _BulkDataImpl extends BulkData {
           data: data,
         );
 
+  /// Returns a shallow copy of this [BulkData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkData copyWith({
     _i2.TableDefinition? tableDefinition,

--- a/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_data_exception.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BulkDataException
     implements
@@ -37,6 +38,9 @@ abstract class BulkDataException
 
   String? query;
 
+  /// Returns a shallow copy of this [BulkDataException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkDataException copyWith({
     String? message,
     String? query,
@@ -74,6 +78,9 @@ class _BulkDataExceptionImpl extends BulkDataException {
           query: query,
         );
 
+  /// Returns a shallow copy of this [BulkDataException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkDataException copyWith({
     String? message,

--- a/packages/serverpod/lib/src/generated/database/bulk_query_column_description.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_query_column_description.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BulkQueryColumnDescription
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -26,6 +27,9 @@ abstract class BulkQueryColumnDescription
 
   String name;
 
+  /// Returns a shallow copy of this [BulkQueryColumnDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkQueryColumnDescription copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
@@ -46,6 +50,9 @@ abstract class BulkQueryColumnDescription
 class _BulkQueryColumnDescriptionImpl extends BulkQueryColumnDescription {
   _BulkQueryColumnDescriptionImpl({required String name}) : super._(name: name);
 
+  /// Returns a shallow copy of this [BulkQueryColumnDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkQueryColumnDescription copyWith({String? name}) {
     return BulkQueryColumnDescription(name: name ?? this.name);

--- a/packages/serverpod/lib/src/generated/database/bulk_query_result.dart
+++ b/packages/serverpod/lib/src/generated/database/bulk_query_result.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/bulk_query_column_description.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class BulkQueryResult
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -49,6 +50,9 @@ abstract class BulkQueryResult
 
   Duration duration;
 
+  /// Returns a shallow copy of this [BulkQueryResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkQueryResult copyWith({
     List<_i2.BulkQueryColumnDescription>? headers,
     String? data,
@@ -94,6 +98,9 @@ class _BulkQueryResultImpl extends BulkQueryResult {
           duration: duration,
         );
 
+  /// Returns a shallow copy of this [BulkQueryResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkQueryResult copyWith({
     List<_i2.BulkQueryColumnDescription>? headers,

--- a/packages/serverpod/lib/src/generated/database/column_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/column_definition.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/column_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// The definition of a (desired) column in the database.
 abstract class ColumnDefinition
@@ -59,6 +60,9 @@ abstract class ColumnDefinition
   /// analyzing the database.
   String? dartType;
 
+  /// Returns a shallow copy of this [ColumnDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ColumnDefinition copyWith({
     String? name,
     _i2.ColumnType? columnType,
@@ -111,6 +115,9 @@ class _ColumnDefinitionImpl extends ColumnDefinition {
           dartType: dartType,
         );
 
+  /// Returns a shallow copy of this [ColumnDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ColumnDefinition copyWith({
     String? name,

--- a/packages/serverpod/lib/src/generated/database/column_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/column_migration.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ColumnMigration
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -49,6 +50,9 @@ abstract class ColumnMigration
 
   String? newDefault;
 
+  /// Returns a shallow copy of this [ColumnMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ColumnMigration copyWith({
     String? columnName,
     bool? addNullable,
@@ -101,6 +105,9 @@ class _ColumnMigrationImpl extends ColumnMigration {
           newDefault: newDefault,
         );
 
+  /// Returns a shallow copy of this [ColumnMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ColumnMigration copyWith({
     String? columnName,

--- a/packages/serverpod/lib/src/generated/database/database_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definition.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/table_definition.dart' as _i2;
 import '../database/database_migration_version.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Defines the structure of the database used by Serverpod.
 abstract class DatabaseDefinition
@@ -64,6 +65,9 @@ abstract class DatabaseDefinition
   /// The version of the database definition.
   int migrationApiVersion;
 
+  /// Returns a shallow copy of this [DatabaseDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseDefinition copyWith({
     String? name,
     String? moduleName,
@@ -118,6 +122,9 @@ class _DatabaseDefinitionImpl extends DatabaseDefinition {
           migrationApiVersion: migrationApiVersion,
         );
 
+  /// Returns a shallow copy of this [DatabaseDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseDefinition copyWith({
     Object? name = _Undefined,

--- a/packages/serverpod/lib/src/generated/database/database_definitions.dart
+++ b/packages/serverpod/lib/src/generated/database/database_definitions.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/table_definition.dart' as _i2;
 import '../database/database_migration_version.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Defines the current state of the database, including information about
 /// installed modules and migrations.
@@ -63,6 +64,9 @@ abstract class DatabaseDefinitions
   /// The latest available migrations that can be applied.
   List<_i3.DatabaseMigrationVersion> latestAvailableMigrations;
 
+  /// Returns a shallow copy of this [DatabaseDefinitions]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseDefinitions copyWith({
     List<_i2.TableDefinition>? target,
     List<_i2.TableDefinition>? live,
@@ -112,6 +116,9 @@ class _DatabaseDefinitionsImpl extends DatabaseDefinitions {
           latestAvailableMigrations: latestAvailableMigrations,
         );
 
+  /// Returns a shallow copy of this [DatabaseDefinitions]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseDefinitions copyWith({
     List<_i2.TableDefinition>? target,

--- a/packages/serverpod/lib/src/generated/database/database_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/database_migration_action.dart' as _i2;
 import '../database/database_migration_warning.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class DatabaseMigration
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -47,6 +48,9 @@ abstract class DatabaseMigration
 
   int migrationApiVersion;
 
+  /// Returns a shallow copy of this [DatabaseMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigration copyWith({
     List<_i2.DatabaseMigrationAction>? actions,
     List<_i3.DatabaseMigrationWarning>? warnings,
@@ -87,6 +91,9 @@ class _DatabaseMigrationImpl extends DatabaseMigration {
           migrationApiVersion: migrationApiVersion,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigration copyWith({
     List<_i2.DatabaseMigrationAction>? actions,

--- a/packages/serverpod/lib/src/generated/database/database_migration_action.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_action.dart
@@ -13,6 +13,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/database_migration_action_type.dart' as _i2;
 import '../database/table_migration.dart' as _i3;
 import '../database/table_definition.dart' as _i4;
+import 'package:meta/meta.dart';
 
 abstract class DatabaseMigrationAction
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -55,6 +56,9 @@ abstract class DatabaseMigrationAction
 
   _i4.TableDefinition? createTable;
 
+  /// Returns a shallow copy of this [DatabaseMigrationAction]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigrationAction copyWith({
     _i2.DatabaseMigrationActionType? type,
     String? deleteTable,
@@ -102,6 +106,9 @@ class _DatabaseMigrationActionImpl extends DatabaseMigrationAction {
           createTable: createTable,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigrationAction]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigrationAction copyWith({
     _i2.DatabaseMigrationActionType? type,

--- a/packages/serverpod/lib/src/generated/database/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_version.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a version of a database migration.
 abstract class DatabaseMigrationVersion
@@ -59,6 +60,9 @@ abstract class DatabaseMigrationVersion
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DatabaseMigrationVersion]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigrationVersion copyWith({
     int? id,
     String? module,
@@ -130,6 +134,9 @@ class _DatabaseMigrationVersionImpl extends DatabaseMigrationVersion {
           timestamp: timestamp,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigrationVersion]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigrationVersion copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/database/database_migration_warning.dart
+++ b/packages/serverpod/lib/src/generated/database/database_migration_warning.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/database_migration_warning_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class DatabaseMigrationWarning
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -54,6 +55,9 @@ abstract class DatabaseMigrationWarning
 
   bool destrucive;
 
+  /// Returns a shallow copy of this [DatabaseMigrationWarning]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigrationWarning copyWith({
     _i2.DatabaseMigrationWarningType? type,
     String? message,
@@ -104,6 +108,9 @@ class _DatabaseMigrationWarningImpl extends DatabaseMigrationWarning {
           destrucive: destrucive,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigrationWarning]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigrationWarning copyWith({
     _i2.DatabaseMigrationWarningType? type,

--- a/packages/serverpod/lib/src/generated/database/filter/filter.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../database/filter/filter_constraint.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Filter
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -43,6 +44,9 @@ abstract class Filter
 
   List<_i2.FilterConstraint> constraints;
 
+  /// Returns a shallow copy of this [Filter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Filter copyWith({
     String? name,
     String? table,
@@ -84,6 +88,9 @@ class _FilterImpl extends Filter {
           constraints: constraints,
         );
 
+  /// Returns a shallow copy of this [Filter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Filter copyWith({
     String? name,

--- a/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
+++ b/packages/serverpod/lib/src/generated/database/filter/filter_constraint.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../database/filter/filter_constraint_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class FilterConstraint
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -46,6 +47,9 @@ abstract class FilterConstraint
 
   String? value2;
 
+  /// Returns a shallow copy of this [FilterConstraint]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   FilterConstraint copyWith({
     _i2.FilterConstraintType? type,
     String? column,
@@ -93,6 +97,9 @@ class _FilterConstraintImpl extends FilterConstraint {
           value2: value2,
         );
 
+  /// Returns a shallow copy of this [FilterConstraint]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   FilterConstraint copyWith({
     _i2.FilterConstraintType? type,

--- a/packages/serverpod/lib/src/generated/database/foreign_key_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/foreign_key_definition.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/foreign_key_action.dart' as _i2;
 import '../database/foreign_key_match_type.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Represents a foreign key.
 abstract class ForeignKeyDefinition
@@ -89,6 +90,9 @@ abstract class ForeignKeyDefinition
   /// The match type of the foreign key
   _i3.ForeignKeyMatchType? matchType;
 
+  /// Returns a shallow copy of this [ForeignKeyDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ForeignKeyDefinition copyWith({
     String? constraintName,
     List<String>? columns,
@@ -156,6 +160,9 @@ class _ForeignKeyDefinitionImpl extends ForeignKeyDefinition {
           matchType: matchType,
         );
 
+  /// Returns a shallow copy of this [ForeignKeyDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ForeignKeyDefinition copyWith({
     String? constraintName,

--- a/packages/serverpod/lib/src/generated/database/index_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/index_definition.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/index_element_definition.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// The definition of a (desired) index in the database.
 abstract class IndexDefinition
@@ -72,6 +73,9 @@ abstract class IndexDefinition
   /// The predicate of this partial index, if it is one.
   String? predicate;
 
+  /// Returns a shallow copy of this [IndexDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IndexDefinition copyWith({
     String? indexName,
     String? tableSpace,
@@ -134,6 +138,9 @@ class _IndexDefinitionImpl extends IndexDefinition {
           predicate: predicate,
         );
 
+  /// Returns a shallow copy of this [IndexDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IndexDefinition copyWith({
     String? indexName,

--- a/packages/serverpod/lib/src/generated/database/index_element_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/index_element_definition.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/index_element_definition_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Defines an element of an index.
 abstract class IndexElementDefinition
@@ -40,6 +41,9 @@ abstract class IndexElementDefinition
   /// Depending on the [type], this is either a column name or an expression.
   String definition;
 
+  /// Returns a shallow copy of this [IndexElementDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IndexElementDefinition copyWith({
     _i2.IndexElementDefinitionType? type,
     String? definition,
@@ -75,6 +79,9 @@ class _IndexElementDefinitionImpl extends IndexElementDefinition {
           definition: definition,
         );
 
+  /// Returns a shallow copy of this [IndexElementDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IndexElementDefinition copyWith({
     _i2.IndexElementDefinitionType? type,

--- a/packages/serverpod/lib/src/generated/database/table_definition.dart
+++ b/packages/serverpod/lib/src/generated/database/table_definition.dart
@@ -13,6 +13,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import '../database/column_definition.dart' as _i2;
 import '../database/foreign_key_definition.dart' as _i3;
 import '../database/index_definition.dart' as _i4;
+import 'package:meta/meta.dart';
 
 /// The definition of a (desired) table in the database.
 abstract class TableDefinition
@@ -92,6 +93,9 @@ abstract class TableDefinition
   /// Null, if this is unknown.
   bool? managed;
 
+  /// Returns a shallow copy of this [TableDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TableDefinition copyWith({
     String? name,
     String? dartName,
@@ -165,6 +169,9 @@ class _TableDefinitionImpl extends TableDefinition {
           managed: managed,
         );
 
+  /// Returns a shallow copy of this [TableDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TableDefinition copyWith({
     String? name,

--- a/packages/serverpod/lib/src/generated/database/table_migration.dart
+++ b/packages/serverpod/lib/src/generated/database/table_migration.dart
@@ -15,6 +15,7 @@ import '../database/column_migration.dart' as _i3;
 import '../database/index_definition.dart' as _i4;
 import '../database/foreign_key_definition.dart' as _i5;
 import '../database/database_migration_warning.dart' as _i6;
+import 'package:meta/meta.dart';
 
 abstract class TableMigration
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -108,6 +109,9 @@ abstract class TableMigration
 
   List<_i6.DatabaseMigrationWarning> warnings;
 
+  /// Returns a shallow copy of this [TableMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TableMigration copyWith({
     String? name,
     String? dartName,
@@ -199,6 +203,9 @@ class _TableMigrationImpl extends TableMigration {
           warnings: warnings,
         );
 
+  /// Returns a shallow copy of this [TableMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TableMigration copyWith({
     String? name,

--- a/packages/serverpod/lib/src/generated/distributed_cache_entry.dart
+++ b/packages/serverpod/lib/src/generated/distributed_cache_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// An entry in the distributed cache.
 abstract class DistributedCacheEntry
@@ -27,6 +28,9 @@ abstract class DistributedCacheEntry
   /// The cached data.
   String data;
 
+  /// Returns a shallow copy of this [DistributedCacheEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DistributedCacheEntry copyWith({String? data});
   @override
   Map<String, dynamic> toJson() {
@@ -47,6 +51,9 @@ abstract class DistributedCacheEntry
 class _DistributedCacheEntryImpl extends DistributedCacheEntry {
   _DistributedCacheEntryImpl({required String data}) : super._(data: data);
 
+  /// Returns a shallow copy of this [DistributedCacheEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DistributedCacheEntry copyWith({String? data}) {
     return DistributedCacheEntry(data: data ?? this.data);

--- a/packages/serverpod/lib/src/generated/exceptions/access_denied.dart
+++ b/packages/serverpod/lib/src/generated/exceptions/access_denied.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class AccessDeniedException
     implements
@@ -29,6 +30,9 @@ abstract class AccessDeniedException
 
   String message;
 
+  /// Returns a shallow copy of this [AccessDeniedException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AccessDeniedException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
@@ -50,6 +54,9 @@ class _AccessDeniedExceptionImpl extends AccessDeniedException {
   _AccessDeniedExceptionImpl({required String message})
       : super._(message: message);
 
+  /// Returns a shallow copy of this [AccessDeniedException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AccessDeniedException copyWith({String? message}) {
     return AccessDeniedException(message: message ?? this.message);

--- a/packages/serverpod/lib/src/generated/exceptions/file_not_found.dart
+++ b/packages/serverpod/lib/src/generated/exceptions/file_not_found.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class FileNotFoundException
     implements
@@ -29,6 +30,9 @@ abstract class FileNotFoundException
 
   String message;
 
+  /// Returns a shallow copy of this [FileNotFoundException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   FileNotFoundException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
@@ -50,6 +54,9 @@ class _FileNotFoundExceptionImpl extends FileNotFoundException {
   _FileNotFoundExceptionImpl({required String message})
       : super._(message: message);
 
+  /// Returns a shallow copy of this [FileNotFoundException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   FileNotFoundException copyWith({String? message}) {
     return FileNotFoundException(message: message ?? this.message);

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A serialized future call with bindings to the database.
 abstract class FutureCallEntry
@@ -68,6 +69,9 @@ abstract class FutureCallEntry
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [FutureCallEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   FutureCallEntry copyWith({
     int? id,
     String? name,
@@ -149,6 +153,9 @@ class _FutureCallEntryImpl extends FutureCallEntry {
           identifier: identifier,
         );
 
+  /// Returns a shallow copy of this [FutureCallEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   FutureCallEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'log_level.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Bindings to a log entry in the database.
 abstract class LogEntry implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -98,6 +99,9 @@ abstract class LogEntry implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [LogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogEntry copyWith({
     int? id,
     int? sessionLogId,
@@ -204,6 +208,9 @@ class _LogEntryImpl extends LogEntry {
           order: order,
         );
 
+  /// Returns a shallow copy of this [LogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/log_result.dart
+++ b/packages/serverpod/lib/src/generated/log_result.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'log_entry.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A list of log entries, used to return logging data.
 abstract class LogResult
@@ -29,6 +30,9 @@ abstract class LogResult
   /// The log entries in this result.
   List<_i2.LogEntry> entries;
 
+  /// Returns a shallow copy of this [LogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogResult copyWith({List<_i2.LogEntry>? entries});
   @override
   Map<String, dynamic> toJson() {
@@ -52,6 +56,9 @@ class _LogResultImpl extends LogResult {
   _LogResultImpl({required List<_i2.LogEntry> entries})
       : super._(entries: entries);
 
+  /// Returns a shallow copy of this [LogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogResult copyWith({List<_i2.LogEntry>? entries}) {
     return LogResult(

--- a/packages/serverpod/lib/src/generated/log_settings.dart
+++ b/packages/serverpod/lib/src/generated/log_settings.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'log_level.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Log settings for the server.
 abstract class LogSettings
@@ -90,6 +91,9 @@ abstract class LogSettings
   /// The duration in seconds for a query to be considered slow.
   double slowQueryDuration;
 
+  /// Returns a shallow copy of this [LogSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogSettings copyWith({
     _i2.LogLevel? logLevel,
     bool? logAllSessions,
@@ -165,6 +169,9 @@ class _LogSettingsImpl extends LogSettings {
           slowQueryDuration: slowQueryDuration,
         );
 
+  /// Returns a shallow copy of this [LogSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogSettings copyWith({
     _i2.LogLevel? logLevel,

--- a/packages/serverpod/lib/src/generated/log_settings_override.dart
+++ b/packages/serverpod/lib/src/generated/log_settings_override.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'log_settings.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Information about an override for log settings for either an entire
 /// endpoint or a specific method.
@@ -52,6 +53,9 @@ abstract class LogSettingsOverride
   /// Log settings override.
   _i2.LogSettings logSettings;
 
+  /// Returns a shallow copy of this [LogSettingsOverride]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogSettingsOverride copyWith({
     String? module,
     String? endpoint,
@@ -99,6 +103,9 @@ class _LogSettingsOverrideImpl extends LogSettingsOverride {
           logSettings: logSettings,
         );
 
+  /// Returns a shallow copy of this [LogSettingsOverride]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogSettingsOverride copyWith({
     Object? module = _Undefined,

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A log entry for a message sent in a streaming session.
 abstract class MessageLogEntry
@@ -100,6 +101,9 @@ abstract class MessageLogEntry
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [MessageLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MessageLogEntry copyWith({
     int? id,
     int? sessionLogId,
@@ -206,6 +210,9 @@ class _MessageLogEntryImpl extends MessageLogEntry {
           order: order,
         );
 
+  /// Returns a shallow copy of this [MessageLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MessageLogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a server method.
 abstract class MethodInfo implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -49,6 +50,9 @@ abstract class MethodInfo implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [MethodInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MethodInfo copyWith({
     int? id,
     String? endpoint,
@@ -115,6 +119,9 @@ class _MethodInfoImpl extends MethodInfo {
           method: method,
         );
 
+  /// Returns a shallow copy of this [MethodInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MethodInfo copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A log entry for a database query.
 abstract class QueryLogEntry
@@ -100,6 +101,9 @@ abstract class QueryLogEntry
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [QueryLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   QueryLogEntry copyWith({
     int? id,
     String? serverId,
@@ -206,6 +210,9 @@ class _QueryLogEntryImpl extends QueryLogEntry {
           order: order,
         );
 
+  /// Returns a shallow copy of this [QueryLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   QueryLogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database mapping for a read/write test that is performed by the default
 /// health checks.
@@ -45,6 +46,9 @@ abstract class ReadWriteTestEntry
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ReadWriteTestEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ReadWriteTestEntry copyWith({
     int? id,
     int? number,
@@ -106,6 +110,9 @@ class _ReadWriteTestEntryImpl extends ReadWriteTestEntry {
           number: number,
         );
 
+  /// Returns a shallow copy of this [ReadWriteTestEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ReadWriteTestEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'log_settings.dart' as _i2;
 import 'log_settings_override.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Runtime settings of the server.
 abstract class RuntimeSettings
@@ -68,6 +69,9 @@ abstract class RuntimeSettings
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [RuntimeSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RuntimeSettings copyWith({
     int? id,
     _i2.LogSettings? logSettings,
@@ -146,6 +150,9 @@ class _RuntimeSettingsImpl extends RuntimeSettings {
           logMalformedCalls: logMalformedCalls,
         );
 
+  /// Returns a shallow copy of this [RuntimeSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RuntimeSettings copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a snapshot of the number of open connections the server currently
 /// is handling. An entry is written every minute for each server. All health
@@ -79,6 +80,9 @@ abstract class ServerHealthConnectionInfo
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ServerHealthConnectionInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerHealthConnectionInfo copyWith({
     int? id,
     String? serverId,
@@ -165,6 +169,9 @@ class _ServerHealthConnectionInfoImpl extends ServerHealthConnectionInfo {
           granularity: granularity,
         );
 
+  /// Returns a shallow copy of this [ServerHealthConnectionInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerHealthConnectionInfo copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a snapshot of a specific health metric. An entry is written every
 /// minute for each server. All health data can be accessed through Serverpod
@@ -78,6 +79,9 @@ abstract class ServerHealthMetric
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ServerHealthMetric]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerHealthMetric copyWith({
     int? id,
     String? name,
@@ -164,6 +168,9 @@ class _ServerHealthMetricImpl extends ServerHealthMetric {
           granularity: granularity,
         );
 
+  /// Returns a shallow copy of this [ServerHealthMetric]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerHealthMetric copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/server_health_result.dart
+++ b/packages/serverpod/lib/src/generated/server_health_result.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'server_health_metric.dart' as _i2;
 import 'server_health_connection_info.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Information about health and connection metrics.
 abstract class ServerHealthResult
@@ -45,6 +46,9 @@ abstract class ServerHealthResult
   /// List of connection metrics.
   List<_i3.ServerHealthConnectionInfo> connectionInfos;
 
+  /// Returns a shallow copy of this [ServerHealthResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerHealthResult copyWith({
     List<_i2.ServerHealthMetric>? metrics,
     List<_i3.ServerHealthConnectionInfo>? connectionInfos,
@@ -81,6 +85,9 @@ class _ServerHealthResultImpl extends ServerHealthResult {
           connectionInfos: connectionInfos,
         );
 
+  /// Returns a shallow copy of this [ServerHealthResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerHealthResult copyWith({
     List<_i2.ServerHealthMetric>? metrics,

--- a/packages/serverpod/lib/src/generated/serverpod_sql_exception.dart
+++ b/packages/serverpod/lib/src/generated/serverpod_sql_exception.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ServerpodSqlException
     implements
@@ -38,6 +39,9 @@ abstract class ServerpodSqlException
 
   String sql;
 
+  /// Returns a shallow copy of this [ServerpodSqlException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerpodSqlException copyWith({
     String? message,
     String? sql,
@@ -73,6 +77,9 @@ class _ServerpodSqlExceptionImpl extends ServerpodSqlException {
           sql: sql,
         );
 
+  /// Returns a shallow copy of this [ServerpodSqlException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerpodSqlException copyWith({
     String? message,

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Log entry for a session.
 abstract class SessionLogEntry
@@ -120,6 +121,9 @@ abstract class SessionLogEntry
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [SessionLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogEntry copyWith({
     int? id,
     String? serverId,
@@ -243,6 +247,9 @@ class _SessionLogEntryImpl extends SessionLogEntry {
           touched: touched,
         );
 
+  /// Returns a shallow copy of this [SessionLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod/lib/src/generated/session_log_filter.dart
+++ b/packages/serverpod/lib/src/generated/session_log_filter.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// The log filter is used when searching for specific log entries.
 abstract class SessionLogFilter
@@ -67,6 +68,9 @@ abstract class SessionLogFilter
   /// Last session id to start the list of logs from. Used for pagination.
   int? lastSessionLogId;
 
+  /// Returns a shallow copy of this [SessionLogFilter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogFilter copyWith({
     String? endpoint,
     String? method,
@@ -129,6 +133,9 @@ class _SessionLogFilterImpl extends SessionLogFilter {
           lastSessionLogId: lastSessionLogId,
         );
 
+  /// Returns a shallow copy of this [SessionLogFilter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogFilter copyWith({
     Object? endpoint = _Undefined,

--- a/packages/serverpod/lib/src/generated/session_log_info.dart
+++ b/packages/serverpod/lib/src/generated/session_log_info.dart
@@ -14,6 +14,7 @@ import 'session_log_entry.dart' as _i2;
 import 'query_log_entry.dart' as _i3;
 import 'log_entry.dart' as _i4;
 import 'message_log_entry.dart' as _i5;
+import 'package:meta/meta.dart';
 
 /// Compounded information about a session log.
 abstract class SessionLogInfo
@@ -60,6 +61,9 @@ abstract class SessionLogInfo
   /// List of messages sent during the session.
   List<_i5.MessageLogEntry> messages;
 
+  /// Returns a shallow copy of this [SessionLogInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogInfo copyWith({
     _i2.SessionLogEntry? sessionLogEntry,
     List<_i3.QueryLogEntry>? queries,
@@ -105,6 +109,9 @@ class _SessionLogInfoImpl extends SessionLogInfo {
           messages: messages,
         );
 
+  /// Returns a shallow copy of this [SessionLogInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogInfo copyWith({
     _i2.SessionLogEntry? sessionLogEntry,

--- a/packages/serverpod/lib/src/generated/session_log_result.dart
+++ b/packages/serverpod/lib/src/generated/session_log_result.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'session_log_info.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A list of SessionLogInfo.
 abstract class SessionLogResult
@@ -31,6 +32,9 @@ abstract class SessionLogResult
   /// The list of SessionLogInfo.
   List<_i2.SessionLogInfo> sessionLog;
 
+  /// Returns a shallow copy of this [SessionLogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog});
   @override
   Map<String, dynamic> toJson() {
@@ -54,6 +58,9 @@ class _SessionLogResultImpl extends SessionLogResult {
   _SessionLogResultImpl({required List<_i2.SessionLogInfo> sessionLog})
       : super._(sessionLog: sessionLog);
 
+  /// Returns a shallow copy of this [SessionLogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog}) {
     return SessionLogResult(

--- a/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cache_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Provides high level information about a cache.
 abstract class CacheInfo implements _i1.SerializableModel {
@@ -44,6 +45,9 @@ abstract class CacheInfo implements _i1.SerializableModel {
   /// Optional list of keys used by the cache.
   List<String>? keys;
 
+  /// Returns a shallow copy of this [CacheInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CacheInfo copyWith({
     int? numEntries,
     int? maxEntries,
@@ -77,6 +81,9 @@ class _CacheInfoImpl extends CacheInfo {
           keys: keys,
         );
 
+  /// Returns a shallow copy of this [CacheInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CacheInfo copyWith({
     int? numEntries,

--- a/packages/serverpod_service_client/lib/src/protocol/caches_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/caches_info.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'cache_info.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// High level information about the caches.
 abstract class CachesInfo implements _i1.SerializableModel {
@@ -46,6 +47,9 @@ abstract class CachesInfo implements _i1.SerializableModel {
   /// Information about the global cache.
   _i2.CacheInfo global;
 
+  /// Returns a shallow copy of this [CachesInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CachesInfo copyWith({
     _i2.CacheInfo? local,
     _i2.CacheInfo? localPrio,
@@ -77,6 +81,9 @@ class _CachesInfoImpl extends CachesInfo {
           global: global,
         );
 
+  /// Returns a shallow copy of this [CachesInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CachesInfo copyWith({
     _i2.CacheInfo? local,

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:meta/meta.dart';
 
 /// An entry in the database for an uploaded file.
 abstract class CloudStorageEntry implements _i1.SerializableModel {
@@ -73,6 +74,9 @@ abstract class CloudStorageEntry implements _i1.SerializableModel {
   /// True if the file has been verified as uploaded.
   bool verified;
 
+  /// Returns a shallow copy of this [CloudStorageEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CloudStorageEntry copyWith({
     int? id,
     String? storageId,
@@ -122,6 +126,9 @@ class _CloudStorageEntryImpl extends CloudStorageEntry {
           verified: verified,
         );
 
+  /// Returns a shallow copy of this [CloudStorageEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CloudStorageEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cloud_storage_direct_upload.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Connects a table for handling uploading of files.
 abstract class CloudStorageDirectUploadEntry implements _i1.SerializableModel {
@@ -58,6 +59,9 @@ abstract class CloudStorageDirectUploadEntry implements _i1.SerializableModel {
   /// Access key for retrieving a private file.
   String authKey;
 
+  /// Returns a shallow copy of this [CloudStorageDirectUploadEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CloudStorageDirectUploadEntry copyWith({
     int? id,
     String? storageId,
@@ -99,6 +103,9 @@ class _CloudStorageDirectUploadEntryImpl extends CloudStorageDirectUploadEntry {
           authKey: authKey,
         );
 
+  /// Returns a shallow copy of this [CloudStorageDirectUploadEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CloudStorageDirectUploadEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cluster_info.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'cluster_server_info.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Information about a cluster of servers.
 abstract class ClusterInfo implements _i1.SerializableModel {
@@ -30,6 +31,9 @@ abstract class ClusterInfo implements _i1.SerializableModel {
   /// List of servers in the cluster.
   List<_i2.ClusterServerInfo> servers;
 
+  /// Returns a shallow copy of this [ClusterInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers});
   @override
   Map<String, dynamic> toJson() {
@@ -46,6 +50,9 @@ class _ClusterInfoImpl extends ClusterInfo {
   _ClusterInfoImpl({required List<_i2.ClusterServerInfo> servers})
       : super._(servers: servers);
 
+  /// Returns a shallow copy of this [ClusterInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ClusterInfo copyWith({List<_i2.ClusterServerInfo>? servers}) {
     return ClusterInfo(

--- a/packages/serverpod_service_client/lib/src/protocol/cluster_server_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/cluster_server_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a single server in a cluster.
 abstract class ClusterServerInfo implements _i1.SerializableModel {
@@ -25,6 +26,9 @@ abstract class ClusterServerInfo implements _i1.SerializableModel {
   /// The id of the server.
   String serverId;
 
+  /// Returns a shallow copy of this [ClusterServerInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ClusterServerInfo copyWith({String? serverId});
   @override
   Map<String, dynamic> toJson() {
@@ -41,6 +45,9 @@ class _ClusterServerInfoImpl extends ClusterServerInfo {
   _ClusterServerInfoImpl({required String serverId})
       : super._(serverId: serverId);
 
+  /// Returns a shallow copy of this [ClusterServerInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ClusterServerInfo copyWith({String? serverId}) {
     return ClusterServerInfo(serverId: serverId ?? this.serverId);

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_data.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_data.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/table_definition.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class BulkData implements _i1.SerializableModel {
   BulkData._({
@@ -35,6 +36,9 @@ abstract class BulkData implements _i1.SerializableModel {
 
   String data;
 
+  /// Returns a shallow copy of this [BulkData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkData copyWith({
     _i2.TableDefinition? tableDefinition,
     String? data,
@@ -62,6 +66,9 @@ class _BulkDataImpl extends BulkData {
           data: data,
         );
 
+  /// Returns a shallow copy of this [BulkData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkData copyWith({
     _i2.TableDefinition? tableDefinition,

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_data_exception.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BulkDataException
     implements _i1.SerializableException, _i1.SerializableModel {
@@ -34,6 +35,9 @@ abstract class BulkDataException
 
   String? query;
 
+  /// Returns a shallow copy of this [BulkDataException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkDataException copyWith({
     String? message,
     String? query,
@@ -63,6 +67,9 @@ class _BulkDataExceptionImpl extends BulkDataException {
           query: query,
         );
 
+  /// Returns a shallow copy of this [BulkDataException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkDataException copyWith({
     String? message,

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_column_description.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_column_description.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BulkQueryColumnDescription implements _i1.SerializableModel {
   BulkQueryColumnDescription._({required this.name});
@@ -25,6 +26,9 @@ abstract class BulkQueryColumnDescription implements _i1.SerializableModel {
 
   String name;
 
+  /// Returns a shallow copy of this [BulkQueryColumnDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkQueryColumnDescription copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
@@ -40,6 +44,9 @@ abstract class BulkQueryColumnDescription implements _i1.SerializableModel {
 class _BulkQueryColumnDescriptionImpl extends BulkQueryColumnDescription {
   _BulkQueryColumnDescriptionImpl({required String name}) : super._(name: name);
 
+  /// Returns a shallow copy of this [BulkQueryColumnDescription]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkQueryColumnDescription copyWith({String? name}) {
     return BulkQueryColumnDescription(name: name ?? this.name);

--- a/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/bulk_query_result.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/bulk_query_column_description.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class BulkQueryResult implements _i1.SerializableModel {
   BulkQueryResult._({
@@ -48,6 +49,9 @@ abstract class BulkQueryResult implements _i1.SerializableModel {
 
   Duration duration;
 
+  /// Returns a shallow copy of this [BulkQueryResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BulkQueryResult copyWith({
     List<_i2.BulkQueryColumnDescription>? headers,
     String? data,
@@ -83,6 +87,9 @@ class _BulkQueryResultImpl extends BulkQueryResult {
           duration: duration,
         );
 
+  /// Returns a shallow copy of this [BulkQueryResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BulkQueryResult copyWith({
     List<_i2.BulkQueryColumnDescription>? headers,

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_definition.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/column_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// The definition of a (desired) column in the database.
 abstract class ColumnDefinition implements _i1.SerializableModel {
@@ -58,6 +59,9 @@ abstract class ColumnDefinition implements _i1.SerializableModel {
   /// analyzing the database.
   String? dartType;
 
+  /// Returns a shallow copy of this [ColumnDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ColumnDefinition copyWith({
     String? name,
     _i2.ColumnType? columnType,
@@ -99,6 +103,9 @@ class _ColumnDefinitionImpl extends ColumnDefinition {
           dartType: dartType,
         );
 
+  /// Returns a shallow copy of this [ColumnDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ColumnDefinition copyWith({
     String? name,

--- a/packages/serverpod_service_client/lib/src/protocol/database/column_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/column_migration.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ColumnMigration implements _i1.SerializableModel {
   ColumnMigration._({
@@ -48,6 +49,9 @@ abstract class ColumnMigration implements _i1.SerializableModel {
 
   String? newDefault;
 
+  /// Returns a shallow copy of this [ColumnMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ColumnMigration copyWith({
     String? columnName,
     bool? addNullable,
@@ -89,6 +93,9 @@ class _ColumnMigrationImpl extends ColumnMigration {
           newDefault: newDefault,
         );
 
+  /// Returns a shallow copy of this [ColumnMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ColumnMigration copyWith({
     String? columnName,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definition.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/table_definition.dart' as _i2;
 import '../database/database_migration_version.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Defines the structure of the database used by Serverpod.
 abstract class DatabaseDefinition implements _i1.SerializableModel {
@@ -63,6 +64,9 @@ abstract class DatabaseDefinition implements _i1.SerializableModel {
   /// The version of the database definition.
   int migrationApiVersion;
 
+  /// Returns a shallow copy of this [DatabaseDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseDefinition copyWith({
     String? name,
     String? moduleName,
@@ -105,6 +109,9 @@ class _DatabaseDefinitionImpl extends DatabaseDefinition {
           migrationApiVersion: migrationApiVersion,
         );
 
+  /// Returns a shallow copy of this [DatabaseDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseDefinition copyWith({
     Object? name = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_definitions.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_definitions.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/table_definition.dart' as _i2;
 import '../database/database_migration_version.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Defines the current state of the database, including information about
 /// installed modules and migrations.
@@ -62,6 +63,9 @@ abstract class DatabaseDefinitions implements _i1.SerializableModel {
   /// The latest available migrations that can be applied.
   List<_i3.DatabaseMigrationVersion> latestAvailableMigrations;
 
+  /// Returns a shallow copy of this [DatabaseDefinitions]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseDefinitions copyWith({
     List<_i2.TableDefinition>? target,
     List<_i2.TableDefinition>? live,
@@ -99,6 +103,9 @@ class _DatabaseDefinitionsImpl extends DatabaseDefinitions {
           latestAvailableMigrations: latestAvailableMigrations,
         );
 
+  /// Returns a shallow copy of this [DatabaseDefinitions]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseDefinitions copyWith({
     List<_i2.TableDefinition>? target,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/database_migration_action.dart' as _i2;
 import '../database/database_migration_warning.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class DatabaseMigration implements _i1.SerializableModel {
   DatabaseMigration._({
@@ -46,6 +47,9 @@ abstract class DatabaseMigration implements _i1.SerializableModel {
 
   int migrationApiVersion;
 
+  /// Returns a shallow copy of this [DatabaseMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigration copyWith({
     List<_i2.DatabaseMigrationAction>? actions,
     List<_i3.DatabaseMigrationWarning>? warnings,
@@ -77,6 +81,9 @@ class _DatabaseMigrationImpl extends DatabaseMigration {
           migrationApiVersion: migrationApiVersion,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigration copyWith({
     List<_i2.DatabaseMigrationAction>? actions,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_action.dart
@@ -13,6 +13,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/database_migration_action_type.dart' as _i2;
 import '../database/table_migration.dart' as _i3;
 import '../database/table_definition.dart' as _i4;
+import 'package:meta/meta.dart';
 
 abstract class DatabaseMigrationAction implements _i1.SerializableModel {
   DatabaseMigrationAction._({
@@ -54,6 +55,9 @@ abstract class DatabaseMigrationAction implements _i1.SerializableModel {
 
   _i4.TableDefinition? createTable;
 
+  /// Returns a shallow copy of this [DatabaseMigrationAction]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigrationAction copyWith({
     _i2.DatabaseMigrationActionType? type,
     String? deleteTable,
@@ -91,6 +95,9 @@ class _DatabaseMigrationActionImpl extends DatabaseMigrationAction {
           createTable: createTable,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigrationAction]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigrationAction copyWith({
     _i2.DatabaseMigrationActionType? type,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_version.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a version of a database migration.
 abstract class DatabaseMigrationVersion implements _i1.SerializableModel {
@@ -53,6 +54,9 @@ abstract class DatabaseMigrationVersion implements _i1.SerializableModel {
   /// The timestamp of the migration. Only set if the migration is applied.
   DateTime? timestamp;
 
+  /// Returns a shallow copy of this [DatabaseMigrationVersion]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigrationVersion copyWith({
     int? id,
     String? module,
@@ -90,6 +94,9 @@ class _DatabaseMigrationVersionImpl extends DatabaseMigrationVersion {
           timestamp: timestamp,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigrationVersion]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigrationVersion copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/database_migration_warning.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/database_migration_warning_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class DatabaseMigrationWarning implements _i1.SerializableModel {
   DatabaseMigrationWarning._({
@@ -53,6 +54,9 @@ abstract class DatabaseMigrationWarning implements _i1.SerializableModel {
 
   bool destrucive;
 
+  /// Returns a shallow copy of this [DatabaseMigrationWarning]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DatabaseMigrationWarning copyWith({
     _i2.DatabaseMigrationWarningType? type,
     String? message,
@@ -92,6 +96,9 @@ class _DatabaseMigrationWarningImpl extends DatabaseMigrationWarning {
           destrucive: destrucive,
         );
 
+  /// Returns a shallow copy of this [DatabaseMigrationWarning]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DatabaseMigrationWarning copyWith({
     _i2.DatabaseMigrationWarningType? type,

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../database/filter/filter_constraint.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Filter implements _i1.SerializableModel {
   Filter._({
@@ -42,6 +43,9 @@ abstract class Filter implements _i1.SerializableModel {
 
   List<_i2.FilterConstraint> constraints;
 
+  /// Returns a shallow copy of this [Filter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Filter copyWith({
     String? name,
     String? table,
@@ -73,6 +77,9 @@ class _FilterImpl extends Filter {
           constraints: constraints,
         );
 
+  /// Returns a shallow copy of this [Filter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Filter copyWith({
     String? name,

--- a/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/filter/filter_constraint.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../database/filter/filter_constraint_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class FilterConstraint implements _i1.SerializableModel {
   FilterConstraint._({
@@ -45,6 +46,9 @@ abstract class FilterConstraint implements _i1.SerializableModel {
 
   String? value2;
 
+  /// Returns a shallow copy of this [FilterConstraint]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   FilterConstraint copyWith({
     _i2.FilterConstraintType? type,
     String? column,
@@ -82,6 +86,9 @@ class _FilterConstraintImpl extends FilterConstraint {
           value2: value2,
         );
 
+  /// Returns a shallow copy of this [FilterConstraint]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   FilterConstraint copyWith({
     _i2.FilterConstraintType? type,

--- a/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/foreign_key_definition.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/foreign_key_action.dart' as _i2;
 import '../database/foreign_key_match_type.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Represents a foreign key.
 abstract class ForeignKeyDefinition implements _i1.SerializableModel {
@@ -88,6 +89,9 @@ abstract class ForeignKeyDefinition implements _i1.SerializableModel {
   /// The match type of the foreign key
   _i3.ForeignKeyMatchType? matchType;
 
+  /// Returns a shallow copy of this [ForeignKeyDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ForeignKeyDefinition copyWith({
     String? constraintName,
     List<String>? columns,
@@ -141,6 +145,9 @@ class _ForeignKeyDefinitionImpl extends ForeignKeyDefinition {
           matchType: matchType,
         );
 
+  /// Returns a shallow copy of this [ForeignKeyDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ForeignKeyDefinition copyWith({
     String? constraintName,

--- a/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/index_definition.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/index_element_definition.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// The definition of a (desired) index in the database.
 abstract class IndexDefinition implements _i1.SerializableModel {
@@ -71,6 +72,9 @@ abstract class IndexDefinition implements _i1.SerializableModel {
   /// The predicate of this partial index, if it is one.
   String? predicate;
 
+  /// Returns a shallow copy of this [IndexDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IndexDefinition copyWith({
     String? indexName,
     String? tableSpace,
@@ -120,6 +124,9 @@ class _IndexDefinitionImpl extends IndexDefinition {
           predicate: predicate,
         );
 
+  /// Returns a shallow copy of this [IndexDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IndexDefinition copyWith({
     String? indexName,

--- a/packages/serverpod_service_client/lib/src/protocol/database/index_element_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/index_element_definition.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/index_element_definition_type.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Defines an element of an index.
 abstract class IndexElementDefinition implements _i1.SerializableModel {
@@ -39,6 +40,9 @@ abstract class IndexElementDefinition implements _i1.SerializableModel {
   /// Depending on the [type], this is either a column name or an expression.
   String definition;
 
+  /// Returns a shallow copy of this [IndexElementDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IndexElementDefinition copyWith({
     _i2.IndexElementDefinitionType? type,
     String? definition,
@@ -66,6 +70,9 @@ class _IndexElementDefinitionImpl extends IndexElementDefinition {
           definition: definition,
         );
 
+  /// Returns a shallow copy of this [IndexElementDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IndexElementDefinition copyWith({
     _i2.IndexElementDefinitionType? type,

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_definition.dart
@@ -13,6 +13,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../database/column_definition.dart' as _i2;
 import '../database/foreign_key_definition.dart' as _i3;
 import '../database/index_definition.dart' as _i4;
+import 'package:meta/meta.dart';
 
 /// The definition of a (desired) table in the database.
 abstract class TableDefinition implements _i1.SerializableModel {
@@ -91,6 +92,9 @@ abstract class TableDefinition implements _i1.SerializableModel {
   /// Null, if this is unknown.
   bool? managed;
 
+  /// Returns a shallow copy of this [TableDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TableDefinition copyWith({
     String? name,
     String? dartName,
@@ -148,6 +152,9 @@ class _TableDefinitionImpl extends TableDefinition {
           managed: managed,
         );
 
+  /// Returns a shallow copy of this [TableDefinition]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TableDefinition copyWith({
     String? name,

--- a/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/database/table_migration.dart
@@ -15,6 +15,7 @@ import '../database/column_migration.dart' as _i3;
 import '../database/index_definition.dart' as _i4;
 import '../database/foreign_key_definition.dart' as _i5;
 import '../database/database_migration_warning.dart' as _i6;
+import 'package:meta/meta.dart';
 
 abstract class TableMigration implements _i1.SerializableModel {
   TableMigration._({
@@ -107,6 +108,9 @@ abstract class TableMigration implements _i1.SerializableModel {
 
   List<_i6.DatabaseMigrationWarning> warnings;
 
+  /// Returns a shallow copy of this [TableMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TableMigration copyWith({
     String? name,
     String? dartName,
@@ -176,6 +180,9 @@ class _TableMigrationImpl extends TableMigration {
           warnings: warnings,
         );
 
+  /// Returns a shallow copy of this [TableMigration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TableMigration copyWith({
     String? name,

--- a/packages/serverpod_service_client/lib/src/protocol/distributed_cache_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/distributed_cache_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// An entry in the distributed cache.
 abstract class DistributedCacheEntry implements _i1.SerializableModel {
@@ -26,6 +27,9 @@ abstract class DistributedCacheEntry implements _i1.SerializableModel {
   /// The cached data.
   String data;
 
+  /// Returns a shallow copy of this [DistributedCacheEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DistributedCacheEntry copyWith({String? data});
   @override
   Map<String, dynamic> toJson() {
@@ -41,6 +45,9 @@ abstract class DistributedCacheEntry implements _i1.SerializableModel {
 class _DistributedCacheEntryImpl extends DistributedCacheEntry {
   _DistributedCacheEntryImpl({required String data}) : super._(data: data);
 
+  /// Returns a shallow copy of this [DistributedCacheEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DistributedCacheEntry copyWith({String? data}) {
     return DistributedCacheEntry(data: data ?? this.data);

--- a/packages/serverpod_service_client/lib/src/protocol/exceptions/access_denied.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/exceptions/access_denied.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class AccessDeniedException
     implements _i1.SerializableException, _i1.SerializableModel {
@@ -26,6 +27,9 @@ abstract class AccessDeniedException
 
   String message;
 
+  /// Returns a shallow copy of this [AccessDeniedException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   AccessDeniedException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
@@ -42,6 +46,9 @@ class _AccessDeniedExceptionImpl extends AccessDeniedException {
   _AccessDeniedExceptionImpl({required String message})
       : super._(message: message);
 
+  /// Returns a shallow copy of this [AccessDeniedException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   AccessDeniedException copyWith({String? message}) {
     return AccessDeniedException(message: message ?? this.message);

--- a/packages/serverpod_service_client/lib/src/protocol/exceptions/file_not_found.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/exceptions/file_not_found.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class FileNotFoundException
     implements _i1.SerializableException, _i1.SerializableModel {
@@ -26,6 +27,9 @@ abstract class FileNotFoundException
 
   String message;
 
+  /// Returns a shallow copy of this [FileNotFoundException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   FileNotFoundException copyWith({String? message});
   @override
   Map<String, dynamic> toJson() {
@@ -42,6 +46,9 @@ class _FileNotFoundExceptionImpl extends FileNotFoundException {
   _FileNotFoundExceptionImpl({required String message})
       : super._(message: message);
 
+  /// Returns a shallow copy of this [FileNotFoundException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   FileNotFoundException copyWith({String? message}) {
     return FileNotFoundException(message: message ?? this.message);

--- a/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/future_call_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A serialized future call with bindings to the database.
 abstract class FutureCallEntry implements _i1.SerializableModel {
@@ -62,6 +63,9 @@ abstract class FutureCallEntry implements _i1.SerializableModel {
   /// An optional identifier which can be used to cancel the call.
   String? identifier;
 
+  /// Returns a shallow copy of this [FutureCallEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   FutureCallEntry copyWith({
     int? id,
     String? name,
@@ -107,6 +111,9 @@ class _FutureCallEntryImpl extends FutureCallEntry {
           identifier: identifier,
         );
 
+  /// Returns a shallow copy of this [FutureCallEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   FutureCallEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_entry.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'log_level.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Bindings to a log entry in the database.
 abstract class LogEntry implements _i1.SerializableModel {
@@ -93,6 +94,9 @@ abstract class LogEntry implements _i1.SerializableModel {
   /// The order of this log entry, used for sorting.
   int order;
 
+  /// Returns a shallow copy of this [LogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogEntry copyWith({
     int? id,
     int? sessionLogId,
@@ -158,6 +162,9 @@ class _LogEntryImpl extends LogEntry {
           order: order,
         );
 
+  /// Returns a shallow copy of this [LogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_result.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'log_entry.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A list of log entries, used to return logging data.
 abstract class LogResult implements _i1.SerializableModel {
@@ -28,6 +29,9 @@ abstract class LogResult implements _i1.SerializableModel {
   /// The log entries in this result.
   List<_i2.LogEntry> entries;
 
+  /// Returns a shallow copy of this [LogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogResult copyWith({List<_i2.LogEntry>? entries});
   @override
   Map<String, dynamic> toJson() {
@@ -44,6 +48,9 @@ class _LogResultImpl extends LogResult {
   _LogResultImpl({required List<_i2.LogEntry> entries})
       : super._(entries: entries);
 
+  /// Returns a shallow copy of this [LogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogResult copyWith({List<_i2.LogEntry>? entries}) {
     return LogResult(

--- a/packages/serverpod_service_client/lib/src/protocol/log_settings.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_settings.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'log_level.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Log settings for the server.
 abstract class LogSettings implements _i1.SerializableModel {
@@ -89,6 +90,9 @@ abstract class LogSettings implements _i1.SerializableModel {
   /// The duration in seconds for a query to be considered slow.
   double slowQueryDuration;
 
+  /// Returns a shallow copy of this [LogSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogSettings copyWith({
     _i2.LogLevel? logLevel,
     bool? logAllSessions,
@@ -148,6 +152,9 @@ class _LogSettingsImpl extends LogSettings {
           slowQueryDuration: slowQueryDuration,
         );
 
+  /// Returns a shallow copy of this [LogSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogSettings copyWith({
     _i2.LogLevel? logLevel,

--- a/packages/serverpod_service_client/lib/src/protocol/log_settings_override.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/log_settings_override.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'log_settings.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// Information about an override for log settings for either an entire
 /// endpoint or a specific method.
@@ -51,6 +52,9 @@ abstract class LogSettingsOverride implements _i1.SerializableModel {
   /// Log settings override.
   _i2.LogSettings logSettings;
 
+  /// Returns a shallow copy of this [LogSettingsOverride]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LogSettingsOverride copyWith({
     String? module,
     String? endpoint,
@@ -88,6 +92,9 @@ class _LogSettingsOverrideImpl extends LogSettingsOverride {
           logSettings: logSettings,
         );
 
+  /// Returns a shallow copy of this [LogSettingsOverride]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LogSettingsOverride copyWith({
     Object? module = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/message_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/message_log_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A log entry for a message sent in a streaming session.
 abstract class MessageLogEntry implements _i1.SerializableModel {
@@ -94,6 +95,9 @@ abstract class MessageLogEntry implements _i1.SerializableModel {
   /// Used for sorting the message log.
   int order;
 
+  /// Returns a shallow copy of this [MessageLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MessageLogEntry copyWith({
     int? id,
     int? sessionLogId,
@@ -159,6 +163,9 @@ class _MessageLogEntryImpl extends MessageLogEntry {
           order: order,
         );
 
+  /// Returns a shallow copy of this [MessageLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MessageLogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/method_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/method_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Information about a server method.
 abstract class MethodInfo implements _i1.SerializableModel {
@@ -44,6 +45,9 @@ abstract class MethodInfo implements _i1.SerializableModel {
   /// The name of this method.
   String method;
 
+  /// Returns a shallow copy of this [MethodInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MethodInfo copyWith({
     int? id,
     String? endpoint,
@@ -77,6 +81,9 @@ class _MethodInfoImpl extends MethodInfo {
           method: method,
         );
 
+  /// Returns a shallow copy of this [MethodInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MethodInfo copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/query_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/query_log_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// A log entry for a database query.
 abstract class QueryLogEntry implements _i1.SerializableModel {
@@ -94,6 +95,9 @@ abstract class QueryLogEntry implements _i1.SerializableModel {
   /// used for sorting the query log.
   int order;
 
+  /// Returns a shallow copy of this [QueryLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   QueryLogEntry copyWith({
     int? id,
     String? serverId,
@@ -159,6 +163,9 @@ class _QueryLogEntryImpl extends QueryLogEntry {
           order: order,
         );
 
+  /// Returns a shallow copy of this [QueryLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   QueryLogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/readwrite_test.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/readwrite_test.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Database mapping for a read/write test that is performed by the default
 /// health checks.
@@ -39,6 +40,9 @@ abstract class ReadWriteTestEntry implements _i1.SerializableModel {
   /// A random number, to verify that the write/read was performed correctly.
   int number;
 
+  /// Returns a shallow copy of this [ReadWriteTestEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ReadWriteTestEntry copyWith({
     int? id,
     int? number,
@@ -68,6 +72,9 @@ class _ReadWriteTestEntryImpl extends ReadWriteTestEntry {
           number: number,
         );
 
+  /// Returns a shallow copy of this [ReadWriteTestEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ReadWriteTestEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/runtime_settings.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'log_settings.dart' as _i2;
 import 'log_settings_override.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Runtime settings of the server.
 abstract class RuntimeSettings implements _i1.SerializableModel {
@@ -62,6 +63,9 @@ abstract class RuntimeSettings implements _i1.SerializableModel {
   /// True if malformed calls should be logged.
   bool logMalformedCalls;
 
+  /// Returns a shallow copy of this [RuntimeSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RuntimeSettings copyWith({
     int? id,
     _i2.LogSettings? logSettings,
@@ -104,6 +108,9 @@ class _RuntimeSettingsImpl extends RuntimeSettings {
           logMalformedCalls: logMalformedCalls,
         );
 
+  /// Returns a shallow copy of this [RuntimeSettings]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RuntimeSettings copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_connection_info.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a snapshot of the number of open connections the server currently
 /// is handling. An entry is written every minute for each server. All health
@@ -73,6 +74,9 @@ abstract class ServerHealthConnectionInfo implements _i1.SerializableModel {
   /// values are 60 minutes and 1440 minutes (one day).
   int granularity;
 
+  /// Returns a shallow copy of this [ServerHealthConnectionInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerHealthConnectionInfo copyWith({
     int? id,
     String? serverId,
@@ -122,6 +126,9 @@ class _ServerHealthConnectionInfoImpl extends ServerHealthConnectionInfo {
           granularity: granularity,
         );
 
+  /// Returns a shallow copy of this [ServerHealthConnectionInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerHealthConnectionInfo copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_metric.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Represents a snapshot of a specific health metric. An entry is written every
 /// minute for each server. All health data can be accessed through Serverpod
@@ -72,6 +73,9 @@ abstract class ServerHealthMetric implements _i1.SerializableModel {
   /// values are 60 minutes and 1440 minutes (one day).
   int granularity;
 
+  /// Returns a shallow copy of this [ServerHealthMetric]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerHealthMetric copyWith({
     int? id,
     String? name,
@@ -121,6 +125,9 @@ class _ServerHealthMetricImpl extends ServerHealthMetric {
           granularity: granularity,
         );
 
+  /// Returns a shallow copy of this [ServerHealthMetric]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerHealthMetric copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/server_health_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/server_health_result.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'server_health_metric.dart' as _i2;
 import 'server_health_connection_info.dart' as _i3;
+import 'package:meta/meta.dart';
 
 /// Information about health and connection metrics.
 abstract class ServerHealthResult implements _i1.SerializableModel {
@@ -44,6 +45,9 @@ abstract class ServerHealthResult implements _i1.SerializableModel {
   /// List of connection metrics.
   List<_i3.ServerHealthConnectionInfo> connectionInfos;
 
+  /// Returns a shallow copy of this [ServerHealthResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerHealthResult copyWith({
     List<_i2.ServerHealthMetric>? metrics,
     List<_i3.ServerHealthConnectionInfo>? connectionInfos,
@@ -71,6 +75,9 @@ class _ServerHealthResultImpl extends ServerHealthResult {
           connectionInfos: connectionInfos,
         );
 
+  /// Returns a shallow copy of this [ServerHealthResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerHealthResult copyWith({
     List<_i2.ServerHealthMetric>? metrics,

--- a/packages/serverpod_service_client/lib/src/protocol/serverpod_sql_exception.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/serverpod_sql_exception.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ServerpodSqlException
     implements _i1.SerializableException, _i1.SerializableModel {
@@ -35,6 +36,9 @@ abstract class ServerpodSqlException
 
   String sql;
 
+  /// Returns a shallow copy of this [ServerpodSqlException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerpodSqlException copyWith({
     String? message,
     String? sql,
@@ -62,6 +66,9 @@ class _ServerpodSqlExceptionImpl extends ServerpodSqlException {
           sql: sql,
         );
 
+  /// Returns a shallow copy of this [ServerpodSqlException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerpodSqlException copyWith({
     String? message,

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_entry.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Log entry for a session.
 abstract class SessionLogEntry implements _i1.SerializableModel {
@@ -114,6 +115,9 @@ abstract class SessionLogEntry implements _i1.SerializableModel {
   /// Timestamp of the last time this record was modified.
   DateTime touched;
 
+  /// Returns a shallow copy of this [SessionLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogEntry copyWith({
     int? id,
     String? serverId,
@@ -192,6 +196,9 @@ class _SessionLogEntryImpl extends SessionLogEntry {
           touched: touched,
         );
 
+  /// Returns a shallow copy of this [SessionLogEntry]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogEntry copyWith({
     Object? id = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_filter.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_filter.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// The log filter is used when searching for specific log entries.
 abstract class SessionLogFilter implements _i1.SerializableModel {
@@ -66,6 +67,9 @@ abstract class SessionLogFilter implements _i1.SerializableModel {
   /// Last session id to start the list of logs from. Used for pagination.
   int? lastSessionLogId;
 
+  /// Returns a shallow copy of this [SessionLogFilter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogFilter copyWith({
     String? endpoint,
     String? method,
@@ -115,6 +119,9 @@ class _SessionLogFilterImpl extends SessionLogFilter {
           lastSessionLogId: lastSessionLogId,
         );
 
+  /// Returns a shallow copy of this [SessionLogFilter]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogFilter copyWith({
     Object? endpoint = _Undefined,

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_info.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_info.dart
@@ -14,6 +14,7 @@ import 'session_log_entry.dart' as _i2;
 import 'query_log_entry.dart' as _i3;
 import 'log_entry.dart' as _i4;
 import 'message_log_entry.dart' as _i5;
+import 'package:meta/meta.dart';
 
 /// Compounded information about a session log.
 abstract class SessionLogInfo implements _i1.SerializableModel {
@@ -59,6 +60,9 @@ abstract class SessionLogInfo implements _i1.SerializableModel {
   /// List of messages sent during the session.
   List<_i5.MessageLogEntry> messages;
 
+  /// Returns a shallow copy of this [SessionLogInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogInfo copyWith({
     _i2.SessionLogEntry? sessionLogEntry,
     List<_i3.QueryLogEntry>? queries,
@@ -94,6 +98,9 @@ class _SessionLogInfoImpl extends SessionLogInfo {
           messages: messages,
         );
 
+  /// Returns a shallow copy of this [SessionLogInfo]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogInfo copyWith({
     _i2.SessionLogEntry? sessionLogEntry,

--- a/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/session_log_result.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'session_log_info.dart' as _i2;
+import 'package:meta/meta.dart';
 
 /// A list of SessionLogInfo.
 abstract class SessionLogResult implements _i1.SerializableModel {
@@ -30,6 +31,9 @@ abstract class SessionLogResult implements _i1.SerializableModel {
   /// The list of SessionLogInfo.
   List<_i2.SessionLogInfo> sessionLog;
 
+  /// Returns a shallow copy of this [SessionLogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog});
   @override
   Map<String, dynamic> toJson() {
@@ -46,6 +50,9 @@ class _SessionLogResultImpl extends SessionLogResult {
   _SessionLogResultImpl({required List<_i2.SessionLogInfo> sessionLog})
       : super._(sessionLog: sessionLog);
 
+  /// Returns a shallow copy of this [SessionLogResult]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SessionLogResult copyWith({List<_i2.SessionLogInfo>? sessionLog}) {
     return SessionLogResult(

--- a/templates/serverpod_templates/modulename_client/lib/src/protocol/module_class.dart
+++ b/templates/serverpod_templates/modulename_client/lib/src/protocol/module_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ModuleClass implements _i1.SerializableModel {
   ModuleClass._({
@@ -33,6 +34,9 @@ abstract class ModuleClass implements _i1.SerializableModel {
 
   int data;
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ModuleClass copyWith({
     String? name,
     int? data,
@@ -60,6 +64,9 @@ class _ModuleClassImpl extends ModuleClass {
           data: data,
         );
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ModuleClass copyWith({
     String? name,

--- a/templates/serverpod_templates/modulename_server/lib/src/generated/module_class.dart
+++ b/templates/serverpod_templates/modulename_server/lib/src/generated/module_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ModuleClass
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -34,6 +35,9 @@ abstract class ModuleClass
 
   int data;
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ModuleClass copyWith({
     String? name,
     int? data,
@@ -69,6 +73,9 @@ class _ModuleClassImpl extends ModuleClass {
           data: data,
         );
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ModuleClass copyWith({
     String? name,

--- a/templates/serverpod_templates/projectname_client/lib/src/protocol/example.dart
+++ b/templates/serverpod_templates/projectname_client/lib/src/protocol/example.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class Example implements _i1.SerializableModel {
   Example._({
@@ -33,6 +34,9 @@ abstract class Example implements _i1.SerializableModel {
 
   int data;
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Example copyWith({
     String? name,
     int? data,
@@ -60,6 +64,9 @@ class _ExampleImpl extends Example {
           data: data,
         );
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Example copyWith({
     String? name,

--- a/templates/serverpod_templates/projectname_server/lib/src/generated/example.dart
+++ b/templates/serverpod_templates/projectname_server/lib/src/generated/example.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class Example
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -34,6 +35,9 @@ abstract class Example
 
   int data;
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Example copyWith({
     String? name,
     int? data,
@@ -69,6 +73,9 @@ class _ExampleImpl extends Example {
           data: data,
         );
 
+  /// Returns a shallow copy of this [Example]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Example copyWith({
     String? name,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefault implements _i1.SerializableModel {
   BoolDefault._({
@@ -48,6 +49,9 @@ abstract class BoolDefault implements _i1.SerializableModel {
 
   bool? boolDefaultNullFalse;
 
+  /// Returns a shallow copy of this [BoolDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefault copyWith({
     int? id,
     bool? boolDefaultTrue,
@@ -86,6 +90,9 @@ class _BoolDefaultImpl extends BoolDefault {
           boolDefaultNullFalse: boolDefaultNullFalse,
         );
 
+  /// Returns a shallow copy of this [BoolDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefaultMix implements _i1.SerializableModel {
   BoolDefaultMix._({
@@ -52,6 +53,9 @@ abstract class BoolDefaultMix implements _i1.SerializableModel {
 
   bool boolDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [BoolDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefaultMix copyWith({
     int? id,
     bool? boolDefaultAndDefaultModel,
@@ -89,6 +93,9 @@ class _BoolDefaultMixImpl extends BoolDefaultMix {
           boolDefaultModelAndDefaultPersist: boolDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [BoolDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefaultModel implements _i1.SerializableModel {
   BoolDefaultModel._({
@@ -49,6 +50,9 @@ abstract class BoolDefaultModel implements _i1.SerializableModel {
 
   bool boolDefaultModelNullFalse;
 
+  /// Returns a shallow copy of this [BoolDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefaultModel copyWith({
     int? id,
     bool? boolDefaultModelTrue,
@@ -86,6 +90,9 @@ class _BoolDefaultModelImpl extends BoolDefaultModel {
           boolDefaultModelNullFalse: boolDefaultModelNullFalse,
         );
 
+  /// Returns a shallow copy of this [BoolDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/boolean/bool_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefaultPersist implements _i1.SerializableModel {
   BoolDefaultPersist._({
@@ -43,6 +44,9 @@ abstract class BoolDefaultPersist implements _i1.SerializableModel {
 
   bool? boolDefaultPersistFalse;
 
+  /// Returns a shallow copy of this [BoolDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefaultPersist copyWith({
     int? id,
     bool? boolDefaultPersistTrue,
@@ -78,6 +82,9 @@ class _BoolDefaultPersistImpl extends BoolDefaultPersist {
           boolDefaultPersistFalse: boolDefaultPersistFalse,
         );
 
+  /// Returns a shallow copy of this [BoolDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefault implements _i1.SerializableModel {
   DateTimeDefault._({
@@ -56,6 +57,9 @@ abstract class DateTimeDefault implements _i1.SerializableModel {
 
   DateTime? dateTimeDefaultStrNull;
 
+  /// Returns a shallow copy of this [DateTimeDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefault copyWith({
     int? id,
     DateTime? dateTimeDefaultNow,
@@ -94,6 +98,9 @@ class _DateTimeDefaultImpl extends DateTimeDefault {
           dateTimeDefaultStrNull: dateTimeDefaultStrNull,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefaultMix implements _i1.SerializableModel {
   DateTimeDefaultMix._({
@@ -55,6 +56,9 @@ abstract class DateTimeDefaultMix implements _i1.SerializableModel {
 
   DateTime dateTimeDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [DateTimeDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefaultMix copyWith({
     int? id,
     DateTime? dateTimeDefaultAndDefaultModel,
@@ -95,6 +99,9 @@ class _DateTimeDefaultMixImpl extends DateTimeDefaultMix {
               dateTimeDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefaultModel implements _i1.SerializableModel {
   DateTimeDefaultModel._({
@@ -57,6 +58,9 @@ abstract class DateTimeDefaultModel implements _i1.SerializableModel {
 
   DateTime? dateTimeDefaultModelStrNull;
 
+  /// Returns a shallow copy of this [DateTimeDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefaultModel copyWith({
     int? id,
     DateTime? dateTimeDefaultModelNow,
@@ -95,6 +99,9 @@ class _DateTimeDefaultModelImpl extends DateTimeDefaultModel {
           dateTimeDefaultModelStrNull: dateTimeDefaultModelStrNull,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/datetime/datetime_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefaultPersist implements _i1.SerializableModel {
   DateTimeDefaultPersist._({
@@ -50,6 +51,9 @@ abstract class DateTimeDefaultPersist implements _i1.SerializableModel {
 
   DateTime? dateTimeDefaultPersistStr;
 
+  /// Returns a shallow copy of this [DateTimeDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefaultPersist copyWith({
     int? id,
     DateTime? dateTimeDefaultPersistNow,
@@ -85,6 +89,9 @@ class _DateTimeDefaultPersistImpl extends DateTimeDefaultPersist {
           dateTimeDefaultPersistStr: dateTimeDefaultPersistStr,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefault implements _i1.SerializableModel {
   DoubleDefault._({
@@ -43,6 +44,9 @@ abstract class DoubleDefault implements _i1.SerializableModel {
 
   double? doubleDefaultNull;
 
+  /// Returns a shallow copy of this [DoubleDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefault copyWith({
     int? id,
     double? doubleDefault,
@@ -76,6 +80,9 @@ class _DoubleDefaultImpl extends DoubleDefault {
           doubleDefaultNull: doubleDefaultNull,
         );
 
+  /// Returns a shallow copy of this [DoubleDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefaultMix implements _i1.SerializableModel {
   DoubleDefaultMix._({
@@ -54,6 +55,9 @@ abstract class DoubleDefaultMix implements _i1.SerializableModel {
 
   double doubleDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [DoubleDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefaultMix copyWith({
     int? id,
     double? doubleDefaultAndDefaultModel,
@@ -93,6 +97,9 @@ class _DoubleDefaultMixImpl extends DoubleDefaultMix {
               doubleDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DoubleDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefaultModel implements _i1.SerializableModel {
   DoubleDefaultModel._({
@@ -44,6 +45,9 @@ abstract class DoubleDefaultModel implements _i1.SerializableModel {
 
   double doubleDefaultModelNull;
 
+  /// Returns a shallow copy of this [DoubleDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefaultModel copyWith({
     int? id,
     double? doubleDefaultModel,
@@ -77,6 +81,9 @@ class _DoubleDefaultModelImpl extends DoubleDefaultModel {
           doubleDefaultModelNull: doubleDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [DoubleDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/double/double_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefaultPersist implements _i1.SerializableModel {
   DoubleDefaultPersist._({
@@ -38,6 +39,9 @@ abstract class DoubleDefaultPersist implements _i1.SerializableModel {
 
   double? doubleDefaultPersist;
 
+  /// Returns a shallow copy of this [DoubleDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefaultPersist copyWith({
     int? id,
     double? doubleDefaultPersist,
@@ -68,6 +72,9 @@ class _DoubleDefaultPersistImpl extends DoubleDefaultPersist {
           doubleDefaultPersist: doubleDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DoubleDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefault implements _i1.SerializableModel {
   DurationDefault._({
@@ -60,6 +61,9 @@ abstract class DurationDefault implements _i1.SerializableModel {
 
   Duration? durationDefaultNull;
 
+  /// Returns a shallow copy of this [DurationDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefault copyWith({
     int? id,
     Duration? durationDefault,
@@ -94,6 +98,9 @@ class _DurationDefaultImpl extends DurationDefault {
           durationDefaultNull: durationDefaultNull,
         );
 
+  /// Returns a shallow copy of this [DurationDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefaultMix implements _i1.SerializableModel {
   DurationDefaultMix._({
@@ -73,6 +74,9 @@ abstract class DurationDefaultMix implements _i1.SerializableModel {
 
   Duration durationDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [DurationDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefaultMix copyWith({
     int? id,
     Duration? durationDefaultAndDefaultModel,
@@ -113,6 +117,9 @@ class _DurationDefaultMixImpl extends DurationDefaultMix {
               durationDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DurationDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefaultModel implements _i1.SerializableModel {
   DurationDefaultModel._({
@@ -62,6 +63,9 @@ abstract class DurationDefaultModel implements _i1.SerializableModel {
 
   Duration? durationDefaultModelNull;
 
+  /// Returns a shallow copy of this [DurationDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefaultModel copyWith({
     int? id,
     Duration? durationDefaultModel,
@@ -96,6 +100,9 @@ class _DurationDefaultModelImpl extends DurationDefaultModel {
           durationDefaultModelNull: durationDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [DurationDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/duration/duration_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefaultPersist implements _i1.SerializableModel {
   DurationDefaultPersist._({
@@ -41,6 +42,9 @@ abstract class DurationDefaultPersist implements _i1.SerializableModel {
 
   Duration? durationDefaultPersist;
 
+  /// Returns a shallow copy of this [DurationDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefaultPersist copyWith({
     int? id,
     Duration? durationDefaultPersist,
@@ -71,6 +75,9 @@ class _DurationDefaultPersistImpl extends DurationDefaultPersist {
           durationDefaultPersist: durationDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DurationDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import '../../defaults/enum/enums/by_index_enum.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefault implements _i1.SerializableModel {
   EnumDefault._({
@@ -66,6 +67,9 @@ abstract class EnumDefault implements _i1.SerializableModel {
 
   _i3.ByIndexEnum? byIndexEnumDefaultNull;
 
+  /// Returns a shallow copy of this [EnumDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefault copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefault,
@@ -109,6 +113,9 @@ class _EnumDefaultImpl extends EnumDefault {
           byIndexEnumDefaultNull: byIndexEnumDefaultNull,
         );
 
+  /// Returns a shallow copy of this [EnumDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default_mix.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefaultMix implements _i1.SerializableModel {
   EnumDefaultMix._({
@@ -56,6 +57,9 @@ abstract class EnumDefaultMix implements _i1.SerializableModel {
 
   _i2.ByNameEnum byNameEnumDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [EnumDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefaultMix copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultAndDefaultModel,
@@ -98,6 +102,9 @@ class _EnumDefaultMixImpl extends EnumDefaultMix {
               byNameEnumDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [EnumDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default_model.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import '../../defaults/enum/enums/by_index_enum.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefaultModel implements _i1.SerializableModel {
   EnumDefaultModel._({
@@ -70,6 +71,9 @@ abstract class EnumDefaultModel implements _i1.SerializableModel {
 
   _i3.ByIndexEnum? byIndexEnumDefaultModelNull;
 
+  /// Returns a shallow copy of this [EnumDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefaultModel copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultModel,
@@ -113,6 +117,9 @@ class _EnumDefaultModelImpl extends EnumDefaultModel {
           byIndexEnumDefaultModelNull: byIndexEnumDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [EnumDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enum_default_persist.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import '../../defaults/enum/enums/by_index_enum.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefaultPersist implements _i1.SerializableModel {
   EnumDefaultPersist._({
@@ -51,6 +52,9 @@ abstract class EnumDefaultPersist implements _i1.SerializableModel {
 
   _i3.ByIndexEnum? byIndexEnumDefaultPersist;
 
+  /// Returns a shallow copy of this [EnumDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefaultPersist copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultPersist,
@@ -86,6 +90,9 @@ class _EnumDefaultPersistImpl extends EnumDefaultPersist {
           byIndexEnumDefaultPersist: byIndexEnumDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [EnumDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/exception/default_exception.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/exception/default_exception.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import 'package:uuid/uuid.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class DefaultException
     implements _i1.SerializableException, _i1.SerializableModel {
@@ -96,6 +97,9 @@ abstract class DefaultException
 
   String defaultMixField;
 
+  /// Returns a shallow copy of this [DefaultException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DefaultException copyWith({
     bool? defaultBoolean,
     DateTime? defaultDateTime,
@@ -155,6 +159,9 @@ class _DefaultExceptionImpl extends DefaultException {
           defaultMixField: defaultMixField,
         );
 
+  /// Returns a shallow copy of this [DefaultException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DefaultException copyWith({
     bool? defaultBoolean,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefault implements _i1.SerializableModel {
   IntDefault._({
@@ -42,6 +43,9 @@ abstract class IntDefault implements _i1.SerializableModel {
 
   int? intDefaultNull;
 
+  /// Returns a shallow copy of this [IntDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefault copyWith({
     int? id,
     int? intDefault,
@@ -75,6 +79,9 @@ class _IntDefaultImpl extends IntDefault {
           intDefaultNull: intDefaultNull,
         );
 
+  /// Returns a shallow copy of this [IntDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefaultMix implements _i1.SerializableModel {
   IntDefaultMix._({
@@ -52,6 +53,9 @@ abstract class IntDefaultMix implements _i1.SerializableModel {
 
   int intDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [IntDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefaultMix copyWith({
     int? id,
     int? intDefaultAndDefaultModel,
@@ -89,6 +93,9 @@ class _IntDefaultMixImpl extends IntDefaultMix {
           intDefaultModelAndDefaultPersist: intDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [IntDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefaultModel implements _i1.SerializableModel {
   IntDefaultModel._({
@@ -42,6 +43,9 @@ abstract class IntDefaultModel implements _i1.SerializableModel {
 
   int intDefaultModelNull;
 
+  /// Returns a shallow copy of this [IntDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefaultModel copyWith({
     int? id,
     int? intDefaultModel,
@@ -75,6 +79,9 @@ class _IntDefaultModelImpl extends IntDefaultModel {
           intDefaultModelNull: intDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [IntDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/integer/int_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefaultPersist implements _i1.SerializableModel {
   IntDefaultPersist._({
@@ -36,6 +37,9 @@ abstract class IntDefaultPersist implements _i1.SerializableModel {
 
   int? intDefaultPersist;
 
+  /// Returns a shallow copy of this [IntDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefaultPersist copyWith({
     int? id,
     int? intDefaultPersist,
@@ -65,6 +69,9 @@ class _IntDefaultPersistImpl extends IntDefaultPersist {
           intDefaultPersist: intDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [IntDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefault implements _i1.SerializableModel {
   StringDefault._({
@@ -42,6 +43,9 @@ abstract class StringDefault implements _i1.SerializableModel {
 
   String? stringDefaultNull;
 
+  /// Returns a shallow copy of this [StringDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefault copyWith({
     int? id,
     String? stringDefault,
@@ -75,6 +79,9 @@ class _StringDefaultImpl extends StringDefault {
           stringDefaultNull: stringDefaultNull,
         );
 
+  /// Returns a shallow copy of this [StringDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefaultMix implements _i1.SerializableModel {
   StringDefaultMix._({
@@ -54,6 +55,9 @@ abstract class StringDefaultMix implements _i1.SerializableModel {
 
   String stringDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [StringDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefaultMix copyWith({
     int? id,
     String? stringDefaultAndDefaultModel,
@@ -93,6 +97,9 @@ class _StringDefaultMixImpl extends StringDefaultMix {
               stringDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [StringDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefaultModel implements _i1.SerializableModel {
   StringDefaultModel._({
@@ -45,6 +46,9 @@ abstract class StringDefaultModel implements _i1.SerializableModel {
 
   String stringDefaultModelNull;
 
+  /// Returns a shallow copy of this [StringDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefaultModel copyWith({
     int? id,
     String? stringDefaultModel,
@@ -78,6 +82,9 @@ class _StringDefaultModelImpl extends StringDefaultModel {
           stringDefaultModelNull: stringDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [StringDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/string/string_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefaultPersist implements _i1.SerializableModel {
   StringDefaultPersist._({
@@ -98,6 +99,9 @@ abstract class StringDefaultPersist implements _i1.SerializableModel {
 
   String? stringDefaultPersistDoubleQuoteWithTwoSingleQuote;
 
+  /// Returns a shallow copy of this [StringDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefaultPersist copyWith({
     int? id,
     String? stringDefaultPersist,
@@ -184,6 +188,9 @@ class _StringDefaultPersistImpl extends StringDefaultPersist {
               stringDefaultPersistDoubleQuoteWithTwoSingleQuote,
         );
 
+  /// Returns a shallow copy of this [StringDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefault implements _i1.SerializableModel {
   UuidDefault._({
@@ -65,6 +66,9 @@ abstract class UuidDefault implements _i1.SerializableModel {
 
   _i1.UuidValue? uuidDefaultStrNull;
 
+  /// Returns a shallow copy of this [UuidDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefault copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultRandom,
@@ -108,6 +112,9 @@ class _UuidDefaultImpl extends UuidDefault {
           uuidDefaultStrNull: uuidDefaultStrNull,
         );
 
+  /// Returns a shallow copy of this [UuidDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefaultMix implements _i1.SerializableModel {
   UuidDefaultMix._({
@@ -54,6 +55,9 @@ abstract class UuidDefaultMix implements _i1.SerializableModel {
 
   _i1.UuidValue uuidDefaultModelAndDefaultPersist;
 
+  /// Returns a shallow copy of this [UuidDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefaultMix copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultAndDefaultModel,
@@ -92,6 +96,9 @@ class _UuidDefaultMixImpl extends UuidDefaultMix {
           uuidDefaultModelAndDefaultPersist: uuidDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [UuidDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default_model.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefaultModel implements _i1.SerializableModel {
   UuidDefaultModel._({
@@ -68,6 +69,9 @@ abstract class UuidDefaultModel implements _i1.SerializableModel {
 
   _i1.UuidValue? uuidDefaultModelStrNull;
 
+  /// Returns a shallow copy of this [UuidDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefaultModel copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultModelRandom,
@@ -111,6 +115,9 @@ class _UuidDefaultModelImpl extends UuidDefaultModel {
           uuidDefaultModelStrNull: uuidDefaultModelStrNull,
         );
 
+  /// Returns a shallow copy of this [UuidDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/uuid/uuid_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefaultPersist implements _i1.SerializableModel {
   UuidDefaultPersist._({
@@ -48,6 +49,9 @@ abstract class UuidDefaultPersist implements _i1.SerializableModel {
 
   _i1.UuidValue? uuidDefaultPersistStr;
 
+  /// Returns a shallow copy of this [UuidDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefaultPersist copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultPersistRandom,
@@ -83,6 +87,9 @@ class _UuidDefaultPersistImpl extends UuidDefaultPersist {
           uuidDefaultPersistStr: uuidDefaultPersistStr,
         );
 
+  /// Returns a shallow copy of this [UuidDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/empty_model/empty_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/empty_model/empty_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class EmptyModel implements _i1.SerializableModel {
   EmptyModel._();
@@ -20,6 +21,9 @@ abstract class EmptyModel implements _i1.SerializableModel {
     return EmptyModel();
   }
 
+  /// Returns a shallow copy of this [EmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmptyModel copyWith();
   @override
   Map<String, dynamic> toJson() {
@@ -35,6 +39,9 @@ abstract class EmptyModel implements _i1.SerializableModel {
 class _EmptyModelImpl extends EmptyModel {
   _EmptyModelImpl() : super._();
 
+  /// Returns a shallow copy of this [EmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmptyModel copyWith() {
     return EmptyModel();

--- a/tests/serverpod_test_client/lib/src/protocol/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/empty_model/empty_model_relation_item.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class EmptyModelRelationItem implements _i1.SerializableModel {
   EmptyModelRelationItem._({
@@ -37,6 +38,9 @@ abstract class EmptyModelRelationItem implements _i1.SerializableModel {
 
   String name;
 
+  /// Returns a shallow copy of this [EmptyModelRelationItem]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmptyModelRelationItem copyWith({
     int? id,
     String? name,
@@ -66,6 +70,9 @@ class _EmptyModelRelationItemImpl extends EmptyModelRelationItem {
           name: name,
         );
 
+  /// Returns a shallow copy of this [EmptyModelRelationItem]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmptyModelRelationItem copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/empty_model/empty_model_with_table.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class EmptyModelWithTable implements _i1.SerializableModel {
   EmptyModelWithTable._({this.id});
@@ -25,6 +26,9 @@ abstract class EmptyModelWithTable implements _i1.SerializableModel {
   /// the id will be null.
   int? id;
 
+  /// Returns a shallow copy of this [EmptyModelWithTable]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmptyModelWithTable copyWith({int? id});
   @override
   Map<String, dynamic> toJson() {
@@ -42,6 +46,9 @@ class _Undefined {}
 class _EmptyModelWithTableImpl extends EmptyModelWithTable {
   _EmptyModelWithTableImpl({int? id}) : super._(id: id);
 
+  /// Returns a shallow copy of this [EmptyModelWithTable]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmptyModelWithTable copyWith({Object? id = _Undefined}) {
     return EmptyModelWithTable(id: id is int? ? id : this.id);

--- a/tests/serverpod_test_client/lib/src/protocol/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/empty_model/relation_empy_model.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../empty_model/empty_model_relation_item.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class RelationEmptyModel implements _i1.SerializableModel {
   RelationEmptyModel._({
@@ -40,6 +41,9 @@ abstract class RelationEmptyModel implements _i1.SerializableModel {
 
   List<_i2.EmptyModelRelationItem>? items;
 
+  /// Returns a shallow copy of this [RelationEmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RelationEmptyModel copyWith({
     int? id,
     List<_i2.EmptyModelRelationItem>? items,
@@ -69,6 +73,9 @@ class _RelationEmptyModelImpl extends RelationEmptyModel {
           items: items,
         );
 
+  /// Returns a shallow copy of this [RelationEmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RelationEmptyModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/exception_with_data.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ExceptionWithData
     implements _i1.SerializableException, _i1.SerializableModel {
@@ -47,6 +48,9 @@ abstract class ExceptionWithData
 
   int? someNullableField;
 
+  /// Returns a shallow copy of this [ExceptionWithData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ExceptionWithData copyWith({
     String? message,
     DateTime? creationDate,
@@ -84,6 +88,9 @@ class _ExceptionWithDataImpl extends ExceptionWithData {
           someNullableField: someNullableField,
         );
 
+  /// Returns a shallow copy of this [ExceptionWithData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ExceptionWithData copyWith({
     String? message,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/child_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/child_class.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod_client/serverpod_client.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ChildClass extends _i1.ParentClass
     implements _i2.SerializableModel {
@@ -39,7 +40,10 @@ abstract class ChildClass extends _i1.ParentClass
 
   int childField;
 
+  /// Returns a shallow copy of this [ChildClass]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   ChildClass copyWith({
     Object? id,
     String? grandParentField,
@@ -77,6 +81,9 @@ class _ChildClassImpl extends ChildClass {
           childField: childField,
         );
 
+  /// Returns a shallow copy of this [ChildClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChildClass copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/child_with_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/child_with_default.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod_client/serverpod_client.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ChildWithDefault extends _i1.ParentWithDefault
     implements _i2.SerializableModel {
@@ -41,7 +42,10 @@ abstract class ChildWithDefault extends _i1.ParentWithDefault
 
   int childDefault;
 
+  /// Returns a shallow copy of this [ChildWithDefault]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   ChildWithDefault copyWith({
     String? name,
     int? parentDefault,
@@ -77,6 +81,9 @@ class _ChildWithDefaultImpl extends ChildWithDefault {
           childDefault: childDefault,
         );
 
+  /// Returns a shallow copy of this [ChildWithDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChildWithDefault copyWith({
     String? name,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/grandparent_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/grandparent_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 class GrandparentClass implements _i1.SerializableModel {
   GrandparentClass({required this.grandParentField});
@@ -21,6 +22,9 @@ class GrandparentClass implements _i1.SerializableModel {
 
   String grandParentField;
 
+  /// Returns a shallow copy of this [GrandparentClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   GrandparentClass copyWith({String? grandParentField}) {
     return GrandparentClass(
         grandParentField: grandParentField ?? this.grandParentField);

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/parent_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/parent_class.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod_client/serverpod_client.dart' as _i2;
+import 'package:meta/meta.dart';
 
 class ParentClass extends _i1.GrandparentClass
     implements _i2.SerializableModel {
@@ -35,6 +36,9 @@ class ParentClass extends _i1.GrandparentClass
 
   String parentField;
 
+  /// Returns a shallow copy of this [ParentClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ParentClass copyWith({
     Object? id = _Undefined,
     String? grandParentField,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/parent_with_default.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/parent_with_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 class ParentWithDefault implements _i1.SerializableModel {
   ParentWithDefault({
@@ -28,6 +29,9 @@ class ParentWithDefault implements _i1.SerializableModel {
 
   int parentDefault;
 
+  /// Returns a shallow copy of this [ParentWithDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ParentWithDefault copyWith({
     String? name,
     int? parentDefault,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_child.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_child.dart
@@ -27,6 +27,9 @@ class SealedChild extends _i1.SealedParent implements _i2.SerializableModel {
 
   int? nullableInt;
 
+  /// Returns a shallow copy of this [SealedChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SealedChild copyWith({
     int? sealedInt,
     String? sealedString,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_grandchild.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_grandchild.dart
@@ -38,7 +38,10 @@ abstract class SealedGrandChild extends _i1.SealedChild
 
   String sealedGrandchildField;
 
+  /// Returns a shallow copy of this [SealedGrandChild]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   SealedGrandChild copyWith({
     int? sealedInt,
     String? sealedString,
@@ -74,6 +77,9 @@ class _SealedGrandChildImpl extends SealedGrandChild {
           sealedGrandchildField: sealedGrandchildField,
         );
 
+  /// Returns a shallow copy of this [SealedGrandChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SealedGrandChild copyWith({
     int? sealedInt,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_other_child.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_other_child.dart
@@ -34,6 +34,9 @@ abstract class SealedOtherChild extends _i1.SealedParent
 
   int sealedOtherChildField;
 
+  /// Returns a shallow copy of this [SealedOtherChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SealedOtherChild copyWith({
     int? sealedInt,
     String? sealedString,
@@ -65,6 +68,9 @@ class _SealedOtherChildImpl extends SealedOtherChild {
           sealedOtherChildField: sealedOtherChildField,
         );
 
+  /// Returns a shallow copy of this [SealedOtherChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SealedOtherChild copyWith({
     int? sealedInt,

--- a/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_parent.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/inheritance/sealed_parent.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod_client/serverpod_client.dart' as _i2;
+import 'package:meta/meta.dart';
 part 'sealed_child.dart';
 part 'sealed_grandchild.dart';
 part 'sealed_other_child.dart';

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -14,6 +14,7 @@ import '../../long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i2;
 import '../../long_identifiers/deep_includes/organization_with_long_table_name.dart'
     as _i3;
+import 'package:meta/meta.dart';
 
 abstract class CityWithLongTableName implements _i1.SerializableModel {
   CityWithLongTableName._({
@@ -57,6 +58,9 @@ abstract class CityWithLongTableName implements _i1.SerializableModel {
 
   List<_i3.OrganizationWithLongTableName>? organizations;
 
+  /// Returns a shallow copy of this [CityWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CityWithLongTableName copyWith({
     int? id,
     String? name,
@@ -96,6 +100,9 @@ class _CityWithLongTableNameImpl extends CityWithLongTableName {
           organizations: organizations,
         );
 
+  /// Returns a shallow copy of this [CityWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CityWithLongTableName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -14,6 +14,7 @@ import '../../long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i2;
 import '../../long_identifiers/deep_includes/city_with_long_table_name.dart'
     as _i3;
+import 'package:meta/meta.dart';
 
 abstract class OrganizationWithLongTableName implements _i1.SerializableModel {
   OrganizationWithLongTableName._({
@@ -62,6 +63,9 @@ abstract class OrganizationWithLongTableName implements _i1.SerializableModel {
 
   _i3.CityWithLongTableName? city;
 
+  /// Returns a shallow copy of this [OrganizationWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   OrganizationWithLongTableName copyWith({
     int? id,
     String? name,
@@ -104,6 +108,9 @@ class _OrganizationWithLongTableNameImpl extends OrganizationWithLongTableName {
           city: city,
         );
 
+  /// Returns a shallow copy of this [OrganizationWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   OrganizationWithLongTableName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../long_identifiers/deep_includes/organization_with_long_table_name.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class PersonWithLongTableName implements _i1.SerializableModel {
   PersonWithLongTableName._({
@@ -52,6 +53,9 @@ abstract class PersonWithLongTableName implements _i1.SerializableModel {
 
   _i2.OrganizationWithLongTableName? organization;
 
+  /// Returns a shallow copy of this [PersonWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   PersonWithLongTableName copyWith({
     int? id,
     String? name,
@@ -89,6 +93,9 @@ class _PersonWithLongTableNameImpl extends PersonWithLongTableName {
           organization: organization,
         );
 
+  /// Returns a shallow copy of this [PersonWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   PersonWithLongTableName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/max_field_name.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MaxFieldName implements _i1.SerializableModel {
   MaxFieldName._({
@@ -40,6 +41,9 @@ abstract class MaxFieldName implements _i1.SerializableModel {
 
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo;
 
+  /// Returns a shallow copy of this [MaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MaxFieldName copyWith({
     int? id,
     String? thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo,
@@ -72,6 +76,9 @@ class _MaxFieldNameImpl extends MaxFieldName {
               thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo,
         );
 
+  /// Returns a shallow copy of this [MaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MaxFieldName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class LongImplicitIdField implements _i1.SerializableModel {
   LongImplicitIdField._({
@@ -36,6 +37,9 @@ abstract class LongImplicitIdField implements _i1.SerializableModel {
 
   String name;
 
+  /// Returns a shallow copy of this [LongImplicitIdField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LongImplicitIdField copyWith({
     int? id,
     String? name,
@@ -65,6 +69,9 @@ class _LongImplicitIdFieldImpl extends LongImplicitIdField {
           name: name,
         );
 
+  /// Returns a shallow copy of this [LongImplicitIdField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LongImplicitIdField copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../long_identifiers/models_with_relations/long_implicit_id_field.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class LongImplicitIdFieldCollection implements _i1.SerializableModel {
   LongImplicitIdFieldCollection._({
@@ -52,6 +53,9 @@ abstract class LongImplicitIdFieldCollection implements _i1.SerializableModel {
   List<_i2.LongImplicitIdField>?
       thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa;
 
+  /// Returns a shallow copy of this [LongImplicitIdFieldCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LongImplicitIdFieldCollection copyWith({
     int? id,
     String? name,
@@ -91,6 +95,9 @@ class _LongImplicitIdFieldCollectionImpl extends LongImplicitIdFieldCollection {
               thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa,
         );
 
+  /// Returns a shallow copy of this [LongImplicitIdFieldCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LongImplicitIdFieldCollection copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../long_identifiers/multiple_max_field_name.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class RelationToMultipleMaxFieldName implements _i1.SerializableModel {
   RelationToMultipleMaxFieldName._({
@@ -47,6 +48,9 @@ abstract class RelationToMultipleMaxFieldName implements _i1.SerializableModel {
 
   List<_i2.MultipleMaxFieldName>? multipleMaxFieldNames;
 
+  /// Returns a shallow copy of this [RelationToMultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RelationToMultipleMaxFieldName copyWith({
     int? id,
     String? name,
@@ -83,6 +87,9 @@ class _RelationToMultipleMaxFieldNameImpl
           multipleMaxFieldNames: multipleMaxFieldNames,
         );
 
+  /// Returns a shallow copy of this [RelationToMultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RelationToMultipleMaxFieldName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UserNote implements _i1.SerializableModel {
   UserNote._({
@@ -36,6 +37,9 @@ abstract class UserNote implements _i1.SerializableModel {
 
   String name;
 
+  /// Returns a shallow copy of this [UserNote]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNote copyWith({
     int? id,
     String? name,
@@ -65,6 +69,9 @@ class _UserNoteImpl extends UserNote {
           name: name,
         );
 
+  /// Returns a shallow copy of this [UserNote]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNote copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../long_identifiers/models_with_relations/user_note.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UserNoteCollection implements _i1.SerializableModel {
   UserNoteCollection._({
@@ -45,6 +46,9 @@ abstract class UserNoteCollection implements _i1.SerializableModel {
 
   List<_i2.UserNote>? userNotesPropertyName;
 
+  /// Returns a shallow copy of this [UserNoteCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNoteCollection copyWith({
     int? id,
     String? name,
@@ -80,6 +84,9 @@ class _UserNoteCollectionImpl extends UserNoteCollection {
           userNotesPropertyName: userNotesPropertyName,
         );
 
+  /// Returns a shallow copy of this [UserNoteCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNoteCollection copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UserNoteCollectionWithALongName
     implements _i1.SerializableModel {
@@ -48,6 +49,9 @@ abstract class UserNoteCollectionWithALongName
 
   List<_i2.UserNoteWithALongName>? notes;
 
+  /// Returns a shallow copy of this [UserNoteCollectionWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNoteCollectionWithALongName copyWith({
     int? id,
     String? name,
@@ -82,6 +86,9 @@ class _UserNoteCollectionWithALongNameImpl
           notes: notes,
         );
 
+  /// Returns a shallow copy of this [UserNoteCollectionWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNoteCollectionWithALongName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UserNoteWithALongName implements _i1.SerializableModel {
   UserNoteWithALongName._({
@@ -37,6 +38,9 @@ abstract class UserNoteWithALongName implements _i1.SerializableModel {
 
   String name;
 
+  /// Returns a shallow copy of this [UserNoteWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNoteWithALongName copyWith({
     int? id,
     String? name,
@@ -66,6 +70,9 @@ class _UserNoteWithALongNameImpl extends UserNoteWithALongName {
           name: name,
         );
 
+  /// Returns a shallow copy of this [UserNoteWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNoteWithALongName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/long_identifiers/multiple_max_field_name.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MultipleMaxFieldName implements _i1.SerializableModel {
   MultipleMaxFieldName._({
@@ -50,6 +51,9 @@ abstract class MultipleMaxFieldName implements _i1.SerializableModel {
 
   String thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2;
 
+  /// Returns a shallow copy of this [MultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MultipleMaxFieldName copyWith({
     int? id,
     String? thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1,
@@ -89,6 +93,9 @@ class _MultipleMaxFieldNameImpl extends MultipleMaxFieldName {
               thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2,
         );
 
+  /// Returns a shallow copy of this [MultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MultipleMaxFieldName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/city.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../models_with_list_relations/person.dart' as _i2;
 import '../models_with_list_relations/organization.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class City implements _i1.SerializableModel {
   City._({
@@ -52,6 +53,9 @@ abstract class City implements _i1.SerializableModel {
 
   List<_i3.Organization>? organizations;
 
+  /// Returns a shallow copy of this [City]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   City copyWith({
     int? id,
     String? name,
@@ -91,6 +95,9 @@ class _CityImpl extends City {
           organizations: organizations,
         );
 
+  /// Returns a shallow copy of this [City]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   City copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/organization.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../models_with_list_relations/person.dart' as _i2;
 import '../models_with_list_relations/city.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Organization implements _i1.SerializableModel {
   Organization._({
@@ -58,6 +59,9 @@ abstract class Organization implements _i1.SerializableModel {
 
   _i3.City? city;
 
+  /// Returns a shallow copy of this [Organization]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Organization copyWith({
     int? id,
     String? name,
@@ -100,6 +104,9 @@ class _OrganizationImpl extends Organization {
           city: city,
         );
 
+  /// Returns a shallow copy of this [Organization]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Organization copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_list_relations/person.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../models_with_list_relations/organization.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Person implements _i1.SerializableModel {
   Person._({
@@ -50,6 +51,9 @@ abstract class Person implements _i1.SerializableModel {
 
   _i2.Organization? organization;
 
+  /// Returns a shallow copy of this [Person]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Person copyWith({
     int? id,
     String? name,
@@ -87,6 +91,9 @@ class _PersonImpl extends Person {
           organization: organization,
         );
 
+  /// Returns a shallow copy of this [Person]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Person copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/many_to_many/enrollment.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Course implements _i1.SerializableModel {
   Course._({
@@ -44,6 +45,9 @@ abstract class Course implements _i1.SerializableModel {
 
   List<_i2.Enrollment>? enrollments;
 
+  /// Returns a shallow copy of this [Course]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Course copyWith({
     int? id,
     String? name,
@@ -78,6 +82,9 @@ class _CourseImpl extends Course {
           enrollments: enrollments,
         );
 
+  /// Returns a shallow copy of this [Course]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Course copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/many_to_many/student.dart' as _i2;
 import '../../models_with_relations/many_to_many/course.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Enrollment implements _i1.SerializableModel {
   Enrollment._({
@@ -59,6 +60,9 @@ abstract class Enrollment implements _i1.SerializableModel {
 
   _i3.Course? course;
 
+  /// Returns a shallow copy of this [Enrollment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Enrollment copyWith({
     int? id,
     int? studentId,
@@ -100,6 +104,9 @@ class _EnrollmentImpl extends Enrollment {
           course: course,
         );
 
+  /// Returns a shallow copy of this [Enrollment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Enrollment copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/many_to_many/enrollment.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Student implements _i1.SerializableModel {
   Student._({
@@ -44,6 +45,9 @@ abstract class Student implements _i1.SerializableModel {
 
   List<_i2.Enrollment>? enrollments;
 
+  /// Returns a shallow copy of this [Student]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Student copyWith({
     int? id,
     String? name,
@@ -78,6 +82,9 @@ class _StudentImpl extends Student {
           enrollments: enrollments,
         );
 
+  /// Returns a shallow copy of this [Student]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Student copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/module/object_user.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectUser implements _i1.SerializableModel {
   ObjectUser._({
@@ -50,6 +51,9 @@ abstract class ObjectUser implements _i1.SerializableModel {
 
   _i2.UserInfo? userInfo;
 
+  /// Returns a shallow copy of this [ObjectUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectUser copyWith({
     int? id,
     String? name,
@@ -87,6 +91,9 @@ class _ObjectUserImpl extends ObjectUser {
           userInfo: userInfo,
         );
 
+  /// Returns a shallow copy of this [ObjectUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectUser copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/module/parent_user.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ParentUser implements _i1.SerializableModel {
   ParentUser._({
@@ -41,6 +42,9 @@ abstract class ParentUser implements _i1.SerializableModel {
 
   int? userInfoId;
 
+  /// Returns a shallow copy of this [ParentUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ParentUser copyWith({
     int? id,
     String? name,
@@ -74,6 +78,9 @@ class _ParentUserImpl extends ParentUser {
           userInfoId: userInfoId,
         );
 
+  /// Returns a shallow copy of this [ParentUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ParentUser copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/nested_one_to_many/team.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Arena implements _i1.SerializableModel {
   Arena._({
@@ -45,6 +46,9 @@ abstract class Arena implements _i1.SerializableModel {
 
   _i2.Team? team;
 
+  /// Returns a shallow copy of this [Arena]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Arena copyWith({
     int? id,
     String? name,
@@ -78,6 +82,9 @@ class _ArenaImpl extends Arena {
           team: team,
         );
 
+  /// Returns a shallow copy of this [Arena]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Arena copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/nested_one_to_many/team.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Player implements _i1.SerializableModel {
   Player._({
@@ -50,6 +51,9 @@ abstract class Player implements _i1.SerializableModel {
 
   _i2.Team? team;
 
+  /// Returns a shallow copy of this [Player]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Player copyWith({
     int? id,
     String? name,
@@ -87,6 +91,9 @@ class _PlayerImpl extends Player {
           team: team,
         );
 
+  /// Returns a shallow copy of this [Player]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Player copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/nested_one_to_many/arena.dart' as _i2;
 import '../../models_with_relations/nested_one_to_many/player.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Team implements _i1.SerializableModel {
   Team._({
@@ -58,6 +59,9 @@ abstract class Team implements _i1.SerializableModel {
 
   List<_i3.Player>? players;
 
+  /// Returns a shallow copy of this [Team]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Team copyWith({
     int? id,
     String? name,
@@ -100,6 +104,9 @@ class _TeamImpl extends Team {
           players: players,
         );
 
+  /// Returns a shallow copy of this [Team]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Team copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/one_to_many/order.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Comment implements _i1.SerializableModel {
   Comment._({
@@ -50,6 +51,9 @@ abstract class Comment implements _i1.SerializableModel {
 
   _i2.Order? order;
 
+  /// Returns a shallow copy of this [Comment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Comment copyWith({
     int? id,
     String? description,
@@ -87,6 +91,9 @@ class _CommentImpl extends Comment {
           order: order,
         );
 
+  /// Returns a shallow copy of this [Comment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Comment copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/one_to_many/order.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Customer implements _i1.SerializableModel {
   Customer._({
@@ -44,6 +45,9 @@ abstract class Customer implements _i1.SerializableModel {
 
   List<_i2.Order>? orders;
 
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Customer copyWith({
     int? id,
     String? name,
@@ -78,6 +82,9 @@ class _CustomerImpl extends Customer {
           orders: orders,
         );
 
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Customer copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/one_to_many/customer.dart' as _i2;
 import '../../models_with_relations/one_to_many/comment.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Order implements _i1.SerializableModel {
   Order._({
@@ -58,6 +59,9 @@ abstract class Order implements _i1.SerializableModel {
 
   List<_i3.Comment>? comments;
 
+  /// Returns a shallow copy of this [Order]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Order copyWith({
     int? id,
     String? description,
@@ -100,6 +104,9 @@ class _OrderImpl extends Order {
           comments: comments,
         );
 
+  /// Returns a shallow copy of this [Order]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Order copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/one_to_one/citizen.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Address implements _i1.SerializableModel {
   Address._({
@@ -50,6 +51,9 @@ abstract class Address implements _i1.SerializableModel {
 
   _i2.Citizen? inhabitant;
 
+  /// Returns a shallow copy of this [Address]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Address copyWith({
     int? id,
     String? street,
@@ -87,6 +91,9 @@ class _AddressImpl extends Address {
           inhabitant: inhabitant,
         );
 
+  /// Returns a shallow copy of this [Address]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Address copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/one_to_one/address.dart' as _i2;
 import '../../models_with_relations/one_to_one/company.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Citizen implements _i1.SerializableModel {
   Citizen._({
@@ -72,6 +73,9 @@ abstract class Citizen implements _i1.SerializableModel {
 
   _i3.Company? oldCompany;
 
+  /// Returns a shallow copy of this [Citizen]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Citizen copyWith({
     int? id,
     String? name,
@@ -121,6 +125,9 @@ class _CitizenImpl extends Citizen {
           oldCompany: oldCompany,
         );
 
+  /// Returns a shallow copy of this [Citizen]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Citizen copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/one_to_one/town.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Company implements _i1.SerializableModel {
   Company._({
@@ -50,6 +51,9 @@ abstract class Company implements _i1.SerializableModel {
 
   _i2.Town? town;
 
+  /// Returns a shallow copy of this [Company]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Company copyWith({
     int? id,
     String? name,
@@ -87,6 +91,9 @@ class _CompanyImpl extends Company {
           town: town,
         );
 
+  /// Returns a shallow copy of this [Company]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Company copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../models_with_relations/one_to_one/citizen.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Town implements _i1.SerializableModel {
   Town._({
@@ -50,6 +51,9 @@ abstract class Town implements _i1.SerializableModel {
 
   _i2.Citizen? mayor;
 
+  /// Returns a shallow copy of this [Town]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Town copyWith({
     int? id,
     String? name,
@@ -87,6 +91,9 @@ class _TownImpl extends Town {
           mayor: mayor,
         );
 
+  /// Returns a shallow copy of this [Town]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Town copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../models_with_relations/self_relation/many_to_many/member.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Blocking implements _i1.SerializableModel {
   Blocking._({
@@ -59,6 +60,9 @@ abstract class Blocking implements _i1.SerializableModel {
 
   _i2.Member? blockedBy;
 
+  /// Returns a shallow copy of this [Blocking]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Blocking copyWith({
     int? id,
     int? blockedId,
@@ -100,6 +104,9 @@ class _BlockingImpl extends Blocking {
           blockedBy: blockedBy,
         );
 
+  /// Returns a shallow copy of this [Blocking]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Blocking copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../models_with_relations/self_relation/many_to_many/blocking.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Member implements _i1.SerializableModel {
   Member._({
@@ -52,6 +53,9 @@ abstract class Member implements _i1.SerializableModel {
 
   List<_i2.Blocking>? blockedBy;
 
+  /// Returns a shallow copy of this [Member]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Member copyWith({
     int? id,
     String? name,
@@ -91,6 +95,9 @@ class _MemberImpl extends Member {
           blockedBy: blockedBy,
         );
 
+  /// Returns a shallow copy of this [Member]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Member copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../models_with_relations/self_relation/one_to_many/cat.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Cat implements _i1.SerializableModel {
   Cat._({
@@ -58,6 +59,9 @@ abstract class Cat implements _i1.SerializableModel {
 
   List<_i2.Cat>? kittens;
 
+  /// Returns a shallow copy of this [Cat]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Cat copyWith({
     int? id,
     String? name,
@@ -100,6 +104,9 @@ class _CatImpl extends Cat {
           kittens: kittens,
         );
 
+  /// Returns a shallow copy of this [Cat]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Cat copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../../../models_with_relations/self_relation/one_to_one/post.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Post implements _i1.SerializableModel {
   Post._({
@@ -59,6 +60,9 @@ abstract class Post implements _i1.SerializableModel {
 
   _i2.Post? next;
 
+  /// Returns a shallow copy of this [Post]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Post copyWith({
     int? id,
     String? content,
@@ -100,6 +104,9 @@ class _PostImpl extends Post {
           next: next,
         );
 
+  /// Returns a shallow copy of this [Post]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Post copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/module_datatype.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/module_datatype.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ModuleDatatype implements _i1.SerializableModel {
   ModuleDatatype._({
@@ -46,6 +47,9 @@ abstract class ModuleDatatype implements _i1.SerializableModel {
 
   Map<String, _i2.ModuleClass> map;
 
+  /// Returns a shallow copy of this [ModuleDatatype]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ModuleDatatype copyWith({
     _i2.ModuleClass? model,
     List<_i2.ModuleClass>? list,
@@ -77,6 +81,9 @@ class _ModuleDatatypeImpl extends ModuleDatatype {
           map: map,
         );
 
+  /// Returns a shallow copy of this [ModuleDatatype]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ModuleDatatype copyWith({
     _i2.ModuleClass? model,

--- a/tests/serverpod_test_client/lib/src/protocol/my_feature/models/my_feature_model.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/my_feature/models/my_feature_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MyFeatureModel implements _i1.SerializableModel {
   MyFeatureModel._({required this.name});
@@ -22,6 +23,9 @@ abstract class MyFeatureModel implements _i1.SerializableModel {
 
   String name;
 
+  /// Returns a shallow copy of this [MyFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MyFeatureModel copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
@@ -37,6 +41,9 @@ abstract class MyFeatureModel implements _i1.SerializableModel {
 class _MyFeatureModelImpl extends MyFeatureModel {
   _MyFeatureModelImpl({required String name}) : super._(name: name);
 
+  /// Returns a shallow copy of this [MyFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MyFeatureModel copyWith({String? name}) {
     return MyFeatureModel(name: name ?? this.name);

--- a/tests/serverpod_test_client/lib/src/protocol/nullability.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/nullability.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'simple_data.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Nullability implements _i1.SerializableModel {
   Nullability._({
@@ -359,6 +360,9 @@ abstract class Nullability implements _i1.SerializableModel {
 
   Map<String, int?>? aNullableMapWithNullableInts;
 
+  /// Returns a shallow copy of this [Nullability]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Nullability copyWith({
     int? anInt,
     int? aNullableInt,
@@ -599,6 +603,9 @@ class _NullabilityImpl extends Nullability {
           aNullableMapWithNullableInts: aNullableMapWithNullableInts,
         );
 
+  /// Returns a shallow copy of this [Nullability]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Nullability copyWith({
     int? anInt,

--- a/tests/serverpod_test_client/lib/src/protocol/object_field_persist.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_field_persist.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectFieldPersist implements _i1.SerializableModel {
   ObjectFieldPersist._({
@@ -50,6 +51,9 @@ abstract class ObjectFieldPersist implements _i1.SerializableModel {
 
   _i2.SimpleData? data;
 
+  /// Returns a shallow copy of this [ObjectFieldPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectFieldPersist copyWith({
     int? id,
     String? normal,
@@ -87,6 +91,9 @@ class _ObjectFieldPersistImpl extends ObjectFieldPersist {
           data: data,
         );
 
+  /// Returns a shallow copy of this [ObjectFieldPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectFieldPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_field_scopes.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectFieldScopes implements _i1.SerializableModel {
   ObjectFieldScopes._({
@@ -41,6 +42,9 @@ abstract class ObjectFieldScopes implements _i1.SerializableModel {
 
   String? api;
 
+  /// Returns a shallow copy of this [ObjectFieldScopes]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectFieldScopes copyWith({
     int? id,
     String? normal,
@@ -74,6 +78,9 @@ class _ObjectFieldScopesImpl extends ObjectFieldScopes {
           api: api,
         );
 
+  /// Returns a shallow copy of this [ObjectFieldScopes]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectFieldScopes copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_bytedata.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithByteData implements _i1.SerializableModel {
   ObjectWithByteData._({
@@ -38,6 +39,9 @@ abstract class ObjectWithByteData implements _i1.SerializableModel {
 
   _i2.ByteData byteData;
 
+  /// Returns a shallow copy of this [ObjectWithByteData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithByteData copyWith({
     int? id,
     _i2.ByteData? byteData,
@@ -67,6 +71,9 @@ class _ObjectWithByteDataImpl extends ObjectWithByteData {
           byteData: byteData,
         );
 
+  /// Returns a shallow copy of this [ObjectWithByteData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithByteData copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_custom_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_custom_class.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithCustomClass implements _i1.SerializableModel {
   ObjectWithCustomClass._({
@@ -51,6 +52,9 @@ abstract class ObjectWithCustomClass implements _i1.SerializableModel {
   _i2.CustomClassWithProtocolSerializationMethod
       customClassWithProtocolSerializationMethod;
 
+  /// Returns a shallow copy of this [ObjectWithCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithCustomClass copyWith({
     _i2.CustomClassWithoutProtocolSerialization?
         customClassWithoutProtocolSerialization,
@@ -94,6 +98,9 @@ class _ObjectWithCustomClassImpl extends ObjectWithCustomClass {
               customClassWithProtocolSerializationMethod,
         );
 
+  /// Returns a shallow copy of this [ObjectWithCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithCustomClass copyWith({
     _i2.CustomClassWithoutProtocolSerialization?

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_duration.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithDuration implements _i1.SerializableModel {
   ObjectWithDuration._({
@@ -37,6 +38,9 @@ abstract class ObjectWithDuration implements _i1.SerializableModel {
 
   Duration duration;
 
+  /// Returns a shallow copy of this [ObjectWithDuration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithDuration copyWith({
     int? id,
     Duration? duration,
@@ -66,6 +70,9 @@ class _ObjectWithDurationImpl extends ObjectWithDuration {
           duration: duration,
         );
 
+  /// Returns a shallow copy of this [ObjectWithDuration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithDuration copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_enum.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'test_enum.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithEnum implements _i1.SerializableModel {
   ObjectWithEnum._({
@@ -67,6 +68,9 @@ abstract class ObjectWithEnum implements _i1.SerializableModel {
 
   List<List<_i2.TestEnum>> enumListList;
 
+  /// Returns a shallow copy of this [ObjectWithEnum]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithEnum copyWith({
     int? id,
     _i2.TestEnum? testEnum,
@@ -114,6 +118,9 @@ class _ObjectWithEnumImpl extends ObjectWithEnum {
           enumListList: enumListList,
         );
 
+  /// Returns a shallow copy of this [ObjectWithEnum]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithEnum copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_index.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_index.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithIndex implements _i1.SerializableModel {
   ObjectWithIndex._({
@@ -41,6 +42,9 @@ abstract class ObjectWithIndex implements _i1.SerializableModel {
 
   int indexed2;
 
+  /// Returns a shallow copy of this [ObjectWithIndex]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithIndex copyWith({
     int? id,
     int? indexed,
@@ -74,6 +78,9 @@ class _ObjectWithIndexImpl extends ObjectWithIndex {
           indexed2: indexed2,
         );
 
+  /// Returns a shallow copy of this [ObjectWithIndex]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithIndex copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_maps.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'simple_data.dart' as _i2;
 import 'dart:typed_data' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithMaps implements _i1.SerializableModel {
   ObjectWithMaps._({
@@ -155,6 +156,9 @@ abstract class ObjectWithMaps implements _i1.SerializableModel {
 
   Map<int, int> intIntMap;
 
+  /// Returns a shallow copy of this [ObjectWithMaps]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithMaps copyWith({
     Map<String, _i2.SimpleData>? dataMap,
     Map<String, int>? intMap,
@@ -239,6 +243,9 @@ class _ObjectWithMapsImpl extends ObjectWithMaps {
           intIntMap: intIntMap,
         );
 
+  /// Returns a shallow copy of this [ObjectWithMaps]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithMaps copyWith({
     Map<String, _i2.SimpleData>? dataMap,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_object.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithObject implements _i1.SerializableModel {
   ObjectWithObject._({
@@ -122,6 +123,9 @@ abstract class ObjectWithObject implements _i1.SerializableModel {
 
   Map<String, Map<int, _i2.SimpleData>>? nestedDataMap;
 
+  /// Returns a shallow copy of this [ObjectWithObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithObject copyWith({
     int? id,
     _i2.SimpleData? data,
@@ -197,6 +201,9 @@ class _ObjectWithObjectImpl extends ObjectWithObject {
           nestedDataMap: nestedDataMap,
         );
 
+  /// Returns a shallow copy of this [ObjectWithObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithObject copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_parent.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_parent.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithParent implements _i1.SerializableModel {
   ObjectWithParent._({
@@ -36,6 +37,9 @@ abstract class ObjectWithParent implements _i1.SerializableModel {
 
   int other;
 
+  /// Returns a shallow copy of this [ObjectWithParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithParent copyWith({
     int? id,
     int? other,
@@ -65,6 +69,9 @@ class _ObjectWithParentImpl extends ObjectWithParent {
           other: other,
         );
 
+  /// Returns a shallow copy of this [ObjectWithParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithParent copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_self_parent.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithSelfParent implements _i1.SerializableModel {
   ObjectWithSelfParent._({
@@ -37,6 +38,9 @@ abstract class ObjectWithSelfParent implements _i1.SerializableModel {
 
   int? other;
 
+  /// Returns a shallow copy of this [ObjectWithSelfParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithSelfParent copyWith({
     int? id,
     int? other,
@@ -66,6 +70,9 @@ class _ObjectWithSelfParentImpl extends ObjectWithSelfParent {
           other: other,
         );
 
+  /// Returns a shallow copy of this [ObjectWithSelfParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithSelfParent copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/object_with_uuid.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithUuid implements _i1.SerializableModel {
   ObjectWithUuid._({
@@ -44,6 +45,9 @@ abstract class ObjectWithUuid implements _i1.SerializableModel {
 
   _i1.UuidValue? uuidNullable;
 
+  /// Returns a shallow copy of this [ObjectWithUuid]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithUuid copyWith({
     int? id,
     _i1.UuidValue? uuid,
@@ -77,6 +81,9 @@ class _ObjectWithUuidImpl extends ObjectWithUuid {
           uuidNullable: uuidNullable,
         );
 
+  /// Returns a shallow copy of this [ObjectWithUuid]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithUuid copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/related_unique_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/related_unique_data.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'unique_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class RelatedUniqueData implements _i1.SerializableModel {
   RelatedUniqueData._({
@@ -50,6 +51,9 @@ abstract class RelatedUniqueData implements _i1.SerializableModel {
 
   int number;
 
+  /// Returns a shallow copy of this [RelatedUniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RelatedUniqueData copyWith({
     int? id,
     int? uniqueDataId,
@@ -87,6 +91,9 @@ class _RelatedUniqueDataImpl extends RelatedUniqueData {
           number: number,
         );
 
+  /// Returns a shallow copy of this [RelatedUniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RelatedUniqueData copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/scope_none_fields.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ScopeNoneFields implements _i1.SerializableModel {
   ScopeNoneFields._({this.id});
@@ -25,6 +26,9 @@ abstract class ScopeNoneFields implements _i1.SerializableModel {
   /// the id will be null.
   int? id;
 
+  /// Returns a shallow copy of this [ScopeNoneFields]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ScopeNoneFields copyWith({int? id});
   @override
   Map<String, dynamic> toJson() {
@@ -42,6 +46,9 @@ class _Undefined {}
 class _ScopeNoneFieldsImpl extends ScopeNoneFields {
   _ScopeNoneFieldsImpl({int? id}) : super._(id: id);
 
+  /// Returns a shallow copy of this [ScopeNoneFields]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ScopeNoneFields copyWith({Object? id = _Undefined}) {
     return ScopeNoneFields(id: id is int? ? id : this.id);

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import '../types.dart' as _i2;
 import '../scopes/scope_server_only_field.dart' as _i3;
+import 'package:meta/meta.dart';
 
 class ScopeServerOnlyField implements _i1.SerializableModel {
   ScopeServerOnlyField({
@@ -37,6 +38,9 @@ class ScopeServerOnlyField implements _i1.SerializableModel {
 
   _i3.ScopeServerOnlyField? nested;
 
+  /// Returns a shallow copy of this [ScopeServerOnlyField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ScopeServerOnlyField copyWith({
     Object? allScope = _Undefined,
     Object? nested = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field_child.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/scope_server_only_field_child.dart
@@ -13,6 +13,7 @@ import '../protocol.dart' as _i1;
 import 'package:serverpod_client/serverpod_client.dart' as _i2;
 import '../types.dart' as _i3;
 import '../scopes/scope_server_only_field.dart' as _i4;
+import 'package:meta/meta.dart';
 
 abstract class ScopeServerOnlyFieldChild extends _i1.ScopeServerOnlyField
     implements _i2.SerializableModel {
@@ -45,7 +46,10 @@ abstract class ScopeServerOnlyFieldChild extends _i1.ScopeServerOnlyField
 
   String childFoo;
 
+  /// Returns a shallow copy of this [ScopeServerOnlyFieldChild]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   ScopeServerOnlyFieldChild copyWith({
     Object? allScope,
     Object? nested,
@@ -79,6 +83,9 @@ class _ScopeServerOnlyFieldChildImpl extends ScopeServerOnlyFieldChild {
           childFoo: childFoo,
         );
 
+  /// Returns a shallow copy of this [ScopeServerOnlyFieldChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ScopeServerOnlyFieldChild copyWith({
     Object? allScope = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/default_server_only_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/default_server_only_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DefaultServerOnlyClass implements _i1.SerializableModel {
   DefaultServerOnlyClass._({required this.foo});
@@ -24,6 +25,9 @@ abstract class DefaultServerOnlyClass implements _i1.SerializableModel {
 
   String foo;
 
+  /// Returns a shallow copy of this [DefaultServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DefaultServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
@@ -39,6 +43,9 @@ abstract class DefaultServerOnlyClass implements _i1.SerializableModel {
 class _DefaultServerOnlyClassImpl extends DefaultServerOnlyClass {
   _DefaultServerOnlyClassImpl({required String foo}) : super._(foo: foo);
 
+  /// Returns a shallow copy of this [DefaultServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DefaultServerOnlyClass copyWith({String? foo}) {
     return DefaultServerOnlyClass(foo: foo ?? this.foo);

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/not_server_only_class.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/serverOnly/not_server_only_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class NotServerOnlyClass implements _i1.SerializableModel {
   NotServerOnlyClass._({required this.foo});
@@ -22,6 +23,9 @@ abstract class NotServerOnlyClass implements _i1.SerializableModel {
 
   String foo;
 
+  /// Returns a shallow copy of this [NotServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   NotServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
@@ -37,6 +41,9 @@ abstract class NotServerOnlyClass implements _i1.SerializableModel {
 class _NotServerOnlyClassImpl extends NotServerOnlyClass {
   _NotServerOnlyClassImpl({required String foo}) : super._(foo: foo);
 
+  /// Returns a shallow copy of this [NotServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   NotServerOnlyClass copyWith({String? foo}) {
     return NotServerOnlyClass(foo: foo ?? this.foo);

--- a/tests/serverpod_test_client/lib/src/protocol/scopes/server_only_class_field.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/scopes/server_only_class_field.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ServerOnlyClassField implements _i1.SerializableModel {
   ServerOnlyClassField._();
@@ -21,6 +22,9 @@ abstract class ServerOnlyClassField implements _i1.SerializableModel {
     return ServerOnlyClassField();
   }
 
+  /// Returns a shallow copy of this [ServerOnlyClassField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerOnlyClassField copyWith();
   @override
   Map<String, dynamic> toJson() {
@@ -36,6 +40,9 @@ abstract class ServerOnlyClassField implements _i1.SerializableModel {
 class _ServerOnlyClassFieldImpl extends ServerOnlyClassField {
   _ServerOnlyClassFieldImpl() : super._();
 
+  /// Returns a shallow copy of this [ServerOnlyClassField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerOnlyClassField copyWith() {
     return ServerOnlyClassField();

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Just some simple data.
 abstract class SimpleData implements _i1.SerializableModel {
@@ -40,6 +41,9 @@ abstract class SimpleData implements _i1.SerializableModel {
   /// Second Value Extra Text
   int num;
 
+  /// Returns a shallow copy of this [SimpleData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleData copyWith({
     int? id,
     int? num,
@@ -69,6 +73,9 @@ class _SimpleDataImpl extends SimpleData {
           num: num,
         );
 
+  /// Returns a shallow copy of this [SimpleData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleData copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_list.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class SimpleDataList implements _i1.SerializableModel {
   SimpleDataList._({required this.rows});
@@ -27,6 +28,9 @@ abstract class SimpleDataList implements _i1.SerializableModel {
 
   List<_i2.SimpleData> rows;
 
+  /// Returns a shallow copy of this [SimpleDataList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDataList copyWith({List<_i2.SimpleData>? rows});
   @override
   Map<String, dynamic> toJson() {
@@ -43,6 +47,9 @@ class _SimpleDataListImpl extends SimpleDataList {
   _SimpleDataListImpl({required List<_i2.SimpleData> rows})
       : super._(rows: rows);
 
+  /// Returns a shallow copy of this [SimpleDataList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDataList copyWith({List<_i2.SimpleData>? rows}) {
     return SimpleDataList(

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_map.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class SimpleDataMap implements _i1.SerializableModel {
   SimpleDataMap._({required this.data});
@@ -28,6 +29,9 @@ abstract class SimpleDataMap implements _i1.SerializableModel {
 
   Map<String, _i2.SimpleData> data;
 
+  /// Returns a shallow copy of this [SimpleDataMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data});
   @override
   Map<String, dynamic> toJson() {
@@ -44,6 +48,9 @@ class _SimpleDataMapImpl extends SimpleDataMap {
   _SimpleDataMapImpl({required Map<String, _i2.SimpleData> data})
       : super._(data: data);
 
+  /// Returns a shallow copy of this [SimpleDataMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data}) {
     return SimpleDataMap(

--- a/tests/serverpod_test_client/lib/src/protocol/simple_data_object.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_data_object.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class SimpleDataObject implements _i1.SerializableModel {
   SimpleDataObject._({required this.object});
@@ -26,6 +27,9 @@ abstract class SimpleDataObject implements _i1.SerializableModel {
 
   _i2.SimpleData object;
 
+  /// Returns a shallow copy of this [SimpleDataObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDataObject copyWith({_i2.SimpleData? object});
   @override
   Map<String, dynamic> toJson() {
@@ -42,6 +46,9 @@ class _SimpleDataObjectImpl extends SimpleDataObject {
   _SimpleDataObjectImpl({required _i2.SimpleData object})
       : super._(object: object);
 
+  /// Returns a shallow copy of this [SimpleDataObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDataObject copyWith({_i2.SimpleData? object}) {
     return SimpleDataObject(object: object ?? this.object.copyWith());

--- a/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/simple_date_time.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Just some simple data.
 abstract class SimpleDateTime implements _i1.SerializableModel {
@@ -39,6 +40,9 @@ abstract class SimpleDateTime implements _i1.SerializableModel {
   /// The only field of [SimpleDateTime]
   DateTime dateTime;
 
+  /// Returns a shallow copy of this [SimpleDateTime]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDateTime copyWith({
     int? id,
     DateTime? dateTime,
@@ -68,6 +72,9 @@ class _SimpleDateTimeImpl extends SimpleDateTime {
           dateTime: dateTime,
         );
 
+  /// Returns a shallow copy of this [SimpleDateTime]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDateTime copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types.dart
@@ -13,6 +13,7 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'test_enum.dart' as _i3;
 import 'test_enum_stringified.dart' as _i4;
+import 'package:meta/meta.dart';
 
 abstract class Types implements _i1.SerializableModel {
   Types._({
@@ -97,6 +98,9 @@ abstract class Types implements _i1.SerializableModel {
 
   _i4.TestEnumStringified? aStringifiedEnum;
 
+  /// Returns a shallow copy of this [Types]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Types copyWith({
     int? id,
     int? anInt,
@@ -163,6 +167,9 @@ class _TypesImpl extends Types {
           aStringifiedEnum: aStringifiedEnum,
         );
 
+  /// Returns a shallow copy of this [Types]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Types copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/types_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types_list.dart
@@ -14,6 +14,7 @@ import 'dart:typed_data' as _i2;
 import 'test_enum.dart' as _i3;
 import 'test_enum_stringified.dart' as _i4;
 import 'types.dart' as _i5;
+import 'package:meta/meta.dart';
 
 abstract class TypesList implements _i1.SerializableModel {
   TypesList._({
@@ -121,6 +122,9 @@ abstract class TypesList implements _i1.SerializableModel {
 
   List<List<_i5.Types>>? aList;
 
+  /// Returns a shallow copy of this [TypesList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TypesList copyWith({
     List<int>? anInt,
     List<bool>? aBool,
@@ -205,6 +209,9 @@ class _TypesListImpl extends TypesList {
           aList: aList,
         );
 
+  /// Returns a shallow copy of this [TypesList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TypesList copyWith({
     Object? anInt = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/types_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/types_map.dart
@@ -14,6 +14,7 @@ import 'dart:typed_data' as _i2;
 import 'test_enum.dart' as _i3;
 import 'test_enum_stringified.dart' as _i4;
 import 'types.dart' as _i5;
+import 'package:meta/meta.dart';
 
 abstract class TypesMap implements _i1.SerializableModel {
   TypesMap._({
@@ -290,6 +291,9 @@ abstract class TypesMap implements _i1.SerializableModel {
 
   Map<String, List<_i5.Types>>? aListValue;
 
+  /// Returns a shallow copy of this [TypesMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TypesMap copyWith({
     Map<int, String>? anIntKey,
     Map<bool, String>? aBoolKey,
@@ -442,6 +446,9 @@ class _TypesMapImpl extends TypesMap {
           aListValue: aListValue,
         );
 
+  /// Returns a shallow copy of this [TypesMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TypesMap copyWith({
     Object? anIntKey = _Undefined,

--- a/tests/serverpod_test_client/lib/src/protocol/unique_data.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/unique_data.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UniqueData implements _i1.SerializableModel {
   UniqueData._({
@@ -41,6 +42,9 @@ abstract class UniqueData implements _i1.SerializableModel {
 
   String email;
 
+  /// Returns a shallow copy of this [UniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UniqueData copyWith({
     int? id,
     int? number,
@@ -74,6 +78,9 @@ class _UniqueDataImpl extends UniqueData {
           email: email,
         );
 
+  /// Returns a shallow copy of this [UniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UniqueData copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/module_class.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/module_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ModuleClass implements _i1.SerializableModel {
   ModuleClass._({
@@ -33,6 +34,9 @@ abstract class ModuleClass implements _i1.SerializableModel {
 
   int data;
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ModuleClass copyWith({
     String? name,
     int? data,
@@ -60,6 +64,9 @@ class _ModuleClassImpl extends ModuleClass {
           data: data,
         );
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ModuleClass copyWith({
     String? name,

--- a/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/module_feature/models/my_feature_model.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_client/lib/src/protocol/module_feature/models/my_feature_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MyModuleFeatureModel implements _i1.SerializableModel {
   MyModuleFeatureModel._({required this.name});
@@ -24,6 +25,9 @@ abstract class MyModuleFeatureModel implements _i1.SerializableModel {
 
   String name;
 
+  /// Returns a shallow copy of this [MyModuleFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MyModuleFeatureModel copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
@@ -39,6 +43,9 @@ abstract class MyModuleFeatureModel implements _i1.SerializableModel {
 class _MyModuleFeatureModelImpl extends MyModuleFeatureModel {
   _MyModuleFeatureModelImpl({required String name}) : super._(name: name);
 
+  /// Returns a shallow copy of this [MyModuleFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MyModuleFeatureModel copyWith({String? name}) {
     return MyModuleFeatureModel(name: name ?? this.name);

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/module_class.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/module_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ModuleClass
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -34,6 +35,9 @@ abstract class ModuleClass
 
   int data;
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ModuleClass copyWith({
     String? name,
     int? data,
@@ -69,6 +73,9 @@ class _ModuleClassImpl extends ModuleClass {
           data: data,
         );
 
+  /// Returns a shallow copy of this [ModuleClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ModuleClass copyWith({
     String? name,

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/module_feature/models/my_feature_model.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/module_feature/models/my_feature_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MyModuleFeatureModel
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -25,6 +26,9 @@ abstract class MyModuleFeatureModel
 
   String name;
 
+  /// Returns a shallow copy of this [MyModuleFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MyModuleFeatureModel copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
@@ -45,6 +49,9 @@ abstract class MyModuleFeatureModel
 class _MyModuleFeatureModelImpl extends MyModuleFeatureModel {
   _MyModuleFeatureModelImpl({required String name}) : super._(name: name);
 
+  /// Returns a shallow copy of this [MyModuleFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MyModuleFeatureModel copyWith({String? name}) {
     return MyModuleFeatureModel(name: name ?? this.name);

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   BoolDefault._({
@@ -53,6 +54,9 @@ abstract class BoolDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [BoolDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefault copyWith({
     int? id,
     bool? boolDefaultTrue,
@@ -126,6 +130,9 @@ class _BoolDefaultImpl extends BoolDefault {
           boolDefaultNullFalse: boolDefaultNullFalse,
         );
 
+  /// Returns a shallow copy of this [BoolDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -58,6 +59,9 @@ abstract class BoolDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [BoolDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefaultMix copyWith({
     int? id,
     bool? boolDefaultAndDefaultModel,
@@ -129,6 +133,9 @@ class _BoolDefaultMixImpl extends BoolDefaultMix {
           boolDefaultModelAndDefaultPersist: boolDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [BoolDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -55,6 +56,9 @@ abstract class BoolDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [BoolDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefaultModel copyWith({
     int? id,
     bool? boolDefaultModelTrue,
@@ -126,6 +130,9 @@ class _BoolDefaultModelImpl extends BoolDefaultModel {
           boolDefaultModelNullFalse: boolDefaultModelNullFalse,
         );
 
+  /// Returns a shallow copy of this [BoolDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class BoolDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -49,6 +50,9 @@ abstract class BoolDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [BoolDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   BoolDefaultPersist copyWith({
     int? id,
     bool? boolDefaultPersistTrue,
@@ -119,6 +123,9 @@ class _BoolDefaultPersistImpl extends BoolDefaultPersist {
           boolDefaultPersistFalse: boolDefaultPersistFalse,
         );
 
+  /// Returns a shallow copy of this [BoolDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   BoolDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -62,6 +63,9 @@ abstract class DateTimeDefault
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DateTimeDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefault copyWith({
     int? id,
     DateTime? dateTimeDefaultNow,
@@ -135,6 +139,9 @@ class _DateTimeDefaultImpl extends DateTimeDefault {
           dateTimeDefaultStrNull: dateTimeDefaultStrNull,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -61,6 +62,9 @@ abstract class DateTimeDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DateTimeDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefaultMix copyWith({
     int? id,
     DateTime? dateTimeDefaultAndDefaultModel,
@@ -137,6 +141,9 @@ class _DateTimeDefaultMixImpl extends DateTimeDefaultMix {
               dateTimeDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -63,6 +64,9 @@ abstract class DateTimeDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DateTimeDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefaultModel copyWith({
     int? id,
     DateTime? dateTimeDefaultModelNow,
@@ -136,6 +140,9 @@ class _DateTimeDefaultModelImpl extends DateTimeDefaultModel {
           dateTimeDefaultModelStrNull: dateTimeDefaultModelStrNull,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DateTimeDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -56,6 +57,9 @@ abstract class DateTimeDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DateTimeDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DateTimeDefaultPersist copyWith({
     int? id,
     DateTime? dateTimeDefaultPersistNow,
@@ -126,6 +130,9 @@ class _DateTimeDefaultPersistImpl extends DateTimeDefaultPersist {
           dateTimeDefaultPersistStr: dateTimeDefaultPersistStr,
         );
 
+  /// Returns a shallow copy of this [DateTimeDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DateTimeDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -49,6 +50,9 @@ abstract class DoubleDefault
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DoubleDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefault copyWith({
     int? id,
     double? doubleDefault,
@@ -115,6 +119,9 @@ class _DoubleDefaultImpl extends DoubleDefault {
           doubleDefaultNull: doubleDefaultNull,
         );
 
+  /// Returns a shallow copy of this [DoubleDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -60,6 +61,9 @@ abstract class DoubleDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DoubleDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefaultMix copyWith({
     int? id,
     double? doubleDefaultAndDefaultModel,
@@ -134,6 +138,9 @@ class _DoubleDefaultMixImpl extends DoubleDefaultMix {
               doubleDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DoubleDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -50,6 +51,9 @@ abstract class DoubleDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DoubleDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefaultModel copyWith({
     int? id,
     double? doubleDefaultModel,
@@ -116,6 +120,9 @@ class _DoubleDefaultModelImpl extends DoubleDefaultModel {
           doubleDefaultModelNull: doubleDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [DoubleDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DoubleDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -44,6 +45,9 @@ abstract class DoubleDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DoubleDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DoubleDefaultPersist copyWith({
     int? id,
     double? doubleDefaultPersist,
@@ -107,6 +111,9 @@ class _DoubleDefaultPersistImpl extends DoubleDefaultPersist {
           doubleDefaultPersist: doubleDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DoubleDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DoubleDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -66,6 +67,9 @@ abstract class DurationDefault
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DurationDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefault copyWith({
     int? id,
     Duration? durationDefault,
@@ -134,6 +138,9 @@ class _DurationDefaultImpl extends DurationDefault {
           durationDefaultNull: durationDefaultNull,
         );
 
+  /// Returns a shallow copy of this [DurationDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -79,6 +80,9 @@ abstract class DurationDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DurationDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefaultMix copyWith({
     int? id,
     Duration? durationDefaultAndDefaultModel,
@@ -155,6 +159,9 @@ class _DurationDefaultMixImpl extends DurationDefaultMix {
               durationDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DurationDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -68,6 +69,9 @@ abstract class DurationDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DurationDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefaultModel copyWith({
     int? id,
     Duration? durationDefaultModel,
@@ -136,6 +140,9 @@ class _DurationDefaultModelImpl extends DurationDefaultModel {
           durationDefaultModelNull: durationDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [DurationDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DurationDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -47,6 +48,9 @@ abstract class DurationDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [DurationDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DurationDefaultPersist copyWith({
     int? id,
     Duration? durationDefaultPersist,
@@ -110,6 +114,9 @@ class _DurationDefaultPersistImpl extends DurationDefaultPersist {
           durationDefaultPersist: durationDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [DurationDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DurationDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import '../../defaults/enum/enums/by_index_enum.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   EnumDefault._({
@@ -71,6 +72,9 @@ abstract class EnumDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EnumDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefault copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefault,
@@ -151,6 +155,9 @@ class _EnumDefaultImpl extends EnumDefault {
           byIndexEnumDefaultNull: byIndexEnumDefaultNull,
         );
 
+  /// Returns a shallow copy of this [EnumDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -62,6 +63,9 @@ abstract class EnumDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EnumDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefaultMix copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultAndDefaultModel,
@@ -141,6 +145,9 @@ class _EnumDefaultMixImpl extends EnumDefaultMix {
               byNameEnumDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [EnumDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import '../../defaults/enum/enums/by_index_enum.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -76,6 +77,9 @@ abstract class EnumDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EnumDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefaultModel copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultModel,
@@ -156,6 +160,9 @@ class _EnumDefaultModelImpl extends EnumDefaultModel {
           byIndexEnumDefaultModelNull: byIndexEnumDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [EnumDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import '../../defaults/enum/enums/by_index_enum.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class EnumDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -57,6 +58,9 @@ abstract class EnumDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EnumDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EnumDefaultPersist copyWith({
     int? id,
     _i2.ByNameEnum? byNameEnumDefaultPersist,
@@ -127,6 +131,9 @@ class _EnumDefaultPersistImpl extends EnumDefaultPersist {
           byIndexEnumDefaultPersist: byIndexEnumDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [EnumDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EnumDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/exception/default_exception.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/exception/default_exception.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../defaults/enum/enums/by_name_enum.dart' as _i2;
 import 'package:uuid/uuid.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class DefaultException
     implements
@@ -99,6 +100,9 @@ abstract class DefaultException
 
   String defaultMixField;
 
+  /// Returns a shallow copy of this [DefaultException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DefaultException copyWith({
     bool? defaultBoolean,
     DateTime? defaultDateTime,
@@ -174,6 +178,9 @@ class _DefaultExceptionImpl extends DefaultException {
           defaultMixField: defaultMixField,
         );
 
+  /// Returns a shallow copy of this [DefaultException]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DefaultException copyWith({
     bool? defaultBoolean,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   IntDefault._({
@@ -47,6 +48,9 @@ abstract class IntDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [IntDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefault copyWith({
     int? id,
     int? intDefault,
@@ -113,6 +117,9 @@ class _IntDefaultImpl extends IntDefault {
           intDefaultNull: intDefaultNull,
         );
 
+  /// Returns a shallow copy of this [IntDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -58,6 +59,9 @@ abstract class IntDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [IntDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefaultMix copyWith({
     int? id,
     int? intDefaultAndDefaultModel,
@@ -129,6 +133,9 @@ class _IntDefaultMixImpl extends IntDefaultMix {
           intDefaultModelAndDefaultPersist: intDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [IntDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -48,6 +49,9 @@ abstract class IntDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [IntDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefaultModel copyWith({
     int? id,
     int? intDefaultModel,
@@ -114,6 +118,9 @@ class _IntDefaultModelImpl extends IntDefaultModel {
           intDefaultModelNull: intDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [IntDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class IntDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -42,6 +43,9 @@ abstract class IntDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [IntDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   IntDefaultPersist copyWith({
     int? id,
     int? intDefaultPersist,
@@ -103,6 +107,9 @@ class _IntDefaultPersistImpl extends IntDefaultPersist {
           intDefaultPersist: intDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [IntDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   IntDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefault
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -48,6 +49,9 @@ abstract class StringDefault
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [StringDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefault copyWith({
     int? id,
     String? stringDefault,
@@ -114,6 +118,9 @@ class _StringDefaultImpl extends StringDefault {
           stringDefaultNull: stringDefaultNull,
         );
 
+  /// Returns a shallow copy of this [StringDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -60,6 +61,9 @@ abstract class StringDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [StringDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefaultMix copyWith({
     int? id,
     String? stringDefaultAndDefaultModel,
@@ -134,6 +138,9 @@ class _StringDefaultMixImpl extends StringDefaultMix {
               stringDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [StringDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -51,6 +52,9 @@ abstract class StringDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [StringDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefaultModel copyWith({
     int? id,
     String? stringDefaultModel,
@@ -117,6 +121,9 @@ class _StringDefaultModelImpl extends StringDefaultModel {
           stringDefaultModelNull: stringDefaultModelNull,
         );
 
+  /// Returns a shallow copy of this [StringDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class StringDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -104,6 +105,9 @@ abstract class StringDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [StringDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   StringDefaultPersist copyWith({
     int? id,
     String? stringDefaultPersist,
@@ -247,6 +251,9 @@ class _StringDefaultPersistImpl extends StringDefaultPersist {
               stringDefaultPersistDoubleQuoteWithTwoSingleQuote,
         );
 
+  /// Returns a shallow copy of this [StringDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   StringDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   UuidDefault._({
@@ -70,6 +71,9 @@ abstract class UuidDefault implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UuidDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefault copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultRandom,
@@ -150,6 +154,9 @@ class _UuidDefaultImpl extends UuidDefault {
           uuidDefaultStrNull: uuidDefaultStrNull,
         );
 
+  /// Returns a shallow copy of this [UuidDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefault copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefaultMix
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -60,6 +61,9 @@ abstract class UuidDefaultMix
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UuidDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefaultMix copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultAndDefaultModel,
@@ -133,6 +137,9 @@ class _UuidDefaultMixImpl extends UuidDefaultMix {
           uuidDefaultModelAndDefaultPersist: uuidDefaultModelAndDefaultPersist,
         );
 
+  /// Returns a shallow copy of this [UuidDefaultMix]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefaultMix copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:uuid/uuid.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefaultModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -74,6 +75,9 @@ abstract class UuidDefaultModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UuidDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefaultModel copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultModelRandom,
@@ -154,6 +158,9 @@ class _UuidDefaultModelImpl extends UuidDefaultModel {
           uuidDefaultModelStrNull: uuidDefaultModelStrNull,
         );
 
+  /// Returns a shallow copy of this [UuidDefaultModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefaultModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UuidDefaultPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -54,6 +55,9 @@ abstract class UuidDefaultPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UuidDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UuidDefaultPersist copyWith({
     int? id,
     _i1.UuidValue? uuidDefaultPersistRandom,
@@ -124,6 +128,9 @@ class _UuidDefaultPersistImpl extends UuidDefaultPersist {
           uuidDefaultPersistStr: uuidDefaultPersistStr,
         );
 
+  /// Returns a shallow copy of this [UuidDefaultPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UuidDefaultPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class EmptyModel
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -21,6 +22,9 @@ abstract class EmptyModel
     return EmptyModel();
   }
 
+  /// Returns a shallow copy of this [EmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmptyModel copyWith();
   @override
   Map<String, dynamic> toJson() {
@@ -41,6 +45,9 @@ abstract class EmptyModel
 class _EmptyModelImpl extends EmptyModel {
   _EmptyModelImpl() : super._();
 
+  /// Returns a shallow copy of this [EmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmptyModel copyWith() {
     return EmptyModel();

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class EmptyModelRelationItem
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -45,6 +46,9 @@ abstract class EmptyModelRelationItem
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EmptyModelRelationItem]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmptyModelRelationItem copyWith({
     int? id,
     String? name,
@@ -109,6 +113,9 @@ class _EmptyModelRelationItemImpl extends EmptyModelRelationItem {
           name: name,
         );
 
+  /// Returns a shallow copy of this [EmptyModelRelationItem]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmptyModelRelationItem copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class EmptyModelWithTable
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -31,6 +32,9 @@ abstract class EmptyModelWithTable
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [EmptyModelWithTable]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   EmptyModelWithTable copyWith({int? id});
   @override
   Map<String, dynamic> toJson() {
@@ -77,6 +81,9 @@ class _Undefined {}
 class _EmptyModelWithTableImpl extends EmptyModelWithTable {
   _EmptyModelWithTableImpl({int? id}) : super._(id: id);
 
+  /// Returns a shallow copy of this [EmptyModelWithTable]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   EmptyModelWithTable copyWith({Object? id = _Undefined}) {
     return EmptyModelWithTable(id: id is int? ? id : this.id);

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../empty_model/empty_model_relation_item.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class RelationEmptyModel
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -46,6 +47,9 @@ abstract class RelationEmptyModel
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [RelationEmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RelationEmptyModel copyWith({
     int? id,
     List<_i2.EmptyModelRelationItem>? items,
@@ -109,6 +113,9 @@ class _RelationEmptyModelImpl extends RelationEmptyModel {
           items: items,
         );
 
+  /// Returns a shallow copy of this [RelationEmptyModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RelationEmptyModel copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/exception_with_data.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ExceptionWithData
     implements
@@ -50,6 +51,9 @@ abstract class ExceptionWithData
 
   int? someNullableField;
 
+  /// Returns a shallow copy of this [ExceptionWithData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ExceptionWithData copyWith({
     String? message,
     DateTime? creationDate,
@@ -97,6 +101,9 @@ class _ExceptionWithDataImpl extends ExceptionWithData {
           someNullableField: someNullableField,
         );
 
+  /// Returns a shallow copy of this [ExceptionWithData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ExceptionWithData copyWith({
     String? message,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/child_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/child_class.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ChildClass extends _i1.ParentClass
     implements _i2.SerializableModel, _i2.ProtocolSerialization {
@@ -39,7 +40,10 @@ abstract class ChildClass extends _i1.ParentClass
 
   int childField;
 
+  /// Returns a shallow copy of this [ChildClass]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   ChildClass copyWith({
     Object? id,
     String? grandParentField,
@@ -87,6 +91,9 @@ class _ChildClassImpl extends ChildClass {
           childField: childField,
         );
 
+  /// Returns a shallow copy of this [ChildClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChildClass copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_default.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ChildWithDefault extends _i1.ParentWithDefault
     implements _i2.SerializableModel, _i2.ProtocolSerialization {
@@ -41,7 +42,10 @@ abstract class ChildWithDefault extends _i1.ParentWithDefault
 
   int childDefault;
 
+  /// Returns a shallow copy of this [ChildWithDefault]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   ChildWithDefault copyWith({
     String? name,
     int? parentDefault,
@@ -87,6 +91,9 @@ class _ChildWithDefaultImpl extends ChildWithDefault {
           childDefault: childDefault,
         );
 
+  /// Returns a shallow copy of this [ChildWithDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ChildWithDefault copyWith({
     String? name,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/grandparent_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/grandparent_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 class GrandparentClass
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -22,6 +23,9 @@ class GrandparentClass
 
   String grandParentField;
 
+  /// Returns a shallow copy of this [GrandparentClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   GrandparentClass copyWith({String? grandParentField}) {
     return GrandparentClass(
         grandParentField: grandParentField ?? this.grandParentField);

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
+import 'package:meta/meta.dart';
 
 class ParentClass extends _i1.GrandparentClass
     implements _i2.TableRow, _i2.ProtocolSerialization {
@@ -40,6 +41,9 @@ class ParentClass extends _i1.GrandparentClass
   @override
   _i2.Table get table => t;
 
+  /// Returns a shallow copy of this [ParentClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ParentClass copyWith({
     Object? id = _Undefined,
     String? grandParentField,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/parent_with_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/parent_with_default.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 class ParentWithDefault
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -29,6 +30,9 @@ class ParentWithDefault
 
   int parentDefault;
 
+  /// Returns a shallow copy of this [ParentWithDefault]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ParentWithDefault copyWith({
     String? name,
     int? parentDefault,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_child.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_child.dart
@@ -28,6 +28,9 @@ class SealedChild extends _i1.SealedParent
 
   int? nullableInt;
 
+  /// Returns a shallow copy of this [SealedChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SealedChild copyWith({
     int? sealedInt,
     String? sealedString,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_grandchild.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_grandchild.dart
@@ -38,7 +38,10 @@ abstract class SealedGrandChild extends _i1.SealedChild
 
   String sealedGrandchildField;
 
+  /// Returns a shallow copy of this [SealedGrandChild]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   SealedGrandChild copyWith({
     int? sealedInt,
     String? sealedString,
@@ -84,6 +87,9 @@ class _SealedGrandChildImpl extends SealedGrandChild {
           sealedGrandchildField: sealedGrandchildField,
         );
 
+  /// Returns a shallow copy of this [SealedGrandChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SealedGrandChild copyWith({
     int? sealedInt,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_other_child.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_other_child.dart
@@ -34,6 +34,9 @@ abstract class SealedOtherChild extends _i1.SealedParent
 
   int sealedOtherChildField;
 
+  /// Returns a shallow copy of this [SealedOtherChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SealedOtherChild copyWith({
     int? sealedInt,
     String? sealedString,
@@ -74,6 +77,9 @@ class _SealedOtherChildImpl extends SealedOtherChild {
           sealedOtherChildField: sealedOtherChildField,
         );
 
+  /// Returns a shallow copy of this [SealedOtherChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SealedOtherChild copyWith({
     int? sealedInt,

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/sealed_parent.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import '../protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
+import 'package:meta/meta.dart';
 part 'sealed_child.dart';
 part 'sealed_grandchild.dart';
 part 'sealed_other_child.dart';

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -14,6 +14,7 @@ import '../../long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i2;
 import '../../long_identifiers/deep_includes/organization_with_long_table_name.dart'
     as _i3;
+import 'package:meta/meta.dart';
 
 abstract class CityWithLongTableName
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -63,6 +64,9 @@ abstract class CityWithLongTableName
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [CityWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   CityWithLongTableName copyWith({
     int? id,
     String? name,
@@ -145,6 +149,9 @@ class _CityWithLongTableNameImpl extends CityWithLongTableName {
           organizations: organizations,
         );
 
+  /// Returns a shallow copy of this [CityWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   CityWithLongTableName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -14,6 +14,7 @@ import '../../long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i2;
 import '../../long_identifiers/deep_includes/city_with_long_table_name.dart'
     as _i3;
+import 'package:meta/meta.dart';
 
 abstract class OrganizationWithLongTableName
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -68,6 +69,9 @@ abstract class OrganizationWithLongTableName
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [OrganizationWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   OrganizationWithLongTableName copyWith({
     int? id,
     String? name,
@@ -152,6 +156,9 @@ class _OrganizationWithLongTableNameImpl extends OrganizationWithLongTableName {
           city: city,
         );
 
+  /// Returns a shallow copy of this [OrganizationWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   OrganizationWithLongTableName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../long_identifiers/deep_includes/organization_with_long_table_name.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class PersonWithLongTableName
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -60,6 +61,9 @@ abstract class PersonWithLongTableName
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [PersonWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   PersonWithLongTableName copyWith({
     int? id,
     String? name,
@@ -137,6 +141,9 @@ class _PersonWithLongTableNameImpl extends PersonWithLongTableName {
           organization: organization,
         );
 
+  /// Returns a shallow copy of this [PersonWithLongTableName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   PersonWithLongTableName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MaxFieldName implements _i1.TableRow, _i1.ProtocolSerialization {
   MaxFieldName._({
@@ -45,6 +46,9 @@ abstract class MaxFieldName implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [MaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MaxFieldName copyWith({
     int? id,
     String? thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo,
@@ -110,6 +114,9 @@ class _MaxFieldNameImpl extends MaxFieldName {
               thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNameFo,
         );
 
+  /// Returns a shallow copy of this [MaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MaxFieldName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class LongImplicitIdField
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -44,6 +45,9 @@ abstract class LongImplicitIdField
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [LongImplicitIdField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LongImplicitIdField copyWith({
     int? id,
     String? name,
@@ -109,6 +113,9 @@ class _LongImplicitIdFieldImpl extends LongImplicitIdField {
           name: name,
         );
 
+  /// Returns a shallow copy of this [LongImplicitIdField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LongImplicitIdField copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../long_identifiers/models_with_relations/long_implicit_id_field.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class LongImplicitIdFieldCollection
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -58,6 +59,9 @@ abstract class LongImplicitIdFieldCollection
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [LongImplicitIdFieldCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   LongImplicitIdFieldCollection copyWith({
     int? id,
     String? name,
@@ -137,6 +141,9 @@ class _LongImplicitIdFieldCollectionImpl extends LongImplicitIdFieldCollection {
               thisFieldIsExactly61CharactersLongAndIsThereforeAValidFieldNa,
         );
 
+  /// Returns a shallow copy of this [LongImplicitIdFieldCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   LongImplicitIdFieldCollection copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../long_identifiers/multiple_max_field_name.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class RelationToMultipleMaxFieldName
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -53,6 +54,9 @@ abstract class RelationToMultipleMaxFieldName
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [RelationToMultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RelationToMultipleMaxFieldName copyWith({
     int? id,
     String? name,
@@ -126,6 +130,9 @@ class _RelationToMultipleMaxFieldNameImpl
           multipleMaxFieldNames: multipleMaxFieldNames,
         );
 
+  /// Returns a shallow copy of this [RelationToMultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RelationToMultipleMaxFieldName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UserNote implements _i1.TableRow, _i1.ProtocolSerialization {
   UserNote._({
@@ -43,6 +44,9 @@ abstract class UserNote implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UserNote]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNote copyWith({
     int? id,
     String? name,
@@ -108,6 +112,9 @@ class _UserNoteImpl extends UserNote {
           name: name,
         );
 
+  /// Returns a shallow copy of this [UserNote]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNote copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../long_identifiers/models_with_relations/user_note.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UserNoteCollection
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -51,6 +52,9 @@ abstract class UserNoteCollection
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UserNoteCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNoteCollection copyWith({
     int? id,
     String? name,
@@ -123,6 +127,9 @@ class _UserNoteCollectionImpl extends UserNoteCollection {
           userNotesPropertyName: userNotesPropertyName,
         );
 
+  /// Returns a shallow copy of this [UserNoteCollection]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNoteCollection copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class UserNoteCollectionWithALongName
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -53,6 +54,9 @@ abstract class UserNoteCollectionWithALongName
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UserNoteCollectionWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNoteCollectionWithALongName copyWith({
     int? id,
     String? name,
@@ -122,6 +126,9 @@ class _UserNoteCollectionWithALongNameImpl
           notes: notes,
         );
 
+  /// Returns a shallow copy of this [UserNoteCollectionWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNoteCollectionWithALongName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UserNoteWithALongName
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -45,6 +46,9 @@ abstract class UserNoteWithALongName
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UserNoteWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UserNoteWithALongName copyWith({
     int? id,
     String? name,
@@ -110,6 +114,9 @@ class _UserNoteWithALongNameImpl extends UserNoteWithALongName {
           name: name,
         );
 
+  /// Returns a shallow copy of this [UserNoteWithALongName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UserNoteWithALongName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MultipleMaxFieldName
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -58,6 +59,9 @@ abstract class MultipleMaxFieldName
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [MultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MultipleMaxFieldName copyWith({
     int? id,
     String? thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames1,
@@ -136,6 +140,9 @@ class _MultipleMaxFieldNameImpl extends MultipleMaxFieldName {
               thisFieldIsExactly61CharactersLongAndIsThereforeValidAsNames2,
         );
 
+  /// Returns a shallow copy of this [MultipleMaxFieldName]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MultipleMaxFieldName copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../models_with_list_relations/person.dart' as _i2;
 import '../models_with_list_relations/organization.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class City implements _i1.TableRow, _i1.ProtocolSerialization {
   City._({
@@ -57,6 +58,9 @@ abstract class City implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [City]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   City copyWith({
     int? id,
     String? name,
@@ -139,6 +143,9 @@ class _CityImpl extends City {
           organizations: organizations,
         );
 
+  /// Returns a shallow copy of this [City]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   City copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../models_with_list_relations/person.dart' as _i2;
 import '../models_with_list_relations/city.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Organization implements _i1.TableRow, _i1.ProtocolSerialization {
   Organization._({
@@ -63,6 +64,9 @@ abstract class Organization implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Organization]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Organization copyWith({
     int? id,
     String? name,
@@ -147,6 +151,9 @@ class _OrganizationImpl extends Organization {
           city: city,
         );
 
+  /// Returns a shallow copy of this [Organization]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Organization copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../models_with_list_relations/organization.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Person implements _i1.TableRow, _i1.ProtocolSerialization {
   Person._({
@@ -57,6 +58,9 @@ abstract class Person implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Person]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Person copyWith({
     int? id,
     String? name,
@@ -131,6 +135,9 @@ class _PersonImpl extends Person {
           organization: organization,
         );
 
+  /// Returns a shallow copy of this [Person]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Person copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/many_to_many/enrollment.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Course implements _i1.TableRow, _i1.ProtocolSerialization {
   Course._({
@@ -49,6 +50,9 @@ abstract class Course implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Course]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Course copyWith({
     int? id,
     String? name,
@@ -118,6 +122,9 @@ class _CourseImpl extends Course {
           enrollments: enrollments,
         );
 
+  /// Returns a shallow copy of this [Course]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Course copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/many_to_many/student.dart' as _i2;
 import '../../models_with_relations/many_to_many/course.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Enrollment implements _i1.TableRow, _i1.ProtocolSerialization {
   Enrollment._({
@@ -64,6 +65,9 @@ abstract class Enrollment implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Enrollment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Enrollment copyWith({
     int? id,
     int? studentId,
@@ -146,6 +150,9 @@ class _EnrollmentImpl extends Enrollment {
           course: course,
         );
 
+  /// Returns a shallow copy of this [Enrollment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Enrollment copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/many_to_many/enrollment.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Student implements _i1.TableRow, _i1.ProtocolSerialization {
   Student._({
@@ -49,6 +50,9 @@ abstract class Student implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Student]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Student copyWith({
     int? id,
     String? name,
@@ -118,6 +122,9 @@ class _StudentImpl extends Student {
           enrollments: enrollments,
         );
 
+  /// Returns a shallow copy of this [Student]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Student copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectUser implements _i1.TableRow, _i1.ProtocolSerialization {
   ObjectUser._({
@@ -55,6 +56,9 @@ abstract class ObjectUser implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectUser copyWith({
     int? id,
     String? name,
@@ -126,6 +130,9 @@ class _ObjectUserImpl extends ObjectUser {
           userInfo: userInfo,
         );
 
+  /// Returns a shallow copy of this [ObjectUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectUser copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ParentUser implements _i1.TableRow, _i1.ProtocolSerialization {
   ParentUser._({
@@ -46,6 +47,9 @@ abstract class ParentUser implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ParentUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ParentUser copyWith({
     int? id,
     String? name,
@@ -112,6 +116,9 @@ class _ParentUserImpl extends ParentUser {
           userInfoId: userInfoId,
         );
 
+  /// Returns a shallow copy of this [ParentUser]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ParentUser copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/nested_one_to_many/team.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Arena implements _i1.TableRow, _i1.ProtocolSerialization {
   Arena._({
@@ -50,6 +51,9 @@ abstract class Arena implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Arena]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Arena copyWith({
     int? id,
     String? name,
@@ -116,6 +120,9 @@ class _ArenaImpl extends Arena {
           team: team,
         );
 
+  /// Returns a shallow copy of this [Arena]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Arena copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/nested_one_to_many/team.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Player implements _i1.TableRow, _i1.ProtocolSerialization {
   Player._({
@@ -55,6 +56,9 @@ abstract class Player implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Player]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Player copyWith({
     int? id,
     String? name,
@@ -126,6 +130,9 @@ class _PlayerImpl extends Player {
           team: team,
         );
 
+  /// Returns a shallow copy of this [Player]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Player copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/nested_one_to_many/arena.dart' as _i2;
 import '../../models_with_relations/nested_one_to_many/player.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Team implements _i1.TableRow, _i1.ProtocolSerialization {
   Team._({
@@ -63,6 +64,9 @@ abstract class Team implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Team]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Team copyWith({
     int? id,
     String? name,
@@ -147,6 +151,9 @@ class _TeamImpl extends Team {
           players: players,
         );
 
+  /// Returns a shallow copy of this [Team]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Team copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/one_to_many/order.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Comment implements _i1.TableRow, _i1.ProtocolSerialization {
   Comment._({
@@ -55,6 +56,9 @@ abstract class Comment implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Comment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Comment copyWith({
     int? id,
     String? description,
@@ -126,6 +130,9 @@ class _CommentImpl extends Comment {
           order: order,
         );
 
+  /// Returns a shallow copy of this [Comment]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Comment copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/one_to_many/order.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Customer implements _i1.TableRow, _i1.ProtocolSerialization {
   Customer._({
@@ -49,6 +50,9 @@ abstract class Customer implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Customer copyWith({
     int? id,
     String? name,
@@ -117,6 +121,9 @@ class _CustomerImpl extends Customer {
           orders: orders,
         );
 
+  /// Returns a shallow copy of this [Customer]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Customer copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/one_to_many/customer.dart' as _i2;
 import '../../models_with_relations/one_to_many/comment.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Order implements _i1.TableRow, _i1.ProtocolSerialization {
   Order._({
@@ -63,6 +64,9 @@ abstract class Order implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Order]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Order copyWith({
     int? id,
     String? description,
@@ -147,6 +151,9 @@ class _OrderImpl extends Order {
           comments: comments,
         );
 
+  /// Returns a shallow copy of this [Order]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Order copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/one_to_one/citizen.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Address implements _i1.TableRow, _i1.ProtocolSerialization {
   Address._({
@@ -55,6 +56,9 @@ abstract class Address implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Address]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Address copyWith({
     int? id,
     String? street,
@@ -126,6 +130,9 @@ class _AddressImpl extends Address {
           inhabitant: inhabitant,
         );
 
+  /// Returns a shallow copy of this [Address]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Address copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/one_to_one/address.dart' as _i2;
 import '../../models_with_relations/one_to_one/company.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Citizen implements _i1.TableRow, _i1.ProtocolSerialization {
   Citizen._({
@@ -77,6 +78,9 @@ abstract class Citizen implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Citizen]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Citizen copyWith({
     int? id,
     String? name,
@@ -171,6 +175,9 @@ class _CitizenImpl extends Citizen {
           oldCompany: oldCompany,
         );
 
+  /// Returns a shallow copy of this [Citizen]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Citizen copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/one_to_one/town.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Company implements _i1.TableRow, _i1.ProtocolSerialization {
   Company._({
@@ -55,6 +56,9 @@ abstract class Company implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Company]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Company copyWith({
     int? id,
     String? name,
@@ -126,6 +130,9 @@ class _CompanyImpl extends Company {
           town: town,
         );
 
+  /// Returns a shallow copy of this [Company]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Company copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../models_with_relations/one_to_one/citizen.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Town implements _i1.TableRow, _i1.ProtocolSerialization {
   Town._({
@@ -55,6 +56,9 @@ abstract class Town implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Town]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Town copyWith({
     int? id,
     String? name,
@@ -126,6 +130,9 @@ class _TownImpl extends Town {
           mayor: mayor,
         );
 
+  /// Returns a shallow copy of this [Town]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Town copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../models_with_relations/self_relation/many_to_many/member.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Blocking implements _i1.TableRow, _i1.ProtocolSerialization {
   Blocking._({
@@ -64,6 +65,9 @@ abstract class Blocking implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Blocking]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Blocking copyWith({
     int? id,
     int? blockedId,
@@ -146,6 +150,9 @@ class _BlockingImpl extends Blocking {
           blockedBy: blockedBy,
         );
 
+  /// Returns a shallow copy of this [Blocking]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Blocking copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../models_with_relations/self_relation/many_to_many/blocking.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Member implements _i1.TableRow, _i1.ProtocolSerialization {
   Member._({
@@ -57,6 +58,9 @@ abstract class Member implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Member]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Member copyWith({
     int? id,
     String? name,
@@ -139,6 +143,9 @@ class _MemberImpl extends Member {
           blockedBy: blockedBy,
         );
 
+  /// Returns a shallow copy of this [Member]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Member copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../models_with_relations/self_relation/one_to_many/cat.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Cat implements _i1.TableRow, _i1.ProtocolSerialization {
   Cat._({
@@ -63,6 +64,9 @@ abstract class Cat implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Cat]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Cat copyWith({
     int? id,
     String? name,
@@ -147,6 +151,9 @@ class _CatImpl extends Cat {
           kittens: kittens,
         );
 
+  /// Returns a shallow copy of this [Cat]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Cat copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../../../models_with_relations/self_relation/one_to_one/post.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class Post implements _i1.TableRow, _i1.ProtocolSerialization {
   Post._({
@@ -64,6 +65,9 @@ abstract class Post implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Post]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Post copyWith({
     int? id,
     String? content,
@@ -146,6 +150,9 @@ class _PostImpl extends Post {
           next: next,
         );
 
+  /// Returns a shallow copy of this [Post]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Post copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/module_datatype.dart
+++ b/tests/serverpod_test_server/lib/src/generated/module_datatype.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_test_module_server/serverpod_test_module_server.dart'
     as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ModuleDatatype
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -47,6 +48,9 @@ abstract class ModuleDatatype
 
   Map<String, _i2.ModuleClass> map;
 
+  /// Returns a shallow copy of this [ModuleDatatype]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ModuleDatatype copyWith({
     _i2.ModuleClass? model,
     List<_i2.ModuleClass>? list,
@@ -87,6 +91,9 @@ class _ModuleDatatypeImpl extends ModuleDatatype {
           map: map,
         );
 
+  /// Returns a shallow copy of this [ModuleDatatype]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ModuleDatatype copyWith({
     _i2.ModuleClass? model,

--- a/tests/serverpod_test_server/lib/src/generated/my_feature/models/my_feature_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/my_feature/models/my_feature_model.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class MyFeatureModel
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -23,6 +24,9 @@ abstract class MyFeatureModel
 
   String name;
 
+  /// Returns a shallow copy of this [MyFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   MyFeatureModel copyWith({String? name});
   @override
   Map<String, dynamic> toJson() {
@@ -43,6 +47,9 @@ abstract class MyFeatureModel
 class _MyFeatureModelImpl extends MyFeatureModel {
   _MyFeatureModelImpl({required String name}) : super._(name: name);
 
+  /// Returns a shallow copy of this [MyFeatureModel]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   MyFeatureModel copyWith({String? name}) {
     return MyFeatureModel(name: name ?? this.name);

--- a/tests/serverpod_test_server/lib/src/generated/nullability.dart
+++ b/tests/serverpod_test_server/lib/src/generated/nullability.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'simple_data.dart' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class Nullability
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -360,6 +361,9 @@ abstract class Nullability
 
   Map<String, int?>? aNullableMapWithNullableInts;
 
+  /// Returns a shallow copy of this [Nullability]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Nullability copyWith({
     int? anInt,
     int? aNullableInt,
@@ -686,6 +690,9 @@ class _NullabilityImpl extends Nullability {
           aNullableMapWithNullableInts: aNullableMapWithNullableInts,
         );
 
+  /// Returns a shallow copy of this [Nullability]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Nullability copyWith({
     int? anInt,

--- a/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectFieldPersist
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -56,6 +57,9 @@ abstract class ObjectFieldPersist
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectFieldPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectFieldPersist copyWith({
     int? id,
     String? normal,
@@ -127,6 +131,9 @@ class _ObjectFieldPersistImpl extends ObjectFieldPersist {
           data: data,
         );
 
+  /// Returns a shallow copy of this [ObjectFieldPersist]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectFieldPersist copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectFieldScopes
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -52,6 +53,9 @@ abstract class ObjectFieldScopes
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectFieldScopes]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectFieldScopes copyWith({
     int? id,
     String? normal,
@@ -122,6 +126,9 @@ class _ObjectFieldScopesImpl extends ObjectFieldScopes {
           database: database,
         );
 
+  /// Returns a shallow copy of this [ObjectFieldScopes]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectFieldScopes copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithByteData
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -44,6 +45,9 @@ abstract class ObjectWithByteData
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithByteData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithByteData copyWith({
     int? id,
     _i2.ByteData? byteData,
@@ -105,6 +109,9 @@ class _ObjectWithByteDataImpl extends ObjectWithByteData {
           byteData: byteData,
         );
 
+  /// Returns a shallow copy of this [ObjectWithByteData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithByteData copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_custom_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_custom_class.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithCustomClass
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -52,6 +53,9 @@ abstract class ObjectWithCustomClass
   _i2.CustomClassWithProtocolSerializationMethod
       customClassWithProtocolSerializationMethod;
 
+  /// Returns a shallow copy of this [ObjectWithCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithCustomClass copyWith({
     _i2.CustomClassWithoutProtocolSerialization?
         customClassWithoutProtocolSerialization,
@@ -123,6 +127,9 @@ class _ObjectWithCustomClassImpl extends ObjectWithCustomClass {
               customClassWithProtocolSerializationMethod,
         );
 
+  /// Returns a shallow copy of this [ObjectWithCustomClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithCustomClass copyWith({
     _i2.CustomClassWithoutProtocolSerialization?

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithDuration
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -43,6 +44,9 @@ abstract class ObjectWithDuration
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithDuration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithDuration copyWith({
     int? id,
     Duration? duration,
@@ -104,6 +108,9 @@ class _ObjectWithDurationImpl extends ObjectWithDuration {
           duration: duration,
         );
 
+  /// Returns a shallow copy of this [ObjectWithDuration]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithDuration copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'test_enum.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithEnum
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -73,6 +74,9 @@ abstract class ObjectWithEnum
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithEnum]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithEnum copyWith({
     int? id,
     _i2.TestEnum? testEnum,
@@ -158,6 +162,9 @@ class _ObjectWithEnumImpl extends ObjectWithEnum {
           enumListList: enumListList,
         );
 
+  /// Returns a shallow copy of this [ObjectWithEnum]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithEnum copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithIndex
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -47,6 +48,9 @@ abstract class ObjectWithIndex
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithIndex]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithIndex copyWith({
     int? id,
     int? indexed,
@@ -113,6 +117,9 @@ class _ObjectWithIndexImpl extends ObjectWithIndex {
           indexed2: indexed2,
         );
 
+  /// Returns a shallow copy of this [ObjectWithIndex]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithIndex copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_maps.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'simple_data.dart' as _i2;
 import 'dart:typed_data' as _i3;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithMaps
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -156,6 +157,9 @@ abstract class ObjectWithMaps
 
   Map<int, int> intIntMap;
 
+  /// Returns a shallow copy of this [ObjectWithMaps]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithMaps copyWith({
     Map<String, _i2.SimpleData>? dataMap,
     Map<String, int>? intMap,
@@ -266,6 +270,9 @@ class _ObjectWithMapsImpl extends ObjectWithMaps {
           intIntMap: intIntMap,
         );
 
+  /// Returns a shallow copy of this [ObjectWithMaps]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithMaps copyWith({
     Map<String, _i2.SimpleData>? dataMap,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithObject
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -128,6 +129,9 @@ abstract class ObjectWithObject
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithObject copyWith({
     int? id,
     _i2.SimpleData? data,
@@ -260,6 +264,9 @@ class _ObjectWithObjectImpl extends ObjectWithObject {
           nestedDataMap: nestedDataMap,
         );
 
+  /// Returns a shallow copy of this [ObjectWithObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithObject copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithParent
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -42,6 +43,9 @@ abstract class ObjectWithParent
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithParent copyWith({
     int? id,
     int? other,
@@ -103,6 +107,9 @@ class _ObjectWithParentImpl extends ObjectWithParent {
           other: other,
         );
 
+  /// Returns a shallow copy of this [ObjectWithParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithParent copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithSelfParent
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -43,6 +44,9 @@ abstract class ObjectWithSelfParent
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithSelfParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithSelfParent copyWith({
     int? id,
     int? other,
@@ -104,6 +108,9 @@ class _ObjectWithSelfParentImpl extends ObjectWithSelfParent {
           other: other,
         );
 
+  /// Returns a shallow copy of this [ObjectWithSelfParent]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithSelfParent copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ObjectWithUuid
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -50,6 +51,9 @@ abstract class ObjectWithUuid
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ObjectWithUuid]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ObjectWithUuid copyWith({
     int? id,
     _i1.UuidValue? uuid,
@@ -116,6 +120,9 @@ class _ObjectWithUuidImpl extends ObjectWithUuid {
           uuidNullable: uuidNullable,
         );
 
+  /// Returns a shallow copy of this [ObjectWithUuid]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ObjectWithUuid copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'unique_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class RelatedUniqueData
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -56,6 +57,9 @@ abstract class RelatedUniqueData
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [RelatedUniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   RelatedUniqueData copyWith({
     int? id,
     int? uniqueDataId,
@@ -127,6 +131,9 @@ class _RelatedUniqueDataImpl extends RelatedUniqueData {
           number: number,
         );
 
+  /// Returns a shallow copy of this [RelatedUniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   RelatedUniqueData copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ScopeNoneFields
     implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -33,6 +34,9 @@ abstract class ScopeNoneFields
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [ScopeNoneFields]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ScopeNoneFields copyWith({int? id});
   @override
   Map<String, dynamic> toJson() {
@@ -82,6 +86,9 @@ class _Undefined {}
 class _ScopeNoneFieldsImpl extends ScopeNoneFields {
   _ScopeNoneFieldsImpl({int? id}) : super._(id: id);
 
+  /// Returns a shallow copy of this [ScopeNoneFields]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ScopeNoneFields copyWith({Object? id = _Undefined}) {
     return ScopeNoneFields(id: id is int? ? id : this.id);

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field.dart
@@ -12,6 +12,7 @@
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../types.dart' as _i2;
 import '../scopes/scope_server_only_field.dart' as _i3;
+import 'package:meta/meta.dart';
 
 class ScopeServerOnlyField
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -45,6 +46,9 @@ class ScopeServerOnlyField
 
   _i3.ScopeServerOnlyField? nested;
 
+  /// Returns a shallow copy of this [ScopeServerOnlyField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ScopeServerOnlyField copyWith({
     Object? allScope = _Undefined,
     Object? serverOnlyScope = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field_child.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_server_only_field_child.dart
@@ -13,6 +13,7 @@ import '../protocol.dart' as _i1;
 import 'package:serverpod/serverpod.dart' as _i2;
 import '../types.dart' as _i3;
 import '../scopes/scope_server_only_field.dart' as _i4;
+import 'package:meta/meta.dart';
 
 abstract class ScopeServerOnlyFieldChild extends _i1.ScopeServerOnlyField
     implements _i2.SerializableModel, _i2.ProtocolSerialization {
@@ -51,7 +52,10 @@ abstract class ScopeServerOnlyFieldChild extends _i1.ScopeServerOnlyField
 
   String childFoo;
 
+  /// Returns a shallow copy of this [ScopeServerOnlyFieldChild]
+  /// with some or all fields replaced by the given arguments.
   @override
+  @useResult
   ScopeServerOnlyFieldChild copyWith({
     Object? allScope,
     Object? serverOnlyScope,
@@ -98,6 +102,9 @@ class _ScopeServerOnlyFieldChildImpl extends ScopeServerOnlyFieldChild {
           childFoo: childFoo,
         );
 
+  /// Returns a shallow copy of this [ScopeServerOnlyFieldChild]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ScopeServerOnlyFieldChild copyWith({
     Object? allScope = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/default_server_only_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/default_server_only_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class DefaultServerOnlyClass
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -25,6 +26,9 @@ abstract class DefaultServerOnlyClass
 
   String foo;
 
+  /// Returns a shallow copy of this [DefaultServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   DefaultServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
@@ -45,6 +49,9 @@ abstract class DefaultServerOnlyClass
 class _DefaultServerOnlyClassImpl extends DefaultServerOnlyClass {
   _DefaultServerOnlyClassImpl({required String foo}) : super._(foo: foo);
 
+  /// Returns a shallow copy of this [DefaultServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   DefaultServerOnlyClass copyWith({String? foo}) {
     return DefaultServerOnlyClass(foo: foo ?? this.foo);

--- a/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/not_server_only_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/not_server_only_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class NotServerOnlyClass
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -23,6 +24,9 @@ abstract class NotServerOnlyClass
 
   String foo;
 
+  /// Returns a shallow copy of this [NotServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   NotServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
@@ -43,6 +47,9 @@ abstract class NotServerOnlyClass
 class _NotServerOnlyClassImpl extends NotServerOnlyClass {
   _NotServerOnlyClassImpl({required String foo}) : super._(foo: foo);
 
+  /// Returns a shallow copy of this [NotServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   NotServerOnlyClass copyWith({String? foo}) {
     return NotServerOnlyClass(foo: foo ?? this.foo);

--- a/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/server_only_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/serverOnly/server_only_class.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class ServerOnlyClass
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -23,6 +24,9 @@ abstract class ServerOnlyClass
 
   String foo;
 
+  /// Returns a shallow copy of this [ServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerOnlyClass copyWith({String? foo});
   @override
   Map<String, dynamic> toJson() {
@@ -43,6 +47,9 @@ abstract class ServerOnlyClass
 class _ServerOnlyClassImpl extends ServerOnlyClass {
   _ServerOnlyClassImpl({required String foo}) : super._(foo: foo);
 
+  /// Returns a shallow copy of this [ServerOnlyClass]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerOnlyClass copyWith({String? foo}) {
     return ServerOnlyClass(foo: foo ?? this.foo);

--- a/tests/serverpod_test_server/lib/src/generated/scopes/server_only_class_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/server_only_class_field.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import '../scopes/serverOnly/server_only_class.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class ServerOnlyClassField
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -43,6 +44,9 @@ abstract class ServerOnlyClassField
 
   Map<String, _i2.ServerOnlyClass>? serverOnlyClassMap;
 
+  /// Returns a shallow copy of this [ServerOnlyClassField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   ServerOnlyClassField copyWith({
     List<_i2.ServerOnlyClass>? serverOnlyClassList,
     Map<String, _i2.ServerOnlyClass>? serverOnlyClassMap,
@@ -81,6 +85,9 @@ class _ServerOnlyClassFieldImpl extends ServerOnlyClassField {
           serverOnlyClassMap: serverOnlyClassMap,
         );
 
+  /// Returns a shallow copy of this [ServerOnlyClassField]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   ServerOnlyClassField copyWith({
     Object? serverOnlyClassList = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Just some simple data.
 abstract class SimpleData implements _i1.TableRow, _i1.ProtocolSerialization {
@@ -45,6 +46,9 @@ abstract class SimpleData implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [SimpleData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleData copyWith({
     int? id,
     int? num,
@@ -106,6 +110,9 @@ class _SimpleDataImpl extends SimpleData {
           num: num,
         );
 
+  /// Returns a shallow copy of this [SimpleData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleData copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_list.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class SimpleDataList
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -28,6 +29,9 @@ abstract class SimpleDataList
 
   List<_i2.SimpleData> rows;
 
+  /// Returns a shallow copy of this [SimpleDataList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDataList copyWith({List<_i2.SimpleData>? rows});
   @override
   Map<String, dynamic> toJson() {
@@ -49,6 +53,9 @@ class _SimpleDataListImpl extends SimpleDataList {
   _SimpleDataListImpl({required List<_i2.SimpleData> rows})
       : super._(rows: rows);
 
+  /// Returns a shallow copy of this [SimpleDataList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDataList copyWith({List<_i2.SimpleData>? rows}) {
     return SimpleDataList(

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_map.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class SimpleDataMap
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -29,6 +30,9 @@ abstract class SimpleDataMap
 
   Map<String, _i2.SimpleData> data;
 
+  /// Returns a shallow copy of this [SimpleDataMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data});
   @override
   Map<String, dynamic> toJson() {
@@ -50,6 +54,9 @@ class _SimpleDataMapImpl extends SimpleDataMap {
   _SimpleDataMapImpl({required Map<String, _i2.SimpleData> data})
       : super._(data: data);
 
+  /// Returns a shallow copy of this [SimpleDataMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDataMap copyWith({Map<String, _i2.SimpleData>? data}) {
     return SimpleDataMap(

--- a/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data_object.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'simple_data.dart' as _i2;
+import 'package:meta/meta.dart';
 
 abstract class SimpleDataObject
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -27,6 +28,9 @@ abstract class SimpleDataObject
 
   _i2.SimpleData object;
 
+  /// Returns a shallow copy of this [SimpleDataObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDataObject copyWith({_i2.SimpleData? object});
   @override
   Map<String, dynamic> toJson() {
@@ -48,6 +52,9 @@ class _SimpleDataObjectImpl extends SimpleDataObject {
   _SimpleDataObjectImpl({required _i2.SimpleData object})
       : super._(object: object);
 
+  /// Returns a shallow copy of this [SimpleDataObject]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDataObject copyWith({_i2.SimpleData? object}) {
     return SimpleDataObject(object: object ?? this.object.copyWith());

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 /// Just some simple data.
 abstract class SimpleDateTime
@@ -45,6 +46,9 @@ abstract class SimpleDateTime
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [SimpleDateTime]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   SimpleDateTime copyWith({
     int? id,
     DateTime? dateTime,
@@ -106,6 +110,9 @@ class _SimpleDateTimeImpl extends SimpleDateTime {
           dateTime: dateTime,
         );
 
+  /// Returns a shallow copy of this [SimpleDateTime]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   SimpleDateTime copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -13,6 +13,7 @@ import 'package:serverpod/serverpod.dart' as _i1;
 import 'dart:typed_data' as _i2;
 import 'test_enum.dart' as _i3;
 import 'test_enum_stringified.dart' as _i4;
+import 'package:meta/meta.dart';
 
 abstract class Types implements _i1.TableRow, _i1.ProtocolSerialization {
   Types._({
@@ -102,6 +103,9 @@ abstract class Types implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [Types]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   Types copyWith({
     int? id,
     int? anInt,
@@ -210,6 +214,9 @@ class _TypesImpl extends Types {
           aStringifiedEnum: aStringifiedEnum,
         );
 
+  /// Returns a shallow copy of this [Types]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   Types copyWith({
     Object? id = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/types_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types_list.dart
@@ -14,6 +14,7 @@ import 'dart:typed_data' as _i2;
 import 'test_enum.dart' as _i3;
 import 'test_enum_stringified.dart' as _i4;
 import 'types.dart' as _i5;
+import 'package:meta/meta.dart';
 
 abstract class TypesList
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -122,6 +123,9 @@ abstract class TypesList
 
   List<List<_i5.Types>>? aList;
 
+  /// Returns a shallow copy of this [TypesList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TypesList copyWith({
     List<int>? anInt,
     List<bool>? aBool,
@@ -238,6 +242,9 @@ class _TypesListImpl extends TypesList {
           aList: aList,
         );
 
+  /// Returns a shallow copy of this [TypesList]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TypesList copyWith({
     Object? anInt = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/types_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types_map.dart
@@ -14,6 +14,7 @@ import 'dart:typed_data' as _i2;
 import 'test_enum.dart' as _i3;
 import 'test_enum_stringified.dart' as _i4;
 import 'types.dart' as _i5;
+import 'package:meta/meta.dart';
 
 abstract class TypesMap
     implements _i1.SerializableModel, _i1.ProtocolSerialization {
@@ -291,6 +292,9 @@ abstract class TypesMap
 
   Map<String, List<_i5.Types>>? aListValue;
 
+  /// Returns a shallow copy of this [TypesMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   TypesMap copyWith({
     Map<int, String>? anIntKey,
     Map<bool, String>? aBoolKey,
@@ -508,6 +512,9 @@ class _TypesMapImpl extends TypesMap {
           aListValue: aListValue,
         );
 
+  /// Returns a shallow copy of this [TypesMap]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   TypesMap copyWith({
     Object? anIntKey = _Undefined,

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -10,6 +10,7 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
+import 'package:meta/meta.dart';
 
 abstract class UniqueData implements _i1.TableRow, _i1.ProtocolSerialization {
   UniqueData._({
@@ -46,6 +47,9 @@ abstract class UniqueData implements _i1.TableRow, _i1.ProtocolSerialization {
   @override
   _i1.Table get table => t;
 
+  /// Returns a shallow copy of this [UniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   UniqueData copyWith({
     int? id,
     int? number,
@@ -112,6 +116,9 @@ class _UniqueDataImpl extends UniqueData {
           email: email,
         );
 
+  /// Returns a shallow copy of this [UniqueData]
+  /// with some or all fields replaced by the given arguments.
+  @useResult
   @override
   UniqueData copyWith({
     Object? id = _Undefined,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1,7 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:path/path.dart' as p;
 import 'package:recase/recase.dart';
-
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/utils/duration_utils.dart';
@@ -74,6 +73,10 @@ class SerializableModelLibraryGenerator {
             from: p.dirname(classDefinition.filePath),
           );
           libraryBuilder.directives.add(Directive.partOf(topNodePath));
+        } else if (!(classDefinition.isSealedTopNode &&
+            classDefinition.childClasses.isEmpty)) {
+          libraryBuilder.directives
+              .insert(0, Directive.import('package:meta/meta.dart'));
         }
 
         libraryBuilder.body.addAll([
@@ -481,6 +484,9 @@ class SerializableModelLibraryGenerator {
       }
 
       methodBuilder
+        ..docs.add('/// Returns a shallow copy of this [$className]\n'
+            '/// with some or all fields replaced by the given arguments.')
+        ..annotations.add(const CodeExpression(Code('useResult')))
         ..name = 'copyWith'
         ..optionalParameters.addAll(
           _buildAbstractCopyWithParameters(
@@ -499,6 +505,10 @@ class SerializableModelLibraryGenerator {
     return Method(
       (m) {
         m.name = 'copyWith';
+        m.docs.add(
+            '/// Returns a shallow copy of this [${classDefinition.className}] \n'
+            '/// with some or all fields replaced by the given arguments.');
+        m.annotations.add(const CodeExpression(Code('useResult')));
         if (!classDefinition.isParentClass) {
           m.annotations.add(refer('override'));
         }


### PR DESCRIPTION
Annotate `copyWith` with `@useResult` to ensure that callers actually make use of the newly created object

Re-export of the `meta` `useResult` annotation was added to `serverpod` and `serverpod_client` such that consumers don't have to manually add a reference to `meta/meta` in their application project (as otherwise you'd get the warning that the generated code is importing a package which is not a dependency).

Relates to #1237