### PR TITLE
feat: Interface Model Support after Refactor

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/interfaces/class_overriding_interface_field.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/interfaces/class_overriding_interface_field.dart
@@ -1,0 +1,83 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ClassOverridingInterfaceField
+    implements _i1.SerializableModel, _i2.ExampleInterface {
+  ClassOverridingInterfaceField._({
+    required this.classField,
+    String? interfaceField,
+  }) : interfaceField = interfaceField ?? 'This is a default value';
+
+  factory ClassOverridingInterfaceField({
+    required String classField,
+    String? interfaceField,
+  }) = _ClassOverridingInterfaceFieldImpl;
+
+  factory ClassOverridingInterfaceField.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ClassOverridingInterfaceField(
+      classField: jsonSerialization['classField'] as String,
+      interfaceField: jsonSerialization['interfaceField'] as String,
+    );
+  }
+
+  String classField;
+
+  @override
+  String interfaceField;
+
+  /// Returns a shallow copy of this [ClassOverridingInterfaceField]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ClassOverridingInterfaceField copyWith({
+    String? classField,
+    String? interfaceField,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'classField': classField,
+      'interfaceField': interfaceField,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ClassOverridingInterfaceFieldImpl extends ClassOverridingInterfaceField {
+  _ClassOverridingInterfaceFieldImpl({
+    required String classField,
+    String? interfaceField,
+  }) : super._(
+          classField: classField,
+          interfaceField: interfaceField,
+        );
+
+  /// Returns a shallow copy of this [ClassOverridingInterfaceField]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ClassOverridingInterfaceField copyWith({
+    String? classField,
+    String? interfaceField,
+  }) {
+    return ClassOverridingInterfaceField(
+      classField: classField ?? this.classField,
+      interfaceField: interfaceField ?? this.interfaceField,
+    );
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/interfaces/class_with_interface.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/interfaces/class_with_interface.dart
@@ -1,0 +1,82 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ClassWithInterface
+    implements _i1.SerializableModel, _i2.ExampleInterface {
+  ClassWithInterface._({
+    required this.interfaceField,
+    required this.classField,
+  });
+
+  factory ClassWithInterface({
+    required String interfaceField,
+    required String classField,
+  }) = _ClassWithInterfaceImpl;
+
+  factory ClassWithInterface.fromJson(Map<String, dynamic> jsonSerialization) {
+    return ClassWithInterface(
+      interfaceField: jsonSerialization['interfaceField'] as String,
+      classField: jsonSerialization['classField'] as String,
+    );
+  }
+
+  @override
+  String interfaceField;
+
+  String classField;
+
+  /// Returns a shallow copy of this [ClassWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ClassWithInterface copyWith({
+    String? interfaceField,
+    String? classField,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'interfaceField': interfaceField,
+      'classField': classField,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ClassWithInterfaceImpl extends ClassWithInterface {
+  _ClassWithInterfaceImpl({
+    required String interfaceField,
+    required String classField,
+  }) : super._(
+          interfaceField: interfaceField,
+          classField: classField,
+        );
+
+  /// Returns a shallow copy of this [ClassWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ClassWithInterface copyWith({
+    String? interfaceField,
+    String? classField,
+  }) {
+    return ClassWithInterface(
+      interfaceField: interfaceField ?? this.interfaceField,
+      classField: classField ?? this.classField,
+    );
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/interfaces/example_interface.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/interfaces/example_interface.dart
@@ -1,0 +1,15 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+abstract interface class ExampleInterface {
+  ExampleInterface({required this.interfaceField});
+
+  String interfaceField;
+}

--- a/tests/serverpod_test_client/lib/src/protocol/interfaces/exception_with_interface.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/interfaces/exception_with_interface.dart
@@ -1,0 +1,86 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ExceptionWithInterface
+    implements
+        _i1.SerializableException,
+        _i1.SerializableModel,
+        _i2.ExampleInterface {
+  ExceptionWithInterface._({
+    required this.interfaceField,
+    required this.exceptionField,
+  });
+
+  factory ExceptionWithInterface({
+    required String interfaceField,
+    required String exceptionField,
+  }) = _ExceptionWithInterfaceImpl;
+
+  factory ExceptionWithInterface.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ExceptionWithInterface(
+      interfaceField: jsonSerialization['interfaceField'] as String,
+      exceptionField: jsonSerialization['exceptionField'] as String,
+    );
+  }
+
+  @override
+  String interfaceField;
+
+  String exceptionField;
+
+  /// Returns a shallow copy of this [ExceptionWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ExceptionWithInterface copyWith({
+    String? interfaceField,
+    String? exceptionField,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'interfaceField': interfaceField,
+      'exceptionField': exceptionField,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ExceptionWithInterfaceImpl extends ExceptionWithInterface {
+  _ExceptionWithInterfaceImpl({
+    required String interfaceField,
+    required String exceptionField,
+  }) : super._(
+          interfaceField: interfaceField,
+          exceptionField: exceptionField,
+        );
+
+  /// Returns a shallow copy of this [ExceptionWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ExceptionWithInterface copyWith({
+    String? interfaceField,
+    String? exceptionField,
+  }) {
+    return ExceptionWithInterface(
+      interfaceField: interfaceField ?? this.interfaceField,
+      exceptionField: exceptionField ?? this.exceptionField,
+    );
+  }
+}

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -66,91 +66,94 @@ import 'inheritance/grandparent_class.dart' as _i54;
 import 'inheritance/parent_class.dart' as _i55;
 import 'inheritance/parent_with_default.dart' as _i56;
 import 'inheritance/sealed_parent.dart' as _i57;
-import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i58;
+import 'interfaces/class_overriding_interface_field.dart' as _i58;
+import 'interfaces/class_with_interface.dart' as _i59;
+import 'interfaces/exception_with_interface.dart' as _i60;
+import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i61;
 import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
-    as _i59;
-import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
-    as _i60;
-import 'long_identifiers/max_field_name.dart' as _i61;
-import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
     as _i62;
-import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
+import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i63;
-import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
-    as _i64;
-import 'long_identifiers/models_with_relations/user_note.dart' as _i65;
-import 'long_identifiers/models_with_relations/user_note_collection.dart'
+import 'long_identifiers/max_field_name.dart' as _i64;
+import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
+    as _i65;
+import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
     as _i66;
-import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
+import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
     as _i67;
+import 'long_identifiers/models_with_relations/user_note.dart' as _i68;
+import 'long_identifiers/models_with_relations/user_note_collection.dart'
+    as _i69;
+import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
+    as _i70;
 import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
-    as _i68;
-import 'long_identifiers/multiple_max_field_name.dart' as _i69;
-import 'models_with_list_relations/city.dart' as _i70;
-import 'models_with_list_relations/organization.dart' as _i71;
-import 'models_with_list_relations/person.dart' as _i72;
-import 'models_with_relations/many_to_many/course.dart' as _i73;
-import 'models_with_relations/many_to_many/enrollment.dart' as _i74;
-import 'models_with_relations/many_to_many/student.dart' as _i75;
-import 'models_with_relations/module/object_user.dart' as _i76;
-import 'models_with_relations/module/parent_user.dart' as _i77;
-import 'models_with_relations/nested_one_to_many/arena.dart' as _i78;
-import 'models_with_relations/nested_one_to_many/player.dart' as _i79;
-import 'models_with_relations/nested_one_to_many/team.dart' as _i80;
-import 'models_with_relations/one_to_many/comment.dart' as _i81;
-import 'models_with_relations/one_to_many/customer.dart' as _i82;
-import 'models_with_relations/one_to_many/order.dart' as _i83;
-import 'models_with_relations/one_to_one/address.dart' as _i84;
-import 'models_with_relations/one_to_one/citizen.dart' as _i85;
-import 'models_with_relations/one_to_one/company.dart' as _i86;
-import 'models_with_relations/one_to_one/town.dart' as _i87;
-import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i88;
-import 'models_with_relations/self_relation/many_to_many/member.dart' as _i89;
-import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i90;
-import 'models_with_relations/self_relation/one_to_one/post.dart' as _i91;
-import 'module_datatype.dart' as _i92;
-import 'nullability.dart' as _i93;
-import 'object_field_persist.dart' as _i94;
-import 'object_field_scopes.dart' as _i95;
-import 'object_with_bytedata.dart' as _i96;
-import 'object_with_custom_class.dart' as _i97;
-import 'object_with_duration.dart' as _i98;
-import 'object_with_enum.dart' as _i99;
-import 'object_with_index.dart' as _i100;
-import 'object_with_maps.dart' as _i101;
-import 'object_with_object.dart' as _i102;
-import 'object_with_parent.dart' as _i103;
-import 'object_with_self_parent.dart' as _i104;
-import 'object_with_uuid.dart' as _i105;
-import 'related_unique_data.dart' as _i106;
-import 'scopes/scope_none_fields.dart' as _i107;
-import 'scopes/scope_server_only_field.dart' as _i108;
-import 'scopes/scope_server_only_field_child.dart' as _i109;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i110;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i111;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i112;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i113;
-import 'scopes/server_only_class_field.dart' as _i114;
-import 'simple_data.dart' as _i115;
-import 'simple_data_list.dart' as _i116;
-import 'simple_data_map.dart' as _i117;
-import 'simple_data_object.dart' as _i118;
-import 'simple_date_time.dart' as _i119;
-import 'test_enum.dart' as _i120;
-import 'test_enum_stringified.dart' as _i121;
-import 'types.dart' as _i122;
-import 'types_list.dart' as _i123;
-import 'types_map.dart' as _i124;
-import 'types_set.dart' as _i125;
-import 'unique_data.dart' as _i126;
-import 'my_feature/models/my_feature_model.dart' as _i127;
+    as _i71;
+import 'long_identifiers/multiple_max_field_name.dart' as _i72;
+import 'models_with_list_relations/city.dart' as _i73;
+import 'models_with_list_relations/organization.dart' as _i74;
+import 'models_with_list_relations/person.dart' as _i75;
+import 'models_with_relations/many_to_many/course.dart' as _i76;
+import 'models_with_relations/many_to_many/enrollment.dart' as _i77;
+import 'models_with_relations/many_to_many/student.dart' as _i78;
+import 'models_with_relations/module/object_user.dart' as _i79;
+import 'models_with_relations/module/parent_user.dart' as _i80;
+import 'models_with_relations/nested_one_to_many/arena.dart' as _i81;
+import 'models_with_relations/nested_one_to_many/player.dart' as _i82;
+import 'models_with_relations/nested_one_to_many/team.dart' as _i83;
+import 'models_with_relations/one_to_many/comment.dart' as _i84;
+import 'models_with_relations/one_to_many/customer.dart' as _i85;
+import 'models_with_relations/one_to_many/order.dart' as _i86;
+import 'models_with_relations/one_to_one/address.dart' as _i87;
+import 'models_with_relations/one_to_one/citizen.dart' as _i88;
+import 'models_with_relations/one_to_one/company.dart' as _i89;
+import 'models_with_relations/one_to_one/town.dart' as _i90;
+import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i91;
+import 'models_with_relations/self_relation/many_to_many/member.dart' as _i92;
+import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i93;
+import 'models_with_relations/self_relation/one_to_one/post.dart' as _i94;
+import 'module_datatype.dart' as _i95;
+import 'nullability.dart' as _i96;
+import 'object_field_persist.dart' as _i97;
+import 'object_field_scopes.dart' as _i98;
+import 'object_with_bytedata.dart' as _i99;
+import 'object_with_custom_class.dart' as _i100;
+import 'object_with_duration.dart' as _i101;
+import 'object_with_enum.dart' as _i102;
+import 'object_with_index.dart' as _i103;
+import 'object_with_maps.dart' as _i104;
+import 'object_with_object.dart' as _i105;
+import 'object_with_parent.dart' as _i106;
+import 'object_with_self_parent.dart' as _i107;
+import 'object_with_uuid.dart' as _i108;
+import 'related_unique_data.dart' as _i109;
+import 'scopes/scope_none_fields.dart' as _i110;
+import 'scopes/scope_server_only_field.dart' as _i111;
+import 'scopes/scope_server_only_field_child.dart' as _i112;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i113;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i114;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i115;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i116;
+import 'scopes/server_only_class_field.dart' as _i117;
+import 'simple_data.dart' as _i118;
+import 'simple_data_list.dart' as _i119;
+import 'simple_data_map.dart' as _i120;
+import 'simple_data_object.dart' as _i121;
+import 'simple_date_time.dart' as _i122;
+import 'test_enum.dart' as _i123;
+import 'test_enum_stringified.dart' as _i124;
+import 'types.dart' as _i125;
+import 'types_list.dart' as _i126;
+import 'types_map.dart' as _i127;
+import 'types_set.dart' as _i128;
+import 'unique_data.dart' as _i129;
+import 'my_feature/models/my_feature_model.dart' as _i130;
 import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
-    as _i128;
-import 'dart:typed_data' as _i129;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i130;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i131;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i132;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i133;
+    as _i131;
+import 'dart:typed_data' as _i132;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i133;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i134;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i135;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i136;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
 export 'defaults/bigint/bigint_default.dart';
@@ -208,6 +211,10 @@ export 'inheritance/parent_class.dart';
 export 'inheritance/parent_with_default.dart';
 export 'inheritance/sealed_no_child.dart';
 export 'inheritance/sealed_parent.dart';
+export 'interfaces/class_overriding_interface_field.dart';
+export 'interfaces/class_with_interface.dart';
+export 'interfaces/example_interface.dart';
+export 'interfaces/exception_with_interface.dart';
 export 'long_identifiers/deep_includes/city_with_long_table_name.dart';
 export 'long_identifiers/deep_includes/organization_with_long_table_name.dart';
 export 'long_identifiers/deep_includes/person_with_long_table_name.dart';
@@ -467,215 +474,224 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i57.SealedOtherChild) {
       return _i57.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i58.CityWithLongTableName) {
-      return _i58.CityWithLongTableName.fromJson(data) as T;
+    if (t == _i58.ClassOverridingInterfaceField) {
+      return _i58.ClassOverridingInterfaceField.fromJson(data) as T;
     }
-    if (t == _i59.OrganizationWithLongTableName) {
-      return _i59.OrganizationWithLongTableName.fromJson(data) as T;
+    if (t == _i59.ClassWithInterface) {
+      return _i59.ClassWithInterface.fromJson(data) as T;
     }
-    if (t == _i60.PersonWithLongTableName) {
-      return _i60.PersonWithLongTableName.fromJson(data) as T;
+    if (t == _i60.ExceptionWithInterface) {
+      return _i60.ExceptionWithInterface.fromJson(data) as T;
     }
-    if (t == _i61.MaxFieldName) {
-      return _i61.MaxFieldName.fromJson(data) as T;
+    if (t == _i61.CityWithLongTableName) {
+      return _i61.CityWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i62.LongImplicitIdField) {
-      return _i62.LongImplicitIdField.fromJson(data) as T;
+    if (t == _i62.OrganizationWithLongTableName) {
+      return _i62.OrganizationWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i63.LongImplicitIdFieldCollection) {
-      return _i63.LongImplicitIdFieldCollection.fromJson(data) as T;
+    if (t == _i63.PersonWithLongTableName) {
+      return _i63.PersonWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i64.RelationToMultipleMaxFieldName) {
-      return _i64.RelationToMultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i64.MaxFieldName) {
+      return _i64.MaxFieldName.fromJson(data) as T;
     }
-    if (t == _i65.UserNote) {
-      return _i65.UserNote.fromJson(data) as T;
+    if (t == _i65.LongImplicitIdField) {
+      return _i65.LongImplicitIdField.fromJson(data) as T;
     }
-    if (t == _i66.UserNoteCollection) {
-      return _i66.UserNoteCollection.fromJson(data) as T;
+    if (t == _i66.LongImplicitIdFieldCollection) {
+      return _i66.LongImplicitIdFieldCollection.fromJson(data) as T;
     }
-    if (t == _i67.UserNoteCollectionWithALongName) {
-      return _i67.UserNoteCollectionWithALongName.fromJson(data) as T;
+    if (t == _i67.RelationToMultipleMaxFieldName) {
+      return _i67.RelationToMultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i68.UserNoteWithALongName) {
-      return _i68.UserNoteWithALongName.fromJson(data) as T;
+    if (t == _i68.UserNote) {
+      return _i68.UserNote.fromJson(data) as T;
     }
-    if (t == _i69.MultipleMaxFieldName) {
-      return _i69.MultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i69.UserNoteCollection) {
+      return _i69.UserNoteCollection.fromJson(data) as T;
     }
-    if (t == _i70.City) {
-      return _i70.City.fromJson(data) as T;
+    if (t == _i70.UserNoteCollectionWithALongName) {
+      return _i70.UserNoteCollectionWithALongName.fromJson(data) as T;
     }
-    if (t == _i71.Organization) {
-      return _i71.Organization.fromJson(data) as T;
+    if (t == _i71.UserNoteWithALongName) {
+      return _i71.UserNoteWithALongName.fromJson(data) as T;
     }
-    if (t == _i72.Person) {
-      return _i72.Person.fromJson(data) as T;
+    if (t == _i72.MultipleMaxFieldName) {
+      return _i72.MultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i73.Course) {
-      return _i73.Course.fromJson(data) as T;
+    if (t == _i73.City) {
+      return _i73.City.fromJson(data) as T;
     }
-    if (t == _i74.Enrollment) {
-      return _i74.Enrollment.fromJson(data) as T;
+    if (t == _i74.Organization) {
+      return _i74.Organization.fromJson(data) as T;
     }
-    if (t == _i75.Student) {
-      return _i75.Student.fromJson(data) as T;
+    if (t == _i75.Person) {
+      return _i75.Person.fromJson(data) as T;
     }
-    if (t == _i76.ObjectUser) {
-      return _i76.ObjectUser.fromJson(data) as T;
+    if (t == _i76.Course) {
+      return _i76.Course.fromJson(data) as T;
     }
-    if (t == _i77.ParentUser) {
-      return _i77.ParentUser.fromJson(data) as T;
+    if (t == _i77.Enrollment) {
+      return _i77.Enrollment.fromJson(data) as T;
     }
-    if (t == _i78.Arena) {
-      return _i78.Arena.fromJson(data) as T;
+    if (t == _i78.Student) {
+      return _i78.Student.fromJson(data) as T;
     }
-    if (t == _i79.Player) {
-      return _i79.Player.fromJson(data) as T;
+    if (t == _i79.ObjectUser) {
+      return _i79.ObjectUser.fromJson(data) as T;
     }
-    if (t == _i80.Team) {
-      return _i80.Team.fromJson(data) as T;
+    if (t == _i80.ParentUser) {
+      return _i80.ParentUser.fromJson(data) as T;
     }
-    if (t == _i81.Comment) {
-      return _i81.Comment.fromJson(data) as T;
+    if (t == _i81.Arena) {
+      return _i81.Arena.fromJson(data) as T;
     }
-    if (t == _i82.Customer) {
-      return _i82.Customer.fromJson(data) as T;
+    if (t == _i82.Player) {
+      return _i82.Player.fromJson(data) as T;
     }
-    if (t == _i83.Order) {
-      return _i83.Order.fromJson(data) as T;
+    if (t == _i83.Team) {
+      return _i83.Team.fromJson(data) as T;
     }
-    if (t == _i84.Address) {
-      return _i84.Address.fromJson(data) as T;
+    if (t == _i84.Comment) {
+      return _i84.Comment.fromJson(data) as T;
     }
-    if (t == _i85.Citizen) {
-      return _i85.Citizen.fromJson(data) as T;
+    if (t == _i85.Customer) {
+      return _i85.Customer.fromJson(data) as T;
     }
-    if (t == _i86.Company) {
-      return _i86.Company.fromJson(data) as T;
+    if (t == _i86.Order) {
+      return _i86.Order.fromJson(data) as T;
     }
-    if (t == _i87.Town) {
-      return _i87.Town.fromJson(data) as T;
+    if (t == _i87.Address) {
+      return _i87.Address.fromJson(data) as T;
     }
-    if (t == _i88.Blocking) {
-      return _i88.Blocking.fromJson(data) as T;
+    if (t == _i88.Citizen) {
+      return _i88.Citizen.fromJson(data) as T;
     }
-    if (t == _i89.Member) {
-      return _i89.Member.fromJson(data) as T;
+    if (t == _i89.Company) {
+      return _i89.Company.fromJson(data) as T;
     }
-    if (t == _i90.Cat) {
-      return _i90.Cat.fromJson(data) as T;
+    if (t == _i90.Town) {
+      return _i90.Town.fromJson(data) as T;
     }
-    if (t == _i91.Post) {
-      return _i91.Post.fromJson(data) as T;
+    if (t == _i91.Blocking) {
+      return _i91.Blocking.fromJson(data) as T;
     }
-    if (t == _i92.ModuleDatatype) {
-      return _i92.ModuleDatatype.fromJson(data) as T;
+    if (t == _i92.Member) {
+      return _i92.Member.fromJson(data) as T;
     }
-    if (t == _i93.Nullability) {
-      return _i93.Nullability.fromJson(data) as T;
+    if (t == _i93.Cat) {
+      return _i93.Cat.fromJson(data) as T;
     }
-    if (t == _i94.ObjectFieldPersist) {
-      return _i94.ObjectFieldPersist.fromJson(data) as T;
+    if (t == _i94.Post) {
+      return _i94.Post.fromJson(data) as T;
     }
-    if (t == _i95.ObjectFieldScopes) {
-      return _i95.ObjectFieldScopes.fromJson(data) as T;
+    if (t == _i95.ModuleDatatype) {
+      return _i95.ModuleDatatype.fromJson(data) as T;
     }
-    if (t == _i96.ObjectWithByteData) {
-      return _i96.ObjectWithByteData.fromJson(data) as T;
+    if (t == _i96.Nullability) {
+      return _i96.Nullability.fromJson(data) as T;
     }
-    if (t == _i97.ObjectWithCustomClass) {
-      return _i97.ObjectWithCustomClass.fromJson(data) as T;
+    if (t == _i97.ObjectFieldPersist) {
+      return _i97.ObjectFieldPersist.fromJson(data) as T;
     }
-    if (t == _i98.ObjectWithDuration) {
-      return _i98.ObjectWithDuration.fromJson(data) as T;
+    if (t == _i98.ObjectFieldScopes) {
+      return _i98.ObjectFieldScopes.fromJson(data) as T;
     }
-    if (t == _i99.ObjectWithEnum) {
-      return _i99.ObjectWithEnum.fromJson(data) as T;
+    if (t == _i99.ObjectWithByteData) {
+      return _i99.ObjectWithByteData.fromJson(data) as T;
     }
-    if (t == _i100.ObjectWithIndex) {
-      return _i100.ObjectWithIndex.fromJson(data) as T;
+    if (t == _i100.ObjectWithCustomClass) {
+      return _i100.ObjectWithCustomClass.fromJson(data) as T;
     }
-    if (t == _i101.ObjectWithMaps) {
-      return _i101.ObjectWithMaps.fromJson(data) as T;
+    if (t == _i101.ObjectWithDuration) {
+      return _i101.ObjectWithDuration.fromJson(data) as T;
     }
-    if (t == _i102.ObjectWithObject) {
-      return _i102.ObjectWithObject.fromJson(data) as T;
+    if (t == _i102.ObjectWithEnum) {
+      return _i102.ObjectWithEnum.fromJson(data) as T;
     }
-    if (t == _i103.ObjectWithParent) {
-      return _i103.ObjectWithParent.fromJson(data) as T;
+    if (t == _i103.ObjectWithIndex) {
+      return _i103.ObjectWithIndex.fromJson(data) as T;
     }
-    if (t == _i104.ObjectWithSelfParent) {
-      return _i104.ObjectWithSelfParent.fromJson(data) as T;
+    if (t == _i104.ObjectWithMaps) {
+      return _i104.ObjectWithMaps.fromJson(data) as T;
     }
-    if (t == _i105.ObjectWithUuid) {
-      return _i105.ObjectWithUuid.fromJson(data) as T;
+    if (t == _i105.ObjectWithObject) {
+      return _i105.ObjectWithObject.fromJson(data) as T;
     }
-    if (t == _i106.RelatedUniqueData) {
-      return _i106.RelatedUniqueData.fromJson(data) as T;
+    if (t == _i106.ObjectWithParent) {
+      return _i106.ObjectWithParent.fromJson(data) as T;
     }
-    if (t == _i107.ScopeNoneFields) {
-      return _i107.ScopeNoneFields.fromJson(data) as T;
+    if (t == _i107.ObjectWithSelfParent) {
+      return _i107.ObjectWithSelfParent.fromJson(data) as T;
     }
-    if (t == _i108.ScopeServerOnlyField) {
-      return _i108.ScopeServerOnlyField.fromJson(data) as T;
+    if (t == _i108.ObjectWithUuid) {
+      return _i108.ObjectWithUuid.fromJson(data) as T;
     }
-    if (t == _i109.ScopeServerOnlyFieldChild) {
-      return _i109.ScopeServerOnlyFieldChild.fromJson(data) as T;
+    if (t == _i109.RelatedUniqueData) {
+      return _i109.RelatedUniqueData.fromJson(data) as T;
     }
-    if (t == _i110.DefaultServerOnlyClass) {
-      return _i110.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i110.ScopeNoneFields) {
+      return _i110.ScopeNoneFields.fromJson(data) as T;
     }
-    if (t == _i111.DefaultServerOnlyEnum) {
-      return _i111.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i111.ScopeServerOnlyField) {
+      return _i111.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i112.NotServerOnlyClass) {
-      return _i112.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i112.ScopeServerOnlyFieldChild) {
+      return _i112.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i113.NotServerOnlyEnum) {
-      return _i113.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i113.DefaultServerOnlyClass) {
+      return _i113.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i114.ServerOnlyClassField) {
-      return _i114.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i114.DefaultServerOnlyEnum) {
+      return _i114.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i115.SimpleData) {
-      return _i115.SimpleData.fromJson(data) as T;
+    if (t == _i115.NotServerOnlyClass) {
+      return _i115.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i116.SimpleDataList) {
-      return _i116.SimpleDataList.fromJson(data) as T;
+    if (t == _i116.NotServerOnlyEnum) {
+      return _i116.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i117.SimpleDataMap) {
-      return _i117.SimpleDataMap.fromJson(data) as T;
+    if (t == _i117.ServerOnlyClassField) {
+      return _i117.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i118.SimpleDataObject) {
-      return _i118.SimpleDataObject.fromJson(data) as T;
+    if (t == _i118.SimpleData) {
+      return _i118.SimpleData.fromJson(data) as T;
     }
-    if (t == _i119.SimpleDateTime) {
-      return _i119.SimpleDateTime.fromJson(data) as T;
+    if (t == _i119.SimpleDataList) {
+      return _i119.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i120.TestEnum) {
-      return _i120.TestEnum.fromJson(data) as T;
+    if (t == _i120.SimpleDataMap) {
+      return _i120.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i121.TestEnumStringified) {
-      return _i121.TestEnumStringified.fromJson(data) as T;
+    if (t == _i121.SimpleDataObject) {
+      return _i121.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i122.Types) {
-      return _i122.Types.fromJson(data) as T;
+    if (t == _i122.SimpleDateTime) {
+      return _i122.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i123.TypesList) {
-      return _i123.TypesList.fromJson(data) as T;
+    if (t == _i123.TestEnum) {
+      return _i123.TestEnum.fromJson(data) as T;
     }
-    if (t == _i124.TypesMap) {
-      return _i124.TypesMap.fromJson(data) as T;
+    if (t == _i124.TestEnumStringified) {
+      return _i124.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i125.TypesSet) {
-      return _i125.TypesSet.fromJson(data) as T;
+    if (t == _i125.Types) {
+      return _i125.Types.fromJson(data) as T;
     }
-    if (t == _i126.UniqueData) {
-      return _i126.UniqueData.fromJson(data) as T;
+    if (t == _i126.TypesList) {
+      return _i126.TypesList.fromJson(data) as T;
     }
-    if (t == _i127.MyFeatureModel) {
-      return _i127.MyFeatureModel.fromJson(data) as T;
+    if (t == _i127.TypesMap) {
+      return _i127.TypesMap.fromJson(data) as T;
+    }
+    if (t == _i128.TypesSet) {
+      return _i128.TypesSet.fromJson(data) as T;
+    }
+    if (t == _i129.UniqueData) {
+      return _i129.UniqueData.fromJson(data) as T;
+    }
+    if (t == _i130.MyFeatureModel) {
+      return _i130.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.ByIndexEnumWithNameValue?>()) {
       return (data != null ? _i2.ByIndexEnumWithNameValue.fromJson(data) : null)
@@ -870,244 +886,257 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i57.SealedOtherChild?>()) {
       return (data != null ? _i57.SealedOtherChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i58.CityWithLongTableName?>()) {
-      return (data != null ? _i58.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i59.OrganizationWithLongTableName?>()) {
+    if (t == _i1.getType<_i58.ClassOverridingInterfaceField?>()) {
       return (data != null
-          ? _i59.OrganizationWithLongTableName.fromJson(data)
+          ? _i58.ClassOverridingInterfaceField.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i60.PersonWithLongTableName?>()) {
-      return (data != null ? _i60.PersonWithLongTableName.fromJson(data) : null)
+    if (t == _i1.getType<_i59.ClassWithInterface?>()) {
+      return (data != null ? _i59.ClassWithInterface.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i61.MaxFieldName?>()) {
-      return (data != null ? _i61.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i62.LongImplicitIdField?>()) {
-      return (data != null ? _i62.LongImplicitIdField.fromJson(data) : null)
+    if (t == _i1.getType<_i60.ExceptionWithInterface?>()) {
+      return (data != null ? _i60.ExceptionWithInterface.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i63.LongImplicitIdFieldCollection?>()) {
+    if (t == _i1.getType<_i61.CityWithLongTableName?>()) {
+      return (data != null ? _i61.CityWithLongTableName.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i62.OrganizationWithLongTableName?>()) {
       return (data != null
-          ? _i63.LongImplicitIdFieldCollection.fromJson(data)
+          ? _i62.OrganizationWithLongTableName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i64.RelationToMultipleMaxFieldName?>()) {
+    if (t == _i1.getType<_i63.PersonWithLongTableName?>()) {
+      return (data != null ? _i63.PersonWithLongTableName.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i64.MaxFieldName?>()) {
+      return (data != null ? _i64.MaxFieldName.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i65.LongImplicitIdField?>()) {
+      return (data != null ? _i65.LongImplicitIdField.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i66.LongImplicitIdFieldCollection?>()) {
       return (data != null
-          ? _i64.RelationToMultipleMaxFieldName.fromJson(data)
+          ? _i66.LongImplicitIdFieldCollection.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i65.UserNote?>()) {
-      return (data != null ? _i65.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i66.UserNoteCollection?>()) {
-      return (data != null ? _i66.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i67.UserNoteCollectionWithALongName?>()) {
+    if (t == _i1.getType<_i67.RelationToMultipleMaxFieldName?>()) {
       return (data != null
-          ? _i67.UserNoteCollectionWithALongName.fromJson(data)
+          ? _i67.RelationToMultipleMaxFieldName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i68.UserNoteWithALongName?>()) {
-      return (data != null ? _i68.UserNoteWithALongName.fromJson(data) : null)
+    if (t == _i1.getType<_i68.UserNote?>()) {
+      return (data != null ? _i68.UserNote.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i69.UserNoteCollection?>()) {
+      return (data != null ? _i69.UserNoteCollection.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i69.MultipleMaxFieldName?>()) {
-      return (data != null ? _i69.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i70.City?>()) {
-      return (data != null ? _i70.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i71.Organization?>()) {
-      return (data != null ? _i71.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i72.Person?>()) {
-      return (data != null ? _i72.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i73.Course?>()) {
-      return (data != null ? _i73.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i74.Enrollment?>()) {
-      return (data != null ? _i74.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.Student?>()) {
-      return (data != null ? _i75.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i76.ObjectUser?>()) {
-      return (data != null ? _i76.ObjectUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i77.ParentUser?>()) {
-      return (data != null ? _i77.ParentUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.Arena?>()) {
-      return (data != null ? _i78.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i79.Player?>()) {
-      return (data != null ? _i79.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i80.Team?>()) {
-      return (data != null ? _i80.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i81.Comment?>()) {
-      return (data != null ? _i81.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i82.Customer?>()) {
-      return (data != null ? _i82.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i83.Order?>()) {
-      return (data != null ? _i83.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i84.Address?>()) {
-      return (data != null ? _i84.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i85.Citizen?>()) {
-      return (data != null ? _i85.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i86.Company?>()) {
-      return (data != null ? _i86.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i87.Town?>()) {
-      return (data != null ? _i87.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i88.Blocking?>()) {
-      return (data != null ? _i88.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i89.Member?>()) {
-      return (data != null ? _i89.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i90.Cat?>()) {
-      return (data != null ? _i90.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i91.Post?>()) {
-      return (data != null ? _i91.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i92.ModuleDatatype?>()) {
-      return (data != null ? _i92.ModuleDatatype.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i93.Nullability?>()) {
-      return (data != null ? _i93.Nullability.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i94.ObjectFieldPersist?>()) {
-      return (data != null ? _i94.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i95.ObjectFieldScopes?>()) {
-      return (data != null ? _i95.ObjectFieldScopes.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i96.ObjectWithByteData?>()) {
-      return (data != null ? _i96.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i97.ObjectWithCustomClass?>()) {
-      return (data != null ? _i97.ObjectWithCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i98.ObjectWithDuration?>()) {
-      return (data != null ? _i98.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i99.ObjectWithEnum?>()) {
-      return (data != null ? _i99.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i100.ObjectWithIndex?>()) {
-      return (data != null ? _i100.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i101.ObjectWithMaps?>()) {
-      return (data != null ? _i101.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i102.ObjectWithObject?>()) {
-      return (data != null ? _i102.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i103.ObjectWithParent?>()) {
-      return (data != null ? _i103.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i104.ObjectWithSelfParent?>()) {
-      return (data != null ? _i104.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i105.ObjectWithUuid?>()) {
-      return (data != null ? _i105.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.RelatedUniqueData?>()) {
-      return (data != null ? _i106.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i107.ScopeNoneFields?>()) {
-      return (data != null ? _i107.ScopeNoneFields.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i108.ScopeServerOnlyField?>()) {
-      return (data != null ? _i108.ScopeServerOnlyField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i109.ScopeServerOnlyFieldChild?>()) {
+    if (t == _i1.getType<_i70.UserNoteCollectionWithALongName?>()) {
       return (data != null
-          ? _i109.ScopeServerOnlyFieldChild.fromJson(data)
+          ? _i70.UserNoteCollectionWithALongName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i110.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i110.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i71.UserNoteWithALongName?>()) {
+      return (data != null ? _i71.UserNoteWithALongName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i111.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i111.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i72.MultipleMaxFieldName?>()) {
+      return (data != null ? _i72.MultipleMaxFieldName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i112.NotServerOnlyClass?>()) {
-      return (data != null ? _i112.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i73.City?>()) {
+      return (data != null ? _i73.City.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i74.Organization?>()) {
+      return (data != null ? _i74.Organization.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i75.Person?>()) {
+      return (data != null ? _i75.Person.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i76.Course?>()) {
+      return (data != null ? _i76.Course.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i77.Enrollment?>()) {
+      return (data != null ? _i77.Enrollment.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i78.Student?>()) {
+      return (data != null ? _i78.Student.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i79.ObjectUser?>()) {
+      return (data != null ? _i79.ObjectUser.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i80.ParentUser?>()) {
+      return (data != null ? _i80.ParentUser.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i81.Arena?>()) {
+      return (data != null ? _i81.Arena.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i82.Player?>()) {
+      return (data != null ? _i82.Player.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i83.Team?>()) {
+      return (data != null ? _i83.Team.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i84.Comment?>()) {
+      return (data != null ? _i84.Comment.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i85.Customer?>()) {
+      return (data != null ? _i85.Customer.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i86.Order?>()) {
+      return (data != null ? _i86.Order.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i87.Address?>()) {
+      return (data != null ? _i87.Address.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i88.Citizen?>()) {
+      return (data != null ? _i88.Citizen.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i89.Company?>()) {
+      return (data != null ? _i89.Company.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i90.Town?>()) {
+      return (data != null ? _i90.Town.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i91.Blocking?>()) {
+      return (data != null ? _i91.Blocking.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i92.Member?>()) {
+      return (data != null ? _i92.Member.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i93.Cat?>()) {
+      return (data != null ? _i93.Cat.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i94.Post?>()) {
+      return (data != null ? _i94.Post.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i95.ModuleDatatype?>()) {
+      return (data != null ? _i95.ModuleDatatype.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i96.Nullability?>()) {
+      return (data != null ? _i96.Nullability.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i97.ObjectFieldPersist?>()) {
+      return (data != null ? _i97.ObjectFieldPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i113.NotServerOnlyEnum?>()) {
-      return (data != null ? _i113.NotServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i98.ObjectFieldScopes?>()) {
+      return (data != null ? _i98.ObjectFieldScopes.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i99.ObjectWithByteData?>()) {
+      return (data != null ? _i99.ObjectWithByteData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i114.ServerOnlyClassField?>()) {
-      return (data != null ? _i114.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i100.ObjectWithCustomClass?>()) {
+      return (data != null ? _i100.ObjectWithCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i115.SimpleData?>()) {
-      return (data != null ? _i115.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i116.SimpleDataList?>()) {
-      return (data != null ? _i116.SimpleDataList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i117.SimpleDataMap?>()) {
-      return (data != null ? _i117.SimpleDataMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i118.SimpleDataObject?>()) {
-      return (data != null ? _i118.SimpleDataObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i119.SimpleDateTime?>()) {
-      return (data != null ? _i119.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i120.TestEnum?>()) {
-      return (data != null ? _i120.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i121.TestEnumStringified?>()) {
-      return (data != null ? _i121.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i101.ObjectWithDuration?>()) {
+      return (data != null ? _i101.ObjectWithDuration.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i122.Types?>()) {
-      return (data != null ? _i122.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i102.ObjectWithEnum?>()) {
+      return (data != null ? _i102.ObjectWithEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i123.TypesList?>()) {
-      return (data != null ? _i123.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i103.ObjectWithIndex?>()) {
+      return (data != null ? _i103.ObjectWithIndex.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i124.TypesMap?>()) {
-      return (data != null ? _i124.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i104.ObjectWithMaps?>()) {
+      return (data != null ? _i104.ObjectWithMaps.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i125.TypesSet?>()) {
-      return (data != null ? _i125.TypesSet.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i105.ObjectWithObject?>()) {
+      return (data != null ? _i105.ObjectWithObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i126.UniqueData?>()) {
-      return (data != null ? _i126.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i106.ObjectWithParent?>()) {
+      return (data != null ? _i106.ObjectWithParent.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i127.MyFeatureModel?>()) {
-      return (data != null ? _i127.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i107.ObjectWithSelfParent?>()) {
+      return (data != null ? _i107.ObjectWithSelfParent.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i108.ObjectWithUuid?>()) {
+      return (data != null ? _i108.ObjectWithUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i109.RelatedUniqueData?>()) {
+      return (data != null ? _i109.RelatedUniqueData.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i110.ScopeNoneFields?>()) {
+      return (data != null ? _i110.ScopeNoneFields.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i111.ScopeServerOnlyField?>()) {
+      return (data != null ? _i111.ScopeServerOnlyField.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i112.ScopeServerOnlyFieldChild?>()) {
+      return (data != null
+          ? _i112.ScopeServerOnlyFieldChild.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i113.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i113.DefaultServerOnlyClass.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i114.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i114.DefaultServerOnlyEnum.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i115.NotServerOnlyClass?>()) {
+      return (data != null ? _i115.NotServerOnlyClass.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i116.NotServerOnlyEnum?>()) {
+      return (data != null ? _i116.NotServerOnlyEnum.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i117.ServerOnlyClassField?>()) {
+      return (data != null ? _i117.ServerOnlyClassField.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i118.SimpleData?>()) {
+      return (data != null ? _i118.SimpleData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i119.SimpleDataList?>()) {
+      return (data != null ? _i119.SimpleDataList.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i120.SimpleDataMap?>()) {
+      return (data != null ? _i120.SimpleDataMap.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i121.SimpleDataObject?>()) {
+      return (data != null ? _i121.SimpleDataObject.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i122.SimpleDateTime?>()) {
+      return (data != null ? _i122.SimpleDateTime.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i123.TestEnum?>()) {
+      return (data != null ? _i123.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i124.TestEnumStringified?>()) {
+      return (data != null ? _i124.TestEnumStringified.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i125.Types?>()) {
+      return (data != null ? _i125.Types.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i126.TypesList?>()) {
+      return (data != null ? _i126.TypesList.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i127.TypesMap?>()) {
+      return (data != null ? _i127.TypesMap.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i128.TypesSet?>()) {
+      return (data != null ? _i128.TypesSet.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i129.UniqueData?>()) {
+      return (data != null ? _i129.UniqueData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i130.MyFeatureModel?>()) {
+      return (data != null ? _i130.MyFeatureModel.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<List<_i48.EmptyModelRelationItem>?>()) {
       return (data != null
@@ -1119,118 +1148,118 @@ class Protocol extends _i1.SerializationManager {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == _i1.getType<List<_i60.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i63.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i63.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i59.OrganizationWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i62.OrganizationWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i59.OrganizationWithLongTableName>(e))
+              .map((e) => deserialize<_i62.OrganizationWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i60.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i63.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i63.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i62.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i65.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i62.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i65.LongImplicitIdField>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i69.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i72.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i69.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i72.MultipleMaxFieldName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i65.UserNote>?>()) {
+    if (t == _i1.getType<List<_i68.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i65.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i68.UserNote>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i68.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i71.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i68.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i71.UserNoteWithALongName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i72.Person>?>()) {
+    if (t == _i1.getType<List<_i75.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i72.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i71.Organization>?>()) {
+    if (t == _i1.getType<List<_i74.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i71.Organization>(e))
+              .map((e) => deserialize<_i74.Organization>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i72.Person>?>()) {
+    if (t == _i1.getType<List<_i75.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i72.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i74.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i77.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i77.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i74.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i77.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i77.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i79.Player>?>()) {
+    if (t == _i1.getType<List<_i82.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i79.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i82.Player>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i83.Order>?>()) {
+    if (t == _i1.getType<List<_i86.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i83.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i86.Order>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i81.Comment>?>()) {
+    if (t == _i1.getType<List<_i84.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i81.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i84.Comment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i88.Blocking>?>()) {
+    if (t == _i1.getType<List<_i91.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i88.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i91.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i88.Blocking>?>()) {
+    if (t == _i1.getType<List<_i91.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i88.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i91.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i90.Cat>?>()) {
+    if (t == _i1.getType<List<_i93.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i90.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i93.Cat>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i128.ModuleClass>) {
+    if (t == List<_i131.ModuleClass>) {
       return (data as List)
-          .map((e) => deserialize<_i128.ModuleClass>(e))
+          .map((e) => deserialize<_i131.ModuleClass>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i128.ModuleClass>) {
+    if (t == Map<String, _i131.ModuleClass>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i128.ModuleClass>(v))) as T;
+          deserialize<String>(k), deserialize<_i131.ModuleClass>(v))) as T;
     }
     if (t == List<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toList() as T;
@@ -1248,25 +1277,25 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i115.SimpleData>) {
+    if (t == List<_i118.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i115.SimpleData>(e))
+          .map((e) => deserialize<_i118.SimpleData>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i115.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i115.SimpleData?>) {
+    if (t == List<_i118.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i115.SimpleData?>(e))
+          .map((e) => deserialize<_i118.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i115.SimpleData?>(e))
+              .map((e) => deserialize<_i118.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -1286,22 +1315,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i129.ByteData>) {
-      return (data as List).map((e) => deserialize<_i129.ByteData>(e)).toList()
+    if (t == List<_i132.ByteData>) {
+      return (data as List).map((e) => deserialize<_i132.ByteData>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i129.ByteData>?>()) {
+    if (t == _i1.getType<List<_i132.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i129.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i132.ByteData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i129.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i129.ByteData?>(e)).toList()
+    if (t == List<_i132.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i132.ByteData?>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i129.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i132.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i129.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i132.ByteData?>(e)).toList()
           : null) as T;
     }
     if (t == List<Duration>) {
@@ -1359,32 +1388,32 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as T;
     }
-    if (t == _i130.CustomClassWithoutProtocolSerialization) {
-      return _i130.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
+    if (t == _i133.CustomClassWithoutProtocolSerialization) {
+      return _i133.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i130.CustomClassWithProtocolSerialization) {
-      return _i130.CustomClassWithProtocolSerialization.fromJson(data) as T;
+    if (t == _i133.CustomClassWithProtocolSerialization) {
+      return _i133.CustomClassWithProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i130.CustomClassWithProtocolSerializationMethod) {
-      return _i130.CustomClassWithProtocolSerializationMethod.fromJson(data)
+    if (t == _i133.CustomClassWithProtocolSerializationMethod) {
+      return _i133.CustomClassWithProtocolSerializationMethod.fromJson(data)
           as T;
     }
-    if (t == List<_i120.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i120.TestEnum>(e)).toList()
+    if (t == List<_i123.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i123.TestEnum>(e)).toList()
           as T;
     }
-    if (t == List<_i120.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i120.TestEnum?>(e)).toList()
+    if (t == List<_i123.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i123.TestEnum?>(e)).toList()
           as T;
     }
-    if (t == List<List<_i120.TestEnum>>) {
+    if (t == List<List<_i123.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i120.TestEnum>>(e))
+          .map((e) => deserialize<List<_i123.TestEnum>>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i115.SimpleData>) {
+    if (t == Map<String, _i118.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i115.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i118.SimpleData>(v))) as T;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -1394,9 +1423,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime>(v))) as T;
     }
-    if (t == Map<String, _i129.ByteData>) {
+    if (t == Map<String, _i132.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i129.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i132.ByteData>(v)))
           as T;
     }
     if (t == Map<String, Duration>) {
@@ -1407,9 +1436,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v))) as T;
     }
-    if (t == Map<String, _i115.SimpleData?>) {
+    if (t == Map<String, _i118.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i115.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i118.SimpleData?>(v))) as T;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -1419,9 +1448,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i129.ByteData?>) {
+    if (t == Map<String, _i132.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i129.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i132.ByteData?>(v)))
           as T;
     }
     if (t == Map<String, Duration?>) {
@@ -1437,53 +1466,53 @@ class Protocol extends _i1.SerializationManager {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i115.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i118.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i118.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i115.SimpleData?>(e))
+              .map((e) => deserialize<_i118.SimpleData?>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<List<_i115.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i118.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i115.SimpleData>>(e))
+              .map((e) => deserialize<List<_i118.SimpleData>>(e))
               .toList()
           : null) as T;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i115.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i118.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i115.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i118.SimpleData>>?>>(v)))
           : null) as T;
     }
-    if (t == List<List<Map<int, _i115.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i118.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i115.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i118.SimpleData>>?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<Map<int, _i115.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i118.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i115.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i118.SimpleData>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<int, _i115.SimpleData>) {
+    if (t == Map<int, _i118.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i115.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i118.SimpleData>(e['v']))))
           as T;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i115.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i118.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i115.SimpleData>>(v)))
+              deserialize<Map<int, _i118.SimpleData>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -1527,9 +1556,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i129.ByteData>?>()) {
+    if (t == _i1.getType<List<_i132.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i129.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i132.ByteData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -1552,43 +1581,43 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i120.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i123.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i123.TestEnum>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i121.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i124.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i121.TestEnumStringified>(e))
+              .map((e) => deserialize<_i124.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i122.Types>?>()) {
+    if (t == _i1.getType<List<_i125.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i122.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i125.Types>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<Map<String, _i122.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i125.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i122.Types>>(e))
+              .map((e) => deserialize<Map<String, _i125.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<String, _i122.Types>) {
+    if (t == Map<String, _i125.Types>) {
       return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<_i122.Types>(v))) as T;
+          MapEntry(deserialize<String>(k), deserialize<_i125.Types>(v))) as T;
     }
-    if (t == _i1.getType<List<List<_i122.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i125.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i122.Types>>(e))
+              .map((e) => deserialize<List<_i125.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == List<_i122.Types>) {
-      return (data as List).map((e) => deserialize<_i122.Types>(e)).toList()
+    if (t == List<_i125.Types>) {
+      return (data as List).map((e) => deserialize<_i125.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -1621,10 +1650,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i129.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i132.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i129.ByteData>(e['k']),
+              deserialize<_i132.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -1652,41 +1681,41 @@ class Protocol extends _i1.SerializationManager {
               deserialize<BigInt>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i120.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i123.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i120.TestEnum>(e['k']),
+              deserialize<_i123.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i121.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i124.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i121.TestEnumStringified>(e['k']),
+              deserialize<_i124.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i122.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i125.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i122.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i125.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<Map<_i122.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i125.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i122.Types, String>>(e['k']),
+              deserialize<Map<_i125.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == Map<_i122.Types, String>) {
+    if (t == Map<_i125.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i122.Types>(e['k']), deserialize<String>(e['v'])))) as T;
+          deserialize<_i125.Types>(e['k']), deserialize<String>(e['v'])))) as T;
     }
-    if (t == _i1.getType<Map<List<_i122.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i125.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i122.Types>>(e['k']),
+              deserialize<List<_i125.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -1720,10 +1749,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i129.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i132.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i129.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i132.ByteData>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -1750,34 +1779,34 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<BigInt>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i120.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i123.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i120.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i123.TestEnum>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i121.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i124.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i121.TestEnumStringified>(v)))
+              deserialize<_i124.TestEnumStringified>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i122.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i125.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i122.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i125.Types>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i122.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i125.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i122.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i125.Types>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, List<_i122.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i125.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i122.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i125.Types>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Set<int>?>()) {
@@ -1805,9 +1834,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i129.ByteData>?>()) {
+    if (t == _i1.getType<Set<_i132.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i129.ByteData>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i132.ByteData>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<Duration>?>()) {
@@ -1825,33 +1854,33 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i120.TestEnum>?>()) {
+    if (t == _i1.getType<Set<_i123.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.TestEnum>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i123.TestEnum>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i121.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Set<_i124.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i121.TestEnumStringified>(e))
+              .map((e) => deserialize<_i124.TestEnumStringified>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i122.Types>?>()) {
+    if (t == _i1.getType<Set<_i125.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i122.Types>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i125.Types>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<Map<String, _i122.Types>>?>()) {
+    if (t == _i1.getType<Set<Map<String, _i125.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i122.Types>>(e))
+              .map((e) => deserialize<Map<String, _i125.Types>>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<List<_i122.Types>>?>()) {
+    if (t == _i1.getType<Set<List<_i125.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i122.Types>>(e)).toSet()
+          ? (data as List).map((e) => deserialize<List<_i125.Types>>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<List<String>?>()) {
@@ -1862,9 +1891,9 @@ class Protocol extends _i1.SerializationManager {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == List<_i131.SimpleData>) {
+    if (t == List<_i134.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i131.SimpleData>(e))
+          .map((e) => deserialize<_i134.SimpleData>(e))
           .toList() as T;
     }
     if (t == List<int>) {
@@ -1921,28 +1950,28 @@ class Protocol extends _i1.SerializationManager {
     if (t == List<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
     }
-    if (t == List<_i129.ByteData>) {
-      return (data as List).map((e) => deserialize<_i129.ByteData>(e)).toList()
+    if (t == List<_i132.ByteData>) {
+      return (data as List).map((e) => deserialize<_i132.ByteData>(e)).toList()
           as T;
     }
-    if (t == List<_i129.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i129.ByteData?>(e)).toList()
+    if (t == List<_i132.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i132.ByteData?>(e)).toList()
           as T;
     }
-    if (t == List<_i131.SimpleData?>) {
+    if (t == List<_i134.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i131.SimpleData?>(e))
+          .map((e) => deserialize<_i134.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i131.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i134.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i131.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i134.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i131.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i134.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i131.SimpleData?>(e))
+              .map((e) => deserialize<_i134.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -1981,13 +2010,13 @@ class Protocol extends _i1.SerializationManager {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<_i132.TestEnum, int>) {
+    if (t == Map<_i135.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i132.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
+          deserialize<_i135.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<String, _i132.TestEnum>) {
+    if (t == Map<String, _i135.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i132.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i135.TestEnum>(v)))
           as T;
     }
     if (t == Map<String, double>) {
@@ -2024,34 +2053,34 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i129.ByteData>) {
+    if (t == Map<String, _i132.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i129.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i132.ByteData>(v)))
           as T;
     }
-    if (t == Map<String, _i129.ByteData?>) {
+    if (t == Map<String, _i132.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i129.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i132.ByteData?>(v)))
           as T;
     }
-    if (t == Map<String, _i131.SimpleData>) {
+    if (t == Map<String, _i134.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i131.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i134.SimpleData>(v))) as T;
     }
-    if (t == Map<String, _i131.SimpleData?>) {
+    if (t == Map<String, _i134.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i131.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i134.SimpleData?>(v))) as T;
     }
-    if (t == _i1.getType<Map<String, _i131.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i134.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i131.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i134.SimpleData>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i131.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i134.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i131.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i134.SimpleData?>(v)))
           : null) as T;
     }
     if (t == Map<String, Duration>) {
@@ -2062,20 +2091,20 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<Duration?>(v))) as T;
     }
-    if (t == List<_i133.UserInfo>) {
-      return (data as List).map((e) => deserialize<_i133.UserInfo>(e)).toList()
+    if (t == List<_i136.UserInfo>) {
+      return (data as List).map((e) => deserialize<_i136.UserInfo>(e)).toList()
           as T;
     }
     if (t == Set<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
     }
-    if (t == Set<_i131.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i131.SimpleData>(e)).toSet()
+    if (t == Set<_i134.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i134.SimpleData>(e)).toSet()
           as T;
     }
-    if (t == List<Set<_i131.SimpleData>>) {
+    if (t == List<Set<_i134.SimpleData>>) {
       return (data as List)
-          .map((e) => deserialize<Set<_i131.SimpleData>>(e))
+          .map((e) => deserialize<Set<_i134.SimpleData>>(e))
           .toList() as T;
     }
     if (t == _i1.getType<(int,)>()) {
@@ -2116,18 +2145,18 @@ class Protocol extends _i1.SerializationManager {
               deserialize<String>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i131.SimpleData>(data['p'][1]),
+        deserialize<_i134.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i131.SimpleData>(data['p'][1]),
+              deserialize<_i134.SimpleData>(data['p'][1]),
             ) as T;
     }
     if (t == _i1.getType<({int number, String text})>()) {
@@ -2144,135 +2173,135 @@ class Protocol extends _i1.SerializationManager {
               text: deserialize<String>(data['n']['text']),
             ) as T;
     }
-    if (t == _i1.getType<({_i131.SimpleData data, int number})>()) {
+    if (t == _i1.getType<({_i134.SimpleData data, int number})>()) {
       return (
         data:
-            deserialize<_i131.SimpleData>(((data as Map)['n'] as Map)['data']),
+            deserialize<_i134.SimpleData>(((data as Map)['n'] as Map)['data']),
         number: deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<({_i131.SimpleData data, int number})?>()) {
+    if (t == _i1.getType<({_i134.SimpleData data, int number})?>()) {
       return (data == null)
           ? null as T
           : (
-              data: deserialize<_i131.SimpleData>(
+              data: deserialize<_i134.SimpleData>(
                   ((data as Map)['n'] as Map)['data']),
               number: deserialize<int>(data['n']['number']),
             ) as T;
     }
-    if (t == _i1.getType<({_i131.SimpleData? data, int? number})>()) {
+    if (t == _i1.getType<({_i134.SimpleData? data, int? number})>()) {
       return (
         data: ((data as Map)['n'] as Map)['data'] == null
             ? null
-            : deserialize<_i131.SimpleData>(data['n']['data']),
+            : deserialize<_i134.SimpleData>(data['n']['data']),
         number: ((data)['n'] as Map)['number'] == null
             ? null
             : deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i131.SimpleData data})>()) {
+    if (t == _i1.getType<(int, {_i134.SimpleData data})>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        data: deserialize<_i131.SimpleData>(data['n']['data']),
+        data: deserialize<_i134.SimpleData>(data['n']['data']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i131.SimpleData data})?>()) {
+    if (t == _i1.getType<(int, {_i134.SimpleData data})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              data: deserialize<_i131.SimpleData>(data['n']['data']),
+              data: deserialize<_i134.SimpleData>(data['n']['data']),
             ) as T;
     }
-    if (t == List<(int, _i131.SimpleData)>) {
+    if (t == List<(int, _i134.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i131.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i134.SimpleData)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i131.SimpleData>(data['p'][1]),
+        deserialize<_i134.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == List<(int, _i131.SimpleData)?>) {
+    if (t == List<(int, _i134.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i131.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i134.SimpleData)?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i131.SimpleData>(data['p'][1]),
+              deserialize<_i134.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Set<(int, _i131.SimpleData)>) {
+    if (t == Set<(int, _i134.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i131.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i134.SimpleData)>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i131.SimpleData>(data['p'][1]),
+        deserialize<_i134.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Set<(int, _i131.SimpleData)?>) {
+    if (t == Set<(int, _i134.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i131.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i134.SimpleData)?>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i131.SimpleData>(data['p'][1]),
+              deserialize<_i134.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<Set<(int, _i131.SimpleData)>?>()) {
+    if (t == _i1.getType<Set<(int, _i134.SimpleData)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(int, _i131.SimpleData)>(e))
+              .map((e) => deserialize<(int, _i134.SimpleData)>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i131.SimpleData>(data['p'][1]),
+        deserialize<_i134.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i131.SimpleData)>) {
+    if (t == Map<String, (int, _i134.SimpleData)>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i131.SimpleData)>(v)))
+              deserialize<String>(k), deserialize<(int, _i134.SimpleData)>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i131.SimpleData>(data['p'][1]),
+        deserialize<_i134.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i131.SimpleData)?>) {
+    if (t == Map<String, (int, _i134.SimpleData)?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i131.SimpleData)?>(v)))
+              deserialize<String>(k), deserialize<(int, _i134.SimpleData)?>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i131.SimpleData>(data['p'][1]),
+              deserialize<_i134.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Map<(String, int), (int, _i131.SimpleData)>) {
+    if (t == Map<(String, int), (int, _i134.SimpleData)>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
           deserialize<(String, int)>(e['k']),
-          deserialize<(int, _i131.SimpleData)>(e['v'])))) as T;
+          deserialize<(int, _i134.SimpleData)>(e['v'])))) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
       return (
@@ -2280,10 +2309,10 @@ class Protocol extends _i1.SerializationManager {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i131.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i134.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i131.SimpleData>(data['p'][1]),
+        deserialize<_i134.SimpleData>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
@@ -2335,56 +2364,56 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<(int,)>()) {
       return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<({(_i131.SimpleData, double) namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i134.SimpleData, double) namedSubRecord})>()) {
       return (
-        namedSubRecord: deserialize<(_i131.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i134.SimpleData, double)>(
             ((data as Map)['n'] as Map)['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i131.SimpleData, double)>()) {
+    if (t == _i1.getType<(_i134.SimpleData, double)>()) {
       return (
-        deserialize<_i131.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<_i134.SimpleData>(((data as Map)['p'] as List)[0]),
         deserialize<double>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<({(_i131.SimpleData, double)? namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i134.SimpleData, double)? namedSubRecord})>()) {
       return (
         namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
             ? null
-            : deserialize<(_i131.SimpleData, double)>(
+            : deserialize<(_i134.SimpleData, double)>(
                 data['n']['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i131.SimpleData, double)?>()) {
+    if (t == _i1.getType<(_i134.SimpleData, double)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i131.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i134.SimpleData>(((data as Map)['p'] as List)[0]),
               deserialize<double>(data['p'][1]),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i131.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i134.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i131.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i134.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
     if (t ==
-        List<((int, String), {(_i131.SimpleData, double) namedSubRecord})>) {
+        List<((int, String), {(_i134.SimpleData, double) namedSubRecord})>) {
       return (data as List)
           .map((e) => deserialize<
-              ((int, String), {(_i131.SimpleData, double) namedSubRecord})>(e))
+              ((int, String), {(_i134.SimpleData, double) namedSubRecord})>(e))
           .toList() as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i131.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i134.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i131.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i134.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
@@ -2444,17 +2473,17 @@ class Protocol extends _i1.SerializationManager {
     if (t == Set<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
     }
-    if (t == Set<_i129.ByteData>) {
-      return (data as List).map((e) => deserialize<_i129.ByteData>(e)).toSet()
+    if (t == Set<_i132.ByteData>) {
+      return (data as List).map((e) => deserialize<_i132.ByteData>(e)).toSet()
           as T;
     }
-    if (t == Set<_i129.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i129.ByteData?>(e)).toSet()
+    if (t == Set<_i132.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i132.ByteData?>(e)).toSet()
           as T;
     }
-    if (t == Set<_i131.SimpleData?>) {
+    if (t == Set<_i134.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i131.SimpleData?>(e))
+          .map((e) => deserialize<_i134.SimpleData?>(e))
           .toSet() as T;
     }
     if (t == Set<Duration>) {
@@ -2486,64 +2515,64 @@ class Protocol extends _i1.SerializationManager {
         deserialize<(int, bool)>(data['p'][1]),
       ) as T;
     }
-    if (t == _i130.CustomClass) {
-      return _i130.CustomClass.fromJson(data) as T;
+    if (t == _i133.CustomClass) {
+      return _i133.CustomClass.fromJson(data) as T;
     }
-    if (t == _i130.CustomClass2) {
-      return _i130.CustomClass2.fromJson(data) as T;
+    if (t == _i133.CustomClass2) {
+      return _i133.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i130.ProtocolCustomClass) {
-      return _i130.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i133.ProtocolCustomClass) {
+      return _i133.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i130.ExternalCustomClass) {
-      return _i130.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i133.ExternalCustomClass) {
+      return _i133.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i130.FreezedCustomClass) {
-      return _i130.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i133.FreezedCustomClass) {
+      return _i133.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i130.CustomClass?>()) {
-      return (data != null ? _i130.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i133.CustomClass?>()) {
+      return (data != null ? _i133.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i130.CustomClass2?>()) {
-      return (data != null ? _i130.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i133.CustomClass2?>()) {
+      return (data != null ? _i133.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i130.CustomClassWithoutProtocolSerialization?>()) {
+    if (t == _i1.getType<_i133.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? _i130.CustomClassWithoutProtocolSerialization.fromJson(data)
+          ? _i133.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i130.CustomClassWithProtocolSerialization?>()) {
+    if (t == _i1.getType<_i133.CustomClassWithProtocolSerialization?>()) {
       return (data != null
-          ? _i130.CustomClassWithProtocolSerialization.fromJson(data)
+          ? _i133.CustomClassWithProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i130.CustomClassWithProtocolSerializationMethod?>()) {
+    if (t == _i1.getType<_i133.CustomClassWithProtocolSerializationMethod?>()) {
       return (data != null
-          ? _i130.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          ? _i133.CustomClassWithProtocolSerializationMethod.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i130.ProtocolCustomClass?>()) {
-      return (data != null ? _i130.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i133.ProtocolCustomClass?>()) {
+      return (data != null ? _i133.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i130.ExternalCustomClass?>()) {
-      return (data != null ? _i130.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i133.ExternalCustomClass?>()) {
+      return (data != null ? _i133.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i130.FreezedCustomClass?>()) {
-      return (data != null ? _i130.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i133.FreezedCustomClass?>()) {
+      return (data != null ? _i133.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<List<_i131.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i134.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i131.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i134.SimpleData>(e)).toList()
           : null) as T;
     }
     try {
-      return _i133.Protocol().deserialize<T>(data, t);
+      return _i136.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i128.Protocol().deserialize<T>(data, t);
+      return _i131.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -2552,28 +2581,28 @@ class Protocol extends _i1.SerializationManager {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i130.CustomClass) {
+    if (data is _i133.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i130.CustomClass2) {
+    if (data is _i133.CustomClass2) {
       return 'CustomClass2';
     }
-    if (data is _i130.CustomClassWithoutProtocolSerialization) {
+    if (data is _i133.CustomClassWithoutProtocolSerialization) {
       return 'CustomClassWithoutProtocolSerialization';
     }
-    if (data is _i130.CustomClassWithProtocolSerialization) {
+    if (data is _i133.CustomClassWithProtocolSerialization) {
       return 'CustomClassWithProtocolSerialization';
     }
-    if (data is _i130.CustomClassWithProtocolSerializationMethod) {
+    if (data is _i133.CustomClassWithProtocolSerializationMethod) {
       return 'CustomClassWithProtocolSerializationMethod';
     }
-    if (data is _i130.ProtocolCustomClass) {
+    if (data is _i133.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
     }
-    if (data is _i130.ExternalCustomClass) {
+    if (data is _i133.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i130.FreezedCustomClass) {
+    if (data is _i133.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.ByIndexEnumWithNameValue) {
@@ -2750,246 +2779,255 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i57.SealedOtherChild) {
       return 'SealedOtherChild';
     }
-    if (data is _i58.CityWithLongTableName) {
+    if (data is _i58.ClassOverridingInterfaceField) {
+      return 'ClassOverridingInterfaceField';
+    }
+    if (data is _i59.ClassWithInterface) {
+      return 'ClassWithInterface';
+    }
+    if (data is _i60.ExceptionWithInterface) {
+      return 'ExceptionWithInterface';
+    }
+    if (data is _i61.CityWithLongTableName) {
       return 'CityWithLongTableName';
     }
-    if (data is _i59.OrganizationWithLongTableName) {
+    if (data is _i62.OrganizationWithLongTableName) {
       return 'OrganizationWithLongTableName';
     }
-    if (data is _i60.PersonWithLongTableName) {
+    if (data is _i63.PersonWithLongTableName) {
       return 'PersonWithLongTableName';
     }
-    if (data is _i61.MaxFieldName) {
+    if (data is _i64.MaxFieldName) {
       return 'MaxFieldName';
     }
-    if (data is _i62.LongImplicitIdField) {
+    if (data is _i65.LongImplicitIdField) {
       return 'LongImplicitIdField';
     }
-    if (data is _i63.LongImplicitIdFieldCollection) {
+    if (data is _i66.LongImplicitIdFieldCollection) {
       return 'LongImplicitIdFieldCollection';
     }
-    if (data is _i64.RelationToMultipleMaxFieldName) {
+    if (data is _i67.RelationToMultipleMaxFieldName) {
       return 'RelationToMultipleMaxFieldName';
     }
-    if (data is _i65.UserNote) {
+    if (data is _i68.UserNote) {
       return 'UserNote';
     }
-    if (data is _i66.UserNoteCollection) {
+    if (data is _i69.UserNoteCollection) {
       return 'UserNoteCollection';
     }
-    if (data is _i67.UserNoteCollectionWithALongName) {
+    if (data is _i70.UserNoteCollectionWithALongName) {
       return 'UserNoteCollectionWithALongName';
     }
-    if (data is _i68.UserNoteWithALongName) {
+    if (data is _i71.UserNoteWithALongName) {
       return 'UserNoteWithALongName';
     }
-    if (data is _i69.MultipleMaxFieldName) {
+    if (data is _i72.MultipleMaxFieldName) {
       return 'MultipleMaxFieldName';
     }
-    if (data is _i70.City) {
+    if (data is _i73.City) {
       return 'City';
     }
-    if (data is _i71.Organization) {
+    if (data is _i74.Organization) {
       return 'Organization';
     }
-    if (data is _i72.Person) {
+    if (data is _i75.Person) {
       return 'Person';
     }
-    if (data is _i73.Course) {
+    if (data is _i76.Course) {
       return 'Course';
     }
-    if (data is _i74.Enrollment) {
+    if (data is _i77.Enrollment) {
       return 'Enrollment';
     }
-    if (data is _i75.Student) {
+    if (data is _i78.Student) {
       return 'Student';
     }
-    if (data is _i76.ObjectUser) {
+    if (data is _i79.ObjectUser) {
       return 'ObjectUser';
     }
-    if (data is _i77.ParentUser) {
+    if (data is _i80.ParentUser) {
       return 'ParentUser';
     }
-    if (data is _i78.Arena) {
+    if (data is _i81.Arena) {
       return 'Arena';
     }
-    if (data is _i79.Player) {
+    if (data is _i82.Player) {
       return 'Player';
     }
-    if (data is _i80.Team) {
+    if (data is _i83.Team) {
       return 'Team';
     }
-    if (data is _i81.Comment) {
+    if (data is _i84.Comment) {
       return 'Comment';
     }
-    if (data is _i82.Customer) {
+    if (data is _i85.Customer) {
       return 'Customer';
     }
-    if (data is _i83.Order) {
+    if (data is _i86.Order) {
       return 'Order';
     }
-    if (data is _i84.Address) {
+    if (data is _i87.Address) {
       return 'Address';
     }
-    if (data is _i85.Citizen) {
+    if (data is _i88.Citizen) {
       return 'Citizen';
     }
-    if (data is _i86.Company) {
+    if (data is _i89.Company) {
       return 'Company';
     }
-    if (data is _i87.Town) {
+    if (data is _i90.Town) {
       return 'Town';
     }
-    if (data is _i88.Blocking) {
+    if (data is _i91.Blocking) {
       return 'Blocking';
     }
-    if (data is _i89.Member) {
+    if (data is _i92.Member) {
       return 'Member';
     }
-    if (data is _i90.Cat) {
+    if (data is _i93.Cat) {
       return 'Cat';
     }
-    if (data is _i91.Post) {
+    if (data is _i94.Post) {
       return 'Post';
     }
-    if (data is _i92.ModuleDatatype) {
+    if (data is _i95.ModuleDatatype) {
       return 'ModuleDatatype';
     }
-    if (data is _i93.Nullability) {
+    if (data is _i96.Nullability) {
       return 'Nullability';
     }
-    if (data is _i94.ObjectFieldPersist) {
+    if (data is _i97.ObjectFieldPersist) {
       return 'ObjectFieldPersist';
     }
-    if (data is _i95.ObjectFieldScopes) {
+    if (data is _i98.ObjectFieldScopes) {
       return 'ObjectFieldScopes';
     }
-    if (data is _i96.ObjectWithByteData) {
+    if (data is _i99.ObjectWithByteData) {
       return 'ObjectWithByteData';
     }
-    if (data is _i97.ObjectWithCustomClass) {
+    if (data is _i100.ObjectWithCustomClass) {
       return 'ObjectWithCustomClass';
     }
-    if (data is _i98.ObjectWithDuration) {
+    if (data is _i101.ObjectWithDuration) {
       return 'ObjectWithDuration';
     }
-    if (data is _i99.ObjectWithEnum) {
+    if (data is _i102.ObjectWithEnum) {
       return 'ObjectWithEnum';
     }
-    if (data is _i100.ObjectWithIndex) {
+    if (data is _i103.ObjectWithIndex) {
       return 'ObjectWithIndex';
     }
-    if (data is _i101.ObjectWithMaps) {
+    if (data is _i104.ObjectWithMaps) {
       return 'ObjectWithMaps';
     }
-    if (data is _i102.ObjectWithObject) {
+    if (data is _i105.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i103.ObjectWithParent) {
+    if (data is _i106.ObjectWithParent) {
       return 'ObjectWithParent';
     }
-    if (data is _i104.ObjectWithSelfParent) {
+    if (data is _i107.ObjectWithSelfParent) {
       return 'ObjectWithSelfParent';
     }
-    if (data is _i105.ObjectWithUuid) {
+    if (data is _i108.ObjectWithUuid) {
       return 'ObjectWithUuid';
     }
-    if (data is _i106.RelatedUniqueData) {
+    if (data is _i109.RelatedUniqueData) {
       return 'RelatedUniqueData';
     }
-    if (data is _i107.ScopeNoneFields) {
+    if (data is _i110.ScopeNoneFields) {
       return 'ScopeNoneFields';
     }
-    if (data is _i108.ScopeServerOnlyField) {
+    if (data is _i111.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i109.ScopeServerOnlyFieldChild) {
+    if (data is _i112.ScopeServerOnlyFieldChild) {
       return 'ScopeServerOnlyFieldChild';
     }
-    if (data is _i110.DefaultServerOnlyClass) {
+    if (data is _i113.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i111.DefaultServerOnlyEnum) {
+    if (data is _i114.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i112.NotServerOnlyClass) {
+    if (data is _i115.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i113.NotServerOnlyEnum) {
+    if (data is _i116.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i114.ServerOnlyClassField) {
+    if (data is _i117.ServerOnlyClassField) {
       return 'ServerOnlyClassField';
     }
-    if (data is _i115.SimpleData) {
+    if (data is _i118.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i116.SimpleDataList) {
+    if (data is _i119.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i117.SimpleDataMap) {
+    if (data is _i120.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i118.SimpleDataObject) {
+    if (data is _i121.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i119.SimpleDateTime) {
+    if (data is _i122.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i120.TestEnum) {
+    if (data is _i123.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i121.TestEnumStringified) {
+    if (data is _i124.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i122.Types) {
+    if (data is _i125.Types) {
       return 'Types';
     }
-    if (data is _i123.TypesList) {
+    if (data is _i126.TypesList) {
       return 'TypesList';
     }
-    if (data is _i124.TypesMap) {
+    if (data is _i127.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i125.TypesSet) {
+    if (data is _i128.TypesSet) {
       return 'TypesSet';
     }
-    if (data is _i126.UniqueData) {
+    if (data is _i129.UniqueData) {
       return 'UniqueData';
     }
-    if (data is _i127.MyFeatureModel) {
+    if (data is _i130.MyFeatureModel) {
       return 'MyFeatureModel';
     }
-    className = _i133.Protocol().getClassNameForObject(data);
+    className = _i136.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    className = _i128.Protocol().getClassNameForObject(data);
+    className = _i131.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i131.SimpleData>) {
+    if (data is List<_i134.SimpleData>) {
       return 'List<SimpleData>';
     }
-    if (data is List<_i133.UserInfo>) {
+    if (data is List<_i136.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i131.SimpleData>?) {
+    if (data is List<_i134.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i131.SimpleData?>) {
+    if (data is List<_i134.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i131.SimpleData>) {
+    if (data is Set<_i134.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i131.SimpleData>>) {
+    if (data is List<Set<_i134.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
     return null;
@@ -3002,31 +3040,31 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CustomClass') {
-      return deserialize<_i130.CustomClass>(data['data']);
+      return deserialize<_i133.CustomClass>(data['data']);
     }
     if (dataClassName == 'CustomClass2') {
-      return deserialize<_i130.CustomClass2>(data['data']);
+      return deserialize<_i133.CustomClass2>(data['data']);
     }
     if (dataClassName == 'CustomClassWithoutProtocolSerialization') {
-      return deserialize<_i130.CustomClassWithoutProtocolSerialization>(
+      return deserialize<_i133.CustomClassWithoutProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerialization') {
-      return deserialize<_i130.CustomClassWithProtocolSerialization>(
+      return deserialize<_i133.CustomClassWithProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerializationMethod') {
-      return deserialize<_i130.CustomClassWithProtocolSerializationMethod>(
+      return deserialize<_i133.CustomClassWithProtocolSerializationMethod>(
           data['data']);
     }
     if (dataClassName == 'ProtocolCustomClass') {
-      return deserialize<_i130.ProtocolCustomClass>(data['data']);
+      return deserialize<_i133.ProtocolCustomClass>(data['data']);
     }
     if (dataClassName == 'ExternalCustomClass') {
-      return deserialize<_i130.ExternalCustomClass>(data['data']);
+      return deserialize<_i133.ExternalCustomClass>(data['data']);
     }
     if (dataClassName == 'FreezedCustomClass') {
-      return deserialize<_i130.FreezedCustomClass>(data['data']);
+      return deserialize<_i133.FreezedCustomClass>(data['data']);
     }
     if (dataClassName == 'ByIndexEnumWithNameValue') {
       return deserialize<_i2.ByIndexEnumWithNameValue>(data['data']);
@@ -3202,247 +3240,256 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'SealedOtherChild') {
       return deserialize<_i57.SealedOtherChild>(data['data']);
     }
+    if (dataClassName == 'ClassOverridingInterfaceField') {
+      return deserialize<_i58.ClassOverridingInterfaceField>(data['data']);
+    }
+    if (dataClassName == 'ClassWithInterface') {
+      return deserialize<_i59.ClassWithInterface>(data['data']);
+    }
+    if (dataClassName == 'ExceptionWithInterface') {
+      return deserialize<_i60.ExceptionWithInterface>(data['data']);
+    }
     if (dataClassName == 'CityWithLongTableName') {
-      return deserialize<_i58.CityWithLongTableName>(data['data']);
+      return deserialize<_i61.CityWithLongTableName>(data['data']);
     }
     if (dataClassName == 'OrganizationWithLongTableName') {
-      return deserialize<_i59.OrganizationWithLongTableName>(data['data']);
+      return deserialize<_i62.OrganizationWithLongTableName>(data['data']);
     }
     if (dataClassName == 'PersonWithLongTableName') {
-      return deserialize<_i60.PersonWithLongTableName>(data['data']);
+      return deserialize<_i63.PersonWithLongTableName>(data['data']);
     }
     if (dataClassName == 'MaxFieldName') {
-      return deserialize<_i61.MaxFieldName>(data['data']);
+      return deserialize<_i64.MaxFieldName>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdField') {
-      return deserialize<_i62.LongImplicitIdField>(data['data']);
+      return deserialize<_i65.LongImplicitIdField>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdFieldCollection') {
-      return deserialize<_i63.LongImplicitIdFieldCollection>(data['data']);
+      return deserialize<_i66.LongImplicitIdFieldCollection>(data['data']);
     }
     if (dataClassName == 'RelationToMultipleMaxFieldName') {
-      return deserialize<_i64.RelationToMultipleMaxFieldName>(data['data']);
+      return deserialize<_i67.RelationToMultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'UserNote') {
-      return deserialize<_i65.UserNote>(data['data']);
+      return deserialize<_i68.UserNote>(data['data']);
     }
     if (dataClassName == 'UserNoteCollection') {
-      return deserialize<_i66.UserNoteCollection>(data['data']);
+      return deserialize<_i69.UserNoteCollection>(data['data']);
     }
     if (dataClassName == 'UserNoteCollectionWithALongName') {
-      return deserialize<_i67.UserNoteCollectionWithALongName>(data['data']);
+      return deserialize<_i70.UserNoteCollectionWithALongName>(data['data']);
     }
     if (dataClassName == 'UserNoteWithALongName') {
-      return deserialize<_i68.UserNoteWithALongName>(data['data']);
+      return deserialize<_i71.UserNoteWithALongName>(data['data']);
     }
     if (dataClassName == 'MultipleMaxFieldName') {
-      return deserialize<_i69.MultipleMaxFieldName>(data['data']);
+      return deserialize<_i72.MultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'City') {
-      return deserialize<_i70.City>(data['data']);
+      return deserialize<_i73.City>(data['data']);
     }
     if (dataClassName == 'Organization') {
-      return deserialize<_i71.Organization>(data['data']);
+      return deserialize<_i74.Organization>(data['data']);
     }
     if (dataClassName == 'Person') {
-      return deserialize<_i72.Person>(data['data']);
+      return deserialize<_i75.Person>(data['data']);
     }
     if (dataClassName == 'Course') {
-      return deserialize<_i73.Course>(data['data']);
+      return deserialize<_i76.Course>(data['data']);
     }
     if (dataClassName == 'Enrollment') {
-      return deserialize<_i74.Enrollment>(data['data']);
+      return deserialize<_i77.Enrollment>(data['data']);
     }
     if (dataClassName == 'Student') {
-      return deserialize<_i75.Student>(data['data']);
+      return deserialize<_i78.Student>(data['data']);
     }
     if (dataClassName == 'ObjectUser') {
-      return deserialize<_i76.ObjectUser>(data['data']);
+      return deserialize<_i79.ObjectUser>(data['data']);
     }
     if (dataClassName == 'ParentUser') {
-      return deserialize<_i77.ParentUser>(data['data']);
+      return deserialize<_i80.ParentUser>(data['data']);
     }
     if (dataClassName == 'Arena') {
-      return deserialize<_i78.Arena>(data['data']);
+      return deserialize<_i81.Arena>(data['data']);
     }
     if (dataClassName == 'Player') {
-      return deserialize<_i79.Player>(data['data']);
+      return deserialize<_i82.Player>(data['data']);
     }
     if (dataClassName == 'Team') {
-      return deserialize<_i80.Team>(data['data']);
+      return deserialize<_i83.Team>(data['data']);
     }
     if (dataClassName == 'Comment') {
-      return deserialize<_i81.Comment>(data['data']);
+      return deserialize<_i84.Comment>(data['data']);
     }
     if (dataClassName == 'Customer') {
-      return deserialize<_i82.Customer>(data['data']);
+      return deserialize<_i85.Customer>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i83.Order>(data['data']);
+      return deserialize<_i86.Order>(data['data']);
     }
     if (dataClassName == 'Address') {
-      return deserialize<_i84.Address>(data['data']);
+      return deserialize<_i87.Address>(data['data']);
     }
     if (dataClassName == 'Citizen') {
-      return deserialize<_i85.Citizen>(data['data']);
+      return deserialize<_i88.Citizen>(data['data']);
     }
     if (dataClassName == 'Company') {
-      return deserialize<_i86.Company>(data['data']);
+      return deserialize<_i89.Company>(data['data']);
     }
     if (dataClassName == 'Town') {
-      return deserialize<_i87.Town>(data['data']);
+      return deserialize<_i90.Town>(data['data']);
     }
     if (dataClassName == 'Blocking') {
-      return deserialize<_i88.Blocking>(data['data']);
+      return deserialize<_i91.Blocking>(data['data']);
     }
     if (dataClassName == 'Member') {
-      return deserialize<_i89.Member>(data['data']);
+      return deserialize<_i92.Member>(data['data']);
     }
     if (dataClassName == 'Cat') {
-      return deserialize<_i90.Cat>(data['data']);
+      return deserialize<_i93.Cat>(data['data']);
     }
     if (dataClassName == 'Post') {
-      return deserialize<_i91.Post>(data['data']);
+      return deserialize<_i94.Post>(data['data']);
     }
     if (dataClassName == 'ModuleDatatype') {
-      return deserialize<_i92.ModuleDatatype>(data['data']);
+      return deserialize<_i95.ModuleDatatype>(data['data']);
     }
     if (dataClassName == 'Nullability') {
-      return deserialize<_i93.Nullability>(data['data']);
+      return deserialize<_i96.Nullability>(data['data']);
     }
     if (dataClassName == 'ObjectFieldPersist') {
-      return deserialize<_i94.ObjectFieldPersist>(data['data']);
+      return deserialize<_i97.ObjectFieldPersist>(data['data']);
     }
     if (dataClassName == 'ObjectFieldScopes') {
-      return deserialize<_i95.ObjectFieldScopes>(data['data']);
+      return deserialize<_i98.ObjectFieldScopes>(data['data']);
     }
     if (dataClassName == 'ObjectWithByteData') {
-      return deserialize<_i96.ObjectWithByteData>(data['data']);
+      return deserialize<_i99.ObjectWithByteData>(data['data']);
     }
     if (dataClassName == 'ObjectWithCustomClass') {
-      return deserialize<_i97.ObjectWithCustomClass>(data['data']);
+      return deserialize<_i100.ObjectWithCustomClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithDuration') {
-      return deserialize<_i98.ObjectWithDuration>(data['data']);
+      return deserialize<_i101.ObjectWithDuration>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnum') {
-      return deserialize<_i99.ObjectWithEnum>(data['data']);
+      return deserialize<_i102.ObjectWithEnum>(data['data']);
     }
     if (dataClassName == 'ObjectWithIndex') {
-      return deserialize<_i100.ObjectWithIndex>(data['data']);
+      return deserialize<_i103.ObjectWithIndex>(data['data']);
     }
     if (dataClassName == 'ObjectWithMaps') {
-      return deserialize<_i101.ObjectWithMaps>(data['data']);
+      return deserialize<_i104.ObjectWithMaps>(data['data']);
     }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i102.ObjectWithObject>(data['data']);
+      return deserialize<_i105.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i103.ObjectWithParent>(data['data']);
+      return deserialize<_i106.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i104.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i107.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i105.ObjectWithUuid>(data['data']);
+      return deserialize<_i108.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i106.RelatedUniqueData>(data['data']);
+      return deserialize<_i109.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ScopeNoneFields') {
-      return deserialize<_i107.ScopeNoneFields>(data['data']);
+      return deserialize<_i110.ScopeNoneFields>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyField') {
-      return deserialize<_i108.ScopeServerOnlyField>(data['data']);
+      return deserialize<_i111.ScopeServerOnlyField>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyFieldChild') {
-      return deserialize<_i109.ScopeServerOnlyFieldChild>(data['data']);
+      return deserialize<_i112.ScopeServerOnlyFieldChild>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
-      return deserialize<_i110.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i113.DefaultServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyEnum') {
-      return deserialize<_i111.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i114.DefaultServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyClass') {
-      return deserialize<_i112.NotServerOnlyClass>(data['data']);
+      return deserialize<_i115.NotServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyEnum') {
-      return deserialize<_i113.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i116.NotServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClassField') {
-      return deserialize<_i114.ServerOnlyClassField>(data['data']);
+      return deserialize<_i117.ServerOnlyClassField>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i115.SimpleData>(data['data']);
+      return deserialize<_i118.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDataList') {
-      return deserialize<_i116.SimpleDataList>(data['data']);
+      return deserialize<_i119.SimpleDataList>(data['data']);
     }
     if (dataClassName == 'SimpleDataMap') {
-      return deserialize<_i117.SimpleDataMap>(data['data']);
+      return deserialize<_i120.SimpleDataMap>(data['data']);
     }
     if (dataClassName == 'SimpleDataObject') {
-      return deserialize<_i118.SimpleDataObject>(data['data']);
+      return deserialize<_i121.SimpleDataObject>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i119.SimpleDateTime>(data['data']);
+      return deserialize<_i122.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i120.TestEnum>(data['data']);
+      return deserialize<_i123.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i121.TestEnumStringified>(data['data']);
+      return deserialize<_i124.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i122.Types>(data['data']);
+      return deserialize<_i125.Types>(data['data']);
     }
     if (dataClassName == 'TypesList') {
-      return deserialize<_i123.TypesList>(data['data']);
+      return deserialize<_i126.TypesList>(data['data']);
     }
     if (dataClassName == 'TypesMap') {
-      return deserialize<_i124.TypesMap>(data['data']);
+      return deserialize<_i127.TypesMap>(data['data']);
     }
     if (dataClassName == 'TypesSet') {
-      return deserialize<_i125.TypesSet>(data['data']);
+      return deserialize<_i128.TypesSet>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i126.UniqueData>(data['data']);
+      return deserialize<_i129.UniqueData>(data['data']);
     }
     if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i127.MyFeatureModel>(data['data']);
+      return deserialize<_i130.MyFeatureModel>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
-      return _i133.Protocol().deserializeByClassName(data);
+      return _i136.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_test_module.')) {
       data['className'] = dataClassName.substring(22);
-      return _i128.Protocol().deserializeByClassName(data);
+      return _i131.Protocol().deserializeByClassName(data);
     }
     if (dataClassName == 'List<int>') {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i131.SimpleData>>(data['data']);
+      return deserialize<List<_i134.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
-      return deserialize<List<_i133.UserInfo>>(data['data']);
+      return deserialize<List<_i136.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i131.SimpleData>?>(data['data']);
+      return deserialize<List<_i134.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i131.SimpleData?>>(data['data']);
+      return deserialize<List<_i134.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i131.SimpleData>>(data['data']);
+      return deserialize<Set<_i134.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i131.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i134.SimpleData>>>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -3479,7 +3526,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, _i131.SimpleData)) {
+  if (record is (int, _i134.SimpleData)) {
     return {
       "p": [
         record.$1,
@@ -3495,7 +3542,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i131.SimpleData data, int number})) {
+  if (record is ({_i134.SimpleData data, int number})) {
     return {
       "n": {
         "data": record.data,
@@ -3503,7 +3550,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i131.SimpleData? data, int? number})) {
+  if (record is ({_i134.SimpleData? data, int? number})) {
     return {
       "n": {
         "data": record.data,
@@ -3511,7 +3558,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (int, {_i131.SimpleData data})) {
+  if (record is (int, {_i134.SimpleData data})) {
     return {
       "p": [
         record.$1,
@@ -3529,14 +3576,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i131.SimpleData, double) namedSubRecord})) {
+  if (record is ({(_i134.SimpleData, double) namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is (_i131.SimpleData, double)) {
+  if (record is (_i134.SimpleData, double)) {
     return {
       "p": [
         record.$1,
@@ -3544,14 +3591,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i131.SimpleData, double)? namedSubRecord})) {
+  if (record is ({(_i134.SimpleData, double)? namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is ((int, String), {(_i131.SimpleData, double) namedSubRecord})) {
+  if (record is ((int, String), {(_i134.SimpleData, double) namedSubRecord})) {
     return {
       "p": [
         mapRecordToJson(record.$1),

--- a/tests/serverpod_test_server/lib/src/generated/interfaces/class_overriding_interface_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/interfaces/class_overriding_interface_field.dart
@@ -1,0 +1,94 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ClassOverridingInterfaceField
+    implements
+        _i1.SerializableModel,
+        _i1.ProtocolSerialization,
+        _i2.ExampleInterface {
+  ClassOverridingInterfaceField._({
+    required this.classField,
+    String? interfaceField,
+  }) : interfaceField = interfaceField ?? 'This is a default value';
+
+  factory ClassOverridingInterfaceField({
+    required String classField,
+    String? interfaceField,
+  }) = _ClassOverridingInterfaceFieldImpl;
+
+  factory ClassOverridingInterfaceField.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ClassOverridingInterfaceField(
+      classField: jsonSerialization['classField'] as String,
+      interfaceField: jsonSerialization['interfaceField'] as String,
+    );
+  }
+
+  String classField;
+
+  @override
+  String interfaceField;
+
+  /// Returns a shallow copy of this [ClassOverridingInterfaceField]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ClassOverridingInterfaceField copyWith({
+    String? classField,
+    String? interfaceField,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'classField': classField,
+      'interfaceField': interfaceField,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      'classField': classField,
+      'interfaceField': interfaceField,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ClassOverridingInterfaceFieldImpl extends ClassOverridingInterfaceField {
+  _ClassOverridingInterfaceFieldImpl({
+    required String classField,
+    String? interfaceField,
+  }) : super._(
+          classField: classField,
+          interfaceField: interfaceField,
+        );
+
+  /// Returns a shallow copy of this [ClassOverridingInterfaceField]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ClassOverridingInterfaceField copyWith({
+    String? classField,
+    String? interfaceField,
+  }) {
+    return ClassOverridingInterfaceField(
+      classField: classField ?? this.classField,
+      interfaceField: interfaceField ?? this.interfaceField,
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/interfaces/class_with_interface.dart
+++ b/tests/serverpod_test_server/lib/src/generated/interfaces/class_with_interface.dart
@@ -1,0 +1,93 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ClassWithInterface
+    implements
+        _i1.SerializableModel,
+        _i1.ProtocolSerialization,
+        _i2.ExampleInterface {
+  ClassWithInterface._({
+    required this.interfaceField,
+    required this.classField,
+  });
+
+  factory ClassWithInterface({
+    required String interfaceField,
+    required String classField,
+  }) = _ClassWithInterfaceImpl;
+
+  factory ClassWithInterface.fromJson(Map<String, dynamic> jsonSerialization) {
+    return ClassWithInterface(
+      interfaceField: jsonSerialization['interfaceField'] as String,
+      classField: jsonSerialization['classField'] as String,
+    );
+  }
+
+  @override
+  String interfaceField;
+
+  String classField;
+
+  /// Returns a shallow copy of this [ClassWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ClassWithInterface copyWith({
+    String? interfaceField,
+    String? classField,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'interfaceField': interfaceField,
+      'classField': classField,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      'interfaceField': interfaceField,
+      'classField': classField,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ClassWithInterfaceImpl extends ClassWithInterface {
+  _ClassWithInterfaceImpl({
+    required String interfaceField,
+    required String classField,
+  }) : super._(
+          interfaceField: interfaceField,
+          classField: classField,
+        );
+
+  /// Returns a shallow copy of this [ClassWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ClassWithInterface copyWith({
+    String? interfaceField,
+    String? classField,
+  }) {
+    return ClassWithInterface(
+      interfaceField: interfaceField ?? this.interfaceField,
+      classField: classField ?? this.classField,
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/interfaces/example_interface.dart
+++ b/tests/serverpod_test_server/lib/src/generated/interfaces/example_interface.dart
@@ -1,0 +1,15 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+abstract interface class ExampleInterface {
+  ExampleInterface({required this.interfaceField});
+
+  String interfaceField;
+}

--- a/tests/serverpod_test_server/lib/src/generated/interfaces/exception_with_interface.dart
+++ b/tests/serverpod_test_server/lib/src/generated/interfaces/exception_with_interface.dart
@@ -1,0 +1,95 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import '../protocol.dart' as _i2;
+
+abstract class ExceptionWithInterface
+    implements
+        _i1.SerializableException,
+        _i1.SerializableModel,
+        _i2.ExampleInterface,
+        _i1.ProtocolSerialization {
+  ExceptionWithInterface._({
+    required this.interfaceField,
+    required this.exceptionField,
+  });
+
+  factory ExceptionWithInterface({
+    required String interfaceField,
+    required String exceptionField,
+  }) = _ExceptionWithInterfaceImpl;
+
+  factory ExceptionWithInterface.fromJson(
+      Map<String, dynamic> jsonSerialization) {
+    return ExceptionWithInterface(
+      interfaceField: jsonSerialization['interfaceField'] as String,
+      exceptionField: jsonSerialization['exceptionField'] as String,
+    );
+  }
+
+  @override
+  String interfaceField;
+
+  String exceptionField;
+
+  /// Returns a shallow copy of this [ExceptionWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  ExceptionWithInterface copyWith({
+    String? interfaceField,
+    String? exceptionField,
+  });
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'interfaceField': interfaceField,
+      'exceptionField': exceptionField,
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      'interfaceField': interfaceField,
+      'exceptionField': exceptionField,
+    };
+  }
+
+  @override
+  String toString() {
+    return _i1.SerializationManager.encode(this);
+  }
+}
+
+class _ExceptionWithInterfaceImpl extends ExceptionWithInterface {
+  _ExceptionWithInterfaceImpl({
+    required String interfaceField,
+    required String exceptionField,
+  }) : super._(
+          interfaceField: interfaceField,
+          exceptionField: exceptionField,
+        );
+
+  /// Returns a shallow copy of this [ExceptionWithInterface]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  ExceptionWithInterface copyWith({
+    String? interfaceField,
+    String? exceptionField,
+  }) {
+    return ExceptionWithInterface(
+      interfaceField: interfaceField ?? this.interfaceField,
+      exceptionField: exceptionField ?? this.exceptionField,
+    );
+  }
+}

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -70,90 +70,93 @@ import 'inheritance/grandparent_class.dart' as _i57;
 import 'inheritance/parent_class.dart' as _i58;
 import 'inheritance/parent_with_default.dart' as _i59;
 import 'inheritance/sealed_parent.dart' as _i60;
-import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i61;
+import 'interfaces/class_overriding_interface_field.dart' as _i61;
+import 'interfaces/class_with_interface.dart' as _i62;
+import 'interfaces/exception_with_interface.dart' as _i63;
+import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i64;
 import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
-    as _i62;
-import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
-    as _i63;
-import 'long_identifiers/max_field_name.dart' as _i64;
-import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
     as _i65;
-import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
+import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i66;
-import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
-    as _i67;
-import 'long_identifiers/models_with_relations/user_note.dart' as _i68;
-import 'long_identifiers/models_with_relations/user_note_collection.dart'
+import 'long_identifiers/max_field_name.dart' as _i67;
+import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
+    as _i68;
+import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
     as _i69;
-import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
+import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
     as _i70;
+import 'long_identifiers/models_with_relations/user_note.dart' as _i71;
+import 'long_identifiers/models_with_relations/user_note_collection.dart'
+    as _i72;
+import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
+    as _i73;
 import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
-    as _i71;
-import 'long_identifiers/multiple_max_field_name.dart' as _i72;
-import 'models_with_list_relations/city.dart' as _i73;
-import 'models_with_list_relations/organization.dart' as _i74;
-import 'models_with_list_relations/person.dart' as _i75;
-import 'models_with_relations/many_to_many/course.dart' as _i76;
-import 'models_with_relations/many_to_many/enrollment.dart' as _i77;
-import 'models_with_relations/many_to_many/student.dart' as _i78;
-import 'models_with_relations/module/object_user.dart' as _i79;
-import 'models_with_relations/module/parent_user.dart' as _i80;
-import 'models_with_relations/nested_one_to_many/arena.dart' as _i81;
-import 'models_with_relations/nested_one_to_many/player.dart' as _i82;
-import 'models_with_relations/nested_one_to_many/team.dart' as _i83;
-import 'models_with_relations/one_to_many/comment.dart' as _i84;
-import 'models_with_relations/one_to_many/customer.dart' as _i85;
-import 'models_with_relations/one_to_many/order.dart' as _i86;
-import 'models_with_relations/one_to_one/address.dart' as _i87;
-import 'models_with_relations/one_to_one/citizen.dart' as _i88;
-import 'models_with_relations/one_to_one/company.dart' as _i89;
-import 'models_with_relations/one_to_one/town.dart' as _i90;
-import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i91;
-import 'models_with_relations/self_relation/many_to_many/member.dart' as _i92;
-import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i93;
-import 'models_with_relations/self_relation/one_to_one/post.dart' as _i94;
-import 'module_datatype.dart' as _i95;
-import 'nullability.dart' as _i96;
-import 'object_field_persist.dart' as _i97;
-import 'object_field_scopes.dart' as _i98;
-import 'object_with_bytedata.dart' as _i99;
-import 'object_with_custom_class.dart' as _i100;
-import 'object_with_duration.dart' as _i101;
-import 'object_with_enum.dart' as _i102;
-import 'object_with_index.dart' as _i103;
-import 'object_with_maps.dart' as _i104;
-import 'object_with_object.dart' as _i105;
-import 'object_with_parent.dart' as _i106;
-import 'object_with_self_parent.dart' as _i107;
-import 'object_with_uuid.dart' as _i108;
-import 'related_unique_data.dart' as _i109;
-import 'scopes/scope_none_fields.dart' as _i110;
-import 'scopes/scope_server_only_field.dart' as _i111;
-import 'scopes/scope_server_only_field_child.dart' as _i112;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i113;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i114;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i115;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i116;
-import 'scopes/serverOnly/server_only_class.dart' as _i117;
-import 'scopes/serverOnly/server_only_enum.dart' as _i118;
-import 'scopes/server_only_class_field.dart' as _i119;
-import 'simple_data.dart' as _i120;
-import 'simple_data_list.dart' as _i121;
-import 'simple_data_map.dart' as _i122;
-import 'simple_data_object.dart' as _i123;
-import 'simple_date_time.dart' as _i124;
-import 'test_enum.dart' as _i125;
-import 'test_enum_stringified.dart' as _i126;
-import 'types.dart' as _i127;
-import 'types_list.dart' as _i128;
-import 'types_map.dart' as _i129;
-import 'types_set.dart' as _i130;
-import 'unique_data.dart' as _i131;
-import 'my_feature/models/my_feature_model.dart' as _i132;
-import 'dart:typed_data' as _i133;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i134;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i135;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i136;
+    as _i74;
+import 'long_identifiers/multiple_max_field_name.dart' as _i75;
+import 'models_with_list_relations/city.dart' as _i76;
+import 'models_with_list_relations/organization.dart' as _i77;
+import 'models_with_list_relations/person.dart' as _i78;
+import 'models_with_relations/many_to_many/course.dart' as _i79;
+import 'models_with_relations/many_to_many/enrollment.dart' as _i80;
+import 'models_with_relations/many_to_many/student.dart' as _i81;
+import 'models_with_relations/module/object_user.dart' as _i82;
+import 'models_with_relations/module/parent_user.dart' as _i83;
+import 'models_with_relations/nested_one_to_many/arena.dart' as _i84;
+import 'models_with_relations/nested_one_to_many/player.dart' as _i85;
+import 'models_with_relations/nested_one_to_many/team.dart' as _i86;
+import 'models_with_relations/one_to_many/comment.dart' as _i87;
+import 'models_with_relations/one_to_many/customer.dart' as _i88;
+import 'models_with_relations/one_to_many/order.dart' as _i89;
+import 'models_with_relations/one_to_one/address.dart' as _i90;
+import 'models_with_relations/one_to_one/citizen.dart' as _i91;
+import 'models_with_relations/one_to_one/company.dart' as _i92;
+import 'models_with_relations/one_to_one/town.dart' as _i93;
+import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i94;
+import 'models_with_relations/self_relation/many_to_many/member.dart' as _i95;
+import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i96;
+import 'models_with_relations/self_relation/one_to_one/post.dart' as _i97;
+import 'module_datatype.dart' as _i98;
+import 'nullability.dart' as _i99;
+import 'object_field_persist.dart' as _i100;
+import 'object_field_scopes.dart' as _i101;
+import 'object_with_bytedata.dart' as _i102;
+import 'object_with_custom_class.dart' as _i103;
+import 'object_with_duration.dart' as _i104;
+import 'object_with_enum.dart' as _i105;
+import 'object_with_index.dart' as _i106;
+import 'object_with_maps.dart' as _i107;
+import 'object_with_object.dart' as _i108;
+import 'object_with_parent.dart' as _i109;
+import 'object_with_self_parent.dart' as _i110;
+import 'object_with_uuid.dart' as _i111;
+import 'related_unique_data.dart' as _i112;
+import 'scopes/scope_none_fields.dart' as _i113;
+import 'scopes/scope_server_only_field.dart' as _i114;
+import 'scopes/scope_server_only_field_child.dart' as _i115;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i116;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i117;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i118;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i119;
+import 'scopes/serverOnly/server_only_class.dart' as _i120;
+import 'scopes/serverOnly/server_only_enum.dart' as _i121;
+import 'scopes/server_only_class_field.dart' as _i122;
+import 'simple_data.dart' as _i123;
+import 'simple_data_list.dart' as _i124;
+import 'simple_data_map.dart' as _i125;
+import 'simple_data_object.dart' as _i126;
+import 'simple_date_time.dart' as _i127;
+import 'test_enum.dart' as _i128;
+import 'test_enum_stringified.dart' as _i129;
+import 'types.dart' as _i130;
+import 'types_list.dart' as _i131;
+import 'types_map.dart' as _i132;
+import 'types_set.dart' as _i133;
+import 'unique_data.dart' as _i134;
+import 'my_feature/models/my_feature_model.dart' as _i135;
+import 'dart:typed_data' as _i136;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i137;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i138;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i139;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
 export 'defaults/bigint/bigint_default.dart';
@@ -211,6 +214,10 @@ export 'inheritance/parent_class.dart';
 export 'inheritance/parent_with_default.dart';
 export 'inheritance/sealed_no_child.dart';
 export 'inheritance/sealed_parent.dart';
+export 'interfaces/class_overriding_interface_field.dart';
+export 'interfaces/class_with_interface.dart';
+export 'interfaces/example_interface.dart';
+export 'interfaces/exception_with_interface.dart';
 export 'long_identifiers/deep_includes/city_with_long_table_name.dart';
 export 'long_identifiers/deep_includes/organization_with_long_table_name.dart';
 export 'long_identifiers/deep_includes/person_with_long_table_name.dart';
@@ -5324,221 +5331,230 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i60.SealedOtherChild) {
       return _i60.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i61.CityWithLongTableName) {
-      return _i61.CityWithLongTableName.fromJson(data) as T;
+    if (t == _i61.ClassOverridingInterfaceField) {
+      return _i61.ClassOverridingInterfaceField.fromJson(data) as T;
     }
-    if (t == _i62.OrganizationWithLongTableName) {
-      return _i62.OrganizationWithLongTableName.fromJson(data) as T;
+    if (t == _i62.ClassWithInterface) {
+      return _i62.ClassWithInterface.fromJson(data) as T;
     }
-    if (t == _i63.PersonWithLongTableName) {
-      return _i63.PersonWithLongTableName.fromJson(data) as T;
+    if (t == _i63.ExceptionWithInterface) {
+      return _i63.ExceptionWithInterface.fromJson(data) as T;
     }
-    if (t == _i64.MaxFieldName) {
-      return _i64.MaxFieldName.fromJson(data) as T;
+    if (t == _i64.CityWithLongTableName) {
+      return _i64.CityWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i65.LongImplicitIdField) {
-      return _i65.LongImplicitIdField.fromJson(data) as T;
+    if (t == _i65.OrganizationWithLongTableName) {
+      return _i65.OrganizationWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i66.LongImplicitIdFieldCollection) {
-      return _i66.LongImplicitIdFieldCollection.fromJson(data) as T;
+    if (t == _i66.PersonWithLongTableName) {
+      return _i66.PersonWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i67.RelationToMultipleMaxFieldName) {
-      return _i67.RelationToMultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i67.MaxFieldName) {
+      return _i67.MaxFieldName.fromJson(data) as T;
     }
-    if (t == _i68.UserNote) {
-      return _i68.UserNote.fromJson(data) as T;
+    if (t == _i68.LongImplicitIdField) {
+      return _i68.LongImplicitIdField.fromJson(data) as T;
     }
-    if (t == _i69.UserNoteCollection) {
-      return _i69.UserNoteCollection.fromJson(data) as T;
+    if (t == _i69.LongImplicitIdFieldCollection) {
+      return _i69.LongImplicitIdFieldCollection.fromJson(data) as T;
     }
-    if (t == _i70.UserNoteCollectionWithALongName) {
-      return _i70.UserNoteCollectionWithALongName.fromJson(data) as T;
+    if (t == _i70.RelationToMultipleMaxFieldName) {
+      return _i70.RelationToMultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i71.UserNoteWithALongName) {
-      return _i71.UserNoteWithALongName.fromJson(data) as T;
+    if (t == _i71.UserNote) {
+      return _i71.UserNote.fromJson(data) as T;
     }
-    if (t == _i72.MultipleMaxFieldName) {
-      return _i72.MultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i72.UserNoteCollection) {
+      return _i72.UserNoteCollection.fromJson(data) as T;
     }
-    if (t == _i73.City) {
-      return _i73.City.fromJson(data) as T;
+    if (t == _i73.UserNoteCollectionWithALongName) {
+      return _i73.UserNoteCollectionWithALongName.fromJson(data) as T;
     }
-    if (t == _i74.Organization) {
-      return _i74.Organization.fromJson(data) as T;
+    if (t == _i74.UserNoteWithALongName) {
+      return _i74.UserNoteWithALongName.fromJson(data) as T;
     }
-    if (t == _i75.Person) {
-      return _i75.Person.fromJson(data) as T;
+    if (t == _i75.MultipleMaxFieldName) {
+      return _i75.MultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i76.Course) {
-      return _i76.Course.fromJson(data) as T;
+    if (t == _i76.City) {
+      return _i76.City.fromJson(data) as T;
     }
-    if (t == _i77.Enrollment) {
-      return _i77.Enrollment.fromJson(data) as T;
+    if (t == _i77.Organization) {
+      return _i77.Organization.fromJson(data) as T;
     }
-    if (t == _i78.Student) {
-      return _i78.Student.fromJson(data) as T;
+    if (t == _i78.Person) {
+      return _i78.Person.fromJson(data) as T;
     }
-    if (t == _i79.ObjectUser) {
-      return _i79.ObjectUser.fromJson(data) as T;
+    if (t == _i79.Course) {
+      return _i79.Course.fromJson(data) as T;
     }
-    if (t == _i80.ParentUser) {
-      return _i80.ParentUser.fromJson(data) as T;
+    if (t == _i80.Enrollment) {
+      return _i80.Enrollment.fromJson(data) as T;
     }
-    if (t == _i81.Arena) {
-      return _i81.Arena.fromJson(data) as T;
+    if (t == _i81.Student) {
+      return _i81.Student.fromJson(data) as T;
     }
-    if (t == _i82.Player) {
-      return _i82.Player.fromJson(data) as T;
+    if (t == _i82.ObjectUser) {
+      return _i82.ObjectUser.fromJson(data) as T;
     }
-    if (t == _i83.Team) {
-      return _i83.Team.fromJson(data) as T;
+    if (t == _i83.ParentUser) {
+      return _i83.ParentUser.fromJson(data) as T;
     }
-    if (t == _i84.Comment) {
-      return _i84.Comment.fromJson(data) as T;
+    if (t == _i84.Arena) {
+      return _i84.Arena.fromJson(data) as T;
     }
-    if (t == _i85.Customer) {
-      return _i85.Customer.fromJson(data) as T;
+    if (t == _i85.Player) {
+      return _i85.Player.fromJson(data) as T;
     }
-    if (t == _i86.Order) {
-      return _i86.Order.fromJson(data) as T;
+    if (t == _i86.Team) {
+      return _i86.Team.fromJson(data) as T;
     }
-    if (t == _i87.Address) {
-      return _i87.Address.fromJson(data) as T;
+    if (t == _i87.Comment) {
+      return _i87.Comment.fromJson(data) as T;
     }
-    if (t == _i88.Citizen) {
-      return _i88.Citizen.fromJson(data) as T;
+    if (t == _i88.Customer) {
+      return _i88.Customer.fromJson(data) as T;
     }
-    if (t == _i89.Company) {
-      return _i89.Company.fromJson(data) as T;
+    if (t == _i89.Order) {
+      return _i89.Order.fromJson(data) as T;
     }
-    if (t == _i90.Town) {
-      return _i90.Town.fromJson(data) as T;
+    if (t == _i90.Address) {
+      return _i90.Address.fromJson(data) as T;
     }
-    if (t == _i91.Blocking) {
-      return _i91.Blocking.fromJson(data) as T;
+    if (t == _i91.Citizen) {
+      return _i91.Citizen.fromJson(data) as T;
     }
-    if (t == _i92.Member) {
-      return _i92.Member.fromJson(data) as T;
+    if (t == _i92.Company) {
+      return _i92.Company.fromJson(data) as T;
     }
-    if (t == _i93.Cat) {
-      return _i93.Cat.fromJson(data) as T;
+    if (t == _i93.Town) {
+      return _i93.Town.fromJson(data) as T;
     }
-    if (t == _i94.Post) {
-      return _i94.Post.fromJson(data) as T;
+    if (t == _i94.Blocking) {
+      return _i94.Blocking.fromJson(data) as T;
     }
-    if (t == _i95.ModuleDatatype) {
-      return _i95.ModuleDatatype.fromJson(data) as T;
+    if (t == _i95.Member) {
+      return _i95.Member.fromJson(data) as T;
     }
-    if (t == _i96.Nullability) {
-      return _i96.Nullability.fromJson(data) as T;
+    if (t == _i96.Cat) {
+      return _i96.Cat.fromJson(data) as T;
     }
-    if (t == _i97.ObjectFieldPersist) {
-      return _i97.ObjectFieldPersist.fromJson(data) as T;
+    if (t == _i97.Post) {
+      return _i97.Post.fromJson(data) as T;
     }
-    if (t == _i98.ObjectFieldScopes) {
-      return _i98.ObjectFieldScopes.fromJson(data) as T;
+    if (t == _i98.ModuleDatatype) {
+      return _i98.ModuleDatatype.fromJson(data) as T;
     }
-    if (t == _i99.ObjectWithByteData) {
-      return _i99.ObjectWithByteData.fromJson(data) as T;
+    if (t == _i99.Nullability) {
+      return _i99.Nullability.fromJson(data) as T;
     }
-    if (t == _i100.ObjectWithCustomClass) {
-      return _i100.ObjectWithCustomClass.fromJson(data) as T;
+    if (t == _i100.ObjectFieldPersist) {
+      return _i100.ObjectFieldPersist.fromJson(data) as T;
     }
-    if (t == _i101.ObjectWithDuration) {
-      return _i101.ObjectWithDuration.fromJson(data) as T;
+    if (t == _i101.ObjectFieldScopes) {
+      return _i101.ObjectFieldScopes.fromJson(data) as T;
     }
-    if (t == _i102.ObjectWithEnum) {
-      return _i102.ObjectWithEnum.fromJson(data) as T;
+    if (t == _i102.ObjectWithByteData) {
+      return _i102.ObjectWithByteData.fromJson(data) as T;
     }
-    if (t == _i103.ObjectWithIndex) {
-      return _i103.ObjectWithIndex.fromJson(data) as T;
+    if (t == _i103.ObjectWithCustomClass) {
+      return _i103.ObjectWithCustomClass.fromJson(data) as T;
     }
-    if (t == _i104.ObjectWithMaps) {
-      return _i104.ObjectWithMaps.fromJson(data) as T;
+    if (t == _i104.ObjectWithDuration) {
+      return _i104.ObjectWithDuration.fromJson(data) as T;
     }
-    if (t == _i105.ObjectWithObject) {
-      return _i105.ObjectWithObject.fromJson(data) as T;
+    if (t == _i105.ObjectWithEnum) {
+      return _i105.ObjectWithEnum.fromJson(data) as T;
     }
-    if (t == _i106.ObjectWithParent) {
-      return _i106.ObjectWithParent.fromJson(data) as T;
+    if (t == _i106.ObjectWithIndex) {
+      return _i106.ObjectWithIndex.fromJson(data) as T;
     }
-    if (t == _i107.ObjectWithSelfParent) {
-      return _i107.ObjectWithSelfParent.fromJson(data) as T;
+    if (t == _i107.ObjectWithMaps) {
+      return _i107.ObjectWithMaps.fromJson(data) as T;
     }
-    if (t == _i108.ObjectWithUuid) {
-      return _i108.ObjectWithUuid.fromJson(data) as T;
+    if (t == _i108.ObjectWithObject) {
+      return _i108.ObjectWithObject.fromJson(data) as T;
     }
-    if (t == _i109.RelatedUniqueData) {
-      return _i109.RelatedUniqueData.fromJson(data) as T;
+    if (t == _i109.ObjectWithParent) {
+      return _i109.ObjectWithParent.fromJson(data) as T;
     }
-    if (t == _i110.ScopeNoneFields) {
-      return _i110.ScopeNoneFields.fromJson(data) as T;
+    if (t == _i110.ObjectWithSelfParent) {
+      return _i110.ObjectWithSelfParent.fromJson(data) as T;
     }
-    if (t == _i111.ScopeServerOnlyField) {
-      return _i111.ScopeServerOnlyField.fromJson(data) as T;
+    if (t == _i111.ObjectWithUuid) {
+      return _i111.ObjectWithUuid.fromJson(data) as T;
     }
-    if (t == _i112.ScopeServerOnlyFieldChild) {
-      return _i112.ScopeServerOnlyFieldChild.fromJson(data) as T;
+    if (t == _i112.RelatedUniqueData) {
+      return _i112.RelatedUniqueData.fromJson(data) as T;
     }
-    if (t == _i113.DefaultServerOnlyClass) {
-      return _i113.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i113.ScopeNoneFields) {
+      return _i113.ScopeNoneFields.fromJson(data) as T;
     }
-    if (t == _i114.DefaultServerOnlyEnum) {
-      return _i114.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i114.ScopeServerOnlyField) {
+      return _i114.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i115.NotServerOnlyClass) {
-      return _i115.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i115.ScopeServerOnlyFieldChild) {
+      return _i115.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i116.NotServerOnlyEnum) {
-      return _i116.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i116.DefaultServerOnlyClass) {
+      return _i116.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i117.ServerOnlyClass) {
-      return _i117.ServerOnlyClass.fromJson(data) as T;
+    if (t == _i117.DefaultServerOnlyEnum) {
+      return _i117.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i118.ServerOnlyEnum) {
-      return _i118.ServerOnlyEnum.fromJson(data) as T;
+    if (t == _i118.NotServerOnlyClass) {
+      return _i118.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i119.ServerOnlyClassField) {
-      return _i119.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i119.NotServerOnlyEnum) {
+      return _i119.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i120.SimpleData) {
-      return _i120.SimpleData.fromJson(data) as T;
+    if (t == _i120.ServerOnlyClass) {
+      return _i120.ServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i121.SimpleDataList) {
-      return _i121.SimpleDataList.fromJson(data) as T;
+    if (t == _i121.ServerOnlyEnum) {
+      return _i121.ServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i122.SimpleDataMap) {
-      return _i122.SimpleDataMap.fromJson(data) as T;
+    if (t == _i122.ServerOnlyClassField) {
+      return _i122.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i123.SimpleDataObject) {
-      return _i123.SimpleDataObject.fromJson(data) as T;
+    if (t == _i123.SimpleData) {
+      return _i123.SimpleData.fromJson(data) as T;
     }
-    if (t == _i124.SimpleDateTime) {
-      return _i124.SimpleDateTime.fromJson(data) as T;
+    if (t == _i124.SimpleDataList) {
+      return _i124.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i125.TestEnum) {
-      return _i125.TestEnum.fromJson(data) as T;
+    if (t == _i125.SimpleDataMap) {
+      return _i125.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i126.TestEnumStringified) {
-      return _i126.TestEnumStringified.fromJson(data) as T;
+    if (t == _i126.SimpleDataObject) {
+      return _i126.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i127.Types) {
-      return _i127.Types.fromJson(data) as T;
+    if (t == _i127.SimpleDateTime) {
+      return _i127.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i128.TypesList) {
-      return _i128.TypesList.fromJson(data) as T;
+    if (t == _i128.TestEnum) {
+      return _i128.TestEnum.fromJson(data) as T;
     }
-    if (t == _i129.TypesMap) {
-      return _i129.TypesMap.fromJson(data) as T;
+    if (t == _i129.TestEnumStringified) {
+      return _i129.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i130.TypesSet) {
-      return _i130.TypesSet.fromJson(data) as T;
+    if (t == _i130.Types) {
+      return _i130.Types.fromJson(data) as T;
     }
-    if (t == _i131.UniqueData) {
-      return _i131.UniqueData.fromJson(data) as T;
+    if (t == _i131.TypesList) {
+      return _i131.TypesList.fromJson(data) as T;
     }
-    if (t == _i132.MyFeatureModel) {
-      return _i132.MyFeatureModel.fromJson(data) as T;
+    if (t == _i132.TypesMap) {
+      return _i132.TypesMap.fromJson(data) as T;
+    }
+    if (t == _i133.TypesSet) {
+      return _i133.TypesSet.fromJson(data) as T;
+    }
+    if (t == _i134.UniqueData) {
+      return _i134.UniqueData.fromJson(data) as T;
+    }
+    if (t == _i135.MyFeatureModel) {
+      return _i135.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i1.getType<_i5.ByIndexEnumWithNameValue?>()) {
       return (data != null ? _i5.ByIndexEnumWithNameValue.fromJson(data) : null)
@@ -5733,250 +5749,264 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i60.SealedOtherChild?>()) {
       return (data != null ? _i60.SealedOtherChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i61.CityWithLongTableName?>()) {
-      return (data != null ? _i61.CityWithLongTableName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i62.OrganizationWithLongTableName?>()) {
+    if (t == _i1.getType<_i61.ClassOverridingInterfaceField?>()) {
       return (data != null
-          ? _i62.OrganizationWithLongTableName.fromJson(data)
+          ? _i61.ClassOverridingInterfaceField.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i63.PersonWithLongTableName?>()) {
-      return (data != null ? _i63.PersonWithLongTableName.fromJson(data) : null)
+    if (t == _i1.getType<_i62.ClassWithInterface?>()) {
+      return (data != null ? _i62.ClassWithInterface.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i64.MaxFieldName?>()) {
-      return (data != null ? _i64.MaxFieldName.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i65.LongImplicitIdField?>()) {
-      return (data != null ? _i65.LongImplicitIdField.fromJson(data) : null)
+    if (t == _i1.getType<_i63.ExceptionWithInterface?>()) {
+      return (data != null ? _i63.ExceptionWithInterface.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i66.LongImplicitIdFieldCollection?>()) {
+    if (t == _i1.getType<_i64.CityWithLongTableName?>()) {
+      return (data != null ? _i64.CityWithLongTableName.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i65.OrganizationWithLongTableName?>()) {
       return (data != null
-          ? _i66.LongImplicitIdFieldCollection.fromJson(data)
+          ? _i65.OrganizationWithLongTableName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i67.RelationToMultipleMaxFieldName?>()) {
+    if (t == _i1.getType<_i66.PersonWithLongTableName?>()) {
+      return (data != null ? _i66.PersonWithLongTableName.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i67.MaxFieldName?>()) {
+      return (data != null ? _i67.MaxFieldName.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i68.LongImplicitIdField?>()) {
+      return (data != null ? _i68.LongImplicitIdField.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i69.LongImplicitIdFieldCollection?>()) {
       return (data != null
-          ? _i67.RelationToMultipleMaxFieldName.fromJson(data)
+          ? _i69.LongImplicitIdFieldCollection.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i68.UserNote?>()) {
-      return (data != null ? _i68.UserNote.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i69.UserNoteCollection?>()) {
-      return (data != null ? _i69.UserNoteCollection.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i70.UserNoteCollectionWithALongName?>()) {
+    if (t == _i1.getType<_i70.RelationToMultipleMaxFieldName?>()) {
       return (data != null
-          ? _i70.UserNoteCollectionWithALongName.fromJson(data)
+          ? _i70.RelationToMultipleMaxFieldName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i71.UserNoteWithALongName?>()) {
-      return (data != null ? _i71.UserNoteWithALongName.fromJson(data) : null)
+    if (t == _i1.getType<_i71.UserNote?>()) {
+      return (data != null ? _i71.UserNote.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i72.UserNoteCollection?>()) {
+      return (data != null ? _i72.UserNoteCollection.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i72.MultipleMaxFieldName?>()) {
-      return (data != null ? _i72.MultipleMaxFieldName.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i73.City?>()) {
-      return (data != null ? _i73.City.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i74.Organization?>()) {
-      return (data != null ? _i74.Organization.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i75.Person?>()) {
-      return (data != null ? _i75.Person.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i76.Course?>()) {
-      return (data != null ? _i76.Course.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i77.Enrollment?>()) {
-      return (data != null ? _i77.Enrollment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i78.Student?>()) {
-      return (data != null ? _i78.Student.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i79.ObjectUser?>()) {
-      return (data != null ? _i79.ObjectUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i80.ParentUser?>()) {
-      return (data != null ? _i80.ParentUser.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i81.Arena?>()) {
-      return (data != null ? _i81.Arena.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i82.Player?>()) {
-      return (data != null ? _i82.Player.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i83.Team?>()) {
-      return (data != null ? _i83.Team.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i84.Comment?>()) {
-      return (data != null ? _i84.Comment.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i85.Customer?>()) {
-      return (data != null ? _i85.Customer.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i86.Order?>()) {
-      return (data != null ? _i86.Order.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i87.Address?>()) {
-      return (data != null ? _i87.Address.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i88.Citizen?>()) {
-      return (data != null ? _i88.Citizen.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i89.Company?>()) {
-      return (data != null ? _i89.Company.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i90.Town?>()) {
-      return (data != null ? _i90.Town.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i91.Blocking?>()) {
-      return (data != null ? _i91.Blocking.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i92.Member?>()) {
-      return (data != null ? _i92.Member.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i93.Cat?>()) {
-      return (data != null ? _i93.Cat.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i94.Post?>()) {
-      return (data != null ? _i94.Post.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i95.ModuleDatatype?>()) {
-      return (data != null ? _i95.ModuleDatatype.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i96.Nullability?>()) {
-      return (data != null ? _i96.Nullability.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i97.ObjectFieldPersist?>()) {
-      return (data != null ? _i97.ObjectFieldPersist.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i98.ObjectFieldScopes?>()) {
-      return (data != null ? _i98.ObjectFieldScopes.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i99.ObjectWithByteData?>()) {
-      return (data != null ? _i99.ObjectWithByteData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i100.ObjectWithCustomClass?>()) {
-      return (data != null ? _i100.ObjectWithCustomClass.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i101.ObjectWithDuration?>()) {
-      return (data != null ? _i101.ObjectWithDuration.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i102.ObjectWithEnum?>()) {
-      return (data != null ? _i102.ObjectWithEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i103.ObjectWithIndex?>()) {
-      return (data != null ? _i103.ObjectWithIndex.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i104.ObjectWithMaps?>()) {
-      return (data != null ? _i104.ObjectWithMaps.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i105.ObjectWithObject?>()) {
-      return (data != null ? _i105.ObjectWithObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i106.ObjectWithParent?>()) {
-      return (data != null ? _i106.ObjectWithParent.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i107.ObjectWithSelfParent?>()) {
-      return (data != null ? _i107.ObjectWithSelfParent.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i108.ObjectWithUuid?>()) {
-      return (data != null ? _i108.ObjectWithUuid.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i109.RelatedUniqueData?>()) {
-      return (data != null ? _i109.RelatedUniqueData.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i110.ScopeNoneFields?>()) {
-      return (data != null ? _i110.ScopeNoneFields.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i111.ScopeServerOnlyField?>()) {
-      return (data != null ? _i111.ScopeServerOnlyField.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i112.ScopeServerOnlyFieldChild?>()) {
+    if (t == _i1.getType<_i73.UserNoteCollectionWithALongName?>()) {
       return (data != null
-          ? _i112.ScopeServerOnlyFieldChild.fromJson(data)
+          ? _i73.UserNoteCollectionWithALongName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i113.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i113.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i74.UserNoteWithALongName?>()) {
+      return (data != null ? _i74.UserNoteWithALongName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i114.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i114.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i75.MultipleMaxFieldName?>()) {
+      return (data != null ? _i75.MultipleMaxFieldName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i115.NotServerOnlyClass?>()) {
-      return (data != null ? _i115.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i76.City?>()) {
+      return (data != null ? _i76.City.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i77.Organization?>()) {
+      return (data != null ? _i77.Organization.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i78.Person?>()) {
+      return (data != null ? _i78.Person.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i79.Course?>()) {
+      return (data != null ? _i79.Course.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i80.Enrollment?>()) {
+      return (data != null ? _i80.Enrollment.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i81.Student?>()) {
+      return (data != null ? _i81.Student.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i82.ObjectUser?>()) {
+      return (data != null ? _i82.ObjectUser.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i83.ParentUser?>()) {
+      return (data != null ? _i83.ParentUser.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i84.Arena?>()) {
+      return (data != null ? _i84.Arena.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i85.Player?>()) {
+      return (data != null ? _i85.Player.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i86.Team?>()) {
+      return (data != null ? _i86.Team.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i87.Comment?>()) {
+      return (data != null ? _i87.Comment.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i88.Customer?>()) {
+      return (data != null ? _i88.Customer.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i89.Order?>()) {
+      return (data != null ? _i89.Order.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i90.Address?>()) {
+      return (data != null ? _i90.Address.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i91.Citizen?>()) {
+      return (data != null ? _i91.Citizen.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i92.Company?>()) {
+      return (data != null ? _i92.Company.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i93.Town?>()) {
+      return (data != null ? _i93.Town.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i94.Blocking?>()) {
+      return (data != null ? _i94.Blocking.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i95.Member?>()) {
+      return (data != null ? _i95.Member.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i96.Cat?>()) {
+      return (data != null ? _i96.Cat.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i97.Post?>()) {
+      return (data != null ? _i97.Post.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i98.ModuleDatatype?>()) {
+      return (data != null ? _i98.ModuleDatatype.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i99.Nullability?>()) {
+      return (data != null ? _i99.Nullability.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i100.ObjectFieldPersist?>()) {
+      return (data != null ? _i100.ObjectFieldPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i116.NotServerOnlyEnum?>()) {
-      return (data != null ? _i116.NotServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i101.ObjectFieldScopes?>()) {
+      return (data != null ? _i101.ObjectFieldScopes.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i117.ServerOnlyClass?>()) {
-      return (data != null ? _i117.ServerOnlyClass.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i118.ServerOnlyEnum?>()) {
-      return (data != null ? _i118.ServerOnlyEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i119.ServerOnlyClassField?>()) {
-      return (data != null ? _i119.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i102.ObjectWithByteData?>()) {
+      return (data != null ? _i102.ObjectWithByteData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i120.SimpleData?>()) {
-      return (data != null ? _i120.SimpleData.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i121.SimpleDataList?>()) {
-      return (data != null ? _i121.SimpleDataList.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i122.SimpleDataMap?>()) {
-      return (data != null ? _i122.SimpleDataMap.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i123.SimpleDataObject?>()) {
-      return (data != null ? _i123.SimpleDataObject.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i124.SimpleDateTime?>()) {
-      return (data != null ? _i124.SimpleDateTime.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i125.TestEnum?>()) {
-      return (data != null ? _i125.TestEnum.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i126.TestEnumStringified?>()) {
-      return (data != null ? _i126.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i103.ObjectWithCustomClass?>()) {
+      return (data != null ? _i103.ObjectWithCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i127.Types?>()) {
-      return (data != null ? _i127.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i104.ObjectWithDuration?>()) {
+      return (data != null ? _i104.ObjectWithDuration.fromJson(data) : null)
+          as T;
     }
-    if (t == _i1.getType<_i128.TypesList?>()) {
-      return (data != null ? _i128.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i105.ObjectWithEnum?>()) {
+      return (data != null ? _i105.ObjectWithEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i129.TypesMap?>()) {
-      return (data != null ? _i129.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i106.ObjectWithIndex?>()) {
+      return (data != null ? _i106.ObjectWithIndex.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i130.TypesSet?>()) {
-      return (data != null ? _i130.TypesSet.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i107.ObjectWithMaps?>()) {
+      return (data != null ? _i107.ObjectWithMaps.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i131.UniqueData?>()) {
-      return (data != null ? _i131.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i108.ObjectWithObject?>()) {
+      return (data != null ? _i108.ObjectWithObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i132.MyFeatureModel?>()) {
-      return (data != null ? _i132.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i109.ObjectWithParent?>()) {
+      return (data != null ? _i109.ObjectWithParent.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i110.ObjectWithSelfParent?>()) {
+      return (data != null ? _i110.ObjectWithSelfParent.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i111.ObjectWithUuid?>()) {
+      return (data != null ? _i111.ObjectWithUuid.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i112.RelatedUniqueData?>()) {
+      return (data != null ? _i112.RelatedUniqueData.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i113.ScopeNoneFields?>()) {
+      return (data != null ? _i113.ScopeNoneFields.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i114.ScopeServerOnlyField?>()) {
+      return (data != null ? _i114.ScopeServerOnlyField.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i115.ScopeServerOnlyFieldChild?>()) {
+      return (data != null
+          ? _i115.ScopeServerOnlyFieldChild.fromJson(data)
+          : null) as T;
+    }
+    if (t == _i1.getType<_i116.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i116.DefaultServerOnlyClass.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i117.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i117.DefaultServerOnlyEnum.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i118.NotServerOnlyClass?>()) {
+      return (data != null ? _i118.NotServerOnlyClass.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i119.NotServerOnlyEnum?>()) {
+      return (data != null ? _i119.NotServerOnlyEnum.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i120.ServerOnlyClass?>()) {
+      return (data != null ? _i120.ServerOnlyClass.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i121.ServerOnlyEnum?>()) {
+      return (data != null ? _i121.ServerOnlyEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i122.ServerOnlyClassField?>()) {
+      return (data != null ? _i122.ServerOnlyClassField.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i123.SimpleData?>()) {
+      return (data != null ? _i123.SimpleData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i124.SimpleDataList?>()) {
+      return (data != null ? _i124.SimpleDataList.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i125.SimpleDataMap?>()) {
+      return (data != null ? _i125.SimpleDataMap.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i126.SimpleDataObject?>()) {
+      return (data != null ? _i126.SimpleDataObject.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i127.SimpleDateTime?>()) {
+      return (data != null ? _i127.SimpleDateTime.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i128.TestEnum?>()) {
+      return (data != null ? _i128.TestEnum.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i129.TestEnumStringified?>()) {
+      return (data != null ? _i129.TestEnumStringified.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i130.Types?>()) {
+      return (data != null ? _i130.Types.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i131.TypesList?>()) {
+      return (data != null ? _i131.TypesList.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i132.TypesMap?>()) {
+      return (data != null ? _i132.TypesMap.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i133.TypesSet?>()) {
+      return (data != null ? _i133.TypesSet.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i134.UniqueData?>()) {
+      return (data != null ? _i134.UniqueData.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i135.MyFeatureModel?>()) {
+      return (data != null ? _i135.MyFeatureModel.fromJson(data) : null) as T;
     }
     if (t == _i1.getType<List<_i51.EmptyModelRelationItem>?>()) {
       return (data != null
@@ -5988,108 +6018,108 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == _i1.getType<List<_i63.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i66.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i66.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i62.OrganizationWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i65.OrganizationWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i62.OrganizationWithLongTableName>(e))
+              .map((e) => deserialize<_i65.OrganizationWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i63.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i66.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i66.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i65.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i68.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i65.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i68.LongImplicitIdField>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i72.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i75.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i72.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i75.MultipleMaxFieldName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i68.UserNote>?>()) {
+    if (t == _i1.getType<List<_i71.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i68.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i71.UserNote>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i71.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i74.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i71.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i74.UserNoteWithALongName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i75.Person>?>()) {
+    if (t == _i1.getType<List<_i78.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i75.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i78.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i74.Organization>?>()) {
+    if (t == _i1.getType<List<_i77.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i74.Organization>(e))
+              .map((e) => deserialize<_i77.Organization>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i75.Person>?>()) {
+    if (t == _i1.getType<List<_i78.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i75.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i78.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i77.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i80.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i77.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i80.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i77.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i80.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i77.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i80.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i82.Player>?>()) {
+    if (t == _i1.getType<List<_i85.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i82.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i85.Player>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i86.Order>?>()) {
+    if (t == _i1.getType<List<_i89.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i86.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i89.Order>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i84.Comment>?>()) {
+    if (t == _i1.getType<List<_i87.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i84.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i87.Comment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i91.Blocking>?>()) {
+    if (t == _i1.getType<List<_i94.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i91.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i94.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i91.Blocking>?>()) {
+    if (t == _i1.getType<List<_i94.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i91.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i94.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i93.Cat>?>()) {
+    if (t == _i1.getType<List<_i96.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i93.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i96.Cat>(e)).toList()
           : null) as T;
     }
     if (t == List<_i4.ModuleClass>) {
@@ -6117,25 +6147,25 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i120.SimpleData>) {
+    if (t == List<_i123.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i120.SimpleData>(e))
+          .map((e) => deserialize<_i123.SimpleData>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i123.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i123.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i120.SimpleData?>) {
+    if (t == List<_i123.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i120.SimpleData?>(e))
+          .map((e) => deserialize<_i123.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i123.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i120.SimpleData?>(e))
+              .map((e) => deserialize<_i123.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -6155,22 +6185,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i133.ByteData>) {
-      return (data as List).map((e) => deserialize<_i133.ByteData>(e)).toList()
+    if (t == List<_i136.ByteData>) {
+      return (data as List).map((e) => deserialize<_i136.ByteData>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i133.ByteData>?>()) {
+    if (t == _i1.getType<List<_i136.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i133.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i136.ByteData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i133.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i133.ByteData?>(e)).toList()
+    if (t == List<_i136.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i136.ByteData?>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i133.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i136.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i133.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i136.ByteData?>(e)).toList()
           : null) as T;
     }
     if (t == List<Duration>) {
@@ -6228,32 +6258,32 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as T;
     }
-    if (t == _i134.CustomClassWithoutProtocolSerialization) {
-      return _i134.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
+    if (t == _i137.CustomClassWithoutProtocolSerialization) {
+      return _i137.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i134.CustomClassWithProtocolSerialization) {
-      return _i134.CustomClassWithProtocolSerialization.fromJson(data) as T;
+    if (t == _i137.CustomClassWithProtocolSerialization) {
+      return _i137.CustomClassWithProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i134.CustomClassWithProtocolSerializationMethod) {
-      return _i134.CustomClassWithProtocolSerializationMethod.fromJson(data)
+    if (t == _i137.CustomClassWithProtocolSerializationMethod) {
+      return _i137.CustomClassWithProtocolSerializationMethod.fromJson(data)
           as T;
     }
-    if (t == List<_i125.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i125.TestEnum>(e)).toList()
+    if (t == List<_i128.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i128.TestEnum>(e)).toList()
           as T;
     }
-    if (t == List<_i125.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i125.TestEnum?>(e)).toList()
+    if (t == List<_i128.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i128.TestEnum?>(e)).toList()
           as T;
     }
-    if (t == List<List<_i125.TestEnum>>) {
+    if (t == List<List<_i128.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i125.TestEnum>>(e))
+          .map((e) => deserialize<List<_i128.TestEnum>>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i120.SimpleData>) {
+    if (t == Map<String, _i123.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i120.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i123.SimpleData>(v))) as T;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -6263,9 +6293,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime>(v))) as T;
     }
-    if (t == Map<String, _i133.ByteData>) {
+    if (t == Map<String, _i136.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i133.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i136.ByteData>(v)))
           as T;
     }
     if (t == Map<String, Duration>) {
@@ -6276,9 +6306,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v))) as T;
     }
-    if (t == Map<String, _i120.SimpleData?>) {
+    if (t == Map<String, _i123.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i120.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i123.SimpleData?>(v))) as T;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -6288,9 +6318,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i133.ByteData?>) {
+    if (t == Map<String, _i136.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i133.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i136.ByteData?>(v)))
           as T;
     }
     if (t == Map<String, Duration?>) {
@@ -6306,66 +6336,66 @@ class Protocol extends _i1.SerializationManagerServer {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i123.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i123.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i123.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i120.SimpleData?>(e))
+              .map((e) => deserialize<_i123.SimpleData?>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<List<_i120.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i123.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i120.SimpleData>>(e))
+              .map((e) => deserialize<List<_i123.SimpleData>>(e))
               .toList()
           : null) as T;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i120.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i123.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i120.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i123.SimpleData>>?>>(v)))
           : null) as T;
     }
-    if (t == List<List<Map<int, _i120.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i123.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i120.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i123.SimpleData>>?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<Map<int, _i120.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i123.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i120.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i123.SimpleData>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<int, _i120.SimpleData>) {
+    if (t == Map<int, _i123.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i120.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i123.SimpleData>(e['v']))))
           as T;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i120.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i123.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i120.SimpleData>>(v)))
+              deserialize<Map<int, _i123.SimpleData>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<List<_i117.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<List<_i120.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.ServerOnlyClass>(e))
+              .map((e) => deserialize<_i120.ServerOnlyClass>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i117.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<Map<String, _i120.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i117.ServerOnlyClass>(v)))
+              deserialize<String>(k), deserialize<_i120.ServerOnlyClass>(v)))
           : null) as T;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -6409,9 +6439,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i133.ByteData>?>()) {
+    if (t == _i1.getType<List<_i136.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i133.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i136.ByteData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -6434,43 +6464,43 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i125.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i128.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i125.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i128.TestEnum>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i126.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i129.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i126.TestEnumStringified>(e))
+              .map((e) => deserialize<_i129.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i127.Types>?>()) {
+    if (t == _i1.getType<List<_i130.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i127.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i130.Types>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<Map<String, _i127.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i130.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i127.Types>>(e))
+              .map((e) => deserialize<Map<String, _i130.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<String, _i127.Types>) {
+    if (t == Map<String, _i130.Types>) {
       return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<_i127.Types>(v))) as T;
+          MapEntry(deserialize<String>(k), deserialize<_i130.Types>(v))) as T;
     }
-    if (t == _i1.getType<List<List<_i127.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i130.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i127.Types>>(e))
+              .map((e) => deserialize<List<_i130.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == List<_i127.Types>) {
-      return (data as List).map((e) => deserialize<_i127.Types>(e)).toList()
+    if (t == List<_i130.Types>) {
+      return (data as List).map((e) => deserialize<_i130.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<Map<int, String>?>()) {
@@ -6503,10 +6533,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i133.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i136.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i133.ByteData>(e['k']),
+              deserialize<_i136.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -6534,41 +6564,41 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<BigInt>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i125.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i128.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i125.TestEnum>(e['k']),
+              deserialize<_i128.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i126.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i129.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i126.TestEnumStringified>(e['k']),
+              deserialize<_i129.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i127.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i130.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i127.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i130.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<Map<_i127.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i130.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i127.Types, String>>(e['k']),
+              deserialize<Map<_i130.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == Map<_i127.Types, String>) {
+    if (t == Map<_i130.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i127.Types>(e['k']), deserialize<String>(e['v'])))) as T;
+          deserialize<_i130.Types>(e['k']), deserialize<String>(e['v'])))) as T;
     }
-    if (t == _i1.getType<Map<List<_i127.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i130.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i127.Types>>(e['k']),
+              deserialize<List<_i130.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -6602,10 +6632,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i133.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i136.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i133.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i136.ByteData>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -6632,34 +6662,34 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<BigInt>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i125.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i128.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i125.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i128.TestEnum>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i126.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i129.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i126.TestEnumStringified>(v)))
+              deserialize<_i129.TestEnumStringified>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i127.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i130.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i127.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i130.Types>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i127.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i130.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i127.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i130.Types>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, List<_i127.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i130.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i127.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i130.Types>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Set<int>?>()) {
@@ -6687,9 +6717,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i133.ByteData>?>()) {
+    if (t == _i1.getType<Set<_i136.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i133.ByteData>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i136.ByteData>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<Duration>?>()) {
@@ -6707,33 +6737,33 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i125.TestEnum>?>()) {
+    if (t == _i1.getType<Set<_i128.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i125.TestEnum>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i128.TestEnum>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i126.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Set<_i129.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i126.TestEnumStringified>(e))
+              .map((e) => deserialize<_i129.TestEnumStringified>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i127.Types>?>()) {
+    if (t == _i1.getType<Set<_i130.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i127.Types>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i130.Types>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<Map<String, _i127.Types>>?>()) {
+    if (t == _i1.getType<Set<Map<String, _i130.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i127.Types>>(e))
+              .map((e) => deserialize<Map<String, _i130.Types>>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<List<_i127.Types>>?>()) {
+    if (t == _i1.getType<Set<List<_i130.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i127.Types>>(e)).toSet()
+          ? (data as List).map((e) => deserialize<List<_i130.Types>>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<List<String>?>()) {
@@ -6744,9 +6774,9 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == List<_i135.SimpleData>) {
+    if (t == List<_i138.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i135.SimpleData>(e))
+          .map((e) => deserialize<_i138.SimpleData>(e))
           .toList() as T;
     }
     if (t == List<int>) {
@@ -6803,28 +6833,28 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == List<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
     }
-    if (t == List<_i133.ByteData>) {
-      return (data as List).map((e) => deserialize<_i133.ByteData>(e)).toList()
+    if (t == List<_i136.ByteData>) {
+      return (data as List).map((e) => deserialize<_i136.ByteData>(e)).toList()
           as T;
     }
-    if (t == List<_i133.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i133.ByteData?>(e)).toList()
+    if (t == List<_i136.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i136.ByteData?>(e)).toList()
           as T;
     }
-    if (t == List<_i135.SimpleData?>) {
+    if (t == List<_i138.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i135.SimpleData?>(e))
+          .map((e) => deserialize<_i138.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i135.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i138.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i135.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i138.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i135.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i138.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i135.SimpleData?>(e))
+              .map((e) => deserialize<_i138.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -6863,13 +6893,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<_i136.TestEnum, int>) {
+    if (t == Map<_i139.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i136.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
+          deserialize<_i139.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<String, _i136.TestEnum>) {
+    if (t == Map<String, _i139.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i136.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i139.TestEnum>(v)))
           as T;
     }
     if (t == Map<String, double>) {
@@ -6906,34 +6936,34 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i133.ByteData>) {
+    if (t == Map<String, _i136.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i133.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i136.ByteData>(v)))
           as T;
     }
-    if (t == Map<String, _i133.ByteData?>) {
+    if (t == Map<String, _i136.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i133.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i136.ByteData?>(v)))
           as T;
     }
-    if (t == Map<String, _i135.SimpleData>) {
+    if (t == Map<String, _i138.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i135.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i138.SimpleData>(v))) as T;
     }
-    if (t == Map<String, _i135.SimpleData?>) {
+    if (t == Map<String, _i138.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i135.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i138.SimpleData?>(v))) as T;
     }
-    if (t == _i1.getType<Map<String, _i135.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i138.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i135.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i138.SimpleData>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i135.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i138.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i135.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i138.SimpleData?>(v)))
           : null) as T;
     }
     if (t == Map<String, Duration>) {
@@ -6951,13 +6981,13 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
     }
-    if (t == Set<_i135.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i135.SimpleData>(e)).toSet()
+    if (t == Set<_i138.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i138.SimpleData>(e)).toSet()
           as T;
     }
-    if (t == List<Set<_i135.SimpleData>>) {
+    if (t == List<Set<_i138.SimpleData>>) {
       return (data as List)
-          .map((e) => deserialize<Set<_i135.SimpleData>>(e))
+          .map((e) => deserialize<Set<_i138.SimpleData>>(e))
           .toList() as T;
     }
     if (t == _i1.getType<(int,)>()) {
@@ -6998,18 +7028,18 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<String>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i135.SimpleData>(data['p'][1]),
+        deserialize<_i138.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i135.SimpleData>(data['p'][1]),
+              deserialize<_i138.SimpleData>(data['p'][1]),
             ) as T;
     }
     if (t == _i1.getType<({int number, String text})>()) {
@@ -7026,135 +7056,135 @@ class Protocol extends _i1.SerializationManagerServer {
               text: deserialize<String>(data['n']['text']),
             ) as T;
     }
-    if (t == _i1.getType<({_i135.SimpleData data, int number})>()) {
+    if (t == _i1.getType<({_i138.SimpleData data, int number})>()) {
       return (
         data:
-            deserialize<_i135.SimpleData>(((data as Map)['n'] as Map)['data']),
+            deserialize<_i138.SimpleData>(((data as Map)['n'] as Map)['data']),
         number: deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<({_i135.SimpleData data, int number})?>()) {
+    if (t == _i1.getType<({_i138.SimpleData data, int number})?>()) {
       return (data == null)
           ? null as T
           : (
-              data: deserialize<_i135.SimpleData>(
+              data: deserialize<_i138.SimpleData>(
                   ((data as Map)['n'] as Map)['data']),
               number: deserialize<int>(data['n']['number']),
             ) as T;
     }
-    if (t == _i1.getType<({_i135.SimpleData? data, int? number})>()) {
+    if (t == _i1.getType<({_i138.SimpleData? data, int? number})>()) {
       return (
         data: ((data as Map)['n'] as Map)['data'] == null
             ? null
-            : deserialize<_i135.SimpleData>(data['n']['data']),
+            : deserialize<_i138.SimpleData>(data['n']['data']),
         number: ((data)['n'] as Map)['number'] == null
             ? null
             : deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i135.SimpleData data})>()) {
+    if (t == _i1.getType<(int, {_i138.SimpleData data})>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        data: deserialize<_i135.SimpleData>(data['n']['data']),
+        data: deserialize<_i138.SimpleData>(data['n']['data']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i135.SimpleData data})?>()) {
+    if (t == _i1.getType<(int, {_i138.SimpleData data})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              data: deserialize<_i135.SimpleData>(data['n']['data']),
+              data: deserialize<_i138.SimpleData>(data['n']['data']),
             ) as T;
     }
-    if (t == List<(int, _i135.SimpleData)>) {
+    if (t == List<(int, _i138.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i135.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i138.SimpleData)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i135.SimpleData>(data['p'][1]),
+        deserialize<_i138.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == List<(int, _i135.SimpleData)?>) {
+    if (t == List<(int, _i138.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i135.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i138.SimpleData)?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i135.SimpleData>(data['p'][1]),
+              deserialize<_i138.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Set<(int, _i135.SimpleData)>) {
+    if (t == Set<(int, _i138.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i135.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i138.SimpleData)>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i135.SimpleData>(data['p'][1]),
+        deserialize<_i138.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Set<(int, _i135.SimpleData)?>) {
+    if (t == Set<(int, _i138.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i135.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i138.SimpleData)?>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i135.SimpleData>(data['p'][1]),
+              deserialize<_i138.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<Set<(int, _i135.SimpleData)>?>()) {
+    if (t == _i1.getType<Set<(int, _i138.SimpleData)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(int, _i135.SimpleData)>(e))
+              .map((e) => deserialize<(int, _i138.SimpleData)>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i135.SimpleData>(data['p'][1]),
+        deserialize<_i138.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i135.SimpleData)>) {
+    if (t == Map<String, (int, _i138.SimpleData)>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i135.SimpleData)>(v)))
+              deserialize<String>(k), deserialize<(int, _i138.SimpleData)>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i135.SimpleData>(data['p'][1]),
+        deserialize<_i138.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i135.SimpleData)?>) {
+    if (t == Map<String, (int, _i138.SimpleData)?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i135.SimpleData)?>(v)))
+              deserialize<String>(k), deserialize<(int, _i138.SimpleData)?>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i135.SimpleData>(data['p'][1]),
+              deserialize<_i138.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Map<(String, int), (int, _i135.SimpleData)>) {
+    if (t == Map<(String, int), (int, _i138.SimpleData)>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
           deserialize<(String, int)>(e['k']),
-          deserialize<(int, _i135.SimpleData)>(e['v'])))) as T;
+          deserialize<(int, _i138.SimpleData)>(e['v'])))) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
       return (
@@ -7162,10 +7192,10 @@ class Protocol extends _i1.SerializationManagerServer {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i135.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i138.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i135.SimpleData>(data['p'][1]),
+        deserialize<_i138.SimpleData>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
@@ -7217,56 +7247,56 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<(int,)>()) {
       return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<({(_i135.SimpleData, double) namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i138.SimpleData, double) namedSubRecord})>()) {
       return (
-        namedSubRecord: deserialize<(_i135.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i138.SimpleData, double)>(
             ((data as Map)['n'] as Map)['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i135.SimpleData, double)>()) {
+    if (t == _i1.getType<(_i138.SimpleData, double)>()) {
       return (
-        deserialize<_i135.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),
         deserialize<double>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<({(_i135.SimpleData, double)? namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i138.SimpleData, double)? namedSubRecord})>()) {
       return (
         namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
             ? null
-            : deserialize<(_i135.SimpleData, double)>(
+            : deserialize<(_i138.SimpleData, double)>(
                 data['n']['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i135.SimpleData, double)?>()) {
+    if (t == _i1.getType<(_i138.SimpleData, double)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i135.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i138.SimpleData>(((data as Map)['p'] as List)[0]),
               deserialize<double>(data['p'][1]),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i135.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i138.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i135.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i138.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
     if (t ==
-        List<((int, String), {(_i135.SimpleData, double) namedSubRecord})>) {
+        List<((int, String), {(_i138.SimpleData, double) namedSubRecord})>) {
       return (data as List)
           .map((e) => deserialize<
-              ((int, String), {(_i135.SimpleData, double) namedSubRecord})>(e))
+              ((int, String), {(_i138.SimpleData, double) namedSubRecord})>(e))
           .toList() as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i135.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i138.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i135.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i138.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
@@ -7326,17 +7356,17 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
     }
-    if (t == Set<_i133.ByteData>) {
-      return (data as List).map((e) => deserialize<_i133.ByteData>(e)).toSet()
+    if (t == Set<_i136.ByteData>) {
+      return (data as List).map((e) => deserialize<_i136.ByteData>(e)).toSet()
           as T;
     }
-    if (t == Set<_i133.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i133.ByteData?>(e)).toSet()
+    if (t == Set<_i136.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i136.ByteData?>(e)).toSet()
           as T;
     }
-    if (t == Set<_i135.SimpleData?>) {
+    if (t == Set<_i138.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i135.SimpleData?>(e))
+          .map((e) => deserialize<_i138.SimpleData?>(e))
           .toSet() as T;
     }
     if (t == Set<Duration>) {
@@ -7368,57 +7398,57 @@ class Protocol extends _i1.SerializationManagerServer {
         deserialize<(int, bool)>(data['p'][1]),
       ) as T;
     }
-    if (t == _i134.CustomClass) {
-      return _i134.CustomClass.fromJson(data) as T;
+    if (t == _i137.CustomClass) {
+      return _i137.CustomClass.fromJson(data) as T;
     }
-    if (t == _i134.CustomClass2) {
-      return _i134.CustomClass2.fromJson(data) as T;
+    if (t == _i137.CustomClass2) {
+      return _i137.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i134.ProtocolCustomClass) {
-      return _i134.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i137.ProtocolCustomClass) {
+      return _i137.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i134.ExternalCustomClass) {
-      return _i134.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i137.ExternalCustomClass) {
+      return _i137.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i134.FreezedCustomClass) {
-      return _i134.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i137.FreezedCustomClass) {
+      return _i137.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i134.CustomClass?>()) {
-      return (data != null ? _i134.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i137.CustomClass?>()) {
+      return (data != null ? _i137.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i134.CustomClass2?>()) {
-      return (data != null ? _i134.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i137.CustomClass2?>()) {
+      return (data != null ? _i137.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i134.CustomClassWithoutProtocolSerialization?>()) {
+    if (t == _i1.getType<_i137.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? _i134.CustomClassWithoutProtocolSerialization.fromJson(data)
+          ? _i137.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i134.CustomClassWithProtocolSerialization?>()) {
+    if (t == _i1.getType<_i137.CustomClassWithProtocolSerialization?>()) {
       return (data != null
-          ? _i134.CustomClassWithProtocolSerialization.fromJson(data)
+          ? _i137.CustomClassWithProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i134.CustomClassWithProtocolSerializationMethod?>()) {
+    if (t == _i1.getType<_i137.CustomClassWithProtocolSerializationMethod?>()) {
       return (data != null
-          ? _i134.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          ? _i137.CustomClassWithProtocolSerializationMethod.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i134.ProtocolCustomClass?>()) {
-      return (data != null ? _i134.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i137.ProtocolCustomClass?>()) {
+      return (data != null ? _i137.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i134.ExternalCustomClass?>()) {
-      return (data != null ? _i134.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i137.ExternalCustomClass?>()) {
+      return (data != null ? _i137.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i134.FreezedCustomClass?>()) {
-      return (data != null ? _i134.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i137.FreezedCustomClass?>()) {
+      return (data != null ? _i137.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<List<_i135.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i138.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i135.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i138.SimpleData>(e)).toList()
           : null) as T;
     }
     try {
@@ -7437,28 +7467,28 @@ class Protocol extends _i1.SerializationManagerServer {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i134.CustomClass) {
+    if (data is _i137.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i134.CustomClass2) {
+    if (data is _i137.CustomClass2) {
       return 'CustomClass2';
     }
-    if (data is _i134.CustomClassWithoutProtocolSerialization) {
+    if (data is _i137.CustomClassWithoutProtocolSerialization) {
       return 'CustomClassWithoutProtocolSerialization';
     }
-    if (data is _i134.CustomClassWithProtocolSerialization) {
+    if (data is _i137.CustomClassWithProtocolSerialization) {
       return 'CustomClassWithProtocolSerialization';
     }
-    if (data is _i134.CustomClassWithProtocolSerializationMethod) {
+    if (data is _i137.CustomClassWithProtocolSerializationMethod) {
       return 'CustomClassWithProtocolSerializationMethod';
     }
-    if (data is _i134.ProtocolCustomClass) {
+    if (data is _i137.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
     }
-    if (data is _i134.ExternalCustomClass) {
+    if (data is _i137.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i134.FreezedCustomClass) {
+    if (data is _i137.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i5.ByIndexEnumWithNameValue) {
@@ -7635,220 +7665,229 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i60.SealedOtherChild) {
       return 'SealedOtherChild';
     }
-    if (data is _i61.CityWithLongTableName) {
+    if (data is _i61.ClassOverridingInterfaceField) {
+      return 'ClassOverridingInterfaceField';
+    }
+    if (data is _i62.ClassWithInterface) {
+      return 'ClassWithInterface';
+    }
+    if (data is _i63.ExceptionWithInterface) {
+      return 'ExceptionWithInterface';
+    }
+    if (data is _i64.CityWithLongTableName) {
       return 'CityWithLongTableName';
     }
-    if (data is _i62.OrganizationWithLongTableName) {
+    if (data is _i65.OrganizationWithLongTableName) {
       return 'OrganizationWithLongTableName';
     }
-    if (data is _i63.PersonWithLongTableName) {
+    if (data is _i66.PersonWithLongTableName) {
       return 'PersonWithLongTableName';
     }
-    if (data is _i64.MaxFieldName) {
+    if (data is _i67.MaxFieldName) {
       return 'MaxFieldName';
     }
-    if (data is _i65.LongImplicitIdField) {
+    if (data is _i68.LongImplicitIdField) {
       return 'LongImplicitIdField';
     }
-    if (data is _i66.LongImplicitIdFieldCollection) {
+    if (data is _i69.LongImplicitIdFieldCollection) {
       return 'LongImplicitIdFieldCollection';
     }
-    if (data is _i67.RelationToMultipleMaxFieldName) {
+    if (data is _i70.RelationToMultipleMaxFieldName) {
       return 'RelationToMultipleMaxFieldName';
     }
-    if (data is _i68.UserNote) {
+    if (data is _i71.UserNote) {
       return 'UserNote';
     }
-    if (data is _i69.UserNoteCollection) {
+    if (data is _i72.UserNoteCollection) {
       return 'UserNoteCollection';
     }
-    if (data is _i70.UserNoteCollectionWithALongName) {
+    if (data is _i73.UserNoteCollectionWithALongName) {
       return 'UserNoteCollectionWithALongName';
     }
-    if (data is _i71.UserNoteWithALongName) {
+    if (data is _i74.UserNoteWithALongName) {
       return 'UserNoteWithALongName';
     }
-    if (data is _i72.MultipleMaxFieldName) {
+    if (data is _i75.MultipleMaxFieldName) {
       return 'MultipleMaxFieldName';
     }
-    if (data is _i73.City) {
+    if (data is _i76.City) {
       return 'City';
     }
-    if (data is _i74.Organization) {
+    if (data is _i77.Organization) {
       return 'Organization';
     }
-    if (data is _i75.Person) {
+    if (data is _i78.Person) {
       return 'Person';
     }
-    if (data is _i76.Course) {
+    if (data is _i79.Course) {
       return 'Course';
     }
-    if (data is _i77.Enrollment) {
+    if (data is _i80.Enrollment) {
       return 'Enrollment';
     }
-    if (data is _i78.Student) {
+    if (data is _i81.Student) {
       return 'Student';
     }
-    if (data is _i79.ObjectUser) {
+    if (data is _i82.ObjectUser) {
       return 'ObjectUser';
     }
-    if (data is _i80.ParentUser) {
+    if (data is _i83.ParentUser) {
       return 'ParentUser';
     }
-    if (data is _i81.Arena) {
+    if (data is _i84.Arena) {
       return 'Arena';
     }
-    if (data is _i82.Player) {
+    if (data is _i85.Player) {
       return 'Player';
     }
-    if (data is _i83.Team) {
+    if (data is _i86.Team) {
       return 'Team';
     }
-    if (data is _i84.Comment) {
+    if (data is _i87.Comment) {
       return 'Comment';
     }
-    if (data is _i85.Customer) {
+    if (data is _i88.Customer) {
       return 'Customer';
     }
-    if (data is _i86.Order) {
+    if (data is _i89.Order) {
       return 'Order';
     }
-    if (data is _i87.Address) {
+    if (data is _i90.Address) {
       return 'Address';
     }
-    if (data is _i88.Citizen) {
+    if (data is _i91.Citizen) {
       return 'Citizen';
     }
-    if (data is _i89.Company) {
+    if (data is _i92.Company) {
       return 'Company';
     }
-    if (data is _i90.Town) {
+    if (data is _i93.Town) {
       return 'Town';
     }
-    if (data is _i91.Blocking) {
+    if (data is _i94.Blocking) {
       return 'Blocking';
     }
-    if (data is _i92.Member) {
+    if (data is _i95.Member) {
       return 'Member';
     }
-    if (data is _i93.Cat) {
+    if (data is _i96.Cat) {
       return 'Cat';
     }
-    if (data is _i94.Post) {
+    if (data is _i97.Post) {
       return 'Post';
     }
-    if (data is _i95.ModuleDatatype) {
+    if (data is _i98.ModuleDatatype) {
       return 'ModuleDatatype';
     }
-    if (data is _i96.Nullability) {
+    if (data is _i99.Nullability) {
       return 'Nullability';
     }
-    if (data is _i97.ObjectFieldPersist) {
+    if (data is _i100.ObjectFieldPersist) {
       return 'ObjectFieldPersist';
     }
-    if (data is _i98.ObjectFieldScopes) {
+    if (data is _i101.ObjectFieldScopes) {
       return 'ObjectFieldScopes';
     }
-    if (data is _i99.ObjectWithByteData) {
+    if (data is _i102.ObjectWithByteData) {
       return 'ObjectWithByteData';
     }
-    if (data is _i100.ObjectWithCustomClass) {
+    if (data is _i103.ObjectWithCustomClass) {
       return 'ObjectWithCustomClass';
     }
-    if (data is _i101.ObjectWithDuration) {
+    if (data is _i104.ObjectWithDuration) {
       return 'ObjectWithDuration';
     }
-    if (data is _i102.ObjectWithEnum) {
+    if (data is _i105.ObjectWithEnum) {
       return 'ObjectWithEnum';
     }
-    if (data is _i103.ObjectWithIndex) {
+    if (data is _i106.ObjectWithIndex) {
       return 'ObjectWithIndex';
     }
-    if (data is _i104.ObjectWithMaps) {
+    if (data is _i107.ObjectWithMaps) {
       return 'ObjectWithMaps';
     }
-    if (data is _i105.ObjectWithObject) {
+    if (data is _i108.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i106.ObjectWithParent) {
+    if (data is _i109.ObjectWithParent) {
       return 'ObjectWithParent';
     }
-    if (data is _i107.ObjectWithSelfParent) {
+    if (data is _i110.ObjectWithSelfParent) {
       return 'ObjectWithSelfParent';
     }
-    if (data is _i108.ObjectWithUuid) {
+    if (data is _i111.ObjectWithUuid) {
       return 'ObjectWithUuid';
     }
-    if (data is _i109.RelatedUniqueData) {
+    if (data is _i112.RelatedUniqueData) {
       return 'RelatedUniqueData';
     }
-    if (data is _i110.ScopeNoneFields) {
+    if (data is _i113.ScopeNoneFields) {
       return 'ScopeNoneFields';
     }
-    if (data is _i111.ScopeServerOnlyField) {
+    if (data is _i114.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i112.ScopeServerOnlyFieldChild) {
+    if (data is _i115.ScopeServerOnlyFieldChild) {
       return 'ScopeServerOnlyFieldChild';
     }
-    if (data is _i113.DefaultServerOnlyClass) {
+    if (data is _i116.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i114.DefaultServerOnlyEnum) {
+    if (data is _i117.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i115.NotServerOnlyClass) {
+    if (data is _i118.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i116.NotServerOnlyEnum) {
+    if (data is _i119.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i117.ServerOnlyClass) {
+    if (data is _i120.ServerOnlyClass) {
       return 'ServerOnlyClass';
     }
-    if (data is _i118.ServerOnlyEnum) {
+    if (data is _i121.ServerOnlyEnum) {
       return 'ServerOnlyEnum';
     }
-    if (data is _i119.ServerOnlyClassField) {
+    if (data is _i122.ServerOnlyClassField) {
       return 'ServerOnlyClassField';
     }
-    if (data is _i120.SimpleData) {
+    if (data is _i123.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i121.SimpleDataList) {
+    if (data is _i124.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i122.SimpleDataMap) {
+    if (data is _i125.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i123.SimpleDataObject) {
+    if (data is _i126.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i124.SimpleDateTime) {
+    if (data is _i127.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i125.TestEnum) {
+    if (data is _i128.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i126.TestEnumStringified) {
+    if (data is _i129.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i127.Types) {
+    if (data is _i130.Types) {
       return 'Types';
     }
-    if (data is _i128.TypesList) {
+    if (data is _i131.TypesList) {
       return 'TypesList';
     }
-    if (data is _i129.TypesMap) {
+    if (data is _i132.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i130.TypesSet) {
+    if (data is _i133.TypesSet) {
       return 'TypesSet';
     }
-    if (data is _i131.UniqueData) {
+    if (data is _i134.UniqueData) {
       return 'UniqueData';
     }
-    if (data is _i132.MyFeatureModel) {
+    if (data is _i135.MyFeatureModel) {
       return 'MyFeatureModel';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -7866,25 +7905,25 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i135.SimpleData>) {
+    if (data is List<_i138.SimpleData>) {
       return 'List<SimpleData>';
     }
     if (data is List<_i3.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i135.SimpleData>?) {
+    if (data is List<_i138.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i135.SimpleData?>) {
+    if (data is List<_i138.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i135.SimpleData>) {
+    if (data is Set<_i138.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i135.SimpleData>>) {
+    if (data is List<Set<_i138.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
     return null;
@@ -7897,31 +7936,31 @@ class Protocol extends _i1.SerializationManagerServer {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CustomClass') {
-      return deserialize<_i134.CustomClass>(data['data']);
+      return deserialize<_i137.CustomClass>(data['data']);
     }
     if (dataClassName == 'CustomClass2') {
-      return deserialize<_i134.CustomClass2>(data['data']);
+      return deserialize<_i137.CustomClass2>(data['data']);
     }
     if (dataClassName == 'CustomClassWithoutProtocolSerialization') {
-      return deserialize<_i134.CustomClassWithoutProtocolSerialization>(
+      return deserialize<_i137.CustomClassWithoutProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerialization') {
-      return deserialize<_i134.CustomClassWithProtocolSerialization>(
+      return deserialize<_i137.CustomClassWithProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerializationMethod') {
-      return deserialize<_i134.CustomClassWithProtocolSerializationMethod>(
+      return deserialize<_i137.CustomClassWithProtocolSerializationMethod>(
           data['data']);
     }
     if (dataClassName == 'ProtocolCustomClass') {
-      return deserialize<_i134.ProtocolCustomClass>(data['data']);
+      return deserialize<_i137.ProtocolCustomClass>(data['data']);
     }
     if (dataClassName == 'ExternalCustomClass') {
-      return deserialize<_i134.ExternalCustomClass>(data['data']);
+      return deserialize<_i137.ExternalCustomClass>(data['data']);
     }
     if (dataClassName == 'FreezedCustomClass') {
-      return deserialize<_i134.FreezedCustomClass>(data['data']);
+      return deserialize<_i137.FreezedCustomClass>(data['data']);
     }
     if (dataClassName == 'ByIndexEnumWithNameValue') {
       return deserialize<_i5.ByIndexEnumWithNameValue>(data['data']);
@@ -8097,221 +8136,230 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'SealedOtherChild') {
       return deserialize<_i60.SealedOtherChild>(data['data']);
     }
+    if (dataClassName == 'ClassOverridingInterfaceField') {
+      return deserialize<_i61.ClassOverridingInterfaceField>(data['data']);
+    }
+    if (dataClassName == 'ClassWithInterface') {
+      return deserialize<_i62.ClassWithInterface>(data['data']);
+    }
+    if (dataClassName == 'ExceptionWithInterface') {
+      return deserialize<_i63.ExceptionWithInterface>(data['data']);
+    }
     if (dataClassName == 'CityWithLongTableName') {
-      return deserialize<_i61.CityWithLongTableName>(data['data']);
+      return deserialize<_i64.CityWithLongTableName>(data['data']);
     }
     if (dataClassName == 'OrganizationWithLongTableName') {
-      return deserialize<_i62.OrganizationWithLongTableName>(data['data']);
+      return deserialize<_i65.OrganizationWithLongTableName>(data['data']);
     }
     if (dataClassName == 'PersonWithLongTableName') {
-      return deserialize<_i63.PersonWithLongTableName>(data['data']);
+      return deserialize<_i66.PersonWithLongTableName>(data['data']);
     }
     if (dataClassName == 'MaxFieldName') {
-      return deserialize<_i64.MaxFieldName>(data['data']);
+      return deserialize<_i67.MaxFieldName>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdField') {
-      return deserialize<_i65.LongImplicitIdField>(data['data']);
+      return deserialize<_i68.LongImplicitIdField>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdFieldCollection') {
-      return deserialize<_i66.LongImplicitIdFieldCollection>(data['data']);
+      return deserialize<_i69.LongImplicitIdFieldCollection>(data['data']);
     }
     if (dataClassName == 'RelationToMultipleMaxFieldName') {
-      return deserialize<_i67.RelationToMultipleMaxFieldName>(data['data']);
+      return deserialize<_i70.RelationToMultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'UserNote') {
-      return deserialize<_i68.UserNote>(data['data']);
+      return deserialize<_i71.UserNote>(data['data']);
     }
     if (dataClassName == 'UserNoteCollection') {
-      return deserialize<_i69.UserNoteCollection>(data['data']);
+      return deserialize<_i72.UserNoteCollection>(data['data']);
     }
     if (dataClassName == 'UserNoteCollectionWithALongName') {
-      return deserialize<_i70.UserNoteCollectionWithALongName>(data['data']);
+      return deserialize<_i73.UserNoteCollectionWithALongName>(data['data']);
     }
     if (dataClassName == 'UserNoteWithALongName') {
-      return deserialize<_i71.UserNoteWithALongName>(data['data']);
+      return deserialize<_i74.UserNoteWithALongName>(data['data']);
     }
     if (dataClassName == 'MultipleMaxFieldName') {
-      return deserialize<_i72.MultipleMaxFieldName>(data['data']);
+      return deserialize<_i75.MultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'City') {
-      return deserialize<_i73.City>(data['data']);
+      return deserialize<_i76.City>(data['data']);
     }
     if (dataClassName == 'Organization') {
-      return deserialize<_i74.Organization>(data['data']);
+      return deserialize<_i77.Organization>(data['data']);
     }
     if (dataClassName == 'Person') {
-      return deserialize<_i75.Person>(data['data']);
+      return deserialize<_i78.Person>(data['data']);
     }
     if (dataClassName == 'Course') {
-      return deserialize<_i76.Course>(data['data']);
+      return deserialize<_i79.Course>(data['data']);
     }
     if (dataClassName == 'Enrollment') {
-      return deserialize<_i77.Enrollment>(data['data']);
+      return deserialize<_i80.Enrollment>(data['data']);
     }
     if (dataClassName == 'Student') {
-      return deserialize<_i78.Student>(data['data']);
+      return deserialize<_i81.Student>(data['data']);
     }
     if (dataClassName == 'ObjectUser') {
-      return deserialize<_i79.ObjectUser>(data['data']);
+      return deserialize<_i82.ObjectUser>(data['data']);
     }
     if (dataClassName == 'ParentUser') {
-      return deserialize<_i80.ParentUser>(data['data']);
+      return deserialize<_i83.ParentUser>(data['data']);
     }
     if (dataClassName == 'Arena') {
-      return deserialize<_i81.Arena>(data['data']);
+      return deserialize<_i84.Arena>(data['data']);
     }
     if (dataClassName == 'Player') {
-      return deserialize<_i82.Player>(data['data']);
+      return deserialize<_i85.Player>(data['data']);
     }
     if (dataClassName == 'Team') {
-      return deserialize<_i83.Team>(data['data']);
+      return deserialize<_i86.Team>(data['data']);
     }
     if (dataClassName == 'Comment') {
-      return deserialize<_i84.Comment>(data['data']);
+      return deserialize<_i87.Comment>(data['data']);
     }
     if (dataClassName == 'Customer') {
-      return deserialize<_i85.Customer>(data['data']);
+      return deserialize<_i88.Customer>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i86.Order>(data['data']);
+      return deserialize<_i89.Order>(data['data']);
     }
     if (dataClassName == 'Address') {
-      return deserialize<_i87.Address>(data['data']);
+      return deserialize<_i90.Address>(data['data']);
     }
     if (dataClassName == 'Citizen') {
-      return deserialize<_i88.Citizen>(data['data']);
+      return deserialize<_i91.Citizen>(data['data']);
     }
     if (dataClassName == 'Company') {
-      return deserialize<_i89.Company>(data['data']);
+      return deserialize<_i92.Company>(data['data']);
     }
     if (dataClassName == 'Town') {
-      return deserialize<_i90.Town>(data['data']);
+      return deserialize<_i93.Town>(data['data']);
     }
     if (dataClassName == 'Blocking') {
-      return deserialize<_i91.Blocking>(data['data']);
+      return deserialize<_i94.Blocking>(data['data']);
     }
     if (dataClassName == 'Member') {
-      return deserialize<_i92.Member>(data['data']);
+      return deserialize<_i95.Member>(data['data']);
     }
     if (dataClassName == 'Cat') {
-      return deserialize<_i93.Cat>(data['data']);
+      return deserialize<_i96.Cat>(data['data']);
     }
     if (dataClassName == 'Post') {
-      return deserialize<_i94.Post>(data['data']);
+      return deserialize<_i97.Post>(data['data']);
     }
     if (dataClassName == 'ModuleDatatype') {
-      return deserialize<_i95.ModuleDatatype>(data['data']);
+      return deserialize<_i98.ModuleDatatype>(data['data']);
     }
     if (dataClassName == 'Nullability') {
-      return deserialize<_i96.Nullability>(data['data']);
+      return deserialize<_i99.Nullability>(data['data']);
     }
     if (dataClassName == 'ObjectFieldPersist') {
-      return deserialize<_i97.ObjectFieldPersist>(data['data']);
+      return deserialize<_i100.ObjectFieldPersist>(data['data']);
     }
     if (dataClassName == 'ObjectFieldScopes') {
-      return deserialize<_i98.ObjectFieldScopes>(data['data']);
+      return deserialize<_i101.ObjectFieldScopes>(data['data']);
     }
     if (dataClassName == 'ObjectWithByteData') {
-      return deserialize<_i99.ObjectWithByteData>(data['data']);
+      return deserialize<_i102.ObjectWithByteData>(data['data']);
     }
     if (dataClassName == 'ObjectWithCustomClass') {
-      return deserialize<_i100.ObjectWithCustomClass>(data['data']);
+      return deserialize<_i103.ObjectWithCustomClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithDuration') {
-      return deserialize<_i101.ObjectWithDuration>(data['data']);
+      return deserialize<_i104.ObjectWithDuration>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnum') {
-      return deserialize<_i102.ObjectWithEnum>(data['data']);
+      return deserialize<_i105.ObjectWithEnum>(data['data']);
     }
     if (dataClassName == 'ObjectWithIndex') {
-      return deserialize<_i103.ObjectWithIndex>(data['data']);
+      return deserialize<_i106.ObjectWithIndex>(data['data']);
     }
     if (dataClassName == 'ObjectWithMaps') {
-      return deserialize<_i104.ObjectWithMaps>(data['data']);
+      return deserialize<_i107.ObjectWithMaps>(data['data']);
     }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i105.ObjectWithObject>(data['data']);
+      return deserialize<_i108.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i106.ObjectWithParent>(data['data']);
+      return deserialize<_i109.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i107.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i110.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i108.ObjectWithUuid>(data['data']);
+      return deserialize<_i111.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i109.RelatedUniqueData>(data['data']);
+      return deserialize<_i112.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ScopeNoneFields') {
-      return deserialize<_i110.ScopeNoneFields>(data['data']);
+      return deserialize<_i113.ScopeNoneFields>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyField') {
-      return deserialize<_i111.ScopeServerOnlyField>(data['data']);
+      return deserialize<_i114.ScopeServerOnlyField>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyFieldChild') {
-      return deserialize<_i112.ScopeServerOnlyFieldChild>(data['data']);
+      return deserialize<_i115.ScopeServerOnlyFieldChild>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
-      return deserialize<_i113.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i116.DefaultServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyEnum') {
-      return deserialize<_i114.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i117.DefaultServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyClass') {
-      return deserialize<_i115.NotServerOnlyClass>(data['data']);
+      return deserialize<_i118.NotServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyEnum') {
-      return deserialize<_i116.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i119.NotServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClass') {
-      return deserialize<_i117.ServerOnlyClass>(data['data']);
+      return deserialize<_i120.ServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'ServerOnlyEnum') {
-      return deserialize<_i118.ServerOnlyEnum>(data['data']);
+      return deserialize<_i121.ServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClassField') {
-      return deserialize<_i119.ServerOnlyClassField>(data['data']);
+      return deserialize<_i122.ServerOnlyClassField>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i120.SimpleData>(data['data']);
+      return deserialize<_i123.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDataList') {
-      return deserialize<_i121.SimpleDataList>(data['data']);
+      return deserialize<_i124.SimpleDataList>(data['data']);
     }
     if (dataClassName == 'SimpleDataMap') {
-      return deserialize<_i122.SimpleDataMap>(data['data']);
+      return deserialize<_i125.SimpleDataMap>(data['data']);
     }
     if (dataClassName == 'SimpleDataObject') {
-      return deserialize<_i123.SimpleDataObject>(data['data']);
+      return deserialize<_i126.SimpleDataObject>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i124.SimpleDateTime>(data['data']);
+      return deserialize<_i127.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i125.TestEnum>(data['data']);
+      return deserialize<_i128.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i126.TestEnumStringified>(data['data']);
+      return deserialize<_i129.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i127.Types>(data['data']);
+      return deserialize<_i130.Types>(data['data']);
     }
     if (dataClassName == 'TypesList') {
-      return deserialize<_i128.TypesList>(data['data']);
+      return deserialize<_i131.TypesList>(data['data']);
     }
     if (dataClassName == 'TypesMap') {
-      return deserialize<_i129.TypesMap>(data['data']);
+      return deserialize<_i132.TypesMap>(data['data']);
     }
     if (dataClassName == 'TypesSet') {
-      return deserialize<_i130.TypesSet>(data['data']);
+      return deserialize<_i133.TypesSet>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i131.UniqueData>(data['data']);
+      return deserialize<_i134.UniqueData>(data['data']);
     }
     if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i132.MyFeatureModel>(data['data']);
+      return deserialize<_i135.MyFeatureModel>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -8329,25 +8377,25 @@ class Protocol extends _i1.SerializationManagerServer {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i135.SimpleData>>(data['data']);
+      return deserialize<List<_i138.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
       return deserialize<List<_i3.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i135.SimpleData>?>(data['data']);
+      return deserialize<List<_i138.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i135.SimpleData?>>(data['data']);
+      return deserialize<List<_i138.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i135.SimpleData>>(data['data']);
+      return deserialize<Set<_i138.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i135.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i138.SimpleData>>>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -8461,106 +8509,106 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i53.RelationEmptyModel.t;
       case _i58.ParentClass:
         return _i58.ParentClass.t;
-      case _i61.CityWithLongTableName:
-        return _i61.CityWithLongTableName.t;
-      case _i62.OrganizationWithLongTableName:
-        return _i62.OrganizationWithLongTableName.t;
-      case _i63.PersonWithLongTableName:
-        return _i63.PersonWithLongTableName.t;
-      case _i64.MaxFieldName:
-        return _i64.MaxFieldName.t;
-      case _i65.LongImplicitIdField:
-        return _i65.LongImplicitIdField.t;
-      case _i66.LongImplicitIdFieldCollection:
-        return _i66.LongImplicitIdFieldCollection.t;
-      case _i67.RelationToMultipleMaxFieldName:
-        return _i67.RelationToMultipleMaxFieldName.t;
-      case _i68.UserNote:
-        return _i68.UserNote.t;
-      case _i69.UserNoteCollection:
-        return _i69.UserNoteCollection.t;
-      case _i70.UserNoteCollectionWithALongName:
-        return _i70.UserNoteCollectionWithALongName.t;
-      case _i71.UserNoteWithALongName:
-        return _i71.UserNoteWithALongName.t;
-      case _i72.MultipleMaxFieldName:
-        return _i72.MultipleMaxFieldName.t;
-      case _i73.City:
-        return _i73.City.t;
-      case _i74.Organization:
-        return _i74.Organization.t;
-      case _i75.Person:
-        return _i75.Person.t;
-      case _i76.Course:
-        return _i76.Course.t;
-      case _i77.Enrollment:
-        return _i77.Enrollment.t;
-      case _i78.Student:
-        return _i78.Student.t;
-      case _i79.ObjectUser:
-        return _i79.ObjectUser.t;
-      case _i80.ParentUser:
-        return _i80.ParentUser.t;
-      case _i81.Arena:
-        return _i81.Arena.t;
-      case _i82.Player:
-        return _i82.Player.t;
-      case _i83.Team:
-        return _i83.Team.t;
-      case _i84.Comment:
-        return _i84.Comment.t;
-      case _i85.Customer:
-        return _i85.Customer.t;
-      case _i86.Order:
-        return _i86.Order.t;
-      case _i87.Address:
-        return _i87.Address.t;
-      case _i88.Citizen:
-        return _i88.Citizen.t;
-      case _i89.Company:
-        return _i89.Company.t;
-      case _i90.Town:
-        return _i90.Town.t;
-      case _i91.Blocking:
-        return _i91.Blocking.t;
-      case _i92.Member:
-        return _i92.Member.t;
-      case _i93.Cat:
-        return _i93.Cat.t;
-      case _i94.Post:
-        return _i94.Post.t;
-      case _i97.ObjectFieldPersist:
-        return _i97.ObjectFieldPersist.t;
-      case _i98.ObjectFieldScopes:
-        return _i98.ObjectFieldScopes.t;
-      case _i99.ObjectWithByteData:
-        return _i99.ObjectWithByteData.t;
-      case _i101.ObjectWithDuration:
-        return _i101.ObjectWithDuration.t;
-      case _i102.ObjectWithEnum:
-        return _i102.ObjectWithEnum.t;
-      case _i103.ObjectWithIndex:
-        return _i103.ObjectWithIndex.t;
-      case _i105.ObjectWithObject:
-        return _i105.ObjectWithObject.t;
-      case _i106.ObjectWithParent:
-        return _i106.ObjectWithParent.t;
-      case _i107.ObjectWithSelfParent:
-        return _i107.ObjectWithSelfParent.t;
-      case _i108.ObjectWithUuid:
-        return _i108.ObjectWithUuid.t;
-      case _i109.RelatedUniqueData:
-        return _i109.RelatedUniqueData.t;
-      case _i110.ScopeNoneFields:
-        return _i110.ScopeNoneFields.t;
-      case _i120.SimpleData:
-        return _i120.SimpleData.t;
-      case _i124.SimpleDateTime:
-        return _i124.SimpleDateTime.t;
-      case _i127.Types:
-        return _i127.Types.t;
-      case _i131.UniqueData:
-        return _i131.UniqueData.t;
+      case _i64.CityWithLongTableName:
+        return _i64.CityWithLongTableName.t;
+      case _i65.OrganizationWithLongTableName:
+        return _i65.OrganizationWithLongTableName.t;
+      case _i66.PersonWithLongTableName:
+        return _i66.PersonWithLongTableName.t;
+      case _i67.MaxFieldName:
+        return _i67.MaxFieldName.t;
+      case _i68.LongImplicitIdField:
+        return _i68.LongImplicitIdField.t;
+      case _i69.LongImplicitIdFieldCollection:
+        return _i69.LongImplicitIdFieldCollection.t;
+      case _i70.RelationToMultipleMaxFieldName:
+        return _i70.RelationToMultipleMaxFieldName.t;
+      case _i71.UserNote:
+        return _i71.UserNote.t;
+      case _i72.UserNoteCollection:
+        return _i72.UserNoteCollection.t;
+      case _i73.UserNoteCollectionWithALongName:
+        return _i73.UserNoteCollectionWithALongName.t;
+      case _i74.UserNoteWithALongName:
+        return _i74.UserNoteWithALongName.t;
+      case _i75.MultipleMaxFieldName:
+        return _i75.MultipleMaxFieldName.t;
+      case _i76.City:
+        return _i76.City.t;
+      case _i77.Organization:
+        return _i77.Organization.t;
+      case _i78.Person:
+        return _i78.Person.t;
+      case _i79.Course:
+        return _i79.Course.t;
+      case _i80.Enrollment:
+        return _i80.Enrollment.t;
+      case _i81.Student:
+        return _i81.Student.t;
+      case _i82.ObjectUser:
+        return _i82.ObjectUser.t;
+      case _i83.ParentUser:
+        return _i83.ParentUser.t;
+      case _i84.Arena:
+        return _i84.Arena.t;
+      case _i85.Player:
+        return _i85.Player.t;
+      case _i86.Team:
+        return _i86.Team.t;
+      case _i87.Comment:
+        return _i87.Comment.t;
+      case _i88.Customer:
+        return _i88.Customer.t;
+      case _i89.Order:
+        return _i89.Order.t;
+      case _i90.Address:
+        return _i90.Address.t;
+      case _i91.Citizen:
+        return _i91.Citizen.t;
+      case _i92.Company:
+        return _i92.Company.t;
+      case _i93.Town:
+        return _i93.Town.t;
+      case _i94.Blocking:
+        return _i94.Blocking.t;
+      case _i95.Member:
+        return _i95.Member.t;
+      case _i96.Cat:
+        return _i96.Cat.t;
+      case _i97.Post:
+        return _i97.Post.t;
+      case _i100.ObjectFieldPersist:
+        return _i100.ObjectFieldPersist.t;
+      case _i101.ObjectFieldScopes:
+        return _i101.ObjectFieldScopes.t;
+      case _i102.ObjectWithByteData:
+        return _i102.ObjectWithByteData.t;
+      case _i104.ObjectWithDuration:
+        return _i104.ObjectWithDuration.t;
+      case _i105.ObjectWithEnum:
+        return _i105.ObjectWithEnum.t;
+      case _i106.ObjectWithIndex:
+        return _i106.ObjectWithIndex.t;
+      case _i108.ObjectWithObject:
+        return _i108.ObjectWithObject.t;
+      case _i109.ObjectWithParent:
+        return _i109.ObjectWithParent.t;
+      case _i110.ObjectWithSelfParent:
+        return _i110.ObjectWithSelfParent.t;
+      case _i111.ObjectWithUuid:
+        return _i111.ObjectWithUuid.t;
+      case _i112.RelatedUniqueData:
+        return _i112.RelatedUniqueData.t;
+      case _i113.ScopeNoneFields:
+        return _i113.ScopeNoneFields.t;
+      case _i123.SimpleData:
+        return _i123.SimpleData.t;
+      case _i127.SimpleDateTime:
+        return _i127.SimpleDateTime.t;
+      case _i130.Types:
+        return _i130.Types.t;
+      case _i134.UniqueData:
+        return _i134.UniqueData.t;
     }
     return null;
   }
@@ -8604,7 +8652,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, _i135.SimpleData)) {
+  if (record is (int, _i138.SimpleData)) {
     return {
       "p": [
         record.$1,
@@ -8620,7 +8668,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i135.SimpleData data, int number})) {
+  if (record is ({_i138.SimpleData data, int number})) {
     return {
       "n": {
         "data": record.data,
@@ -8628,7 +8676,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i135.SimpleData? data, int? number})) {
+  if (record is ({_i138.SimpleData? data, int? number})) {
     return {
       "n": {
         "data": record.data,
@@ -8636,7 +8684,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (int, {_i135.SimpleData data})) {
+  if (record is (int, {_i138.SimpleData data})) {
     return {
       "p": [
         record.$1,
@@ -8654,14 +8702,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i135.SimpleData, double) namedSubRecord})) {
+  if (record is ({(_i138.SimpleData, double) namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is (_i135.SimpleData, double)) {
+  if (record is (_i138.SimpleData, double)) {
     return {
       "p": [
         record.$1,
@@ -8669,14 +8717,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i135.SimpleData, double)? namedSubRecord})) {
+  if (record is ({(_i138.SimpleData, double)? namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is ((int, String), {(_i135.SimpleData, double) namedSubRecord})) {
+  if (record is ((int, String), {(_i138.SimpleData, double) namedSubRecord})) {
     return {
       "p": [
         mapRecordToJson(record.$1),

--- a/tests/serverpod_test_server/lib/src/models/interfaces/class_overriding_interface_field.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/interfaces/class_overriding_interface_field.spy.yaml
@@ -1,0 +1,5 @@
+class: ClassOverridingInterfaceField
+implements: ExampleInterface
+fields:
+  classField: String
+  interfaceField: String, default="This is a default value"

--- a/tests/serverpod_test_server/lib/src/models/interfaces/class_with_interface.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/interfaces/class_with_interface.spy.yaml
@@ -1,0 +1,4 @@
+class: ClassWithInterface
+implements: ExampleInterface
+fields:
+  classField: String

--- a/tests/serverpod_test_server/lib/src/models/interfaces/example_interface.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/interfaces/example_interface.spy.yaml
@@ -1,0 +1,3 @@
+interface: ExampleInterface
+fields:
+  interfaceField: String

--- a/tests/serverpod_test_server/lib/src/models/interfaces/exception_with_interface.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/interfaces/exception_with_interface.spy.yaml
@@ -1,0 +1,4 @@
+exception: ExceptionWithInterface
+implements: ExampleInterface
+fields:
+  exceptionField: String

--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -41,6 +41,9 @@ sealed class ClassDefinition extends SerializableModelDefinition {
   /// The documentation of this class, line by line.
   final List<String>? documentation;
 
+  /// If set to a List of [ImplementsDefinitions] the class implements one or more interfaces and stores the [ClassDefinition] of the implemented interfaces.
+  List<ImplementsDefinition> isImplementing;
+
   /// Create a new [ClassDefinition].
   ClassDefinition({
     required super.fileName,
@@ -51,11 +54,41 @@ sealed class ClassDefinition extends SerializableModelDefinition {
     required super.type,
     super.subDirParts,
     this.documentation,
-  });
+    List<ImplementsDefinition>? isImplementing,
+  }) : isImplementing = isImplementing ?? <ImplementsDefinition>[];
 
   SerializableModelFieldDefinition? findField(String name) {
     return fields.where((element) => element.name == name).firstOrNull;
   }
+
+  /// Returns a `List<ClassDefinition>` holding all implemented interfaces.
+  /// If there are no implemented interfaces, an empty list is returned.
+  List<ClassDefinition> get implementedInterfaces => isImplementing
+      .whereType<ResolvedImplementsDefinition>()
+      .map((e) => e.interfaceDefinition)
+      .toList();
+
+  /// Returns a list of fields from all implemented interfaces.
+  List<SerializableModelFieldDefinition> get implementedFields {
+    return implementedInterfaces
+        .expand((interfaceClass) => [
+              ...interfaceClass.implementedFields,
+              ...interfaceClass.fields,
+            ])
+        .toList();
+  }
+
+  /// Returns a list of all implemented fields that are not assigned a default
+  ///  in this class.
+  List<SerializableModelFieldDefinition> get uniqueImplementedFields {
+    return implementedFields
+        .where((f) => !fields.any((field) => field.name == f.name))
+        .toList();
+  }
+
+  /// Returns a list of all (unique) implemented fields and the fields of this class.
+  List<SerializableModelFieldDefinition> get fieldsIncludingImplemented =>
+      [...uniqueImplementedFields, ...fields];
 }
 
 /// A [ClassDefinition] specialization that represents a model class.
@@ -94,6 +127,7 @@ final class ModelClassDefinition extends ClassDefinition {
     required super.type,
     required this.isSealed,
     List<InheritanceDefinition>? childClasses,
+    super.isImplementing,
     this.extendsClass,
     this.tableName,
     this.indexes = const [],
@@ -113,7 +147,7 @@ final class ModelClassDefinition extends ClassDefinition {
   /// Returns a list of all fields in the parent class.
   /// If there is no parent class, an empty list is returned.
   List<SerializableModelFieldDefinition> get inheritedFields =>
-      parentClass?.fieldsIncludingInherited ?? [];
+      parentClass?.allFields ?? [];
 
   /// Returns a list of all fields in this class, including inherited fields.
   /// It ensures that the 'id' field, if present, is always included at the beginning of the list.
@@ -123,6 +157,22 @@ final class ModelClassDefinition extends ClassDefinition {
     return [
       if (hasIdField) fields.firstWhere((element) => element.name == 'id'),
       ...inheritedFields,
+      ...fields.where((element) => element.name != 'id'),
+    ];
+  }
+
+  /// Returns a list of all fields this class has.
+  /// This includes:
+  /// - Fields from parent class
+  /// - Fields from interfaces
+  /// - Fields from the class itself
+  List<SerializableModelFieldDefinition> get allFields {
+    bool hasIdField = fields.any((element) => element.name == 'id');
+
+    return [
+      if (hasIdField) fields.firstWhere((element) => element.name == 'id'),
+      ...inheritedFields,
+      ...uniqueImplementedFields,
       ...fields.where((element) => element.name != 'id'),
     ];
   }
@@ -192,6 +242,23 @@ final class ExceptionClassDefinition extends ClassDefinition {
     required super.serverOnly,
     required super.sourceFileName,
     required super.type,
+    super.isImplementing,
+    super.documentation,
+    super.subDirParts,
+  });
+}
+
+/// A [ClassDefinition] specialization that represents an interface.
+final class InterfaceClassDefinition extends ClassDefinition {
+  /// Create a new [InterfaceClassDefinition].
+  InterfaceClassDefinition({
+    required super.className,
+    required super.fields,
+    required super.fileName,
+    required super.serverOnly,
+    required super.sourceFileName,
+    required super.type,
+    super.isImplementing,
     super.documentation,
     super.subDirParts,
   });
@@ -371,18 +438,77 @@ class ProtocolEnumValueDefinition {
   ProtocolEnumValueDefinition(this.name, [this.documentation]);
 }
 
+/// A base class for all inheritance definitions.
+///
+/// This is used to store the information about a class
+/// that is extended by another via the `extends` keyword.
+///
+/// See also:
+/// - [ResolvedInheritanceDefinition]
+/// - [UnresolvedInheritanceDefinition]
 abstract class InheritanceDefinition {}
 
+/// A representation of an unresolved inheritance definition.
+///
+/// This is returned by the [ModelParser] when an extends clause is found.
+/// It contains the name of the class that is being extended.
+///
+/// See also:
+/// - [ResolvedInheritanceDefinition]
 class UnresolvedInheritanceDefinition extends InheritanceDefinition {
   final String className;
 
   UnresolvedInheritanceDefinition(this.className);
 }
 
+/// A representation of a resolved inheritance definition.
+///
+/// This is returned by the [EntityDependencyResolver] when the class has been
+/// validated and parsed.
+/// It contains the [ModelClassDefinition] of the class that is being extended.
+///
+/// See also:
+/// - [UnresolvedInheritanceDefinition]
 class ResolvedInheritanceDefinition extends InheritanceDefinition {
   final ModelClassDefinition classDefinition;
 
   ResolvedInheritanceDefinition(this.classDefinition);
+}
+
+/// A base class for all implements definitions.
+///
+/// This is used to store the information about a interface class
+/// that is implemented another class via the `implements` keyword.
+///
+/// See also:
+/// - [ResolvedImplementsDefinition]
+/// - [UnresolvedImplementsDefinition]
+abstract class ImplementsDefinition {}
+
+/// A representation of an unresolved implements definition.
+///
+/// This is returned by the [ModelParser] when one or multiple implements clauses
+/// are found. It contains the name of a single interface class that is being implemented.
+///
+/// See also:
+/// - [ResolvedImplementsDefinition]
+class UnresolvedImplementsDefinition extends ImplementsDefinition {
+  final String className;
+
+  UnresolvedImplementsDefinition(this.className);
+}
+
+/// A representation of a resolved implements definition.
+///
+/// This is returned by the [EntityDependencyResolver] when the interface classes
+/// have been validated and parsed.
+///
+/// See also:
+/// - [UnresolvedImplementsDefinition]
+class ResolvedImplementsDefinition extends ImplementsDefinition {
+  final ClassDefinition interfaceDefinition;
+
+  ResolvedImplementsDefinition(this.interfaceDefinition);
 }
 
 sealed class RelationDefinition {

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -15,6 +15,7 @@ class ModelDependencyResolver {
       if (classDefinition is ModelClassDefinition) {
         _resolveInheritance(classDefinition, modelDefinitions);
       }
+      _resolveImplements(classDefinition, modelDefinitions);
 
       var fields = classDefinition is ModelClassDefinition
           ? classDefinition.fieldsIncludingInherited
@@ -65,6 +66,33 @@ class ModelDependencyResolver {
     parentClass.childClasses.add(
       ResolvedInheritanceDefinition(classDefinition),
     );
+  }
+
+  static void _resolveImplements(
+    ClassDefinition classDefinition,
+    List<SerializableModelDefinition> modelDefinitions,
+  ) {
+    if (classDefinition.isImplementing.isEmpty) {
+      return;
+    }
+
+    var resolvedImplements = <ImplementsDefinition>[];
+
+    for (var implementedClass in classDefinition.isImplementing) {
+      if (implementedClass is! UnresolvedImplementsDefinition) {
+        continue;
+      }
+
+      var interfaceClass = modelDefinitions
+          .whereType<ClassDefinition>()
+          .where((element) => element.className == implementedClass.className)
+          .firstOrNull;
+
+      if (interfaceClass != null) {
+        resolvedImplements.add(ResolvedImplementsDefinition(interfaceClass));
+      }
+    }
+    classDefinition.isImplementing = resolvedImplements;
   }
 
   static void _resolveFieldIndexes(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -10,6 +10,7 @@ import 'package:serverpod_cli/src/analyzer/models/validation/validate_node.dart'
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/class_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart';
 import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart';
+import 'package:serverpod_cli/src/analyzer/models/yaml_definitions/interface_yaml_definition.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generator/types.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
@@ -34,6 +35,7 @@ class SerializableModelAnalyzer {
     Keyword.classType,
     Keyword.exceptionType,
     Keyword.enumType,
+    Keyword.interfaceType,
   };
 
   /// Best effort attempt to extract a model definition from a yaml file.
@@ -70,6 +72,15 @@ class SerializableModelAnalyzer {
       case Keyword.exceptionType:
         return ModelParser.serializeExceptionClassFile(
           Keyword.exceptionType,
+          modelSource,
+          outFileName,
+          documentContents,
+          docsExtractor,
+          extraClasses,
+        );
+      case Keyword.interfaceType:
+        return ModelParser.serializeInterfaceClassFile(
+          Keyword.interfaceType,
           modelSource,
           outFileName,
           documentContents,
@@ -160,6 +171,11 @@ class SerializableModelAnalyzer {
           restrictions,
         ).documentStructure;
         break;
+      case Keyword.interfaceType:
+        documentStructure = InterfaceYamlDefinition(
+          restrictions,
+        ).documentStructure;
+        break;
       case Keyword.enumType:
         documentStructure = EnumYamlDefinition(restrictions).documentStructure;
         break;
@@ -208,6 +224,10 @@ class SerializableModelAnalyzer {
 
     if (documentContents.nodes[Keyword.exceptionType] != null) {
       return Keyword.exceptionType;
+    }
+
+    if (documentContents.nodes[Keyword.interfaceType] != null) {
+      return Keyword.interfaceType;
     }
 
     if (documentContents.nodes[Keyword.enumType] != null) {

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -43,6 +43,7 @@ class ModelParser {
           required bool serverOnly,
           required List<SerializableModelFieldDefinition> fields,
           required List<String>? classDocumentation,
+          required List<ImplementsDefinition> isImplementing,
         }) {
           var indexes = _parseIndexes(documentContents, fields);
 
@@ -60,6 +61,7 @@ class ModelParser {
             documentation: classDocumentation,
             serverOnly: serverOnly,
             type: classType,
+            isImplementing: isImplementing,
           );
         });
   }
@@ -86,6 +88,7 @@ class ModelParser {
         required bool serverOnly,
         required List<SerializableModelFieldDefinition> fields,
         required List<String>? classDocumentation,
+        required List<ImplementsDefinition> isImplementing,
       }) =>
           ExceptionClassDefinition(
         className: className,
@@ -96,6 +99,45 @@ class ModelParser {
         type: classType,
         subDirParts: protocolSource.subDirPathParts,
         documentation: classDocumentation,
+        isImplementing: isImplementing,
+      ),
+    );
+  }
+
+  static SerializableModelDefinition? serializeInterfaceClassFile(
+    String documentTypeName,
+    ModelSource protocolSource,
+    String outFileName,
+    YamlMap documentContents,
+    YamlDocumentationExtractor docsExtractor,
+    List<TypeDefinition> extraClasses,
+  ) {
+    return _initializeFromClassFields(
+      documentTypeName: documentTypeName,
+      protocolSource: protocolSource,
+      outFileName: outFileName,
+      documentContents: documentContents,
+      docsExtractor: docsExtractor,
+      extraClasses: extraClasses,
+      hasTable: false,
+      initialize: ({
+        required String className,
+        required TypeDefinition classType,
+        required bool serverOnly,
+        required List<SerializableModelFieldDefinition> fields,
+        required List<String>? classDocumentation,
+        required List<ImplementsDefinition> isImplementing,
+      }) =>
+          InterfaceClassDefinition(
+        className: className,
+        fields: fields,
+        fileName: outFileName,
+        serverOnly: serverOnly,
+        sourceFileName: protocolSource.yamlSourceUri.path,
+        type: classType,
+        subDirParts: protocolSource.subDirPathParts,
+        documentation: classDocumentation,
+        isImplementing: isImplementing,
       ),
     );
   }
@@ -119,6 +161,7 @@ class ModelParser {
       required bool serverOnly,
       required List<SerializableModelFieldDefinition> fields,
       required List<String>? classDocumentation,
+      required List<ImplementsDefinition> isImplementing,
     }) initialize,
   }) {
     YamlNode? classNode = documentContents.nodes[documentTypeName];
@@ -142,6 +185,8 @@ class ModelParser {
       extraClasses: extraClasses,
     );
 
+    var isImplementing = _parseIsImplementing(documentContents);
+
     var tableName = _parseTableName(documentContents);
     var serverOnly = _parseServerOnly(documentContents);
     var fields = _parseClassFields(
@@ -158,6 +203,7 @@ class ModelParser {
       serverOnly: serverOnly,
       fields: fields,
       classDocumentation: classDocumentation,
+      isImplementing: isImplementing,
     );
   }
 
@@ -211,6 +257,25 @@ class ModelParser {
     if (extendsClass is! String) return null;
 
     return UnresolvedInheritanceDefinition(extendsClass);
+  }
+
+  static List<UnresolvedImplementsDefinition> _parseIsImplementing(
+    YamlMap documentContents,
+  ) {
+    var implementsNode = documentContents.nodes[Keyword.isImplementing];
+
+    if (implementsNode is! YamlScalar) return [];
+
+    // Split the string by commas and trim whitespace
+    var interfaces = implementsNode.value
+        .toString()
+        .split(',')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .map((e) => UnresolvedImplementsDefinition(e))
+        .toList();
+
+    return interfaces;
   }
 
   static bool _parseServerOnly(YamlMap documentContents) {

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/keywords.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/keywords.dart
@@ -2,11 +2,14 @@ class Keyword {
   static const String classType = 'class';
   static const String exceptionType = 'exception';
   static const String enumType = 'enum';
+  static const String interfaceType = 'interface';
 
   static const String serialized = 'serialized';
 
   static const String isSealed = 'sealed';
   static const String extendsClass = 'extends';
+
+  static const String isImplementing = 'implements';
 
   static const String serverOnly = 'serverOnly';
   static const String table = 'table';

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -328,6 +328,134 @@ class Restrictions {
     return [];
   }
 
+  List<SourceSpanSeverityException> validateImplementedInterfaceNames(
+    String parentNodeName,
+    dynamic implementedInterfaceNames,
+    SourceSpan? span,
+  ) {
+    if (implementedInterfaceNames is! String) {
+      return [
+        SourceSpanSeverityException(
+          'The "implements" property must be a comma separated list of class names.',
+          span,
+        )
+      ];
+    }
+
+    var implementedInterfacesList = implementedInterfaceNames
+        .split(',')
+        .map((name) => name.trim())
+        .toList();
+
+    var duplicates = _findDuplicateNames(implementedInterfacesList);
+    if (duplicates.isNotEmpty) {
+      return duplicates
+          .map((interfaceClass) => SourceSpanSeverityException(
+                'The interface name "$interfaceClass" is duplicated.',
+                span,
+              ))
+          .toList();
+    }
+
+    for (var implementedInterface in implementedInterfacesList) {
+      if (_globallyRestrictedKeywords.contains(implementedInterface)) {
+        return [
+          SourceSpanSeverityException(
+            'The interface name "$implementedInterface" is reserved and cannot be used.',
+            span,
+          )
+        ];
+      }
+
+      if (!StringValidators.isValidClassName(implementedInterface)) {
+        return [
+          SourceSpanSeverityException(
+            'The interface name "$implementedInterface" must be a valid class name (e.g. PascalCaseString).',
+            span,
+          )
+        ];
+      }
+
+      var interfaceClass = parsedModels.findByClassName(implementedInterface);
+
+      if (interfaceClass == null) {
+        return [
+          SourceSpanSeverityException(
+            'The implemented interface name "$implementedInterface" was not found in any model.',
+            span,
+          )
+        ];
+      }
+
+      if (interfaceClass is! InterfaceClassDefinition) {
+        return [
+          SourceSpanSeverityException(
+            'The implemented node "$implementedInterface" is not an interface.',
+            span,
+          )
+        ];
+      }
+    }
+
+    if (documentDefinition is InterfaceClassDefinition) {
+      var circularPath = _detectCircularInterfaceDependency(
+        documentDefinition as ClassDefinition,
+        [],
+        {},
+      );
+
+      if (circularPath.isNotEmpty) {
+        return [
+          SourceSpanSeverityException(
+            'Circular interface dependency detected: ${circularPath.join(' → ')}',
+            span,
+          )
+        ];
+      }
+    }
+
+    return [];
+  }
+
+  List<String> _findDuplicateNames(List<String> list) {
+    var seen = <String>{};
+    var duplicates = <String>{};
+
+    for (var item in list) {
+      if (!seen.add(item)) {
+        duplicates.add(item);
+      }
+    }
+
+    return duplicates.toList();
+  }
+
+  List<String> _detectCircularInterfaceDependency(
+      ClassDefinition current, List<String> path, Set<String> visited) {
+    var className = current.className;
+
+    if (path.contains(className)) {
+      return [...path.sublist(path.indexOf(className)), className];
+    }
+
+    if (visited.contains(className)) {
+      return [];
+    }
+
+    path.add(className);
+    visited.add(className);
+
+    for (var interfaceImpl in current.implementedInterfaces) {
+      var result = _detectCircularInterfaceDependency(
+          interfaceImpl, List.from(path), visited);
+      if (result.isNotEmpty) {
+        return result;
+      }
+    }
+
+    return [];
+  }
+
   List<SourceSpanSeverityException> validateParentKey(
     String parentNodeName,
     String _,
@@ -515,6 +643,34 @@ class Restrictions {
           return [
             SourceSpanSeverityException(
               'The field name "$fieldName" is already defined in an inherited class ("${parentClassWithDuplicatedFieldName.className}").',
+              span,
+            )
+          ];
+        }
+      }
+    }
+
+    if (def is ClassDefinition && def.implementedInterfaces.isNotEmpty) {
+      for (var interfaceClass in def.implementedInterfaces) {
+        if (interfaceClass is! InterfaceClassDefinition) {
+          continue;
+        }
+
+        var duplicateInterfaceField = interfaceClass.fields
+            .where((field) => field.name == fieldName)
+            .firstOrNull;
+
+        if (duplicateInterfaceField == null) {
+          continue;
+        }
+
+        var duplicateClassField =
+            def.fields.where((field) => field.name == fieldName).firstOrNull;
+
+        if (duplicateClassField != null && !duplicateClassField.hasDefaults) {
+          return [
+            SourceSpanSeverityException(
+              'Field "$fieldName" from interface "${interfaceClass.className}" must have a default value when redefined in the implementing class. Either set a default value or remove the field from the implementing class.',
               span,
             )
           ];

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/exception_yaml_definition.dart
@@ -26,6 +26,10 @@ class ExceptionYamlDefinition {
         valueRestriction: BooleanValueRestriction().validate,
       ),
       ValidateNode(
+        Keyword.isImplementing,
+        valueRestriction: restrictions.validateImplementedInterfaceNames,
+      ),
+      ValidateNode(
         Keyword.fields,
         isRequired: false,
         nested: {

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/interface_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/interface_yaml_definition.dart
@@ -1,64 +1,25 @@
-import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/keywords.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions/base.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions/default.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/restrictions/scope.dart';
 import 'package:serverpod_cli/src/analyzer/models/validation/validate_node.dart';
-import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 
-class ClassYamlDefinition {
+class InterfaceYamlDefinition {
   late Set<ValidateNode> documentStructure;
 
-  ValidateNode get fieldStructure {
-    return documentStructure
-        .firstWhere((element) => element.key == Keyword.fields)
-        .nested
-        .first;
-  }
-
-  ClassYamlDefinition(Restrictions restrictions) {
+  InterfaceYamlDefinition(Restrictions restrictions) {
     documentStructure = {
       ValidateNode(
-        Keyword.classType,
+        Keyword.interfaceType,
         isRequired: true,
         valueRestriction: restrictions.validateClassName,
       ),
       ValidateNode(
-        Keyword.isSealed,
-        valueRestriction: BooleanValueRestriction().validate,
-        mutuallyExclusiveKeys: {
-          Keyword.table,
-        },
-        isHidden: !restrictions.config
-            .isExperimentalFeatureEnabled(ExperimentalFeature.inheritance),
-      ),
-      ValidateNode(
-        Keyword.extendsClass,
-        valueRestriction: restrictions.validateExtendingClassName,
-        isHidden: !restrictions.config
-            .isExperimentalFeatureEnabled(ExperimentalFeature.inheritance),
-      ),
-      ValidateNode(
         Keyword.isImplementing,
         valueRestriction: restrictions.validateImplementedInterfaceNames,
-      ),
-      ValidateNode(
-        Keyword.table,
-        keyRestriction: restrictions.validateTableNameKey,
-        valueRestriction: restrictions.validateTableName,
-        mutuallyExclusiveKeys: {
-          Keyword.isSealed,
-        },
-      ),
-      ValidateNode(
-        Keyword.managedMigration,
-        valueRestriction: BooleanValueRestriction().validate,
-      ),
-      ValidateNode(
-        Keyword.serverOnly,
-        valueRestriction: BooleanValueRestriction().validate,
       ),
       ValidateNode(
         Keyword.fields,
@@ -199,30 +160,6 @@ class ClassYamlDefinition {
               ),
             },
           ),
-        },
-      ),
-      ValidateNode(
-        Keyword.indexes,
-        nested: {
-          ValidateNode(
-            Keyword.any,
-            keyRestriction: restrictions.validateTableIndexName,
-            nested: {
-              ValidateNode(
-                Keyword.fields,
-                isRequired: true,
-                valueRestriction: restrictions.validateIndexFieldsValue,
-              ),
-              ValidateNode(
-                Keyword.type,
-                valueRestriction: restrictions.validateIndexType,
-              ),
-              ValidateNode(
-                Keyword.unique,
-                valueRestriction: BooleanValueRestriction().validate,
-              ),
-            },
-          )
         },
       ),
     };

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -3,6 +3,7 @@ import 'package:path/path.dart' as p;
 import 'package:recase/recase.dart';
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/database/create_definition.dart';
 import 'package:serverpod_cli/src/generator/shared.dart';
@@ -40,8 +41,10 @@ class LibraryGenerator {
       return isSealedTopNode || isNotPartOfSealedHierarchy;
     }).toList();
 
-    var unsealedModels = allModels
-        .where((model) => !(model is ModelClassDefinition && model.isSealed))
+    var serializableModels = allModels
+        .where((model) =>
+            !(model is ModelClassDefinition && model.isSealed) &&
+            (model is! InterfaceClassDefinition))
         .toList();
 
     // exports
@@ -139,14 +142,14 @@ class LibraryGenerator {
         ..body = Block.of([
           const Code('t ??= T;'),
           ...(<Expression, Code>{
-            for (var classInfo in unsealedModels)
+            for (var classInfo in serializableModels)
               refer(
                   classInfo.className,
                   TypeDefinition.getRef(
                       classInfo)): Code.scope((a) =>
                   '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
                   '.fromJson(data) as T'),
-            for (var classInfo in unsealedModels)
+            for (var classInfo in serializableModels)
               refer('getType', serverpodUrl(serverCode)).call([], {}, [
                 TypeReference(
                   (b) => b
@@ -158,7 +161,7 @@ class LibraryGenerator {
                   '${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}'
                   '.fromJson(data) :null) as T'),
           }..addEntries([
-                  for (var classInfo in unsealedModels)
+                  for (var classInfo in serializableModels)
                     // Generate deserialization for fields of models.
                     if (classInfo is ClassDefinition)
                       for (var field in classInfo.fields.where(
@@ -216,7 +219,7 @@ class LibraryGenerator {
           for (var extraClass in config.extraClasses)
             Code.scope((a) =>
                 'if(data is ${a(extraClass.reference(serverCode, config: config))}) {return \'${extraClass.className}\';}'),
-          for (var classInfo in unsealedModels)
+          for (var classInfo in serializableModels)
             Code.scope((a) =>
                 'if(data is ${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}) {return \'${classInfo.className}\';}'),
           if (config.name != 'serverpod' && serverCode)
@@ -251,7 +254,7 @@ class LibraryGenerator {
             Code.scope((a) =>
                 'if(dataClassName == \'${extraClass.className}\'){'
                 'return deserialize<${a(extraClass.reference(serverCode, config: config))}>(data[\'data\']);}'),
-          for (var classInfo in unsealedModels)
+          for (var classInfo in serializableModels)
             Code.scope((a) => 'if(dataClassName == \'${classInfo.className}\'){'
                 'return deserialize<${a(refer(classInfo.className, TypeDefinition.getRef(classInfo)))}>(data[\'data\']);}'),
           if (config.name != 'serverpod' && serverCode)

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -47,11 +47,21 @@ class SerializableModelLibraryGenerator {
         return _generateExceptionLibrary(classDefinition);
       case ModelClassDefinition():
         return _generateModelClassLibrary(classDefinition);
+      case InterfaceClassDefinition():
+        return _generateInterfaceLibrary(classDefinition);
     }
   }
 
+  Library _generateInterfaceLibrary(InterfaceClassDefinition definition) {
+    return Library((libraryBuilder) {
+      libraryBuilder.body.addAll([
+        _buildInterfaceClass(definition),
+      ]);
+    });
+  }
+
   Library _generateExceptionLibrary(ExceptionClassDefinition definition) {
-    var fields = definition.fields;
+    var fields = definition.fieldsIncludingImplemented;
     var className = definition.className;
     var nonNullableField = fields
         .where((field) => field.shouldIncludeField(serverCode))
@@ -85,7 +95,7 @@ class SerializableModelLibraryGenerator {
   ) {
     String? tableName = classDefinition.tableName;
     var className = classDefinition.className;
-    var fields = classDefinition.fieldsIncludingInherited;
+    var fields = classDefinition.allFields;
     var sealedTopNode = classDefinition.sealedTopNode;
 
     var buildRepository = BuildRepositoryClass(
@@ -191,6 +201,36 @@ class SerializableModelLibraryGenerator {
     );
   }
 
+  Class _buildInterfaceClass(InterfaceClassDefinition definition) {
+    return Class((classBuilder) {
+      classBuilder
+        ..abstract = true
+        ..modifier = ClassModifier.interface
+        ..name = definition.className
+        ..docs.addAll(definition.documentation ?? []);
+
+      classBuilder.implements.addAll(_buildImplementClauses(definition));
+
+      classBuilder.fields.addAll(_buildModelClassFields(
+        definition.fields,
+        null,
+        definition.subDirParts,
+        definition.implementedFields,
+      ));
+
+      classBuilder.constructors.add(
+        _buildModelClassConstructor(
+          definition.fields,
+          null,
+          isParentClass: false,
+          isInterface: true,
+          subDirParts: definition.subDirParts,
+          inheritedFields: [],
+        ),
+      );
+    });
+  }
+
   Class _buildExceptionClass(
     String className,
     ExceptionClassDefinition classDefinition,
@@ -209,15 +249,18 @@ class SerializableModelLibraryGenerator {
       classBuilder.implements
           .add(refer('SerializableModel', serverpodUrl(serverCode)));
 
+      classBuilder.implements.addAll(_buildImplementClauses(classDefinition));
+
       if (serverCode) {
         classBuilder.implements
             .add(refer('ProtocolSerialization', serverpodUrl(serverCode)));
       }
 
       classBuilder.fields.addAll(_buildModelClassFields(
-        classDefinition.fields,
+        fields,
         null,
         classDefinition.subDirParts,
+        classDefinition.implementedFields,
       ));
 
       classBuilder.constructors.addAll([
@@ -226,6 +269,7 @@ class SerializableModelLibraryGenerator {
           null,
           isParentClass: false,
           subDirParts: classDefinition.subDirParts,
+          isInterface: false,
           inheritedFields: [],
         ),
         _buildModelClassFactoryConstructor(
@@ -327,10 +371,13 @@ class SerializableModelLibraryGenerator {
             .add(refer('ProtocolSerialization', serverpodUrl(serverCode)));
       }
 
+      classBuilder.implements.addAll(_buildImplementClauses(classDefinition));
+
       classBuilder.fields.addAll(_buildModelClassFields(
-        classDefinition.fields,
+        classDefinition.fieldsIncludingImplemented,
         tableName,
         classDefinition.subDirParts,
+        classDefinition.implementedFields,
       ));
 
       classBuilder.constructors.addAll([
@@ -338,6 +385,7 @@ class SerializableModelLibraryGenerator {
           fields,
           tableName,
           isParentClass: classDefinition.isParentClass,
+          isInterface: false,
           subDirParts: classDefinition.subDirParts,
           inheritedFields: classDefinition.inheritedFields,
         ),
@@ -406,6 +454,22 @@ class SerializableModelLibraryGenerator {
         classBuilder.methods.add(_buildToStringMethod(serverCode));
       }
     });
+  }
+
+  List<Reference> _buildImplementClauses(ClassDefinition classDefinition) {
+    if (classDefinition.implementedInterfaces.isEmpty) {
+      return [];
+    }
+
+    return classDefinition.implementedInterfaces
+        .map(
+          (e) => e.type.reference(
+            serverCode,
+            subDirParts: classDefinition.subDirParts,
+            config: config,
+          ),
+        )
+        .toList();
   }
 
   bool _shouldCreateUndefinedClass(
@@ -1256,11 +1320,12 @@ class SerializableModelLibraryGenerator {
     List<SerializableModelFieldDefinition> fields,
     String? tableName, {
     required bool isParentClass,
+    required bool isInterface,
     required List<String> subDirParts,
     required List<SerializableModelFieldDefinition> inheritedFields,
   }) {
     return Constructor((c) {
-      if (!isParentClass) {
+      if (!isParentClass && !isInterface) {
         c.name = '_';
       }
       c.optionalParameters.addAll(_buildModelClassConstructorParameters(
@@ -1483,9 +1548,11 @@ class SerializableModelLibraryGenerator {
   }
 
   List<Field> _buildModelClassFields(
-      List<SerializableModelFieldDefinition> fields,
-      String? tableName,
-      List<String> subDirParts) {
+    List<SerializableModelFieldDefinition> fields,
+    String? tableName,
+    List<String> subDirParts,
+    List<SerializableModelFieldDefinition> implementedFields,
+  ) {
     List<Field> modelClassFields = [];
     var classFields = fields
         .where((f) =>
@@ -1504,6 +1571,13 @@ class SerializableModelLibraryGenerator {
           ..name =
               _createSerializableFieldNameReference(serverCode, field).symbol
           ..docs.addAll(field.documentation ?? []);
+
+        var isInterfaceField =
+            implementedFields.any((element) => element.name == field.name);
+
+        if (isInterfaceField) {
+          f.annotations.add(refer('override'));
+        }
       }));
     }
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
@@ -264,7 +264,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'The "table" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.',
+          'The "table" property is not allowed for exception type. Valid keys are {exception, serverOnly, implements, fields}.',
         );
       },
     );
@@ -409,7 +409,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'The "indexes" property is not allowed for exception type. Valid keys are {exception, serverOnly, fields}.',
+          'The "indexes" property is not allowed for exception type. Valid keys are {exception, serverOnly, implements, fields}.',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/inheritance_test.dart
@@ -170,7 +170,7 @@ void main() {
       var error = collector.errors.first;
       expect(
         error.message,
-        'The "extends" property is not allowed for class type. Valid keys are {class, table, managedMigration, serverOnly, fields, indexes}.',
+        'The "extends" property is not allowed for class type. Valid keys are {class, implements, table, managedMigration, serverOnly, fields, indexes}.',
       );
     });
 
@@ -509,7 +509,7 @@ void main() {
     var error = collector.errors.first;
     expect(
       error.message,
-      'The "sealed" property is not allowed for class type. Valid keys are {class, table, managedMigration, serverOnly, fields, indexes}.',
+      'The "sealed" property is not allowed for class type. Valid keys are {class, implements, table, managedMigration, serverOnly, fields, indexes}.',
     );
   });
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/interface_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/interface_test.dart
@@ -1,0 +1,445 @@
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/model_source_builder.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().withEnabledExperimentalFeatures(
+      [ExperimentalFeature.inheritance]).build();
+
+  group('Interface Class Tests', () {
+    test(
+        'Given an interface class, when the class name is not a valid class name, then an error is collected that the name is not valid',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          interface: example
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The "interface" type must be a valid class name (e.g. PascalCaseString).',
+      );
+    });
+
+    test(
+        'Given an interface class, when the class name is a reserved keyword, then an error is collected that the class name is reserved',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          interface: List
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The class name "List" is reserved and cannot be used.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing a single valid interface, then no errors are collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: ValidInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: ValidInterface
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing multiple interfaces, then no errors are collected if all interfaces are valid',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: Interface1, Interface2
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: Interface1
+          fields:
+            id: int
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface2').withYaml(
+          '''
+          interface: Interface2
+          fields:
+            age: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing a non-existent interface, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: NonExistentInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The implemented interface name "NonExistentInterface" was not found in any model.',
+      );
+    });
+
+    test(
+        'Given a class, when implementing duplicate interfaces, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: DuplicateInterface, DuplicateInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: DuplicateInterface
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+      expect(
+        error.message,
+        'The interface name "DuplicateInterface" is duplicated.',
+      );
+    });
+
+    test(
+        'Given a class implementing a non-interface class, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1 ').withYaml(
+          '''
+          class: ExampleClass
+          implements: NonInterfaceClass
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('non_interface_class').withYaml(
+          '''
+          class: NonInterfaceClass
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isNotEmpty,
+        reason: 'Expected an error but none was generated.',
+      );
+
+      var error = collector.errors.first;
+
+      expect(
+        error.message,
+        'The implemented node "NonInterfaceClass" is not an interface.',
+      );
+    });
+
+    test(
+        'Given an exception implementing a valid interface, when generating code, then no errors are collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleException
+          implements: ValidInterface
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: ValidInterface
+          fields:
+            id: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+    });
+
+    test(
+        'Given a class implementing an interface, when the interface also implements another interface, then no errors are collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          class: ExampleClass
+          implements: Interface1, Interface2
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+          interface: Interface1
+          implements: Interface2
+          fields:
+            age: int
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface2').withYaml(
+          '''
+          interface: Interface2
+          fields:
+            createdAt: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(collector.errors, isEmpty);
+    });
+
+    test(
+        'Given a class implementing an interface and assigning a default value to a field from the interface, when generating code, then no errors are collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+        class: ExampleClass
+        implements: Interface1
+        fields:
+          status: String, default='active'
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+        interface: Interface1
+        fields:
+          status: String
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(collector.errors, isEmpty);
+    });
+
+    test(
+        'Given a class implementing an interface with a duplicate field without default value, when generating code, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+        class: ExampleClass
+        implements: Interface1
+        fields:
+          status: String
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+        interface: Interface1
+        fields:
+          status: String
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      expect(collector.errors, isNotEmpty);
+
+      var error = collector.errors.first;
+      expect(error.message,
+          'Field "status" from interface "Interface1" must have a default value when redefined in the implementing class. Either set a default value or remove the field from the implementing class.');
+    });
+
+    test(
+        'Given a circular interface dependency, when generating code, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('example1').withYaml(
+          '''
+          interface: Interface1
+          implements: Interface2
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface2').withYaml(
+          '''
+          interface: Interface2
+          implements: Interface1
+          fields:
+            age: int
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      var error = collector.errors.first;
+      expect(error.message,
+          'Circular interface dependency detected: Interface1 → Interface2 → Interface1');
+    });
+
+    test(
+        'Given a complex circular interface dependency with 3 interfaces, when generating code, then an error is collected',
+        () {
+      var modelSources = [
+        ModelSourceBuilder().withFileName('interface1').withYaml(
+          '''
+        interface: Interface1
+        implements: Interface2
+        fields:
+          name: String
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface2').withYaml(
+          '''
+        interface: Interface2
+        implements: Interface3
+        fields:
+          age: int
+        ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('interface3').withYaml(
+          '''
+        interface: Interface3
+        implements: Interface1
+        fields:
+          isActive: bool
+        ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      StatefulAnalyzer(config, modelSources, onErrorsCollector(collector))
+          .validateAll();
+
+      var error = collector.errors.first;
+      expect(error.message,
+          'Circular interface dependency detected: Interface1 → Interface2 → Interface3 → Interface1');
+    });
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_types_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_types_test.dart
@@ -320,7 +320,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'No {class, exception, enum} type is defined.',
+          'No {class, exception, enum, interface} type is defined.',
         );
       },
     );

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/interface_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/interface_class_test.dart
@@ -1,0 +1,539 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/exception_class_definition_builder.dart';
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/interface_class_definition_builder.dart';
+import '../../../test_util/builders/model_class_definition_builder.dart';
+import '../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  String getExpectedFilePath(String fileName, {List<String>? subDirParts}) =>
+      p.joinAll([
+        'lib',
+        'src',
+        'generated',
+        ...?subDirParts,
+        '$fileName.dart',
+      ]);
+
+  group('Given an interface and a class implementing it, when generating code',
+      () {
+    var exampleInterface = InterfaceClassDefinitionBuilder()
+        .withClassName('ExampleInterface')
+        .withFileName('example_interface')
+        .withSimpleField('age', 'int', nullable: true)
+        .build();
+
+    var exampleClass = ModelClassDefinitionBuilder()
+        .withClassName('Example')
+        .withFileName('example')
+        .withSimpleField('name', 'String')
+        .withImplementedInterfaces([exampleInterface]).build();
+
+    var models = [
+      exampleClass,
+      exampleInterface,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var exampleClassCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exampleClass.fileName)]!)
+        .unit;
+    var exampleInterfaceCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exampleInterface.fileName)]!)
+        .unit;
+
+    group('Then the ${exampleInterface.className}', () {
+      var exampleInterfaceDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exampleInterfaceCompilationUnit,
+        name: exampleInterface.className,
+      );
+
+      test('is defined', () {
+        expect(exampleInterfaceDeclaration, isNotNull);
+      });
+
+      group('does have a constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exampleInterfaceDeclaration!,
+          name: null,
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test('with the passed params', () {
+          expect(constructor?.parameters.toSource(), '({this.age})');
+        });
+      });
+
+      group('has a field definition', () {
+        var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'age',
+        );
+
+        test('defined', () {
+          expect(field, isNotNull);
+        });
+
+        test('without override annotation', () {
+          expect(field?.toSource().contains('override'), false);
+        });
+      });
+
+      test('does NOT have a copyWith method', () {
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'copyWith',
+        );
+
+        expect(copyWithMethod, isNull);
+      });
+
+      test('does NOT have a toJson method', () {
+        var toJsonMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'toJson',
+        );
+
+        expect(toJsonMethod, isNull);
+      });
+
+      test('does NOT have a toJsonForProtocol method', () {
+        var toJsonForProtocolMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'toJsonForProtocol',
+        );
+
+        expect(toJsonForProtocolMethod, isNull);
+      });
+
+      test('does NOT have a toString method', () {
+        var toStringMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleInterfaceDeclaration!,
+          name: 'toString',
+        );
+
+        expect(toStringMethod, isNull);
+      });
+    });
+
+    group('Then the ${exampleClass.className}', () {
+      var exampleClassDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exampleClassCompilationUnit,
+        name: exampleClass.className,
+      );
+
+      test('is defined', () {
+        expect(exampleClassDeclaration, isNotNull);
+      });
+
+      test('implements ${exampleInterface.className}', () {
+        var implementsDirective =
+            CompilationUnitHelpers.tryFindImplementedClass(
+          exampleClassDeclaration!,
+          name: exampleInterface.className,
+        );
+
+        expect(
+          implementsDirective,
+          isNotNull,
+        );
+      });
+
+      group('has a private constructor', () {
+        var privateConstructor =
+            CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exampleClassDeclaration!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(privateConstructor, isNotNull);
+        });
+
+        test('with vars as params from interface and itself', () {
+          expect(
+            privateConstructor?.parameters.toSource(),
+            '({this.age, required this.name})',
+          );
+        });
+      });
+
+      group('has its own fields defined', () {
+        var ownField = CompilationUnitHelpers.tryFindFieldDeclaration(
+          exampleClassDeclaration!,
+          name: 'name',
+        );
+
+        test('without override annotation', () {
+          expect(ownField?.toSource().contains('override'), false);
+        });
+      });
+
+      group('has fields from the interface', () {
+        var interfaceField = CompilationUnitHelpers.tryFindFieldDeclaration(
+          exampleClassDeclaration!,
+          name: 'age',
+        );
+
+        test('defined', () {
+          expect(interfaceField, isNotNull);
+        });
+
+        test('with override annotation', () {
+          expect(interfaceField?.toSource().contains('override'), true);
+        });
+      });
+
+      test('does have a copyWith method', () {
+        var copyWithMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'copyWith',
+        );
+
+        expect(copyWithMethod, isNotNull);
+      });
+
+      test('does have a toJson method', () {
+        var toJsonMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'toJson',
+        );
+
+        expect(toJsonMethod, isNotNull);
+      });
+
+      test('does have a toJsonForProtocol method', () {
+        var toJsonForProtocolMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'toJsonForProtocol',
+        );
+
+        expect(toJsonForProtocolMethod, isNotNull);
+      });
+
+      test('does have a toString method', () {
+        var toStringMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          exampleClassDeclaration!,
+          name: 'toString',
+        );
+
+        expect(toStringMethod, isNotNull);
+      });
+    });
+  });
+
+  group('Given a parent class implementing an interface, when generating code',
+      () {
+    var interfaceClass = InterfaceClassDefinitionBuilder()
+        .withClassName('ExampleInterface')
+        .withFileName('example_interface')
+        .withSimpleField('age', 'int', nullable: true)
+        .build();
+
+    var parent = ModelClassDefinitionBuilder()
+        .withClassName('ExampleParent')
+        .withFileName('example_parent')
+        .withSimpleField('name', 'String')
+        .withImplementedInterfaces([interfaceClass]).build();
+
+    var child = ModelClassDefinitionBuilder()
+        .withClassName('ExampleChild')
+        .withFileName('example_child')
+        .withSimpleField('foo', 'int')
+        .withExtendsClass(parent)
+        .build();
+
+    parent.childClasses.add(ResolvedInheritanceDefinition(child));
+
+    var models = [
+      parent,
+      child,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var childCompilationUnit =
+        parseString(content: codeMap[getExpectedFilePath(child.fileName)]!)
+            .unit;
+
+    group('Then the ${child.className} ', () {
+      var childClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        childCompilationUnit,
+        name: child.className,
+      );
+
+      test('is defined', () {
+        expect(childClass, isNotNull);
+      });
+
+      group('has a private constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          childClass!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test('with vars as params from interface, parent and itself', () {
+          expect(
+            constructor?.parameters.toSource(),
+            '({super.age, required super.name, required this.foo})',
+          );
+        });
+      });
+    });
+  });
+
+  group(
+      'Given a class implementing an interface that implements another interface, when generating code',
+      () {
+    var parentInterface = InterfaceClassDefinitionBuilder()
+        .withClassName('ParentInterface')
+        .withFileName('parent_interface')
+        .withSimpleField('parentField', 'String')
+        .build();
+
+    var childInterface = InterfaceClassDefinitionBuilder()
+        .withClassName('ChildInterface')
+        .withFileName('child_interface')
+        .withSimpleField('childField', 'String')
+        .withImplementedInterfaces([parentInterface]).build();
+
+    var exampleClass = ModelClassDefinitionBuilder()
+        .withClassName('Example')
+        .withFileName('example')
+        .withSimpleField('name', 'String')
+        .withImplementedInterfaces([childInterface]).build();
+
+    var models = [
+      exampleClass,
+      parentInterface,
+      childInterface,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var exampleClassCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exampleClass.fileName)]!)
+        .unit;
+
+    group('Then the ${exampleClass.className}', () {
+      var exampleClassDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exampleClassCompilationUnit,
+        name: exampleClass.className,
+      );
+
+      test('is defined', () {
+        expect(exampleClassDeclaration, isNotNull);
+      });
+
+      test('implements ${childInterface.className}', () {
+        var implementsDirective =
+            CompilationUnitHelpers.tryFindImplementedClass(
+          exampleClassDeclaration!,
+          name: childInterface.className,
+        );
+
+        expect(implementsDirective, isNotNull);
+      });
+
+      group('has a private constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exampleClassDeclaration!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test(
+            'with vars as params from child interface, parent interface and itself',
+            () {
+          expect(
+            constructor?.parameters.toSource(),
+            '({required this.parentField, required this.childField, required this.name})',
+          );
+        });
+      });
+    });
+  });
+  group('Given an exception implementing an interface, when generating code',
+      () {
+    var interfaceClass = InterfaceClassDefinitionBuilder()
+        .withClassName('ExampleInterface')
+        .withFileName('example_interface')
+        .withSimpleField('age', 'int', nullable: true)
+        .build();
+
+    var exceptionClass = ExceptionClassDefinitionBuilder()
+        .withClassName('ExampleException')
+        .withFileName('example_exception')
+        .withSimpleField('name', 'String')
+        .withImplementedInterfaces([interfaceClass]).build();
+
+    var models = [
+      exceptionClass,
+      interfaceClass,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var exceptionCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exceptionClass.fileName)]!)
+        .unit;
+
+    group('Then the ${exceptionClass.className}', () {
+      var exceptionClassDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exceptionCompilationUnit,
+        name: exceptionClass.className,
+      );
+
+      test('is defined', () {
+        expect(exceptionClassDeclaration, isNotNull);
+      });
+
+      test('implements ${interfaceClass.className}', () {
+        var implementsDirective =
+            CompilationUnitHelpers.tryFindImplementedClass(
+          exceptionClassDeclaration!,
+          name: interfaceClass.className,
+        );
+
+        expect(implementsDirective, isNotNull);
+      });
+
+      group('has a private constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exceptionClassDeclaration!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test('with vars as params from interface and itself', () {
+          expect(
+            constructor?.parameters.toSource(),
+            '({this.age, required this.name})',
+          );
+        });
+      });
+
+      group('has its own fields defined', () {
+        var ownField = CompilationUnitHelpers.tryFindFieldDeclaration(
+          exceptionClassDeclaration!,
+          name: 'name',
+        );
+
+        test('without override annotation', () {
+          expect(ownField?.toSource().contains('override'), false);
+        });
+      });
+
+      group('has fields from the interface', () {
+        var interfaceField = CompilationUnitHelpers.tryFindFieldDeclaration(
+          exceptionClassDeclaration!,
+          name: 'age',
+        );
+
+        test('defined', () {
+          expect(interfaceField, isNotNull);
+        });
+
+        test('with override annotation', () {
+          expect(interfaceField?.toSource().contains('override'), true);
+        });
+      });
+    });
+  });
+
+  group(
+      'Given a class implementing an interface and assigning a default value to a field from the interface, when generating code',
+      () {
+    var interfaceClass = InterfaceClassDefinitionBuilder()
+        .withClassName('ExampleInterface')
+        .withFileName('example_interface')
+        .withSimpleField('status', 'String')
+        .build();
+
+    var exampleClass = ModelClassDefinitionBuilder()
+        .withClassName('Example')
+        .withFileName('example')
+        .withSimpleField('name', 'String')
+        .withSimpleField('status', 'String', defaultValue: 'active')
+        .withImplementedInterfaces([interfaceClass]).build();
+
+    var models = [
+      exampleClass,
+      interfaceClass,
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var exampleClassCompilationUnit = parseString(
+            content: codeMap[getExpectedFilePath(exampleClass.fileName)]!)
+        .unit;
+
+    group('Then the ${exampleClass.className}', () {
+      var exampleClassDeclaration =
+          CompilationUnitHelpers.tryFindClassDeclaration(
+        exampleClassCompilationUnit,
+        name: exampleClass.className,
+      );
+
+      group('has a constructor', () {
+        var constructor = CompilationUnitHelpers.tryFindConstructorDeclaration(
+          exampleClassDeclaration!,
+          name: '_',
+        );
+
+        test('defined', () {
+          expect(constructor, isNotNull);
+        });
+
+        test('with a default value for the field from the interface', () {
+          expect(constructor?.initializers.toString(),
+              contains('status = status ?? active'));
+        });
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/interface_protocol_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/protocol/interface_protocol_test.dart
@@ -1,0 +1,145 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/endpoint_definition_builder.dart';
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/interface_class_definition_builder.dart';
+import '../../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+void main() {
+  var expectedFileName = path.join(
+    'lib',
+    'src',
+    'generated',
+    'protocol.dart',
+  );
+
+  group('Given an interface class when generating code', () {
+    var interfaceName = 'ExampleInterface';
+    var interfaceFileName = 'example_interface';
+
+    var interfaceClass = InterfaceClassDefinitionBuilder()
+        .withClassName(interfaceName)
+        .withFileName(interfaceFileName)
+        .build();
+
+    var models = [
+      interfaceClass,
+    ];
+
+    var endpoints = [
+      EndpointDefinitionBuilder().build(),
+    ];
+
+    var protocolDefinition =
+        ProtocolDefinition(endpoints: endpoints, models: models);
+
+    var codeMap = generator.generateProtocolCode(
+      protocolDefinition: protocolDefinition,
+      config: config,
+    );
+
+    var protocolCompilationUnit =
+        parseString(content: codeMap[expectedFileName]!).unit;
+
+    var protocolClass = CompilationUnitHelpers.tryFindClassDeclaration(
+      protocolCompilationUnit,
+      name: 'Protocol',
+    );
+
+    test(
+      'then the protocol.dart file is created.',
+      () {
+        expect(protocolClass, isNotNull);
+      },
+    );
+
+    group('then the protocol.dart file', () {
+      test('does NOT import the $interfaceFileName', () {
+        var interfaceImport = CompilationUnitHelpers.tryFindImportDirective(
+          protocolCompilationUnit,
+          uri: '$interfaceFileName.dart',
+        );
+
+        expect(interfaceImport, isNull);
+      });
+
+      test('does export the $interfaceFileName', () {
+        var interfaceExport = CompilationUnitHelpers.tryFindExportDirective(
+          protocolCompilationUnit,
+          uri: '$interfaceFileName.dart',
+        );
+        expect(interfaceExport, isNotNull);
+      });
+    });
+
+    group('then the Protocol class', () {
+      test('is defined', () {
+        expect(protocolClass, isNotNull);
+      });
+
+      group('with a deserialize method', () {
+        var deserializeMethod = CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'deserialize',
+        );
+
+        test('is defined', () {
+          expect(deserializeMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName.fromJson', () {
+          expect(
+            deserializeMethod!.toSource().contains('$interfaceName.fromJson'),
+            isFalse,
+          );
+        });
+      });
+
+      group('with a getClassNameForObject method', () {
+        var getClassNameForObjectMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'getClassNameForObject',
+        );
+
+        test('is defined', () {
+          expect(getClassNameForObjectMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName', () {
+          expect(
+            getClassNameForObjectMethod!.toSource().contains(interfaceName),
+            isFalse,
+          );
+        });
+      });
+
+      group('with a deserializeByClassName method', () {
+        var deserializeByClassNameMethod =
+            CompilationUnitHelpers.tryFindMethodDeclaration(
+          protocolClass!,
+          name: 'deserializeByClassName',
+        );
+
+        test('is defined', () {
+          expect(deserializeByClassNameMethod, isNotNull);
+        });
+
+        test('that does NOT return $interfaceName', () {
+          expect(
+            deserializeByClassNameMethod!.toSource().contains(interfaceName),
+            isFalse,
+          );
+        });
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/test_util/builders/interface_class_definition_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/interface_class_definition_builder.dart
@@ -5,7 +5,7 @@ import 'type_definition_builder.dart';
 
 typedef _FieldBuilder = SerializableModelFieldDefinition Function();
 
-class ExceptionClassDefinitionBuilder {
+class InterfaceClassDefinitionBuilder {
   String _fileName;
   String _sourceFileName;
   String _className;
@@ -14,7 +14,8 @@ class ExceptionClassDefinitionBuilder {
   List<_FieldBuilder> _fields;
   List<String>? _documentation;
   List<ResolvedImplementsDefinition> _isImplementing;
-  ExceptionClassDefinitionBuilder()
+
+  InterfaceClassDefinitionBuilder()
       : _fileName = 'example',
         _sourceFileName = 'example.yaml',
         _className = 'Example',
@@ -23,8 +24,8 @@ class ExceptionClassDefinitionBuilder {
         _serverOnly = false,
         _isImplementing = [];
 
-  ExceptionClassDefinition build() {
-    return ExceptionClassDefinition(
+  InterfaceClassDefinition build() {
+    return InterfaceClassDefinition(
       fileName: _fileName,
       sourceFileName: _sourceFileName,
       className: _className,
@@ -37,17 +38,12 @@ class ExceptionClassDefinitionBuilder {
     );
   }
 
-  ExceptionClassDefinitionBuilder withFileName(String fileName) {
+  InterfaceClassDefinitionBuilder withFileName(String fileName) {
     _fileName = fileName;
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withSourceFileName(String sourceFileName) {
-    _sourceFileName = sourceFileName;
-    return this;
-  }
-
-  ExceptionClassDefinitionBuilder withSimpleField(
+  InterfaceClassDefinitionBuilder withSimpleField(
     String fieldName,
     String type, {
     dynamic defaultValue,
@@ -63,41 +59,46 @@ class ExceptionClassDefinitionBuilder {
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withClassName(String className) {
+  InterfaceClassDefinitionBuilder withSourceFileName(String sourceFileName) {
+    _sourceFileName = sourceFileName;
+    return this;
+  }
+
+  InterfaceClassDefinitionBuilder withClassName(String className) {
     _className = className;
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withSubDirParts(List<String> subDirParts) {
+  InterfaceClassDefinitionBuilder withSubDirParts(List<String> subDirParts) {
     _subDirParts = subDirParts;
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withServerOnly(bool serverOnly) {
+  InterfaceClassDefinitionBuilder withServerOnly(bool serverOnly) {
     _serverOnly = serverOnly;
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withField(
+  InterfaceClassDefinitionBuilder withField(
       SerializableModelFieldDefinition field) {
     _fields.add(() => field);
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withFields(
+  InterfaceClassDefinitionBuilder withFields(
     List<SerializableModelFieldDefinition> fields,
   ) {
     _fields = fields.map((f) => () => f).toList();
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withDocumentation(
+  InterfaceClassDefinitionBuilder withDocumentation(
       List<String>? documentation) {
     _documentation = documentation;
     return this;
   }
 
-  ExceptionClassDefinitionBuilder withImplementedInterfaces(
+  InterfaceClassDefinitionBuilder withImplementedInterfaces(
     List<ClassDefinition> interfaces,
   ) {
     _isImplementing = [

--- a/tools/serverpod_cli/test/test_util/builders/model_class_definition_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/model_class_definition_builder.dart
@@ -22,6 +22,7 @@ class ModelClassDefinitionBuilder {
   bool _isSealed;
   List<InheritanceDefinition> _childClasses;
   InheritanceDefinition? _extendsClass;
+  List<ImplementsDefinition> _isImplementing;
 
   ModelClassDefinitionBuilder()
       : _fileName = 'example',
@@ -33,6 +34,7 @@ class ModelClassDefinitionBuilder {
         _serverOnly = false,
         _indexes = [],
         _childClasses = [],
+        _isImplementing = [],
         _isSealed = false;
 
   ModelClassDefinition build() {
@@ -61,6 +63,7 @@ class ModelClassDefinitionBuilder {
       documentation: _documentation,
       childClasses: _childClasses,
       extendsClass: _extendsClass,
+      isImplementing: _isImplementing,
       isSealed: _isSealed,
       type: TypeDefinitionBuilder().withClassName(_className).build(),
     );
@@ -321,6 +324,16 @@ class ModelClassDefinitionBuilder {
   ) {
     _childClasses = [
       for (var child in childClasses) ResolvedInheritanceDefinition(child),
+    ];
+    return this;
+  }
+
+  ModelClassDefinitionBuilder withImplementedInterfaces(
+    List<ClassDefinition> interfaces,
+  ) {
+    _isImplementing = [
+      for (var implementedInterface in interfaces)
+        ResolvedImplementsDefinition(implementedInterface)
     ];
     return this;
   }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_helpers.dart
@@ -216,6 +216,22 @@ abstract class CompilationUnitHelpers {
     return matchingImplementsClauses.isNotEmpty;
   }
 
+  /// Returns [NamedType] if the class has an implements clause with the
+  /// given [name], otherwise returns `null`.
+  static NamedType? tryFindImplementedClass(
+    ClassDeclaration classDeclaration, {
+    required String name,
+  }) {
+    var implementsClause = classDeclaration.implementsClause;
+    if (implementsClause == null) {
+      return null;
+    }
+
+    return implementsClause.interfaces
+        .where((type) => type.name2.toString() == name)
+        .firstOrNull;
+  }
+
   /// Returns [ConstructorDeclaration] if the class has a constructor with the
   /// given name and parameters, otherwise returns `null`.
   ///


### PR DESCRIPTION
This PR is a newer version of #3248 after #3270. Enabling the user to declare Interfaces and classes implementing them.

This is done in 4 steps/commits:
1. Enable interface and implements keywords
2. Enable generating interfaces and classes implementing them
3. Exclude interfaces from serialization in protocol
4. Add Examples to serverpod test project

The changes are closer described in each commit message

This PR tries to close #2842

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
No breaking changes. 