### PR TITLE
chore: Bump cli_tools dependency.

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: ^0.2.0
+  cli_tools: ^0.4.0
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: ^0.1.1
+  cli_tools: ^0.2.0
 
 dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -38,13 +38,13 @@ void main(List<String> args) async {
         // Last resort error handling.
         printInternalError(error, stackTrace);
         await _preExit();
-        exit(ExitCodeType.general.exitCode);
+        exit(ExitException.codeError);
       }
     },
     (error, stackTrace) async {
       printInternalError(error, stackTrace);
       await _preExit();
-      exit(ExitCodeType.general.exitCode);
+      exit(ExitException.codeError);
     },
   );
 }

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:args/command_runner.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/commands/analyze_pubspecs.dart';
@@ -55,7 +56,11 @@ Future<void> _main(List<String> args) async {
   // formatted usage messages.
   initializeLogger();
   var runner = buildCommandRunner();
-  await runner.run(args);
+  try {
+    await runner.run(args);
+  } on UsageException {
+    throw ExitException.error();
+  }
 }
 
 ServerpodCommandRunner buildCommandRunner() {

--- a/tools/serverpod_cli/lib/src/commands/analyze_pubspecs.dart
+++ b/tools/serverpod_cli/lib/src/commands/analyze_pubspecs.dart
@@ -45,7 +45,7 @@ class AnalyzePubspecsCommand extends ServerpodCommand {
     if (!await pubspecDependenciesMatch(
       checkLatestVersion: checkLatestVersionObj,
     )) {
-      throw ExitException();
+      throw ExitException.error();
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -45,13 +45,13 @@ class CreateCommand extends ServerpodCommand {
     if (rest == null || rest.isEmpty) {
       log.error('Project name missing.');
       printUsage();
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     if (rest.length > 1) {
       log.error('Multiple project names specified, please specify only.');
       printUsage();
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     var name = rest.last;
@@ -68,7 +68,7 @@ class CreateCommand extends ServerpodCommand {
     }
 
     if (!await performCreate(name, template, force)) {
-      throw ExitException();
+      throw ExitException.error();
     }
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -46,7 +46,7 @@ class CreateMigrationCommand extends ServerpodCommand {
           'Invalid tag name. Tag names can only contain lowercase letters, '
           'number, and dashes.',
         );
-        throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+        throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
       }
     }
 
@@ -54,7 +54,7 @@ class CreateMigrationCommand extends ServerpodCommand {
     try {
       config = await GeneratorConfig.load();
     } catch (_) {
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     if (!config.isFeatureEnabled(ServerpodFeature.database)) {
@@ -62,12 +62,12 @@ class CreateMigrationCommand extends ServerpodCommand {
         'The database feature is not enabled in this project. '
         'This command cannot be used.',
       );
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     var projectName = await getProjectName();
     if (projectName == null) {
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     var generator = MigrationGenerator(
@@ -107,7 +107,7 @@ class CreateMigrationCommand extends ServerpodCommand {
     if (migration == null ||
         projectDirectory == null ||
         migrationName == null) {
-      throw ExitException();
+      throw ExitException.error();
     }
 
     log.info(

--- a/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_repair_migration.dart
@@ -64,14 +64,14 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
         'Invalid tag name. Tag names can only contain lowercase letters, '
         'number, and dashes.',
       );
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     GeneratorConfig config;
     try {
       config = await GeneratorConfig.load();
     } catch (_) {
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     if (!config.isFeatureEnabled(ServerpodFeature.database)) {
@@ -79,12 +79,12 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
         'The database feature is not enabled in this project. '
         'This command cannot be used.',
       );
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     var projectName = await getProjectName();
     if (projectName == null) {
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     var generator = MigrationGenerator(
@@ -132,7 +132,7 @@ class CreateRepairMigrationCommand extends ServerpodCommand {
 
     var repairMigrationPath = repairMigration?.path;
     if (repairMigration == null || repairMigrationPath == null) {
-      throw ExitException();
+      throw ExitException.error();
     }
 
     log.info(

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -41,7 +41,7 @@ class GenerateCommand extends ServerpodCommand {
       config = await GeneratorConfig.load();
     } catch (e) {
       log.error('An error occurred while parsing the server config file: $e');
-      throw ExitException(ExitCodeType.commandInvokedCannotExecute);
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
 
     // Validate cli version is compatible with serverpod packages
@@ -84,7 +84,7 @@ class GenerateCommand extends ServerpodCommand {
     }
 
     if (!success) {
-      throw ExitException();
+      throw ExitException.error();
     } else {
       log.info('Done.', type: TextLogType.success);
     }

--- a/tools/serverpod_cli/lib/src/commands/upgrade.dart
+++ b/tools/serverpod_cli/lib/src/commands/upgrade.dart
@@ -27,7 +27,7 @@ class UpgradeCommand extends ServerpodCommand {
 
     if (!success) {
       log.info('Failed to update Serverpod.');
-      throw ExitException();
+      throw ExitException.error();
     }
 
     log.info('Serverpod is up to date: $templateVersion version.');

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
@@ -2,6 +2,9 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 abstract class ServerpodCommand extends BetterCommand {
+  /// Exit code for when a command is invoked but cannot execute.
+  static const int commandInvokedCannotExecute = 126;
+
   ServerpodCommand()
       : super(
           logInfo: (String message) => log.info(message),

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command.dart
@@ -7,7 +7,7 @@ abstract class ServerpodCommand extends BetterCommand {
 
   ServerpodCommand()
       : super(
-          logInfo: (String message) => log.info(message),
           wrapTextColumn: log.wrapTextColumn,
+          passOutput: MessageOutput(logUsage: log.info),
         );
 }

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -1,4 +1,5 @@
 import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 import 'package:cli_tools/cli_tools.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
@@ -72,8 +73,7 @@ class ServerpodCommandRunner extends BetterCommandRunner {
     super.description, {
     required bool productionMode,
     required Version cliVersion,
-    super.logError,
-    super.logInfo,
+    super.messageOutput,
     super.onBeforeRunCommand,
     super.setLogLevel,
     super.onAnalyticsEvent,
@@ -112,8 +112,10 @@ class ServerpodCommandRunner extends BetterCommandRunner {
     return ServerpodCommandRunner(
       'serverpod',
       'Manage your serverpod app development',
-      logError: log.error,
-      logInfo: log.info,
+      messageOutput: MessageOutput(
+        logUsage: log.info,
+        logUsageException: (UsageException e) => log.error(e.toString()),
+      ),
       setLogLevel: _configureLogLevel,
       onBeforeRunCommand: onBeforeRunCommand,
       onAnalyticsEvent: (String event) => analytics.track(event: event),

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -14,16 +14,16 @@ Future<void> _preCommandEnvironmentChecks() async {
   if (!await CommandLineTools.existsCommand('dart', ['--version'])) {
     log.error(
         'Failed to run serverpod. You need to have dart installed and in your \$PATH');
-    throw ExitException();
+    throw ExitException.error();
   }
   if (!await CommandLineTools.existsCommand('flutter', ['--version'])) {
     log.error(
         'Failed to run serverpod. You need to have flutter installed and in your \$PATH');
-    throw ExitException();
+    throw ExitException.error();
   }
 
   if (!loadEnvironmentVars()) {
-    throw ExitException();
+    throw ExitException.error();
   }
 
   // Make sure all necessary downloads are installed
@@ -32,13 +32,13 @@ Future<void> _preCommandEnvironmentChecks() async {
       await resourceManager.installTemplates();
     } catch (e) {
       log.error('Failed to download templates.');
-      throw ExitException();
+      throw ExitException.error();
     }
 
     if (!resourceManager.isTemplatesInstalled) {
       log.error(
           'Could not download the required resources for Serverpod. Make sure that you are connected to the internet and that you are using the latest version of Serverpod.');
-      throw ExitException();
+      throw ExitException.error();
     }
   }
 }

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: ^0.2.0
+  cli_tools: ^0.4.0
 
 dev_dependencies:
   serverpod_lints: 2.3.1

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   stream_channel: ^2.1.1
   lsp_server: ^0.3.0
   pub_semver: ^2.1.4
-  cli_tools: ^0.1.1
+  cli_tools: ^0.2.0
 
 dev_dependencies:
   serverpod_lints: 2.3.1


### PR DESCRIPTION
Bumps the `cli_tools` dependency to the latest version.

This bump required fixes for two breaking changes in the package:
- The logger interface has been changed so that what is being logged is more explicit.
- `UsageException`s can now be thrown from the `run` method and needs to be handled by the caller.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - behavior should be the same as before.