### PR TITLE
chore: remove docker-compose profiles and make strings consistent

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/docker-compose.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/docker-compose.yaml
@@ -3,51 +3,41 @@ services:
   postgres:
     image: postgres:16.3
     ports:
-      - '8090:5432'
+      - "8090:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: projectname
       POSTGRES_PASSWORD: "DB_PASSWORD"
     volumes:
       - projectname_data:/var/lib/postgresql/data
-    profiles:
-      - '' # Default profile
-      - dev
+
   redis:
     image: redis:6.2.6
     ports:
-      - '8091:6379'
+      - "8091:6379"
     command: redis-server --requirepass "REDIS_PASSWORD"
     environment:
       - REDIS_REPLICATION_MODE=master
-    profiles:
-      - '' # Default profile
-      - dev
 
   # Test services
   postgres_test:
     image: postgres:16.3
     ports:
-      - '9090:5432'
+      - "9090:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: projectname_test
       POSTGRES_PASSWORD: "DB_TEST_PASSWORD"
     volumes:
       - projectname_test_data:/var/lib/postgresql/data
-    profiles:
-      - '' # Default profile
-      - test
+
   redis_test:
     image: redis:6.2.6
     ports:
-      - '9091:6379'
+      - "9091:6379"
     command: redis-server --requirepass "REDIS_TEST_PASSWORD"
     environment:
       - REDIS_REPLICATION_MODE=master
-    profiles:
-      - '' # Default profile
-      - test
 
 volumes:
   projectname_data:


### PR DESCRIPTION
Using empty strings as defaults for docker profiles is undocumented behaviour and may or may not work on a developers device, as discussed in https://github.com/serverpod/serverpod/issues/3143 and the decision was made to run both testing and development services at the same time to reduce friction and because testing should be an integral part of development.

This closes #3143

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes