### PR TITLE
feat: Allow static content to not be cached, by path regexp

### DIFF
--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -23,16 +23,21 @@ final _contentTypeMapping = <String, ContentType>{
 /// A path pattern to match, and the max age that paths that match the pattern
 /// should be cached for, in seconds.
 class PathCacheMaxAge {
+  /// The path pattern to match.
   final Pattern pathPattern;
-  final int maxAge;
+
+  /// The max age that paths that match the pattern should be cached for, in
+  /// seconds.
+  final Duration maxAge;
 
   /// A value for [maxAge] that indicates that the path should not be cached.
-  static const noCache = 0;
+  static const Duration noCache = Duration.zero;
 
   /// A value for [maxAge] that indicates that the path should be cached for
   /// one year.
-  static const oneYear = 31536000;
+  static const Duration oneYear = Duration(days: 365);
 
+  /// Creates a new [PathCacheMaxAge] with the given [pathPattern] and [maxAge].
   PathCacheMaxAge({
     required this.pathPattern,
     required this.maxAge,
@@ -132,12 +137,12 @@ class RouteStaticDirectory extends Route {
       // Set Cache-Control header
       request.response.headers.set(
         'Cache-Control',
-        pathCacheMaxAge == 0
+        pathCacheMaxAge == PathCacheMaxAge.noCache
             // Don't cache this path
             ? 'max-age=0, s-maxage=0, no-cache, no-store'
             // Cache for the specified amount of time, or the default
             // of one year if no pattern matched
-            : 'max-age=$pathCacheMaxAge',
+            : 'max-age=${pathCacheMaxAge.inSeconds}',
       );
 
       var filePath = path.startsWith('/') ? path.substring(1) : path;

--- a/packages/serverpod/lib/src/relic/routes/static_directory.dart
+++ b/packages/serverpod/lib/src/relic/routes/static_directory.dart
@@ -38,17 +38,17 @@ class PathCacheMaxAge {
     required this.maxAge,
   });
 
-bool _shouldCache(String path) {
-  var pattern = pathPattern;
+  bool _shouldCache(String path) {
+    var pattern = pathPattern;
 
-  if (pattern is String) {
-    return path == pattern;
-  } else if (pattern is RegExp) {
-    return pattern.hasMatch(path);
+    if (pattern is String) {
+      return path == pattern;
+    } else if (pattern is RegExp) {
+      return pattern.hasMatch(path);
+    }
+
+    return false;
   }
-
-  return false;
-}
 }
 
 /// Route for serving a directory of static files.
@@ -61,7 +61,6 @@ class RouteStaticDirectory extends Route {
 
   /// The path to serve as the root path ('/'), e.g. '/index.html'.
   final String? serveAsRootPath;
-
 
   /// A regular expression that will be used to determine if a path should not
   /// be cached.

--- a/tests/serverpod_test_server/test_integration/static_files_test.dart
+++ b/tests/serverpod_test_server/test_integration/static_files_test.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as path;
+
+void main() {
+  var directory = Directory(path.join(Directory.current.path, 'web', 'static'));
+  setUp(() async {
+    await directory.create();
+    await File(path.join(directory.path, 'file1.txt'))
+        .writeAsString('contents');
+    await File(path.join(directory.path, 'file2.test'))
+        .writeAsString('contents');
+  });
+
+  tearDownAll(() async {
+    await directory.delete(recursive: true);
+  });
+
+  group('Given a web server with a static directory', () {
+    late Serverpod serverpod;
+
+    setUp(() async {
+      serverpod = IntegrationTestServer.create();
+    });
+
+    tearDown(() async {
+      await serverpod.shutdown(exitProcess: false);
+    });
+
+    group('and a path cache pattern having a max age of 1 second', () {
+      setUp(() async {
+        serverpod.webServer.addRoute(
+          RouteStaticDirectory(
+            serverDirectory: '/static',
+            pathCachePatterns: [
+              PathCacheMaxAge(
+                pathPattern: RegExp(r'.*\.txt'),
+                maxAge: Duration(seconds: 1),
+              ),
+            ],
+          ),
+          '/static/*',
+        );
+        // Server should start after adding the route otherwise web server
+        // will not be started.
+        await serverpod.start();
+      });
+
+      test(
+          'when requesting a static file with the same path pattern '
+          'then the cache-control header is set to max-age=1', () async {
+        var response = await http.get(
+          Uri.parse(
+            'http://localhost:8082/static/file1.txt',
+          ),
+        );
+
+        expect(response.headers['cache-control'], 'max-age=1');
+      });
+
+      test(
+          'when requesting a static file with a different path pattern '
+          'then the cache-control header is set to default max age', () async {
+        var response = await http.get(
+          Uri.parse(
+            'http://localhost:8082/static/file2.test',
+          ),
+        );
+
+        expect(
+          response.headers['cache-control'],
+          'max-age=${PathCacheMaxAge.oneYear.inSeconds}',
+        );
+      });
+    });
+
+    group('and a path cache string having a max age of 1 second', () {
+      setUp(() async {
+        serverpod.webServer.addRoute(
+          RouteStaticDirectory(
+            serverDirectory: '/static',
+            pathCachePatterns: [
+              PathCacheMaxAge(
+                pathPattern: '/static/file1.txt',
+                maxAge: Duration(seconds: 1),
+              ),
+            ],
+          ),
+          '/static/*',
+        );
+        // Server should start after adding the route otherwise web server
+        // will not be started.
+        await serverpod.start();
+      });
+
+      test(
+          'when requesting a static file with the same path string '
+          'then the cache-control header is set to max-age=1', () async {
+        var response = await http.get(
+          Uri.parse(
+            'http://localhost:8082/static/file1.txt',
+          ),
+        );
+
+        expect(response.headers['cache-control'], 'max-age=1');
+      });
+
+      test(
+          'when requesting a static file with a different path string '
+          'then the cache-control header is set to default max age', () async {
+        var response = await http.get(
+          Uri.parse(
+            'http://localhost:8082/static/file2.test',
+          ),
+        );
+
+        expect(
+          response.headers['cache-control'],
+          'max-age=${PathCacheMaxAge.oneYear.inSeconds}',
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
Original PR https://github.com/serverpod/serverpod/pull/2539 by @lukehutch 

> Allow static paths to be excluded from CDN caching, by regexp match.
> 
> Partially addresses #2534, although for that to be fixed, dynamic responses should also include these same cache denial headers. (I didn't make that change in this PR, but it needs to be done...)
> 
> ## Pre-launch Checklist
> * [x]  I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
> * [x]  This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
> * [x]  I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
> * [x]  I listed at least one issue that this PR fixes in the description above.
> * [x]  I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
> * [ ]  I added new tests to check the change I am making.
> * [x]  All existing and new tests are passing.
> * [x]  Any breaking changes are documented below.