### PR TITLE
feat: Interface Model Support

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -35,6 +35,14 @@ class ModelDependencyResolver {
     ClassDefinition classDefinition,
     List<SerializableModelDefinition> modelDefinitions,
   ) {
+    _resolveExtends(classDefinition, modelDefinitions);
+    _resolveImplements(classDefinition, modelDefinitions);
+  }
+
+  static void _resolveExtends(
+    ClassDefinition classDefinition,
+    List<SerializableModelDefinition> modelDefinitions,
+  ) {
     var extendedClass = classDefinition.extendsClass;
     if (extendedClass is! UnresolvedInheritanceDefinition) {
       return;
@@ -55,6 +63,33 @@ class ModelDependencyResolver {
     parentClass.childClasses.add(
       ResolvedInheritanceDefinition(classDefinition),
     );
+  }
+
+  static void _resolveImplements(
+    ClassDefinition classDefinition,
+    List<SerializableModelDefinition> modelDefinitions,
+  ) {
+    if (classDefinition.isImplementing.isEmpty) {
+      return;
+    }
+
+    var resolvedImplements = <InheritanceDefinition>[];
+
+    for (var implementedClass in classDefinition.isImplementing) {
+      if (implementedClass is! UnresolvedInheritanceDefinition) {
+        continue;
+      }
+
+      var interfaceClass = modelDefinitions
+          .whereType<ClassDefinition>()
+          .where((element) => element.className == implementedClass.className)
+          .firstOrNull;
+
+      if (interfaceClass != null) {
+        resolvedImplements.add(ResolvedInheritanceDefinition(interfaceClass));
+      }
+    }
+    classDefinition.isImplementing = resolvedImplements;
   }
 
   static void _resolveFieldIndexes(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -6,6 +6,7 @@ import 'package:serverpod_cli/src/analyzer/models/validation/model_validator.dar
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/class_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart';
+import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/interface_yaml_definition.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
@@ -34,6 +35,7 @@ class SerializableModelAnalyzer {
     Keyword.classType,
     Keyword.exceptionType,
     Keyword.enumType,
+    Keyword.interfaceType,
   };
 
   /// Best effort attempt to extract a model definition from a yaml file.
@@ -82,6 +84,15 @@ class SerializableModelAnalyzer {
           outFileName,
           documentContents,
           docsExtractor,
+        );
+      case Keyword.interfaceType:
+        return ModelParser.serializeClassFile(
+          Keyword.interfaceType,
+          modelSource,
+          outFileName,
+          documentContents,
+          docsExtractor,
+          extraClasses,
         );
       default:
         return null;
@@ -163,6 +174,10 @@ class SerializableModelAnalyzer {
       case Keyword.enumType:
         documentStructure = EnumYamlDefinition(restrictions).documentStructure;
         break;
+      case Keyword.interfaceType:
+        documentStructure =
+            InterfaceYamlDefinition(restrictions).documentStructure;
+        break;
       default:
         throw UnimplementedError(
             'Validation for $definitionType is not implemented.');
@@ -212,6 +227,10 @@ class SerializableModelAnalyzer {
 
     if (documentContents.nodes[Keyword.enumType] != null) {
       return Keyword.enumType;
+    }
+
+    if (documentContents.nodes[Keyword.interfaceType] != null) {
+      return Keyword.interfaceType;
     }
 
     return null;

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -38,6 +38,8 @@ class ModelParser {
     var isSealed = _parseIsSealed(documentContents);
     var extendsClass = _parseExtendsClass(documentContents);
 
+    var isImplementing = _parseIsImplementing(documentContents);
+
     var classType = parseType(
       '${protocolSource.moduleAlias}:$className',
       extraClasses: extraClasses,
@@ -62,6 +64,7 @@ class ModelParser {
       className: className,
       isSealed: isSealed,
       extendsClass: extendsClass,
+      isImplementing: isImplementing,
       sourceFileName: protocolSource.yamlSourceUri.path,
       tableName: tableName,
       manageMigration: manageMigration,
@@ -71,6 +74,7 @@ class ModelParser {
       subDirParts: protocolSource.subDirPathParts,
       documentation: classDocumentation,
       isException: documentTypeName == Keyword.exceptionType,
+      isInterface: documentTypeName == Keyword.interfaceType,
       serverOnly: serverOnly,
       type: classType,
     );
@@ -126,6 +130,25 @@ class ModelParser {
     if (extendsClass is! String) return null;
 
     return UnresolvedInheritanceDefinition(extendsClass);
+  }
+
+  static List<UnresolvedInheritanceDefinition> _parseIsImplementing(
+    YamlMap documentContents,
+  ) {
+    var implementsNode = documentContents.nodes[Keyword.isImplementing];
+
+    if (implementsNode is! YamlScalar) return [];
+
+    // Split the string by commas and trim whitespace
+    var interfaces = implementsNode.value
+        .toString()
+        .split(',')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .map((e) => UnresolvedInheritanceDefinition(e))
+        .toList();
+
+    return interfaces;
   }
 
   static bool _parseServerOnly(YamlMap documentContents) {

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/keywords.dart
@@ -2,11 +2,14 @@ class Keyword {
   static const String classType = 'class';
   static const String exceptionType = 'exception';
   static const String enumType = 'enum';
+  static const String interfaceType = 'interface';
 
   static const String serialized = 'serialized';
 
   static const String isSealed = 'sealed';
   static const String extendsClass = 'extends';
+
+  static const String isImplementing = 'implements';
 
   static const String serverOnly = 'serverOnly';
   static const String table = 'table';

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart
@@ -26,6 +26,10 @@ class ExceptionYamlDefinition {
         valueRestriction: BooleanValueRestriction().validate,
       ),
       ValidateNode(
+        Keyword.isImplementing,
+        valueRestriction: restrictions.validateImplementedInterfaceNames,
+      ),
+      ValidateNode(
         Keyword.fields,
         isRequired: false,
         nested: {

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/interface_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/interface_yaml_definition.dart
@@ -1,64 +1,21 @@
-import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/keywords.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions/base.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions/default.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions/scope.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/validate_node.dart';
-import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 
-class ClassYamlDefinition {
+class InterfaceYamlDefinition {
   late Set<ValidateNode> documentStructure;
 
-  ValidateNode get fieldStructure {
-    return documentStructure
-        .firstWhere((element) => element.key == Keyword.fields)
-        .nested
-        .first;
-  }
-
-  ClassYamlDefinition(Restrictions restrictions) {
+  InterfaceYamlDefinition(Restrictions restrictions) {
     documentStructure = {
       ValidateNode(
-        Keyword.classType,
+        Keyword.interfaceType,
         isRequired: true,
         valueRestriction: restrictions.validateClassName,
-      ),
-      ValidateNode(
-        Keyword.isSealed,
-        valueRestriction: BooleanValueRestriction().validate,
-        mutuallyExclusiveKeys: {
-          Keyword.table,
-        },
-        isHidden: !restrictions.config
-            .isExperimentalFeatureEnabled(ExperimentalFeature.inheritance),
-      ),
-      ValidateNode(
-        Keyword.extendsClass,
-        valueRestriction: restrictions.validateExtendingClassName,
-        isHidden: !restrictions.config
-            .isExperimentalFeatureEnabled(ExperimentalFeature.inheritance),
-      ),
-      ValidateNode(
-        Keyword.isImplementing,
-        valueRestriction: restrictions.validateImplementedInterfaceNames,
-      ),
-      ValidateNode(
-        Keyword.table,
-        keyRestriction: restrictions.validateTableNameKey,
-        valueRestriction: restrictions.validateTableName,
-        mutuallyExclusiveKeys: {
-          Keyword.isSealed,
-        },
-      ),
-      ValidateNode(
-        Keyword.managedMigration,
-        valueRestriction: BooleanValueRestriction().validate,
-      ),
-      ValidateNode(
-        Keyword.serverOnly,
-        valueRestriction: BooleanValueRestriction().validate,
       ),
       ValidateNode(
         Keyword.fields,
@@ -199,30 +156,6 @@ class ClassYamlDefinition {
               ),
             },
           ),
-        },
-      ),
-      ValidateNode(
-        Keyword.indexes,
-        nested: {
-          ValidateNode(
-            Keyword.any,
-            keyRestriction: restrictions.validateTableIndexName,
-            nested: {
-              ValidateNode(
-                Keyword.fields,
-                isRequired: true,
-                valueRestriction: restrictions.validateIndexFieldsValue,
-              ),
-              ValidateNode(
-                Keyword.type,
-                valueRestriction: restrictions.validateIndexType,
-              ),
-              ValidateNode(
-                Keyword.unique,
-                valueRestriction: BooleanValueRestriction().validate,
-              ),
-            },
-          )
         },
       ),
     };

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -40,8 +40,9 @@ class LibraryGenerator {
       return isSealedTopNode || isNotPartOfSealedHierarchy;
     }).toList();
 
-    var unsealedModels = allModels
-        .where((model) => !(model is ClassDefinition && model.isSealed))
+    var serializableModels = allModels
+        .where((model) => !(model is ClassDefinition &&
+            (model.isSealed || model.isInterface)))
         .toList();
 
     // exports
@@ -135,14 +136,14 @@ class LibraryGenerator {
         ..body = Block.of([
           const Code('t ??= T;'),
           ...(<Expression, Code>{
-            for (var classInfo in unsealedModels)
+            for (var classInfo in serializableModels)
               refer(
                   classInfo.className,
                   TypeDefinition.getRef(
                       classInfo)): Code.scope((a) =>
                   '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
                   '.fromJson(data) as T'),
-            for (var classInfo in unsealedModels)
+            for (var classInfo in serializableModels)
               refer('getType', serverpodUrl(serverCode)).call([], {}, [
                 TypeReference(
                   (b) => b
@@ -154,7 +155,7 @@ class LibraryGenerator {
                   '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
                   '.fromJson(data) :null) as T'),
           }..addEntries([
-                  for (var classInfo in unsealedModels)
+                  for (var classInfo in serializableModels)
                     // Generate deserialization for fields of models.
                     if (classInfo is ClassDefinition)
                       for (var field in classInfo.fields.where(
@@ -227,7 +228,7 @@ class LibraryGenerator {
           for (var extraClass in config.extraClasses)
             Code.scope((a) =>
                 'if(data is ${a(extraClass.reference(serverCode, config: config))}) {return \'${extraClass.className}\';}'),
-          for (var classInfo in unsealedModels)
+          for (var classInfo in serializableModels)
             Code.scope((a) =>
                 'if(data is ${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}) {return \'${classInfo.className}\';}'),
           if (config.name != 'serverpod' && serverCode)
@@ -262,7 +263,7 @@ class LibraryGenerator {
             Code.scope((a) =>
                 'if(dataClassName == \'${extraClass.className}\'){'
                 'return deserialize<${a(extraClass.reference(serverCode, config: config))}>(data[\'data\']);}'),
-          for (var classInfo in unsealedModels)
+          for (var classInfo in serializableModels)
             Code.scope((a) => 'if(dataClassName == \'${classInfo.className}\'){'
                 'return deserialize<${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}>(data[\'data\']);}'),
           if (config.name != 'serverpod' && serverCode)

--- a/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
+++ b/tools/serverpod_cli/lib/src/test_util/builders/class_definition_builder.dart
@@ -15,6 +15,7 @@ class ClassDefinitionBuilder {
   List<String> _subDirParts;
   bool _serverOnly;
   bool _isException;
+  bool _isInterface;
   String? _tableName;
   bool _managedMigration;
   List<_FieldBuilder> _fields;
@@ -22,6 +23,7 @@ class ClassDefinitionBuilder {
   List<String>? _documentation;
   bool _isSealed;
   List<InheritanceDefinition> _childClasses;
+  List<InheritanceDefinition> _implementedInterfaces;
   InheritanceDefinition? _extendsClass;
 
   ClassDefinitionBuilder()
@@ -33,8 +35,10 @@ class ClassDefinitionBuilder {
         _managedMigration = true,
         _serverOnly = false,
         _isException = false,
+        _isInterface = false,
         _indexes = [],
         _childClasses = [],
+        _implementedInterfaces = [],
         _isSealed = false;
 
   ClassDefinition build() {
@@ -58,10 +62,12 @@ class ClassDefinitionBuilder {
       subDirParts: _subDirParts,
       serverOnly: _serverOnly,
       isException: _isException,
+      isInterface: _isInterface,
       tableName: _tableName,
       manageMigration: _managedMigration,
       indexes: _indexes,
       documentation: _documentation,
+      isImplementing: _implementedInterfaces,
       childClasses: _childClasses,
       extendsClass: _extendsClass,
       isSealed: _isSealed,
@@ -320,6 +326,21 @@ class ClassDefinitionBuilder {
 
   ClassDefinitionBuilder withIsException(bool isException) {
     _isException = isException;
+    return this;
+  }
+
+  ClassDefinitionBuilder withIsInterface(bool isInterface) {
+    _isInterface = isInterface;
+    return this;
+  }
+
+  ClassDefinitionBuilder withImplementedInterfaces(
+    List<ClassDefinition> interfaces,
+  ) {
+    _implementedInterfaces = [
+      for (var interface in interfaces)
+        ResolvedInheritanceDefinition(interface),
+    ];
     return this;
   }
 

--- a/tools/serverpod_cli/lib/src/test_util/compilation_unit_helpers.dart
+++ b/tools/serverpod_cli/lib/src/test_util/compilation_unit_helpers.dart
@@ -215,6 +215,22 @@ abstract class CompilationUnitHelpers {
     return matchingImplementsClauses.isNotEmpty;
   }
 
+  /// Returns [NamedType] if the class has an implements clause with the
+  /// given [name], otherwise returns `null`.
+  static NamedType? tryFindImplementedClass(
+    ClassDeclaration classDeclaration, {
+    required String name,
+  }) {
+    var implementsClause = classDeclaration.implementsClause;
+    if (implementsClause == null) {
+      return null;
+    }
+
+    return implementsClause.interfaces
+        .where((type) => type.name2.toString() == name)
+        .firstOrNull;
+  }
+
   /// Returns [ConstructorDeclaration] if the class has a constructor with the
   /// given name and parameters, otherwise returns `null`.
   ///

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
@@ -263,7 +263,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'The "table" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.',
+          'The "table" property is not allowed for exception type. Valid keys are {exception, serverOnly, implements, fields}.',
         );
       },
     );
@@ -408,7 +408,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'The "indexes" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.',
+          'The "indexes" property is not allowed for exception type. Valid keys are {exception, serverOnly, implements, fields}.',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
@@ -169,7 +169,7 @@ void main() {
       var error = collector.errors.first;
       expect(
         error.message,
-        'The "extends" property is not allowed for class type. Valid keys are {class, table, managedMigration, serverOnly, fields, indexes}.',
+        'The "extends" property is not allowed for class type. Valid keys are {class, implements, table, managedMigration, serverOnly, fields, indexes}.',
       );
     });
 
@@ -508,7 +508,7 @@ void main() {
     var error = collector.errors.first;
     expect(
       error.message,
-      'The "sealed" property is not allowed for class type. Valid keys are {class, table, managedMigration, serverOnly, fields, indexes}.',
+      'The "sealed" property is not allowed for class type. Valid keys are {class, implements, table, managedMigration, serverOnly, fields, indexes}.',
     );
   });
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/interface_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/interface_test.dart
@@ -1,0 +1,279 @@
+import 'package:test/test.dart';
+
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/model_source_builder.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
+      [ExperimentalFeature.inheritance]).build();
+
+  group('Interface Class Tests', () {
+    test(
+        'Given an interface class, when the class name is not a valid class name, then an error is collected that the name is not valid',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          interface: example
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The "interface" type must be a valid class name (e.g. PascalCaseString).',
+      );
+    });
+
+    test(
+        'Given an interface class, when the class name is a reserved keyword, then an error is collected that the class name is reserved',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          interface: List
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The class name "List" is reserved and cannot be used.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing a single valid interface, then no errors are collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: ValidInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: ValidInterface
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing multiple interfaces, then no errors are collected if all interfaces are valid',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: Interface1, Interface2
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: Interface1
+          fields:
+            id: int
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface2').withYaml(
+          '''
+          interface: Interface2
+          fields:
+            age: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing a non-existent interface, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: NonExistentInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The implemented interface name "NonExistentInterface" was not found in any model.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing duplicate interfaces, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: DuplicateInterface, DuplicateInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: DuplicateInterface
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The interface name "DuplicateInterface" is duplicated.',
+      );
+    });
+
+    test(
+        'Given a class implementing a non-interface class, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1 ').withYaml(
+          '''
+          class: ExampleClass
+          implements: NonInterfaceClass
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('non_interface_class').withYaml(
+          '''
+          class: NonInterfaceClass
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The implemented node "NonInterfaceClass" is not an interface.',
+      );
+    });
+
+    test(
+        'Given an exception implementing a valid interface, when generating code, then no errors are collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleException
+          implements: ValidInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: ValidInterface
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+    });
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_types_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_types_test.dart
@@ -319,7 +319,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'No {class, exception, enum} type is defined.',
+          'No {class, exception, enum, interface} type is defined.',
         );
       },
     );

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/interface_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/protocol/interface_protocol_test.dart
@@ -1,0 +1,148 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:test/test.dart';
+
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartClientCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    '..',
+    'example_project_client',
+    'lib',
+    'src',
+    'protocol',
+    'protocol.dart',
+  );
+
+  group('Given an interface class when generating code', () {
+    var interfaceName = 'ExampleInterface';
+    var interfaceFileName = 'example_interface';
+
+    var interfaceClass = ClassDefinitionBuilder()
+        .withClassName(interfaceName)
+        .withFileName(interfaceFileName)
+        .withIsInterface(true)
+        .build();
+
+    var models = [
+      interfaceClass,
+    ];
+
+    var endpoints = [
+      EndpointDefinitionBuilder().build(),
+    ];
+
+    var protocolDefinition =
+        ProtocolDefinition(endpoints: endpoints, models: models);
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    var protocolCompilationUnit =
+        parseString(content: codeMap[expectedFileName]!).unit;
+
+    var protocolClass = CompilationUnitHelpers.tryFindClassDeclaration(
+      protocolCompilationUnit,
+      name: 'Protocol',
+    );
+
+    test(
+      'then the protocol.dart file is created.',
+      () {
+        expect(protocolClass, isNotNull);
+      },
+    );
+
+    group('then the protocol.dart file', () {
+      test('does NOT import the $interfaceFileName', () {
+        var interfaceImport = CompilationUnitHelpers.tryFindImportDirective(
+          protocolCompilationUnit,
+          uri: '$interfaceFileName.dart',
+        );
+
+        expect(interfaceImport, isNull);
+      });
+
+      test('does export the $interfaceFileName', () {
+        var interfaceExport = CompilationUnitHelpers.tryFindExportDirective(
+          protocolCompilationUnit,
+          uri: '$interfaceFileName.dart',
+        );
+        expect(interfaceExport, isNotNull);
+      });
+    });
+
+    group('then the Protocol class', () {
+      test('is defined', () {
+        expect(protocolClass, isNotNull);
+      });
+
+      group('with a deserialize method', () {
+        var deserializeMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'deserialize',
+        );
+
+        test('is defined', () {
+          expect(deserializeMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName.fromJson', () {
+          expect(
+            deserializeMethod!.toSource().contains('$interfaceName.fromJson'),
+            isFalse,
+          );
+        });
+      });
+
+      group('with a getClassNameForObject method', () {
+        var getClassNameForObjectMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'getClassNameForObject',
+        );
+
+        test('is defined', () {
+          expect(getClassNameForObjectMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName', () {
+          expect(
+            getClassNameForObjectMethod!.toSource().contains(interfaceName),
+            isFalse,
+          );
+        });
+      });
+
+      group('with a deserializeByClassName method', () {
+        var deserializeByClassNameMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'deserializeByClassName',
+        );
+
+        test('is defined', () {
+          expect(deserializeByClassNameMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName', () {
+          expect(
+            deserializeByClassNameMethod!.toSource().contains(interfaceName),
+            isFalse,
+          );
+        });
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/interface_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/interface_class_test.dart
@@ -1,0 +1,341 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:test/test.dart';
+
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  String getExpectedFilePath(String fileName, {List<String>? subDirParts}) =>
+      p.joinAll([
+        'lib',
+        'src',
+        'generated',
+        ...?subDirParts,
+        '$fileName.dart',
+      ]);
+
+  group('Given an interface and a class implementing it, when generating code',
+      () {
+    var exampleInterface = ClassDefinitionBuilder()
+        .withClassName('ExampleInterface')
+        .withFileName('example_interface')
+        .withSimpleField('age', 'int', nullable: true)
+        .withIsInterface(true)
+        .build();
+
+    var exampleClass = ClassDefinitionBuilder()
+        .withClassName('Example')
+        .withFileName('example')
+        .withSimpleField('name', 'String')
+        .withImplementedInterfaces([exampleInterface]).build();
+
+    var models = [
+      exampleClass,
+      exampleInterface,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var exampleClassCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exampleClass.fileName)]!)
+        .unit;
+    var exampleInterfaceCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exampleInterface.fileName)]!)
+        .unit;
+
+    group('Then the ${exampleInterface.className}', () {
+      var exampleInterfaceDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exampleInterfaceCompilationUnit,
+        name: exampleInterface.className,
+      );
+
+      test('is defined', () {
+        expect(exampleInterfaceDeclaration, isNotNull);
+      });
+
+      group('does have a constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exampleInterfaceDeclaration!,
+          name: null,
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test('with the passed params', () {
+          expect(constructor?.parameters.toSource(), '({this.age})');
+        });
+      });
+
+      test('does NOT have a copyWith method', () {
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'copyWith',
+        );
+
+        expect(copyWithMethod, isNull);
+      });
+
+      test('does NOT have a toJson method', () {
+        var toJsonMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'toJson',
+        );
+
+        expect(toJsonMethod, isNull);
+      });
+
+      test('does NOT have a toJsonForProtocol method', () {
+        var toJsonForProtocolMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'toJsonForProtocol',
+        );
+
+        expect(toJsonForProtocolMethod, isNull);
+      });
+
+      test('does NOT have a toString method', () {
+        var toStringMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'toString',
+        );
+
+        expect(toStringMethod, isNull);
+      });
+    });
+
+    group('Then the ${exampleClass.className}', () {
+      var exampleClassDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exampleClassCompilationUnit,
+        name: exampleClass.className,
+      );
+
+      test('is defined', () {
+        expect(exampleClassDeclaration, isNotNull);
+      });
+
+      test('implements ${exampleInterface.className}', () {
+        var implementsDirective =
+            CompilationUnitHelpers.tryFindImplementedClass(
+          exampleClassDeclaration!,
+          name: exampleInterface.className,
+        );
+
+        expect(
+          implementsDirective,
+          isNotNull,
+        );
+      });
+
+      group('has a private constructor', () {
+        var privateConstructor =
+            CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exampleClassDeclaration!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(privateConstructor, isNotNull);
+        });
+
+        test('with vars as params from interface and itself', () {
+          expect(
+            privateConstructor?.parameters.toSource(),
+            '({this.age, required this.name})',
+          );
+        });
+      });
+
+      test('does have a copyWith method', () {
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'copyWith',
+        );
+
+        expect(copyWithMethod, isNotNull);
+      });
+
+      test('does have a toJson method', () {
+        var toJsonMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'toJson',
+        );
+
+        expect(toJsonMethod, isNotNull);
+      });
+
+      test('does have a toJsonForProtocol method', () {
+        var toJsonForProtocolMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'toJsonForProtocol',
+        );
+
+        expect(toJsonForProtocolMethod, isNotNull);
+      });
+
+      test('does have a toString method', () {
+        var toStringMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'toString',
+        );
+
+        expect(toStringMethod, isNotNull);
+      });
+    });
+  });
+
+  group('Given a parent class implementing an interface, when generating code',
+      () {
+    var interfaceClass = ClassDefinitionBuilder()
+        .withClassName('ExampleInterface')
+        .withFileName('example_interface')
+        .withSimpleField('age', 'int', nullable: true)
+        .withIsInterface(true)
+        .build();
+
+    var parent = ClassDefinitionBuilder()
+        .withClassName('ExampleParent')
+        .withFileName('example_parent')
+        .withSimpleField('name', 'String')
+        .withImplementedInterfaces([interfaceClass]).build();
+
+    var child = ClassDefinitionBuilder()
+        .withClassName('ExampleChild')
+        .withFileName('example_child')
+        .withSimpleField('foo', 'int')
+        .withExtendsClass(parent)
+        .build();
+
+    parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+    var models = [
+      parent,
+      child,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var childCompilationUnit =
+        parseString(content: codeMap[getExpectedFilePath(child.fileName)]!)
+            .unit;
+
+    group('Then the ${child.className} ', () {
+      var childClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        childCompilationUnit,
+        name: child.className,
+      );
+
+      test('is defined', () {
+        expect(childClass, isNotNull);
+      });
+
+      group('has a private constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          childClass!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test('with vars as params from interface, parent and itself', () {
+          expect(
+            constructor?.parameters.toSource(),
+            '({super.age, required super.name, required this.foo})',
+          );
+        });
+      });
+    });
+  });
+
+  group('Given an exception implementing an interface, when generating code',
+      () {
+    var interfaceClass = ClassDefinitionBuilder()
+        .withClassName('ExampleInterface')
+        .withFileName('example_interface')
+        .withSimpleField('age', 'int', nullable: true)
+        .withIsInterface(true)
+        .build();
+
+    var exceptionClass = ClassDefinitionBuilder()
+        .withClassName('ExampleException')
+        .withFileName('example_exception')
+        .withSimpleField('name', 'String')
+        .withIsException(true)
+        .withImplementedInterfaces([interfaceClass]).build();
+
+    var models = [
+      exceptionClass,
+      interfaceClass,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var exceptionCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exceptionClass.fileName)]!)
+        .unit;
+
+    group('Then the ${exceptionClass.className}', () {
+      var exceptionClassDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exceptionCompilationUnit,
+        name: exceptionClass.className,
+      );
+
+      test('is defined', () {
+        expect(exceptionClassDeclaration, isNotNull);
+      });
+
+      test('implements ${interfaceClass.className}', () {
+        var implementsDirective =
+            CompilationUnitHelpers.tryFindImplementedClass(
+          exceptionClassDeclaration!,
+          name: interfaceClass.className,
+        );
+
+        expect(implementsDirective, isNotNull);
+      });
+
+      group('has a private constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exceptionClassDeclaration!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test('with vars as params from interface and itself', () {
+          expect(
+            constructor?.parameters.toSource(),
+            '({this.age, required this.name})',
+          );
+        });
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/interface_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/interface_protocol_test.dart
@@ -1,0 +1,146 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:serverpod_cli/src/test_util/builders/class_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/endpoint_definition_builder.dart';
+import 'package:serverpod_cli/src/test_util/builders/generator_config_builder.dart';
+import 'package:serverpod_cli/src/test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    'lib',
+    'src',
+    'generated',
+    'protocol.dart',
+  );
+
+  group('Given an interface class when generating code', () {
+    var interfaceName = 'ExampleInterface';
+    var interfaceFileName = 'example_interface';
+
+    var interfaceClass = ClassDefinitionBuilder()
+        .withClassName(interfaceName)
+        .withFileName(interfaceFileName)
+        .withIsInterface(true)
+        .build();
+
+    var models = [
+      interfaceClass,
+    ];
+
+    var endpoints = [
+      EndpointDefinitionBuilder().build(),
+    ];
+
+    var protocolDefinition =
+        ProtocolDefinition(endpoints: endpoints, models: models);
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    var protocolCompilationUnit =
+        parseString(content: codeMap[expectedFileName]!).unit;
+
+    var protocolClass = CompilationUnitHelpers.tryFindClassDeclaration(
+      protocolCompilationUnit,
+      name: 'Protocol',
+    );
+
+    test(
+      'then the protocol.dart file is created.',
+      () {
+        expect(protocolClass, isNotNull);
+      },
+    );
+
+    group('then the protocol.dart file', () {
+      test('does NOT import the $interfaceFileName', () {
+        var interfaceImport = CompilationUnitHelpers.tryFindImportDirective(
+          protocolCompilationUnit,
+          uri: '$interfaceFileName.dart',
+        );
+
+        expect(interfaceImport, isNull);
+      });
+
+      test('does export the $interfaceFileName', () {
+        var interfaceExport = CompilationUnitHelpers.tryFindExportDirective(
+          protocolCompilationUnit,
+          uri: '$interfaceFileName.dart',
+        );
+        expect(interfaceExport, isNotNull);
+      });
+    });
+
+    group('then the Protocol class', () {
+      test('is defined', () {
+        expect(protocolClass, isNotNull);
+      });
+
+      group('with a deserialize method', () {
+        var deserializeMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'deserialize',
+        );
+
+        test('is defined', () {
+          expect(deserializeMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName.fromJson', () {
+          expect(
+            deserializeMethod!.toSource().contains('$interfaceName.fromJson'),
+            isFalse,
+          );
+        });
+      });
+
+      group('with a getClassNameForObject method', () {
+        var getClassNameForObjectMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'getClassNameForObject',
+        );
+
+        test('is defined', () {
+          expect(getClassNameForObjectMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName', () {
+          expect(
+            getClassNameForObjectMethod!.toSource().contains(interfaceName),
+            isFalse,
+          );
+        });
+      });
+
+      group('with a deserializeByClassName method', () {
+        var deserializeByClassNameMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'deserializeByClassName',
+        );
+
+        test('is defined', () {
+          expect(deserializeByClassNameMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName', () {
+          expect(
+            deserializeByClassNameMethod!.toSource().contains(interfaceName),
+            isFalse,
+          );
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
This PR tries to enable the use of the `interface` and `implements` keyword in model files.

This is done in 3 steps/commits 

1. Enable `interface` and `implements` keywords
2. Enable generating interfaces and classes implementing them
3. Exclude interfaces from serialization in `protocol`

I described every change ordered by file in the commit descriptions. 


This PR tries to close #2842. 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

No breaking changes  