### PR TITLE
fix: Include URI path in web server diagnostic events

### DIFF
--- a/packages/serverpod/lib/src/server/diagnostic_events/operation_context_helpers.dart
+++ b/packages/serverpod/lib/src/server/diagnostic_events/operation_context_helpers.dart
@@ -94,7 +94,7 @@ WebCallOpContext _fromWebCall(
       userAuthInfo: session.authInfoOrNull,
       sessionId: session.sessionId,
       connectionInfo: _safeHttpToConnInfo(httpRequest?.connectionInfo),
-      uri: httpRequest?.uri ?? Uri.http('localhost'),
+      uri: httpRequest?.uri ?? Uri.http('', session.endpoint),
     );
 
 MethodCallOpContext _fromMethodCall(


### PR DESCRIPTION
This fixes the bug when the web server was submitting exception events, the URI path was not included.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a