### PR TITLE
fix: Validate timeout, but don't bound how long.

### DIFF
--- a/tests/serverpod_test_server/test_integration/test_tools/start_timeout_test/start_timeout_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/start_timeout_test/start_timeout_test.dart
@@ -9,17 +9,12 @@ void main() async {
       'Given that withServerpod can not find the database and has a timeout set to 0 seconds '
       'when running the test '
       'then should timeout immediately', () async {
-    var timer = Stopwatch()..start();
     final result = await runTest('test_that_will_timeout.dart');
 
     expect(result.exitCode, 1);
     expect(
-        result.stdout,
-        contains(
-            'Serverpod did not start within the timeout of 0:00:00.000000'));
-    expect(
-      timer.elapsed.inSeconds,
-      lessThan(10), // sanity check
+      result.stdout,
+      contains('Serverpod did not start within the timeout of 0:00:00.000000'),
     );
   }, tags: [defaultIntegrationTestTag]);
 
@@ -37,15 +32,11 @@ void main() async {
           contains(
               'Serverpod did not start within the timeout of 0:00:30.000000'));
       expect(
-          timer.elapsed.inSeconds,
-          allOf(
-            greaterThanOrEqualTo(30),
-            lessThan(40), // sanity check
-          ));
+        timer.elapsed.inSeconds,
+        greaterThanOrEqualTo(30),
+      );
     },
-    timeout: Timeout(
-      Duration(seconds: 40),
-    ),
+    timeout: Timeout(Duration(seconds: 40)),
     tags: [defaultIntegrationTestTag],
   );
 


### PR DESCRIPTION
If timeout exceeded, process should exit 1, and stdout indicate the reason, but don't mandate how long it took.

Mandating how long it took is flaky, and can cause false positives.

fix: #3258 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None