### PR TITLE
fix: Preserve trace for database query exceptions.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -416,7 +416,7 @@ class DatabaseConnection {
         exception: serverpodException,
         trace: trace,
       );
-      throw serverpodException;
+      Error.throwWithStackTrace(serverpodException, trace);
     } on pg.PgException catch (exception, trace) {
       var serverpodException = _PgDatabaseQueryException(exception.message);
       _logQuery(
@@ -426,7 +426,7 @@ class DatabaseConnection {
         exception: serverpodException,
         trace: trace,
       );
-      throw serverpodException;
+      Error.throwWithStackTrace(serverpodException, trace);
     } catch (exception, trace) {
       _logQuery(session, query, startTime, exception: exception, trace: trace);
       rethrow;

--- a/packages/serverpod/lib/src/server/log_manager/log_manager.dart
+++ b/packages/serverpod/lib/src/server/log_manager/log_manager.dart
@@ -338,14 +338,13 @@ class SessionLogManager {
         stderr.writeln('${DateTime.now().toUtc()} FAILED TO LOG SESSION');
         stderr.writeln(
             'CALL: ${session.callName} duration: ${duration.inMilliseconds}ms numQueries: $_numberOfQueries authenticatedUser: $authenticatedUserId');
-        stderr.writeln('CALL error: $exception');
-        stderr.writeln('$logStackTrace');
+        if (exception != null) {
+          stderr.writeln('CALL error: $exception');
+          stderr.writeln('$stackTrace');
+        }
 
-        stderr.writeln('LOG ERRORS');
-        stderr.writeln('$e');
+        stderr.writeln('LOG ERROR: $e');
         stderr.writeln('$logStackTrace');
-        stderr.writeln('Current stacktrace:');
-        stderr.writeln('${StackTrace.current}');
       }
     }
     return null;


### PR DESCRIPTION
Preserves the stack trace from our database library.

Will be used to provide further debug information to: https://github.com/serverpod/serverpod/issues/3307

#### Additional
- Cleaned up the logging for when logging to the database fails.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - Should be fine to modify log message output.