### PR TITLE
fix: Prevent query exception from id column in update queries.

### DIFF
--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -187,7 +187,10 @@ class DatabaseConnection {
 
     if (columns != null) {
       _validateColumnsExists(columns, table);
-      selectedColumns = [table.id, ...columns];
+      selectedColumns = [
+        ...columns,
+        if (!columns.contains(table.id)) table.id,
+      ];
     }
 
     var selectedColumnNames = selectedColumns.map((e) => e.columnName);

--- a/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
+++ b/packages/serverpod/lib/src/database/adapters/postgres/database_connection.dart
@@ -198,7 +198,6 @@ class DatabaseConnection {
     var values = _createQueryValueList(rows, selectedColumns);
 
     var setColumns = selectedColumnNames
-        .where((columnName) => columnName != 'id')
         .map((columnName) => '"$columnName" = data."$columnName"')
         .join(', ');
 

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_test.dart
@@ -783,4 +783,24 @@ void main() async {
       expect(updated.first.anEnum, equals(TestEnum.one));
     });
   });
+
+  group('Given empty model in database', () {
+    late EmptyModelWithTable model;
+    setUp(() async {
+      model = await EmptyModelWithTable.db
+          .insertRow(session, EmptyModelWithTable());
+    });
+
+    tearDown(() async {
+      await EmptyModelWithTable.db
+          .deleteWhere(session, where: (t) => Constant.bool(true));
+    });
+
+    test('when model is updated then update completes', () async {
+      expect(
+        EmptyModelWithTable.db.updateRow(session, model),
+        completes,
+      );
+    });
+  });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_test.dart
@@ -782,6 +782,15 @@ void main() async {
 
       expect(updated.first.anEnum, equals(TestEnum.one));
     });
+
+    test(
+        'when listing id column in an update query of a row then update completes successfully.',
+        () async {
+      expect(
+        Types.db.updateRow(session, type, columns: (t) => [t.id]),
+        completes,
+      );
+    });
   });
 
   group('Given empty model in database', () {


### PR DESCRIPTION
This PR fixes two exceptions that could occur when performing an update query.

1. Prevents update query to throw if an update query was performed on a model without any fields.
2. Prevents update query to throw if the `id` column was specified as a column to be updated.

Found when exploring the fix for #3286 

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple stability fix.