### PR TITLE
Fix: for issue 3148

### DIFF
--- a/tools/serverpod_cli/lib/src/migrations/generator.dart
+++ b/tools/serverpod_cli/lib/src/migrations/generator.dart
@@ -334,10 +334,13 @@ class MigrationGenerator {
     var selectedPaths = (await Future.wait(
       modulePaths.map((modulePath) async {
         var moduleName = await _extractModuleNameFromPath(modulePath);
-        return selectedModules.any((module) => module.name == moduleName)? modulePath
+        return selectedModules.any((module) => module.name == moduleName)
+            ? modulePath
             : null;
       }),
-    )).whereType<Uri>().toList();
+    ))
+        .whereType<Uri>()
+        .toList();
 
     var moduleMigrationVersions = <MigrationVersion>[];
 
@@ -388,9 +391,10 @@ class MigrationGenerator {
     );
   }
 
-  Future<String> _extractModuleNameFromPath(Uri path) async{
+  Future<String> _extractModuleNameFromPath(Uri path) async {
     var packageName = path.pathSegments.last;
-    return await moduleNameFromServerPackageName(packageName, path.pathSegments);
+    return await moduleNameFromServerPackageName(
+        packageName, path.pathSegments);
   }
 
   void _printWarnings(List<DatabaseMigrationWarning> warnings) {

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -159,7 +159,8 @@ Future<List<Uri>> locateAllModulePaths({
   return paths;
 }
 
-Future<String> moduleNameFromServerPackageName(String packageDirName, [List<String> pathSegments = const []]) async{
+Future<String> moduleNameFromServerPackageName(String packageDirName,
+    [List<String> pathSegments = const []]) async {
   var packageName = packageDirName.split('-').first;
 
   if (packageName == 'serverpod') {
@@ -167,9 +168,11 @@ Future<String> moduleNameFromServerPackageName(String packageDirName, [List<Stri
   }
 
   if (!packageName.endsWith(_serverSuffix)) {
-    log.warning("Hint: Found a server package that doesn't end with a suffix of $_serverSuffix: $packageName\n Please make sure that all server packages end with $_serverSuffix.");
-    if(pathSegments.isNotEmpty && await isServerPackage(pathSegments)) {
-      log.info('Assuming package is a server package based on config/generator.yaml');
+    log.warning(
+        "Hint: Found a server package that doesn't end with a suffix of $_serverSuffix: $packageName\n Please make sure that all server packages end with $_serverSuffix.");
+    if (pathSegments.isNotEmpty && await isServerPackage(pathSegments)) {
+      log.info(
+          'Assuming package is a server package based on config/generator.yaml');
       return packageName;
     }
     throw Exception('Not a server package ($packageName)');
@@ -177,7 +180,7 @@ Future<String> moduleNameFromServerPackageName(String packageDirName, [List<Stri
   return packageName.substring(0, packageName.length - _serverSuffix.length);
 }
 
-Future<bool> isServerPackage(List<String> pathSegments) async{
+Future<bool> isServerPackage(List<String> pathSegments) async {
   //Check whether the package is a server package based on the generator.yaml file
   //here we are verifying the type of the package
   //if the type is server then we can assume that the package is a server package
@@ -186,7 +189,7 @@ Future<bool> isServerPackage(List<String> pathSegments) async{
   var generatorConfigUri = Uri.parse(path.joinAll(generateConfigSegments));
   log.info('Reading generator config from: $generatorConfigUri');
   var generatorConfigFile = File.fromUri(generatorConfigUri);
-  if(!await generatorConfigFile.exists()) {
+  if (!await generatorConfigFile.exists()) {
     return false;
   }
 

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -186,10 +186,16 @@ Future<bool> isServerPackage(List<String> pathSegments) async {
   //if the type is server then we can assume that the package is a server package
   var generateConfigSegments = List<String>.from(pathSegments)
     ..addAll(['config', 'generator.yaml']);
-  var generatorConfigUri = Uri.parse(path.joinAll(generateConfigSegments));
+  var filePath = path.joinAll(generateConfigSegments);
+  // Ensure the filePath is absolute; if not, adjust accordingly:
+  if (!path.isAbsolute(filePath)) {
+    filePath = '/$filePath';
+  }
+  var generatorConfigUri = Uri.file(filePath);
   log.info('Reading generator config from: $generatorConfigUri');
   var generatorConfigFile = File.fromUri(generatorConfigUri);
   if (!await generatorConfigFile.exists()) {
+    log.info('config/generator.yaml file not found');
     return false;
   }
 

--- a/tools/serverpod_cli/test/locate_modules_test.dart
+++ b/tools/serverpod_cli/test/locate_modules_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('Locate modules', () {
-    test('moduleNameFromServerPackageName', () async{
+    test('moduleNameFromServerPackageName', () async {
       var moduleName = await moduleNameFromServerPackageName('test_server');
       expect(moduleName, 'test');
 

--- a/tools/serverpod_cli/test/locate_modules_test.dart
+++ b/tools/serverpod_cli/test/locate_modules_test.dart
@@ -3,20 +3,20 @@ import 'package:test/test.dart';
 
 void main() {
   group('Locate modules', () {
-    test('moduleNameFromServerPackageName', () {
-      var moduleName = moduleNameFromServerPackageName('test_server');
+    test('moduleNameFromServerPackageName', () async{
+      var moduleName = await moduleNameFromServerPackageName('test_server');
       expect(moduleName, 'test');
 
-      moduleName = moduleNameFromServerPackageName('test2_server');
+      moduleName = await moduleNameFromServerPackageName('test2_server');
       expect(moduleName, 'test2');
 
-      moduleName = moduleNameFromServerPackageName('serverpod');
+      moduleName = await moduleNameFromServerPackageName('serverpod');
       expect(moduleName, 'serverpod');
 
-      moduleName = moduleNameFromServerPackageName('test_server-1.1.1');
+      moduleName = await moduleNameFromServerPackageName('test_server-1.1.1');
       expect(moduleName, 'test');
 
-      moduleName = moduleNameFromServerPackageName('serverpod-1.1.1');
+      moduleName = await moduleNameFromServerPackageName('serverpod-1.1.1');
       expect(moduleName, 'serverpod');
     });
   });


### PR DESCRIPTION
This PR fixes issue #3148.

Previously, Serverpod determined the server package by checking if the package name had the _server suffix. However, if a user renamed the package, this check would fail and result in a crash.

With this update, the system will:

- Still check for the _server suffix.

- Additionally, inspect the config/generator.yaml file.

- Look for a field that explicitly assigns type: server.

- If this field is present, it will recognize the package as a server package, even if the name has been changed.

- If the package name is changed and type: server is missing from generator.yaml, it will throw an exception.