### PR TITLE
fix: Wasm support in serverpod client

### DIFF
--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -9,7 +9,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import 'serverpod_client_shared_private.dart';
 
 import 'serverpod_client_io.dart'
-    if (dart.library.js) 'serverpod_client_browser.dart'
+    if (dart.library.js_interop) 'serverpod_client_browser.dart'
     if (dart.library.io) 'serverpod_client_io.dart';
 
 /// A callback with no parameters or return value.


### PR DESCRIPTION
Wasm build is broken because serverpod client assumes `dart.library.js` is available in wasm builds but it's not. We should use `dart.library.js_interop` instead which doesn't break the old web users but is now also passing for wasm.

This PR fixes the issue #3333


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._