### PR TITLE
ci: Bump to latest version of Flutter and Dart

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        flutter-version: ['3.27.0']
+        flutter-version: ['3.29.0']
         os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
         os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -123,7 +123,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
         os: [windows-latest, ubuntu-latest]
         path:
           [
@@ -150,7 +150,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
         os: [ubuntu-latest]
         path: ['packages/serverpod_client']
     steps:
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
         path: ['packages/serverpod_shared']
     steps:
       - uses: actions/checkout@v3
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -241,7 +241,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
         os: [windows-latest, ubuntu-latest]
         path: ['tests/bootstrap_project']
     steps:
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
@@ -283,7 +283,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter-version: ['3.19.0', '3.27.0']
+        flutter-version: ['3.19.0', '3.29.0']
         os: [ubuntu-latest]
         path: ['tests/serverpod_cli_e2e_test']
     steps:


### PR DESCRIPTION
New version of [Flutter](https://medium.com/flutter/f90c380c2317) and [Dart](https://medium.com/dartlang/announcing-dart-3-7-bf864a1b195c) are out.

This PR bumps the latest version of Dart and Flutter used in the CI tests.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, simple CI change.