### PR TITLE
Speed up local E2E tests in Docker container

### DIFF
--- a/tests/docker/tests_e2e/Dockerfile-tests
+++ b/tests/docker/tests_e2e/Dockerfile-tests
@@ -4,22 +4,19 @@ FROM dart:3.3.0 AS build
 # Set the working directory
 WORKDIR /app
 
-# Copy the whole serverpod repo into the container.
-COPY . .
-
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
 RUN apt-get update
 RUN apt-get install --fix-missing -y xvfb  
 
 RUN apt-get install -y --no-install-recommends firefox
 
+# Copy the whole serverpod repo into the container.
+COPY . .
 
 WORKDIR /app/tests/serverpod_test_server
 RUN dart pub get
 
 WORKDIR /app
 
-
 # Setup database tables and start the server.
 ENTRYPOINT ["tests/docker/tests_e2e/run-tests.sh"]
-


### PR DESCRIPTION
by only copying the local files after the container is set up (apt-get being done)

That way Docker can use a cache for the previous build steps, and just needs to re-run `pub get` on each run as the files might influence that.