### PR TITLE
ci: Add PR title validator

### DIFF
--- a/.github/workflows/title-validation.yaml
+++ b/.github/workflows/title-validation.yaml
@@ -1,0 +1,34 @@
+# See https://github.com/amannn/action-semantic-pull-request
+name: 'PR Title is Conventional'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          subjectPattern: ^[A-Z].+$
+          subjectPatternError: |
+            The subject of the PR must begin with an uppercase letter.


### PR DESCRIPTION
Adds a PR title validator inspired by the configuration for the flame open source repository: https://github.com/flame-engine/flame/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml?plain=1

Since PR titles are by default used as the commit message to `main`, this linter will help us ensure we follow conventional commits for the squashes in main.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Simple ci fix.