### PR TITLE
Emal login SignInWithEmailDialog default page changed to signIn

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
+++ b/modules/serverpod_auth/serverpod_auth_email_flutter/lib/src/signin_dialog.dart
@@ -56,7 +56,7 @@ class SignInWithEmailDialogState extends State<SignInWithEmailDialog> {
 
   late final EmailAuthController _emailAuth;
 
-  _Page _page = _Page.createAccount;
+  _Page _page = _Page.signIn;
 
   bool _enabled = true;
   bool _isPasswordObscured = true;


### PR DESCRIPTION
The default screen that appears when you tap the SignInWithEmailButton is the createAccount page instead of the signin page.
This is different from the behavior inferred from the name of the SignInWithEmailButton, so the default has been changed to the signin page.

This PR tries to close #3234
## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

