### PR TITLE
feat: Handle SIGTERM and shutdown gracefully

### DIFF
--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -23,7 +23,7 @@ class HealthCheckManager {
 
   bool _running = false;
   Timer? _timer;
-  Completer<void>? _completer;
+  Completer<void>? _pendingHealthCheck;
 
   /// Creates a new [HealthCheckManager].
   HealthCheckManager(this._pod, this.onCompleted);
@@ -45,12 +45,12 @@ class HealthCheckManager {
   Future<void> stop() async {
     _running = false;
     _timer?.cancel();
-    await _completer?.future;
+    await _pendingHealthCheck?.future;
   }
 
   Future<void> _performHealthCheck() async {
     final completer = Completer<void>();
-    _completer = completer;
+    _pendingHealthCheck = completer;
 
     try {
       await _innerPerformHealthCheck();

--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -41,7 +41,7 @@ class HealthCheckManager {
   }
 
   /// Stops the health check manager.
-  void stop() {
+  Future<void> stop() async {
     _running = false;
     _timer?.cancel();
   }

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -543,7 +543,9 @@ class Serverpod {
       var serversStarted = true;
 
       ProcessSignal.sigint.watch().listen(_onShutdownSignal);
-      ProcessSignal.sigterm.watch().listen(_onShutdownSignal);
+      if (!Platform.isWindows) {
+        ProcessSignal.sigterm.watch().listen(_onShutdownSignal);
+      }
 
       // Serverpod Insights.
       if (Features.enableInsights) {

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -542,7 +542,7 @@ class Serverpod {
         commandLineArgs.role == ServerpodRole.serverless) {
       var serversStarted = true;
 
-      ProcessSignal.sigint.watch().listen(_onShutdownSignal);
+      ProcessSignal.sigint.watch().listen(_onInterruptSignal);
       if (!Platform.isWindows) {
         ProcessSignal.sigterm.watch().listen(_onShutdownSignal);
       }
@@ -718,6 +718,22 @@ class Serverpod {
   void _onShutdownSignal(ProcessSignal signal) {
     stdout.writeln('${signal.name} (${signal.signalNumber}) received'
         ', time: ${DateTime.now().toUtc()}');
+    shutdown(exitProcess: true, signalNumber: signal.signalNumber);
+  }
+
+  bool _interruptSignalSent = false;
+
+  void _onInterruptSignal(ProcessSignal signal) {
+    stdout.writeln('${signal.name} (${signal.signalNumber}) received'
+        ', time: ${DateTime.now().toUtc()}');
+
+    if (_interruptSignalSent) {
+      stdout
+          .writeln('SERVERPOD immediate exit, time: ${DateTime.now().toUtc()}');
+      exit(128 + signal.signalNumber);
+    }
+
+    _interruptSignalSent = true;
     shutdown(exitProcess: true, signalNumber: signal.signalNumber);
   }
 

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -849,7 +849,7 @@ class Serverpod {
       await _webServer?.stop();
       await _serviceServer?.shutdown();
       await _futureCallManager?.stop();
-      _healthCheckManager?.stop();
+      await _healthCheckManager?.stop();
 
       // This needs to be closed last as it is used by the other services.
       await _databasePoolManager?.stop();

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -858,6 +858,7 @@ class Serverpod {
         'SERVERPOD initiating shutdown, time: ${DateTime.now().toUtc()}');
 
     var futures = [
+      _shutdownTestAuditor(),
       _internalSession.close(),
       redisController?.stop(),
       server.shutdown(),
@@ -973,6 +974,28 @@ class Serverpod {
   bool _isValidSecret(String? secret) {
     return secret != null && secret.isNotEmpty && secret.length > 20;
   }
+}
+
+Future<void>? _shutdownTestAuditor() {
+  var testThrowerDelaySeconds = int.tryParse(
+    Platform.environment['_SERVERPOD_SHUTDOWN_TEST_AUDITOR'] ?? '',
+  );
+  if (testThrowerDelaySeconds == null) {
+    return null;
+  }
+  return Future(() {
+    stderr.writeln('serverpod shutdown test auditor enabled');
+    if (testThrowerDelaySeconds == 0) {
+      throw Exception('serverpod shutdown test auditor throwing');
+    } else {
+      return Future.delayed(
+        Duration(seconds: testThrowerDelaySeconds),
+        () {
+          throw Exception('serverpod shutdown test auditor throwing');
+        },
+      );
+    }
+  });
 }
 
 /// Experimental API for Serverpod.

--- a/tests/serverpod_test_server/test_integration/shutdown_test.dart
+++ b/tests/serverpod_test_server/test_integration/shutdown_test.dart
@@ -1,0 +1,237 @@
+// ignore_for_file: dead_code
+
+@Timeout(Duration(minutes: 1))
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:async/async.dart';
+import 'package:http/http.dart';
+import 'package:serverpod_test/serverpod_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const signalDelay = Duration(seconds: 2);
+  const terminationTimeout = Duration(seconds: 10);
+  const verbose = false;
+
+  test(
+      'Given a serverpod server with db '
+      'when run in maintenance mode '
+      'then it automatically exits with exit code 0', () async {
+    final processOutput = await startProcess(
+      'dart',
+      [
+        'bin/main.dart',
+        '--mode=test',
+        '--role',
+        'maintenance',
+      ],
+      verbose: verbose,
+    );
+
+    await expectLater(
+      processOutput.outQueue,
+      emitsThrough(contains('SERVERPOD initialized')),
+    );
+
+    await expectLater(
+      processOutput.outQueue,
+      emitsInOrder([
+        emitsThrough(contains('All maintenance tasks completed. Exiting.')),
+      ]),
+    );
+
+    processOutput.outQueue.rest.listen((s) {});
+    processOutput.errQueue.rest.listen((s) {});
+    var exitCode = await processOutput.process.exitCode;
+    expect(exitCode, 0);
+  });
+
+  group('Given a running serverpod server', () {
+    test(
+        'when it is sent SIGINT '
+        'then it exits with exit code 130', () async {
+      final processOutput = await startProcess(
+        'dart',
+        ['bin/main.dart', '--mode=test'],
+        verbose: verbose,
+      );
+
+      await expectLater(
+        processOutput.outQueue,
+        emitsThrough(contains('SERVERPOD initialized')),
+      );
+
+      await Future.delayed(signalDelay);
+      if (verbose) {
+        print('sending process signal...');
+      }
+      processOutput.process.kill(ProcessSignal.sigint);
+
+      await expectLater(
+        processOutput.outQueue,
+        emitsInOrder([
+          emitsThrough(contains('SIGINT (2) received')),
+          emitsThrough(contains('SERVERPOD initiating shutdown')),
+          emitsThrough(contains('SERVERPOD has shutdown')),
+        ]),
+      );
+
+      processOutput.outQueue.rest.listen((s) {});
+      processOutput.errQueue.rest.listen((s) {});
+      var exitCode = await processOutput.process.exitCode.timeout(
+        terminationTimeout,
+      );
+      expect(exitCode, 130);
+    });
+
+    test(
+        'when it is sent SIGTERM '
+        'then it exits with exit code 143', () async {
+      final processOutput = await startProcess(
+        'dart',
+        ['bin/main.dart', '--mode=test'],
+        verbose: verbose,
+      );
+
+      await expectLater(
+        processOutput.outQueue,
+        emitsThrough(contains('SERVERPOD initialized')),
+      );
+
+      await Future.delayed(signalDelay);
+      if (verbose) {
+        print('sending process signal...');
+      }
+      processOutput.process.kill(ProcessSignal.sigterm);
+
+      await expectLater(
+        processOutput.outQueue,
+        emitsInOrder([
+          emitsThrough(contains('SIGTERM (15) received')),
+          emitsThrough(contains('SERVERPOD initiating shutdown')),
+          emitsThrough(contains('SERVERPOD has shutdown')),
+        ]),
+      );
+
+      processOutput.outQueue.rest.listen((s) {});
+      processOutput.errQueue.rest.listen((s) {});
+      var exitCode = await processOutput.process.exitCode.timeout(
+        terminationTimeout,
+      );
+      expect(exitCode, 143);
+    });
+
+    test(
+        'with an ongoing http request '
+        'when it is sent SIGTERM '
+        'then it exits with exit code 143', () async {
+      final processOutput = await startProcess(
+        'dart',
+        ['bin/main.dart', '--mode=test'],
+        verbose: verbose,
+      );
+
+      await expectLater(
+        processOutput.outQueue,
+        emitsThrough(contains('SERVERPOD initialized')),
+      );
+      processOutput.outQueue.rest.listen((s) {});
+      processOutput.errQueue.rest.listen((s) {});
+
+      await Future.delayed(Duration(seconds: 5));
+      print('server should be up');
+
+      final httpClient = Client();
+      print('sending long-running request...');
+      final responseTask = httpClient.post(
+        Uri.parse('http://localhost:8080/failedCalls/slowCall'),
+      );
+
+      await Future.delayed(Duration(milliseconds: 1000));
+
+      if (verbose) {
+        print('sending process signal...');
+      }
+      processOutput.process.kill(ProcessSignal.sigterm);
+
+      await expectLater(
+        processOutput.outQueue,
+        emitsInOrder([
+          emitsThrough(contains('SIGTERM (15) received')),
+          emitsThrough(contains('SERVERPOD initiating shutdown')),
+          emitsThrough(contains('SERVERPOD has shutdown')),
+        ]),
+      );
+
+      print('waiting for response...');
+      final response = await responseTask;
+      print('response received with code ${response.statusCode}');
+      expect(response.statusCode, 200);
+
+      processOutput.outQueue.rest.listen((s) {});
+      processOutput.errQueue.rest.listen((s) {});
+      var exitCode = await processOutput.process.exitCode.timeout(
+        terminationTimeout,
+      );
+      expect(exitCode, 143);
+    }, skip: 'Dart HTTP server does not support this graceful shutdown');
+  }, tags: [defaultIntegrationTestTag]);
+}
+
+typedef ProcessOutput = ({
+  Process process,
+  StreamQueue<String> outQueue,
+  StreamQueue<String> errQueue,
+});
+
+Stream<String> _streamToLines(
+  Stream<List<int>> stream, {
+  bool verbose = false,
+  String? prefix,
+}) {
+  var lines = stream
+      .transform(Utf8Decoder())
+      .expand((str) => str.split('\n').where((l) => l.isNotEmpty));
+  if (!verbose) {
+    return lines;
+  }
+  return lines.map((line) {
+    print('${prefix != null ? '$prefix: ' : ''}$line');
+    return line;
+  });
+}
+
+Future<ProcessOutput> startProcess(
+  String executable,
+  List<String> arguments, {
+  Map<String, String>? environment,
+  bool verbose = false,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    environment: environment,
+  );
+
+  // ensure process is killed when test is done
+  addTearDown(() {
+    process.kill(ProcessSignal.sigkill);
+  });
+
+  return (
+    process: process,
+    outQueue: StreamQueue<String>(_streamToLines(
+      process.stdout,
+      verbose: verbose,
+      prefix: 'stdout',
+    )),
+    errQueue: StreamQueue<String>(_streamToLines(
+      process.stderr,
+      verbose: verbose,
+      prefix: 'stderr',
+    )),
+  );
+}

--- a/tests/serverpod_test_server/test_integration/shutdown_test.dart
+++ b/tests/serverpod_test_server/test_integration/shutdown_test.dart
@@ -47,7 +47,7 @@ void main() {
     processOutput.errQueue.rest.listen((s) {});
     var exitCode = await processOutput.process.exitCode;
     expect(exitCode, 0);
-  });
+  }, tags: [defaultIntegrationTestTag]);
 
   group('Given a running serverpod server', () {
     test(
@@ -122,11 +122,13 @@ void main() {
         terminationTimeout,
       );
       expect(exitCode, 143);
+    }, onPlatform: {
+      'windows': Skip('SIGTERM is not supported on Windows'),
     });
 
     test(
         'with shutdown test auditor enabled '
-        'when it is sent SIGTERM '
+        'when it is sent SIGINT '
         'then it exits with exit code 1', () async {
       final processOutput = await startProcess(
         'dart',
@@ -146,12 +148,12 @@ void main() {
       if (verbose) {
         print('sending process signal...');
       }
-      processOutput.process.kill(ProcessSignal.sigterm);
+      processOutput.process.kill(ProcessSignal.sigint);
 
       await expectLater(
         processOutput.outQueue,
         emitsInOrder([
-          emitsThrough(contains('SIGTERM (15) received')),
+          emitsThrough(contains('SIGINT (2) received')),
           emitsThrough(contains('SERVERPOD initiating shutdown')),
           emitsThrough(contains('SERVERPOD has shutdown')),
         ]),
@@ -176,8 +178,8 @@ void main() {
 
     test(
         'with an ongoing http request '
-        'when it is sent SIGTERM '
-        'then it exits with exit code 143', () async {
+        'when it is sent SIGINT '
+        'then it exits with exit code 130', () async {
       final processOutput = await startProcess(
         'dart',
         ['bin/main.dart', '--mode=test'],
@@ -205,12 +207,12 @@ void main() {
       if (verbose) {
         print('sending process signal...');
       }
-      processOutput.process.kill(ProcessSignal.sigterm);
+      processOutput.process.kill(ProcessSignal.sigint);
 
       await expectLater(
         processOutput.outQueue,
         emitsInOrder([
-          emitsThrough(contains('SIGTERM (15) received')),
+          emitsThrough(contains('SIGINT (2) received')),
           emitsThrough(contains('SERVERPOD initiating shutdown')),
           emitsThrough(contains('SERVERPOD has shutdown')),
         ]),
@@ -226,7 +228,7 @@ void main() {
       var exitCode = await processOutput.process.exitCode.timeout(
         terminationTimeout,
       );
-      expect(exitCode, 143);
+      expect(exitCode, 130);
     }, skip: 'Dart HTTP server does not support this graceful shutdown');
   }, tags: [defaultIntegrationTestTag]);
 }

--- a/tests/serverpod_test_server/test_integration/shutdown_test.dart
+++ b/tests/serverpod_test_server/test_integration/shutdown_test.dart
@@ -75,7 +75,7 @@ void main() {
         emitsInOrder([
           emitsThrough(contains('SIGINT (2) received')),
           emitsThrough(contains('SERVERPOD initiating shutdown')),
-          emitsThrough(contains('SERVERPOD has shutdown')),
+          emitsThrough(contains('SERVERPOD shutdown completed')),
         ]),
       );
 
@@ -112,7 +112,7 @@ void main() {
         emitsInOrder([
           emitsThrough(contains('SIGTERM (15) received')),
           emitsThrough(contains('SERVERPOD initiating shutdown')),
-          emitsThrough(contains('SERVERPOD has shutdown')),
+          emitsThrough(contains('SERVERPOD shutdown completed')),
         ]),
       );
 
@@ -155,7 +155,7 @@ void main() {
         emitsInOrder([
           emitsThrough(contains('SIGINT (2) received')),
           emitsThrough(contains('SERVERPOD initiating shutdown')),
-          emitsThrough(contains('SERVERPOD has shutdown')),
+          emitsThrough(contains('SERVERPOD shutdown completed')),
         ]),
       );
 
@@ -214,7 +214,7 @@ void main() {
         emitsInOrder([
           emitsThrough(contains('SIGINT (2) received')),
           emitsThrough(contains('SERVERPOD initiating shutdown')),
-          emitsThrough(contains('SERVERPOD has shutdown')),
+          emitsThrough(contains('SERVERPOD shutdown completed')),
         ]),
       );
 


### PR DESCRIPTION
Orderly shutdown of Serverpod when SIGTERM or SIGINT (ctrl-c in the terminal) are received.

If ctrl-c is pressed a second time before shutdown is complete then the process exits immediately.

(On Windows SIGTERM is not supported.)

Closes #2147 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a