### PR TITLE
feat: Global default enum value to prevent breaking the client

### DIFF
--- a/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/default_value_enum.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/defaults/enum/enums/default_value_enum.dart
@@ -1,0 +1,33 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+enum DefaultValueEnum implements _i1.SerializableModel {
+  value1,
+  value2;
+
+  static DefaultValueEnum fromJson(int index) {
+    switch (index) {
+      case 0:
+        return DefaultValueEnum.value1;
+      case 1:
+        return DefaultValueEnum.value2;
+      default:
+        return DefaultValueEnum.value2;
+    }
+  }
+
+  @override
+  int toJson() => index;
+  @override
+  String toString() => name;
+}

--- a/tests/serverpod_test_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/protocol.dart
@@ -38,121 +38,122 @@ import 'defaults/enum/enum_default_model.dart' as _i26;
 import 'defaults/enum/enum_default_persist.dart' as _i27;
 import 'defaults/enum/enums/by_index_enum.dart' as _i28;
 import 'defaults/enum/enums/by_name_enum.dart' as _i29;
-import 'defaults/exception/default_exception.dart' as _i30;
-import 'defaults/integer/int_default.dart' as _i31;
-import 'defaults/integer/int_default_mix.dart' as _i32;
-import 'defaults/integer/int_default_model.dart' as _i33;
-import 'defaults/integer/int_default_persist.dart' as _i34;
-import 'defaults/string/string_default.dart' as _i35;
-import 'defaults/string/string_default_mix.dart' as _i36;
-import 'defaults/string/string_default_model.dart' as _i37;
-import 'defaults/string/string_default_persist.dart' as _i38;
-import 'defaults/uri/uri_default.dart' as _i39;
-import 'defaults/uri/uri_default_mix.dart' as _i40;
-import 'defaults/uri/uri_default_model.dart' as _i41;
-import 'defaults/uri/uri_default_persist.dart' as _i42;
-import 'defaults/uuid/uuid_default.dart' as _i43;
-import 'defaults/uuid/uuid_default_mix.dart' as _i44;
-import 'defaults/uuid/uuid_default_model.dart' as _i45;
-import 'defaults/uuid/uuid_default_persist.dart' as _i46;
-import 'empty_model/empty_model.dart' as _i47;
-import 'empty_model/empty_model_relation_item.dart' as _i48;
-import 'empty_model/empty_model_with_table.dart' as _i49;
-import 'empty_model/relation_empy_model.dart' as _i50;
-import 'exception_with_data.dart' as _i51;
-import 'inheritance/child_class.dart' as _i52;
-import 'inheritance/child_with_default.dart' as _i53;
-import 'inheritance/grandparent_class.dart' as _i54;
-import 'inheritance/parent_class.dart' as _i55;
-import 'inheritance/parent_with_default.dart' as _i56;
-import 'inheritance/sealed_parent.dart' as _i57;
-import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i58;
+import 'defaults/enum/enums/default_value_enum.dart' as _i30;
+import 'defaults/exception/default_exception.dart' as _i31;
+import 'defaults/integer/int_default.dart' as _i32;
+import 'defaults/integer/int_default_mix.dart' as _i33;
+import 'defaults/integer/int_default_model.dart' as _i34;
+import 'defaults/integer/int_default_persist.dart' as _i35;
+import 'defaults/string/string_default.dart' as _i36;
+import 'defaults/string/string_default_mix.dart' as _i37;
+import 'defaults/string/string_default_model.dart' as _i38;
+import 'defaults/string/string_default_persist.dart' as _i39;
+import 'defaults/uri/uri_default.dart' as _i40;
+import 'defaults/uri/uri_default_mix.dart' as _i41;
+import 'defaults/uri/uri_default_model.dart' as _i42;
+import 'defaults/uri/uri_default_persist.dart' as _i43;
+import 'defaults/uuid/uuid_default.dart' as _i44;
+import 'defaults/uuid/uuid_default_mix.dart' as _i45;
+import 'defaults/uuid/uuid_default_model.dart' as _i46;
+import 'defaults/uuid/uuid_default_persist.dart' as _i47;
+import 'empty_model/empty_model.dart' as _i48;
+import 'empty_model/empty_model_relation_item.dart' as _i49;
+import 'empty_model/empty_model_with_table.dart' as _i50;
+import 'empty_model/relation_empy_model.dart' as _i51;
+import 'exception_with_data.dart' as _i52;
+import 'inheritance/child_class.dart' as _i53;
+import 'inheritance/child_with_default.dart' as _i54;
+import 'inheritance/grandparent_class.dart' as _i55;
+import 'inheritance/parent_class.dart' as _i56;
+import 'inheritance/parent_with_default.dart' as _i57;
+import 'inheritance/sealed_parent.dart' as _i58;
+import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i59;
 import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
-    as _i59;
-import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i60;
-import 'long_identifiers/max_field_name.dart' as _i61;
+import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
+    as _i61;
+import 'long_identifiers/max_field_name.dart' as _i62;
 import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
-    as _i62;
-import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
     as _i63;
-import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
+import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
     as _i64;
-import 'long_identifiers/models_with_relations/user_note.dart' as _i65;
+import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
+    as _i65;
+import 'long_identifiers/models_with_relations/user_note.dart' as _i66;
 import 'long_identifiers/models_with_relations/user_note_collection.dart'
-    as _i66;
-import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
     as _i67;
-import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
+import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
     as _i68;
-import 'long_identifiers/multiple_max_field_name.dart' as _i69;
-import 'models_with_list_relations/city.dart' as _i70;
-import 'models_with_list_relations/organization.dart' as _i71;
-import 'models_with_list_relations/person.dart' as _i72;
-import 'models_with_relations/many_to_many/course.dart' as _i73;
-import 'models_with_relations/many_to_many/enrollment.dart' as _i74;
-import 'models_with_relations/many_to_many/student.dart' as _i75;
-import 'models_with_relations/module/object_user.dart' as _i76;
-import 'models_with_relations/module/parent_user.dart' as _i77;
-import 'models_with_relations/nested_one_to_many/arena.dart' as _i78;
-import 'models_with_relations/nested_one_to_many/player.dart' as _i79;
-import 'models_with_relations/nested_one_to_many/team.dart' as _i80;
-import 'models_with_relations/one_to_many/comment.dart' as _i81;
-import 'models_with_relations/one_to_many/customer.dart' as _i82;
-import 'models_with_relations/one_to_many/order.dart' as _i83;
-import 'models_with_relations/one_to_one/address.dart' as _i84;
-import 'models_with_relations/one_to_one/citizen.dart' as _i85;
-import 'models_with_relations/one_to_one/company.dart' as _i86;
-import 'models_with_relations/one_to_one/town.dart' as _i87;
-import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i88;
-import 'models_with_relations/self_relation/many_to_many/member.dart' as _i89;
-import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i90;
-import 'models_with_relations/self_relation/one_to_one/post.dart' as _i91;
-import 'module_datatype.dart' as _i92;
-import 'nullability.dart' as _i93;
-import 'object_field_persist.dart' as _i94;
-import 'object_field_scopes.dart' as _i95;
-import 'object_with_bytedata.dart' as _i96;
-import 'object_with_custom_class.dart' as _i97;
-import 'object_with_duration.dart' as _i98;
-import 'object_with_enum.dart' as _i99;
-import 'object_with_index.dart' as _i100;
-import 'object_with_maps.dart' as _i101;
-import 'object_with_object.dart' as _i102;
-import 'object_with_parent.dart' as _i103;
-import 'object_with_self_parent.dart' as _i104;
-import 'object_with_uuid.dart' as _i105;
-import 'related_unique_data.dart' as _i106;
-import 'scopes/scope_none_fields.dart' as _i107;
-import 'scopes/scope_server_only_field.dart' as _i108;
-import 'scopes/scope_server_only_field_child.dart' as _i109;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i110;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i111;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i112;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i113;
-import 'scopes/server_only_class_field.dart' as _i114;
-import 'simple_data.dart' as _i115;
-import 'simple_data_list.dart' as _i116;
-import 'simple_data_map.dart' as _i117;
-import 'simple_data_object.dart' as _i118;
-import 'simple_date_time.dart' as _i119;
-import 'test_enum.dart' as _i120;
-import 'test_enum_stringified.dart' as _i121;
-import 'types.dart' as _i122;
-import 'types_list.dart' as _i123;
-import 'types_map.dart' as _i124;
-import 'types_record.dart' as _i125;
-import 'types_set.dart' as _i126;
-import 'unique_data.dart' as _i127;
-import 'my_feature/models/my_feature_model.dart' as _i128;
+import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
+    as _i69;
+import 'long_identifiers/multiple_max_field_name.dart' as _i70;
+import 'models_with_list_relations/city.dart' as _i71;
+import 'models_with_list_relations/organization.dart' as _i72;
+import 'models_with_list_relations/person.dart' as _i73;
+import 'models_with_relations/many_to_many/course.dart' as _i74;
+import 'models_with_relations/many_to_many/enrollment.dart' as _i75;
+import 'models_with_relations/many_to_many/student.dart' as _i76;
+import 'models_with_relations/module/object_user.dart' as _i77;
+import 'models_with_relations/module/parent_user.dart' as _i78;
+import 'models_with_relations/nested_one_to_many/arena.dart' as _i79;
+import 'models_with_relations/nested_one_to_many/player.dart' as _i80;
+import 'models_with_relations/nested_one_to_many/team.dart' as _i81;
+import 'models_with_relations/one_to_many/comment.dart' as _i82;
+import 'models_with_relations/one_to_many/customer.dart' as _i83;
+import 'models_with_relations/one_to_many/order.dart' as _i84;
+import 'models_with_relations/one_to_one/address.dart' as _i85;
+import 'models_with_relations/one_to_one/citizen.dart' as _i86;
+import 'models_with_relations/one_to_one/company.dart' as _i87;
+import 'models_with_relations/one_to_one/town.dart' as _i88;
+import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i89;
+import 'models_with_relations/self_relation/many_to_many/member.dart' as _i90;
+import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i91;
+import 'models_with_relations/self_relation/one_to_one/post.dart' as _i92;
+import 'module_datatype.dart' as _i93;
+import 'nullability.dart' as _i94;
+import 'object_field_persist.dart' as _i95;
+import 'object_field_scopes.dart' as _i96;
+import 'object_with_bytedata.dart' as _i97;
+import 'object_with_custom_class.dart' as _i98;
+import 'object_with_duration.dart' as _i99;
+import 'object_with_enum.dart' as _i100;
+import 'object_with_index.dart' as _i101;
+import 'object_with_maps.dart' as _i102;
+import 'object_with_object.dart' as _i103;
+import 'object_with_parent.dart' as _i104;
+import 'object_with_self_parent.dart' as _i105;
+import 'object_with_uuid.dart' as _i106;
+import 'related_unique_data.dart' as _i107;
+import 'scopes/scope_none_fields.dart' as _i108;
+import 'scopes/scope_server_only_field.dart' as _i109;
+import 'scopes/scope_server_only_field_child.dart' as _i110;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i111;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i112;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i113;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i114;
+import 'scopes/server_only_class_field.dart' as _i115;
+import 'simple_data.dart' as _i116;
+import 'simple_data_list.dart' as _i117;
+import 'simple_data_map.dart' as _i118;
+import 'simple_data_object.dart' as _i119;
+import 'simple_date_time.dart' as _i120;
+import 'test_enum.dart' as _i121;
+import 'test_enum_stringified.dart' as _i122;
+import 'types.dart' as _i123;
+import 'types_list.dart' as _i124;
+import 'types_map.dart' as _i125;
+import 'types_record.dart' as _i126;
+import 'types_set.dart' as _i127;
+import 'unique_data.dart' as _i128;
+import 'my_feature/models/my_feature_model.dart' as _i129;
 import 'package:serverpod_test_module_client/serverpod_test_module_client.dart'
-    as _i129;
-import 'dart:typed_data' as _i130;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i131;
-import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i132;
-import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i133;
-import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i134;
-import 'package:serverpod_test_client/src/protocol/types.dart' as _i135;
+    as _i130;
+import 'dart:typed_data' as _i131;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i132;
+import 'package:serverpod_test_client/src/protocol/simple_data.dart' as _i133;
+import 'package:serverpod_test_client/src/protocol/test_enum.dart' as _i134;
+import 'package:serverpod_auth_client/serverpod_auth_client.dart' as _i135;
+import 'package:serverpod_test_client/src/protocol/types.dart' as _i136;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
 export 'defaults/bigint/bigint_default.dart';
@@ -181,6 +182,7 @@ export 'defaults/enum/enum_default_model.dart';
 export 'defaults/enum/enum_default_persist.dart';
 export 'defaults/enum/enums/by_index_enum.dart';
 export 'defaults/enum/enums/by_name_enum.dart';
+export 'defaults/enum/enums/default_value_enum.dart';
 export 'defaults/exception/default_exception.dart';
 export 'defaults/integer/int_default.dart';
 export 'defaults/integer/int_default_mix.dart';
@@ -380,308 +382,311 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i29.ByNameEnum) {
       return _i29.ByNameEnum.fromJson(data) as T;
     }
-    if (t == _i30.DefaultException) {
-      return _i30.DefaultException.fromJson(data) as T;
+    if (t == _i30.DefaultValueEnum) {
+      return _i30.DefaultValueEnum.fromJson(data) as T;
     }
-    if (t == _i31.IntDefault) {
-      return _i31.IntDefault.fromJson(data) as T;
+    if (t == _i31.DefaultException) {
+      return _i31.DefaultException.fromJson(data) as T;
     }
-    if (t == _i32.IntDefaultMix) {
-      return _i32.IntDefaultMix.fromJson(data) as T;
+    if (t == _i32.IntDefault) {
+      return _i32.IntDefault.fromJson(data) as T;
     }
-    if (t == _i33.IntDefaultModel) {
-      return _i33.IntDefaultModel.fromJson(data) as T;
+    if (t == _i33.IntDefaultMix) {
+      return _i33.IntDefaultMix.fromJson(data) as T;
     }
-    if (t == _i34.IntDefaultPersist) {
-      return _i34.IntDefaultPersist.fromJson(data) as T;
+    if (t == _i34.IntDefaultModel) {
+      return _i34.IntDefaultModel.fromJson(data) as T;
     }
-    if (t == _i35.StringDefault) {
-      return _i35.StringDefault.fromJson(data) as T;
+    if (t == _i35.IntDefaultPersist) {
+      return _i35.IntDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i36.StringDefaultMix) {
-      return _i36.StringDefaultMix.fromJson(data) as T;
+    if (t == _i36.StringDefault) {
+      return _i36.StringDefault.fromJson(data) as T;
     }
-    if (t == _i37.StringDefaultModel) {
-      return _i37.StringDefaultModel.fromJson(data) as T;
+    if (t == _i37.StringDefaultMix) {
+      return _i37.StringDefaultMix.fromJson(data) as T;
     }
-    if (t == _i38.StringDefaultPersist) {
-      return _i38.StringDefaultPersist.fromJson(data) as T;
+    if (t == _i38.StringDefaultModel) {
+      return _i38.StringDefaultModel.fromJson(data) as T;
     }
-    if (t == _i39.UriDefault) {
-      return _i39.UriDefault.fromJson(data) as T;
+    if (t == _i39.StringDefaultPersist) {
+      return _i39.StringDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i40.UriDefaultMix) {
-      return _i40.UriDefaultMix.fromJson(data) as T;
+    if (t == _i40.UriDefault) {
+      return _i40.UriDefault.fromJson(data) as T;
     }
-    if (t == _i41.UriDefaultModel) {
-      return _i41.UriDefaultModel.fromJson(data) as T;
+    if (t == _i41.UriDefaultMix) {
+      return _i41.UriDefaultMix.fromJson(data) as T;
     }
-    if (t == _i42.UriDefaultPersist) {
-      return _i42.UriDefaultPersist.fromJson(data) as T;
+    if (t == _i42.UriDefaultModel) {
+      return _i42.UriDefaultModel.fromJson(data) as T;
     }
-    if (t == _i43.UuidDefault) {
-      return _i43.UuidDefault.fromJson(data) as T;
+    if (t == _i43.UriDefaultPersist) {
+      return _i43.UriDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i44.UuidDefaultMix) {
-      return _i44.UuidDefaultMix.fromJson(data) as T;
+    if (t == _i44.UuidDefault) {
+      return _i44.UuidDefault.fromJson(data) as T;
     }
-    if (t == _i45.UuidDefaultModel) {
-      return _i45.UuidDefaultModel.fromJson(data) as T;
+    if (t == _i45.UuidDefaultMix) {
+      return _i45.UuidDefaultMix.fromJson(data) as T;
     }
-    if (t == _i46.UuidDefaultPersist) {
-      return _i46.UuidDefaultPersist.fromJson(data) as T;
+    if (t == _i46.UuidDefaultModel) {
+      return _i46.UuidDefaultModel.fromJson(data) as T;
     }
-    if (t == _i47.EmptyModel) {
-      return _i47.EmptyModel.fromJson(data) as T;
+    if (t == _i47.UuidDefaultPersist) {
+      return _i47.UuidDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i48.EmptyModelRelationItem) {
-      return _i48.EmptyModelRelationItem.fromJson(data) as T;
+    if (t == _i48.EmptyModel) {
+      return _i48.EmptyModel.fromJson(data) as T;
     }
-    if (t == _i49.EmptyModelWithTable) {
-      return _i49.EmptyModelWithTable.fromJson(data) as T;
+    if (t == _i49.EmptyModelRelationItem) {
+      return _i49.EmptyModelRelationItem.fromJson(data) as T;
     }
-    if (t == _i50.RelationEmptyModel) {
-      return _i50.RelationEmptyModel.fromJson(data) as T;
+    if (t == _i50.EmptyModelWithTable) {
+      return _i50.EmptyModelWithTable.fromJson(data) as T;
     }
-    if (t == _i51.ExceptionWithData) {
-      return _i51.ExceptionWithData.fromJson(data) as T;
+    if (t == _i51.RelationEmptyModel) {
+      return _i51.RelationEmptyModel.fromJson(data) as T;
     }
-    if (t == _i52.ChildClass) {
-      return _i52.ChildClass.fromJson(data) as T;
+    if (t == _i52.ExceptionWithData) {
+      return _i52.ExceptionWithData.fromJson(data) as T;
     }
-    if (t == _i53.ChildWithDefault) {
-      return _i53.ChildWithDefault.fromJson(data) as T;
+    if (t == _i53.ChildClass) {
+      return _i53.ChildClass.fromJson(data) as T;
     }
-    if (t == _i54.GrandparentClass) {
-      return _i54.GrandparentClass.fromJson(data) as T;
+    if (t == _i54.ChildWithDefault) {
+      return _i54.ChildWithDefault.fromJson(data) as T;
     }
-    if (t == _i55.ParentClass) {
-      return _i55.ParentClass.fromJson(data) as T;
+    if (t == _i55.GrandparentClass) {
+      return _i55.GrandparentClass.fromJson(data) as T;
     }
-    if (t == _i56.ParentWithDefault) {
-      return _i56.ParentWithDefault.fromJson(data) as T;
+    if (t == _i56.ParentClass) {
+      return _i56.ParentClass.fromJson(data) as T;
     }
-    if (t == _i57.SealedChild) {
-      return _i57.SealedChild.fromJson(data) as T;
+    if (t == _i57.ParentWithDefault) {
+      return _i57.ParentWithDefault.fromJson(data) as T;
     }
-    if (t == _i57.SealedGrandChild) {
-      return _i57.SealedGrandChild.fromJson(data) as T;
+    if (t == _i58.SealedChild) {
+      return _i58.SealedChild.fromJson(data) as T;
     }
-    if (t == _i57.SealedOtherChild) {
-      return _i57.SealedOtherChild.fromJson(data) as T;
+    if (t == _i58.SealedGrandChild) {
+      return _i58.SealedGrandChild.fromJson(data) as T;
     }
-    if (t == _i58.CityWithLongTableName) {
-      return _i58.CityWithLongTableName.fromJson(data) as T;
+    if (t == _i58.SealedOtherChild) {
+      return _i58.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i59.OrganizationWithLongTableName) {
-      return _i59.OrganizationWithLongTableName.fromJson(data) as T;
+    if (t == _i59.CityWithLongTableName) {
+      return _i59.CityWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i60.PersonWithLongTableName) {
-      return _i60.PersonWithLongTableName.fromJson(data) as T;
+    if (t == _i60.OrganizationWithLongTableName) {
+      return _i60.OrganizationWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i61.MaxFieldName) {
-      return _i61.MaxFieldName.fromJson(data) as T;
+    if (t == _i61.PersonWithLongTableName) {
+      return _i61.PersonWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i62.LongImplicitIdField) {
-      return _i62.LongImplicitIdField.fromJson(data) as T;
+    if (t == _i62.MaxFieldName) {
+      return _i62.MaxFieldName.fromJson(data) as T;
     }
-    if (t == _i63.LongImplicitIdFieldCollection) {
-      return _i63.LongImplicitIdFieldCollection.fromJson(data) as T;
+    if (t == _i63.LongImplicitIdField) {
+      return _i63.LongImplicitIdField.fromJson(data) as T;
     }
-    if (t == _i64.RelationToMultipleMaxFieldName) {
-      return _i64.RelationToMultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i64.LongImplicitIdFieldCollection) {
+      return _i64.LongImplicitIdFieldCollection.fromJson(data) as T;
     }
-    if (t == _i65.UserNote) {
-      return _i65.UserNote.fromJson(data) as T;
+    if (t == _i65.RelationToMultipleMaxFieldName) {
+      return _i65.RelationToMultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i66.UserNoteCollection) {
-      return _i66.UserNoteCollection.fromJson(data) as T;
+    if (t == _i66.UserNote) {
+      return _i66.UserNote.fromJson(data) as T;
     }
-    if (t == _i67.UserNoteCollectionWithALongName) {
-      return _i67.UserNoteCollectionWithALongName.fromJson(data) as T;
+    if (t == _i67.UserNoteCollection) {
+      return _i67.UserNoteCollection.fromJson(data) as T;
     }
-    if (t == _i68.UserNoteWithALongName) {
-      return _i68.UserNoteWithALongName.fromJson(data) as T;
+    if (t == _i68.UserNoteCollectionWithALongName) {
+      return _i68.UserNoteCollectionWithALongName.fromJson(data) as T;
     }
-    if (t == _i69.MultipleMaxFieldName) {
-      return _i69.MultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i69.UserNoteWithALongName) {
+      return _i69.UserNoteWithALongName.fromJson(data) as T;
     }
-    if (t == _i70.City) {
-      return _i70.City.fromJson(data) as T;
+    if (t == _i70.MultipleMaxFieldName) {
+      return _i70.MultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i71.Organization) {
-      return _i71.Organization.fromJson(data) as T;
+    if (t == _i71.City) {
+      return _i71.City.fromJson(data) as T;
     }
-    if (t == _i72.Person) {
-      return _i72.Person.fromJson(data) as T;
+    if (t == _i72.Organization) {
+      return _i72.Organization.fromJson(data) as T;
     }
-    if (t == _i73.Course) {
-      return _i73.Course.fromJson(data) as T;
+    if (t == _i73.Person) {
+      return _i73.Person.fromJson(data) as T;
     }
-    if (t == _i74.Enrollment) {
-      return _i74.Enrollment.fromJson(data) as T;
+    if (t == _i74.Course) {
+      return _i74.Course.fromJson(data) as T;
     }
-    if (t == _i75.Student) {
-      return _i75.Student.fromJson(data) as T;
+    if (t == _i75.Enrollment) {
+      return _i75.Enrollment.fromJson(data) as T;
     }
-    if (t == _i76.ObjectUser) {
-      return _i76.ObjectUser.fromJson(data) as T;
+    if (t == _i76.Student) {
+      return _i76.Student.fromJson(data) as T;
     }
-    if (t == _i77.ParentUser) {
-      return _i77.ParentUser.fromJson(data) as T;
+    if (t == _i77.ObjectUser) {
+      return _i77.ObjectUser.fromJson(data) as T;
     }
-    if (t == _i78.Arena) {
-      return _i78.Arena.fromJson(data) as T;
+    if (t == _i78.ParentUser) {
+      return _i78.ParentUser.fromJson(data) as T;
     }
-    if (t == _i79.Player) {
-      return _i79.Player.fromJson(data) as T;
+    if (t == _i79.Arena) {
+      return _i79.Arena.fromJson(data) as T;
     }
-    if (t == _i80.Team) {
-      return _i80.Team.fromJson(data) as T;
+    if (t == _i80.Player) {
+      return _i80.Player.fromJson(data) as T;
     }
-    if (t == _i81.Comment) {
-      return _i81.Comment.fromJson(data) as T;
+    if (t == _i81.Team) {
+      return _i81.Team.fromJson(data) as T;
     }
-    if (t == _i82.Customer) {
-      return _i82.Customer.fromJson(data) as T;
+    if (t == _i82.Comment) {
+      return _i82.Comment.fromJson(data) as T;
     }
-    if (t == _i83.Order) {
-      return _i83.Order.fromJson(data) as T;
+    if (t == _i83.Customer) {
+      return _i83.Customer.fromJson(data) as T;
     }
-    if (t == _i84.Address) {
-      return _i84.Address.fromJson(data) as T;
+    if (t == _i84.Order) {
+      return _i84.Order.fromJson(data) as T;
     }
-    if (t == _i85.Citizen) {
-      return _i85.Citizen.fromJson(data) as T;
+    if (t == _i85.Address) {
+      return _i85.Address.fromJson(data) as T;
     }
-    if (t == _i86.Company) {
-      return _i86.Company.fromJson(data) as T;
+    if (t == _i86.Citizen) {
+      return _i86.Citizen.fromJson(data) as T;
     }
-    if (t == _i87.Town) {
-      return _i87.Town.fromJson(data) as T;
+    if (t == _i87.Company) {
+      return _i87.Company.fromJson(data) as T;
     }
-    if (t == _i88.Blocking) {
-      return _i88.Blocking.fromJson(data) as T;
+    if (t == _i88.Town) {
+      return _i88.Town.fromJson(data) as T;
     }
-    if (t == _i89.Member) {
-      return _i89.Member.fromJson(data) as T;
+    if (t == _i89.Blocking) {
+      return _i89.Blocking.fromJson(data) as T;
     }
-    if (t == _i90.Cat) {
-      return _i90.Cat.fromJson(data) as T;
+    if (t == _i90.Member) {
+      return _i90.Member.fromJson(data) as T;
     }
-    if (t == _i91.Post) {
-      return _i91.Post.fromJson(data) as T;
+    if (t == _i91.Cat) {
+      return _i91.Cat.fromJson(data) as T;
     }
-    if (t == _i92.ModuleDatatype) {
-      return _i92.ModuleDatatype.fromJson(data) as T;
+    if (t == _i92.Post) {
+      return _i92.Post.fromJson(data) as T;
     }
-    if (t == _i93.Nullability) {
-      return _i93.Nullability.fromJson(data) as T;
+    if (t == _i93.ModuleDatatype) {
+      return _i93.ModuleDatatype.fromJson(data) as T;
     }
-    if (t == _i94.ObjectFieldPersist) {
-      return _i94.ObjectFieldPersist.fromJson(data) as T;
+    if (t == _i94.Nullability) {
+      return _i94.Nullability.fromJson(data) as T;
     }
-    if (t == _i95.ObjectFieldScopes) {
-      return _i95.ObjectFieldScopes.fromJson(data) as T;
+    if (t == _i95.ObjectFieldPersist) {
+      return _i95.ObjectFieldPersist.fromJson(data) as T;
     }
-    if (t == _i96.ObjectWithByteData) {
-      return _i96.ObjectWithByteData.fromJson(data) as T;
+    if (t == _i96.ObjectFieldScopes) {
+      return _i96.ObjectFieldScopes.fromJson(data) as T;
     }
-    if (t == _i97.ObjectWithCustomClass) {
-      return _i97.ObjectWithCustomClass.fromJson(data) as T;
+    if (t == _i97.ObjectWithByteData) {
+      return _i97.ObjectWithByteData.fromJson(data) as T;
     }
-    if (t == _i98.ObjectWithDuration) {
-      return _i98.ObjectWithDuration.fromJson(data) as T;
+    if (t == _i98.ObjectWithCustomClass) {
+      return _i98.ObjectWithCustomClass.fromJson(data) as T;
     }
-    if (t == _i99.ObjectWithEnum) {
-      return _i99.ObjectWithEnum.fromJson(data) as T;
+    if (t == _i99.ObjectWithDuration) {
+      return _i99.ObjectWithDuration.fromJson(data) as T;
     }
-    if (t == _i100.ObjectWithIndex) {
-      return _i100.ObjectWithIndex.fromJson(data) as T;
+    if (t == _i100.ObjectWithEnum) {
+      return _i100.ObjectWithEnum.fromJson(data) as T;
     }
-    if (t == _i101.ObjectWithMaps) {
-      return _i101.ObjectWithMaps.fromJson(data) as T;
+    if (t == _i101.ObjectWithIndex) {
+      return _i101.ObjectWithIndex.fromJson(data) as T;
     }
-    if (t == _i102.ObjectWithObject) {
-      return _i102.ObjectWithObject.fromJson(data) as T;
+    if (t == _i102.ObjectWithMaps) {
+      return _i102.ObjectWithMaps.fromJson(data) as T;
     }
-    if (t == _i103.ObjectWithParent) {
-      return _i103.ObjectWithParent.fromJson(data) as T;
+    if (t == _i103.ObjectWithObject) {
+      return _i103.ObjectWithObject.fromJson(data) as T;
     }
-    if (t == _i104.ObjectWithSelfParent) {
-      return _i104.ObjectWithSelfParent.fromJson(data) as T;
+    if (t == _i104.ObjectWithParent) {
+      return _i104.ObjectWithParent.fromJson(data) as T;
     }
-    if (t == _i105.ObjectWithUuid) {
-      return _i105.ObjectWithUuid.fromJson(data) as T;
+    if (t == _i105.ObjectWithSelfParent) {
+      return _i105.ObjectWithSelfParent.fromJson(data) as T;
     }
-    if (t == _i106.RelatedUniqueData) {
-      return _i106.RelatedUniqueData.fromJson(data) as T;
+    if (t == _i106.ObjectWithUuid) {
+      return _i106.ObjectWithUuid.fromJson(data) as T;
     }
-    if (t == _i107.ScopeNoneFields) {
-      return _i107.ScopeNoneFields.fromJson(data) as T;
+    if (t == _i107.RelatedUniqueData) {
+      return _i107.RelatedUniqueData.fromJson(data) as T;
     }
-    if (t == _i108.ScopeServerOnlyField) {
-      return _i108.ScopeServerOnlyField.fromJson(data) as T;
+    if (t == _i108.ScopeNoneFields) {
+      return _i108.ScopeNoneFields.fromJson(data) as T;
     }
-    if (t == _i109.ScopeServerOnlyFieldChild) {
-      return _i109.ScopeServerOnlyFieldChild.fromJson(data) as T;
+    if (t == _i109.ScopeServerOnlyField) {
+      return _i109.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i110.DefaultServerOnlyClass) {
-      return _i110.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i110.ScopeServerOnlyFieldChild) {
+      return _i110.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i111.DefaultServerOnlyEnum) {
-      return _i111.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i111.DefaultServerOnlyClass) {
+      return _i111.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i112.NotServerOnlyClass) {
-      return _i112.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i112.DefaultServerOnlyEnum) {
+      return _i112.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i113.NotServerOnlyEnum) {
-      return _i113.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i113.NotServerOnlyClass) {
+      return _i113.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i114.ServerOnlyClassField) {
-      return _i114.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i114.NotServerOnlyEnum) {
+      return _i114.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i115.SimpleData) {
-      return _i115.SimpleData.fromJson(data) as T;
+    if (t == _i115.ServerOnlyClassField) {
+      return _i115.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i116.SimpleDataList) {
-      return _i116.SimpleDataList.fromJson(data) as T;
+    if (t == _i116.SimpleData) {
+      return _i116.SimpleData.fromJson(data) as T;
     }
-    if (t == _i117.SimpleDataMap) {
-      return _i117.SimpleDataMap.fromJson(data) as T;
+    if (t == _i117.SimpleDataList) {
+      return _i117.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i118.SimpleDataObject) {
-      return _i118.SimpleDataObject.fromJson(data) as T;
+    if (t == _i118.SimpleDataMap) {
+      return _i118.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i119.SimpleDateTime) {
-      return _i119.SimpleDateTime.fromJson(data) as T;
+    if (t == _i119.SimpleDataObject) {
+      return _i119.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i120.TestEnum) {
-      return _i120.TestEnum.fromJson(data) as T;
+    if (t == _i120.SimpleDateTime) {
+      return _i120.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i121.TestEnumStringified) {
-      return _i121.TestEnumStringified.fromJson(data) as T;
+    if (t == _i121.TestEnum) {
+      return _i121.TestEnum.fromJson(data) as T;
     }
-    if (t == _i122.Types) {
-      return _i122.Types.fromJson(data) as T;
+    if (t == _i122.TestEnumStringified) {
+      return _i122.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i123.TypesList) {
-      return _i123.TypesList.fromJson(data) as T;
+    if (t == _i123.Types) {
+      return _i123.Types.fromJson(data) as T;
     }
-    if (t == _i124.TypesMap) {
-      return _i124.TypesMap.fromJson(data) as T;
+    if (t == _i124.TypesList) {
+      return _i124.TypesList.fromJson(data) as T;
     }
-    if (t == _i125.TypesRecord) {
-      return _i125.TypesRecord.fromJson(data) as T;
+    if (t == _i125.TypesMap) {
+      return _i125.TypesMap.fromJson(data) as T;
     }
-    if (t == _i126.TypesSet) {
-      return _i126.TypesSet.fromJson(data) as T;
+    if (t == _i126.TypesRecord) {
+      return _i126.TypesRecord.fromJson(data) as T;
     }
-    if (t == _i127.UniqueData) {
-      return _i127.UniqueData.fromJson(data) as T;
+    if (t == _i127.TypesSet) {
+      return _i127.TypesSet.fromJson(data) as T;
     }
-    if (t == _i128.MyFeatureModel) {
-      return _i128.MyFeatureModel.fromJson(data) as T;
+    if (t == _i128.UniqueData) {
+      return _i128.UniqueData.fromJson(data) as T;
+    }
+    if (t == _i129.MyFeatureModel) {
+      return _i129.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.ByIndexEnumWithNameValue?>()) {
       return (data != null ? _i2.ByIndexEnumWithNameValue.fromJson(data) : null)
@@ -780,471 +785,474 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<_i29.ByNameEnum?>()) {
       return (data != null ? _i29.ByNameEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i30.DefaultException?>()) {
-      return (data != null ? _i30.DefaultException.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i30.DefaultValueEnum?>()) {
+      return (data != null ? _i30.DefaultValueEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i31.IntDefault?>()) {
-      return (data != null ? _i31.IntDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i31.DefaultException?>()) {
+      return (data != null ? _i31.DefaultException.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i32.IntDefaultMix?>()) {
-      return (data != null ? _i32.IntDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i32.IntDefault?>()) {
+      return (data != null ? _i32.IntDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i33.IntDefaultModel?>()) {
-      return (data != null ? _i33.IntDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i33.IntDefaultMix?>()) {
+      return (data != null ? _i33.IntDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i34.IntDefaultPersist?>()) {
-      return (data != null ? _i34.IntDefaultPersist.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i34.IntDefaultModel?>()) {
+      return (data != null ? _i34.IntDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i35.StringDefault?>()) {
-      return (data != null ? _i35.StringDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i35.IntDefaultPersist?>()) {
+      return (data != null ? _i35.IntDefaultPersist.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i36.StringDefaultMix?>()) {
-      return (data != null ? _i36.StringDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i36.StringDefault?>()) {
+      return (data != null ? _i36.StringDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i37.StringDefaultModel?>()) {
-      return (data != null ? _i37.StringDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i37.StringDefaultMix?>()) {
+      return (data != null ? _i37.StringDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i38.StringDefaultModel?>()) {
+      return (data != null ? _i38.StringDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i38.StringDefaultPersist?>()) {
-      return (data != null ? _i38.StringDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i39.StringDefaultPersist?>()) {
+      return (data != null ? _i39.StringDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i39.UriDefault?>()) {
-      return (data != null ? _i39.UriDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i40.UriDefault?>()) {
+      return (data != null ? _i40.UriDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i40.UriDefaultMix?>()) {
-      return (data != null ? _i40.UriDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i41.UriDefaultMix?>()) {
+      return (data != null ? _i41.UriDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i41.UriDefaultModel?>()) {
-      return (data != null ? _i41.UriDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i42.UriDefaultModel?>()) {
+      return (data != null ? _i42.UriDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i42.UriDefaultPersist?>()) {
-      return (data != null ? _i42.UriDefaultPersist.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i43.UriDefaultPersist?>()) {
+      return (data != null ? _i43.UriDefaultPersist.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i43.UuidDefault?>()) {
-      return (data != null ? _i43.UuidDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i44.UuidDefault?>()) {
+      return (data != null ? _i44.UuidDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i44.UuidDefaultMix?>()) {
-      return (data != null ? _i44.UuidDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i45.UuidDefaultMix?>()) {
+      return (data != null ? _i45.UuidDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i45.UuidDefaultModel?>()) {
-      return (data != null ? _i45.UuidDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i46.UuidDefaultModel?>()) {
+      return (data != null ? _i46.UuidDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i46.UuidDefaultPersist?>()) {
-      return (data != null ? _i46.UuidDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i47.UuidDefaultPersist?>()) {
+      return (data != null ? _i47.UuidDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i47.EmptyModel?>()) {
-      return (data != null ? _i47.EmptyModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i48.EmptyModel?>()) {
+      return (data != null ? _i48.EmptyModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i48.EmptyModelRelationItem?>()) {
-      return (data != null ? _i48.EmptyModelRelationItem.fromJson(data) : null)
+    if (t == _i1.getType<_i49.EmptyModelRelationItem?>()) {
+      return (data != null ? _i49.EmptyModelRelationItem.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i49.EmptyModelWithTable?>()) {
-      return (data != null ? _i49.EmptyModelWithTable.fromJson(data) : null)
+    if (t == _i1.getType<_i50.EmptyModelWithTable?>()) {
+      return (data != null ? _i50.EmptyModelWithTable.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i50.RelationEmptyModel?>()) {
-      return (data != null ? _i50.RelationEmptyModel.fromJson(data) : null)
+    if (t == _i1.getType<_i51.RelationEmptyModel?>()) {
+      return (data != null ? _i51.RelationEmptyModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i51.ExceptionWithData?>()) {
-      return (data != null ? _i51.ExceptionWithData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i52.ExceptionWithData?>()) {
+      return (data != null ? _i52.ExceptionWithData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i52.ChildClass?>()) {
-      return (data != null ? _i52.ChildClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i53.ChildClass?>()) {
+      return (data != null ? _i53.ChildClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i53.ChildWithDefault?>()) {
-      return (data != null ? _i53.ChildWithDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i54.ChildWithDefault?>()) {
+      return (data != null ? _i54.ChildWithDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i54.GrandparentClass?>()) {
-      return (data != null ? _i54.GrandparentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i55.GrandparentClass?>()) {
+      return (data != null ? _i55.GrandparentClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i55.ParentClass?>()) {
-      return (data != null ? _i55.ParentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i56.ParentClass?>()) {
+      return (data != null ? _i56.ParentClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i56.ParentWithDefault?>()) {
-      return (data != null ? _i56.ParentWithDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i57.ParentWithDefault?>()) {
+      return (data != null ? _i57.ParentWithDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i57.SealedChild?>()) {
-      return (data != null ? _i57.SealedChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i58.SealedChild?>()) {
+      return (data != null ? _i58.SealedChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i57.SealedGrandChild?>()) {
-      return (data != null ? _i57.SealedGrandChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i58.SealedGrandChild?>()) {
+      return (data != null ? _i58.SealedGrandChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i57.SealedOtherChild?>()) {
-      return (data != null ? _i57.SealedOtherChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i58.SealedOtherChild?>()) {
+      return (data != null ? _i58.SealedOtherChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i58.CityWithLongTableName?>()) {
-      return (data != null ? _i58.CityWithLongTableName.fromJson(data) : null)
+    if (t == _i1.getType<_i59.CityWithLongTableName?>()) {
+      return (data != null ? _i59.CityWithLongTableName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i59.OrganizationWithLongTableName?>()) {
+    if (t == _i1.getType<_i60.OrganizationWithLongTableName?>()) {
       return (data != null
-          ? _i59.OrganizationWithLongTableName.fromJson(data)
+          ? _i60.OrganizationWithLongTableName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i60.PersonWithLongTableName?>()) {
-      return (data != null ? _i60.PersonWithLongTableName.fromJson(data) : null)
+    if (t == _i1.getType<_i61.PersonWithLongTableName?>()) {
+      return (data != null ? _i61.PersonWithLongTableName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i61.MaxFieldName?>()) {
-      return (data != null ? _i61.MaxFieldName.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i62.MaxFieldName?>()) {
+      return (data != null ? _i62.MaxFieldName.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i62.LongImplicitIdField?>()) {
-      return (data != null ? _i62.LongImplicitIdField.fromJson(data) : null)
+    if (t == _i1.getType<_i63.LongImplicitIdField?>()) {
+      return (data != null ? _i63.LongImplicitIdField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i63.LongImplicitIdFieldCollection?>()) {
+    if (t == _i1.getType<_i64.LongImplicitIdFieldCollection?>()) {
       return (data != null
-          ? _i63.LongImplicitIdFieldCollection.fromJson(data)
+          ? _i64.LongImplicitIdFieldCollection.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i64.RelationToMultipleMaxFieldName?>()) {
+    if (t == _i1.getType<_i65.RelationToMultipleMaxFieldName?>()) {
       return (data != null
-          ? _i64.RelationToMultipleMaxFieldName.fromJson(data)
+          ? _i65.RelationToMultipleMaxFieldName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i65.UserNote?>()) {
-      return (data != null ? _i65.UserNote.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i66.UserNote?>()) {
+      return (data != null ? _i66.UserNote.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i66.UserNoteCollection?>()) {
-      return (data != null ? _i66.UserNoteCollection.fromJson(data) : null)
+    if (t == _i1.getType<_i67.UserNoteCollection?>()) {
+      return (data != null ? _i67.UserNoteCollection.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i67.UserNoteCollectionWithALongName?>()) {
+    if (t == _i1.getType<_i68.UserNoteCollectionWithALongName?>()) {
       return (data != null
-          ? _i67.UserNoteCollectionWithALongName.fromJson(data)
+          ? _i68.UserNoteCollectionWithALongName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i68.UserNoteWithALongName?>()) {
-      return (data != null ? _i68.UserNoteWithALongName.fromJson(data) : null)
+    if (t == _i1.getType<_i69.UserNoteWithALongName?>()) {
+      return (data != null ? _i69.UserNoteWithALongName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i69.MultipleMaxFieldName?>()) {
-      return (data != null ? _i69.MultipleMaxFieldName.fromJson(data) : null)
+    if (t == _i1.getType<_i70.MultipleMaxFieldName?>()) {
+      return (data != null ? _i70.MultipleMaxFieldName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i70.City?>()) {
-      return (data != null ? _i70.City.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i71.City?>()) {
+      return (data != null ? _i71.City.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i71.Organization?>()) {
-      return (data != null ? _i71.Organization.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i72.Organization?>()) {
+      return (data != null ? _i72.Organization.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i72.Person?>()) {
-      return (data != null ? _i72.Person.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i73.Person?>()) {
+      return (data != null ? _i73.Person.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i73.Course?>()) {
-      return (data != null ? _i73.Course.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i74.Course?>()) {
+      return (data != null ? _i74.Course.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i74.Enrollment?>()) {
-      return (data != null ? _i74.Enrollment.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i75.Enrollment?>()) {
+      return (data != null ? _i75.Enrollment.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i75.Student?>()) {
-      return (data != null ? _i75.Student.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i76.Student?>()) {
+      return (data != null ? _i76.Student.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i76.ObjectUser?>()) {
-      return (data != null ? _i76.ObjectUser.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i77.ObjectUser?>()) {
+      return (data != null ? _i77.ObjectUser.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i77.ParentUser?>()) {
-      return (data != null ? _i77.ParentUser.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i78.ParentUser?>()) {
+      return (data != null ? _i78.ParentUser.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i78.Arena?>()) {
-      return (data != null ? _i78.Arena.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i79.Arena?>()) {
+      return (data != null ? _i79.Arena.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i79.Player?>()) {
-      return (data != null ? _i79.Player.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i80.Player?>()) {
+      return (data != null ? _i80.Player.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i80.Team?>()) {
-      return (data != null ? _i80.Team.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i81.Team?>()) {
+      return (data != null ? _i81.Team.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i81.Comment?>()) {
-      return (data != null ? _i81.Comment.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i82.Comment?>()) {
+      return (data != null ? _i82.Comment.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i82.Customer?>()) {
-      return (data != null ? _i82.Customer.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i83.Customer?>()) {
+      return (data != null ? _i83.Customer.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i83.Order?>()) {
-      return (data != null ? _i83.Order.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i84.Order?>()) {
+      return (data != null ? _i84.Order.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i84.Address?>()) {
-      return (data != null ? _i84.Address.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i85.Address?>()) {
+      return (data != null ? _i85.Address.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i85.Citizen?>()) {
-      return (data != null ? _i85.Citizen.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i86.Citizen?>()) {
+      return (data != null ? _i86.Citizen.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i86.Company?>()) {
-      return (data != null ? _i86.Company.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i87.Company?>()) {
+      return (data != null ? _i87.Company.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i87.Town?>()) {
-      return (data != null ? _i87.Town.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i88.Town?>()) {
+      return (data != null ? _i88.Town.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i88.Blocking?>()) {
-      return (data != null ? _i88.Blocking.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i89.Blocking?>()) {
+      return (data != null ? _i89.Blocking.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i89.Member?>()) {
-      return (data != null ? _i89.Member.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i90.Member?>()) {
+      return (data != null ? _i90.Member.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i90.Cat?>()) {
-      return (data != null ? _i90.Cat.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i91.Cat?>()) {
+      return (data != null ? _i91.Cat.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i91.Post?>()) {
-      return (data != null ? _i91.Post.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i92.Post?>()) {
+      return (data != null ? _i92.Post.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i92.ModuleDatatype?>()) {
-      return (data != null ? _i92.ModuleDatatype.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i93.ModuleDatatype?>()) {
+      return (data != null ? _i93.ModuleDatatype.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i93.Nullability?>()) {
-      return (data != null ? _i93.Nullability.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i94.Nullability?>()) {
+      return (data != null ? _i94.Nullability.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i94.ObjectFieldPersist?>()) {
-      return (data != null ? _i94.ObjectFieldPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i95.ObjectFieldPersist?>()) {
+      return (data != null ? _i95.ObjectFieldPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i95.ObjectFieldScopes?>()) {
-      return (data != null ? _i95.ObjectFieldScopes.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i96.ObjectFieldScopes?>()) {
+      return (data != null ? _i96.ObjectFieldScopes.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i96.ObjectWithByteData?>()) {
-      return (data != null ? _i96.ObjectWithByteData.fromJson(data) : null)
+    if (t == _i1.getType<_i97.ObjectWithByteData?>()) {
+      return (data != null ? _i97.ObjectWithByteData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i97.ObjectWithCustomClass?>()) {
-      return (data != null ? _i97.ObjectWithCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i98.ObjectWithCustomClass?>()) {
+      return (data != null ? _i98.ObjectWithCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i98.ObjectWithDuration?>()) {
-      return (data != null ? _i98.ObjectWithDuration.fromJson(data) : null)
+    if (t == _i1.getType<_i99.ObjectWithDuration?>()) {
+      return (data != null ? _i99.ObjectWithDuration.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i99.ObjectWithEnum?>()) {
-      return (data != null ? _i99.ObjectWithEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i100.ObjectWithEnum?>()) {
+      return (data != null ? _i100.ObjectWithEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i100.ObjectWithIndex?>()) {
-      return (data != null ? _i100.ObjectWithIndex.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i101.ObjectWithIndex?>()) {
+      return (data != null ? _i101.ObjectWithIndex.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i101.ObjectWithMaps?>()) {
-      return (data != null ? _i101.ObjectWithMaps.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i102.ObjectWithMaps?>()) {
+      return (data != null ? _i102.ObjectWithMaps.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i102.ObjectWithObject?>()) {
-      return (data != null ? _i102.ObjectWithObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i103.ObjectWithObject?>()) {
+      return (data != null ? _i103.ObjectWithObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i103.ObjectWithParent?>()) {
-      return (data != null ? _i103.ObjectWithParent.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i104.ObjectWithParent?>()) {
+      return (data != null ? _i104.ObjectWithParent.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i104.ObjectWithSelfParent?>()) {
-      return (data != null ? _i104.ObjectWithSelfParent.fromJson(data) : null)
+    if (t == _i1.getType<_i105.ObjectWithSelfParent?>()) {
+      return (data != null ? _i105.ObjectWithSelfParent.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i105.ObjectWithUuid?>()) {
-      return (data != null ? _i105.ObjectWithUuid.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i106.ObjectWithUuid?>()) {
+      return (data != null ? _i106.ObjectWithUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i106.RelatedUniqueData?>()) {
-      return (data != null ? _i106.RelatedUniqueData.fromJson(data) : null)
+    if (t == _i1.getType<_i107.RelatedUniqueData?>()) {
+      return (data != null ? _i107.RelatedUniqueData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i107.ScopeNoneFields?>()) {
-      return (data != null ? _i107.ScopeNoneFields.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i108.ScopeNoneFields?>()) {
+      return (data != null ? _i108.ScopeNoneFields.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i108.ScopeServerOnlyField?>()) {
-      return (data != null ? _i108.ScopeServerOnlyField.fromJson(data) : null)
+    if (t == _i1.getType<_i109.ScopeServerOnlyField?>()) {
+      return (data != null ? _i109.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i109.ScopeServerOnlyFieldChild?>()) {
+    if (t == _i1.getType<_i110.ScopeServerOnlyFieldChild?>()) {
       return (data != null
-          ? _i109.ScopeServerOnlyFieldChild.fromJson(data)
+          ? _i110.ScopeServerOnlyFieldChild.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i110.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i110.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i111.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i111.DefaultServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i111.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i111.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i112.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i112.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i112.NotServerOnlyClass?>()) {
-      return (data != null ? _i112.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i113.NotServerOnlyClass?>()) {
+      return (data != null ? _i113.NotServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i113.NotServerOnlyEnum?>()) {
-      return (data != null ? _i113.NotServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i114.NotServerOnlyEnum?>()) {
+      return (data != null ? _i114.NotServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i114.ServerOnlyClassField?>()) {
-      return (data != null ? _i114.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i115.ServerOnlyClassField?>()) {
+      return (data != null ? _i115.ServerOnlyClassField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i115.SimpleData?>()) {
-      return (data != null ? _i115.SimpleData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i116.SimpleData?>()) {
+      return (data != null ? _i116.SimpleData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i116.SimpleDataList?>()) {
-      return (data != null ? _i116.SimpleDataList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i117.SimpleDataList?>()) {
+      return (data != null ? _i117.SimpleDataList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i117.SimpleDataMap?>()) {
-      return (data != null ? _i117.SimpleDataMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i118.SimpleDataMap?>()) {
+      return (data != null ? _i118.SimpleDataMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i118.SimpleDataObject?>()) {
-      return (data != null ? _i118.SimpleDataObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i119.SimpleDataObject?>()) {
+      return (data != null ? _i119.SimpleDataObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i119.SimpleDateTime?>()) {
-      return (data != null ? _i119.SimpleDateTime.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i120.SimpleDateTime?>()) {
+      return (data != null ? _i120.SimpleDateTime.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i120.TestEnum?>()) {
-      return (data != null ? _i120.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i121.TestEnum?>()) {
+      return (data != null ? _i121.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i121.TestEnumStringified?>()) {
-      return (data != null ? _i121.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i122.TestEnumStringified?>()) {
+      return (data != null ? _i122.TestEnumStringified.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i122.Types?>()) {
-      return (data != null ? _i122.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i123.Types?>()) {
+      return (data != null ? _i123.Types.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i123.TypesList?>()) {
-      return (data != null ? _i123.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i124.TypesList?>()) {
+      return (data != null ? _i124.TypesList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i124.TypesMap?>()) {
-      return (data != null ? _i124.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i125.TypesMap?>()) {
+      return (data != null ? _i125.TypesMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i125.TypesRecord?>()) {
-      return (data != null ? _i125.TypesRecord.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i126.TypesRecord?>()) {
+      return (data != null ? _i126.TypesRecord.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i126.TypesSet?>()) {
-      return (data != null ? _i126.TypesSet.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i127.TypesSet?>()) {
+      return (data != null ? _i127.TypesSet.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i127.UniqueData?>()) {
-      return (data != null ? _i127.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i128.UniqueData?>()) {
+      return (data != null ? _i128.UniqueData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i128.MyFeatureModel?>()) {
-      return (data != null ? _i128.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i129.MyFeatureModel?>()) {
+      return (data != null ? _i129.MyFeatureModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<List<_i48.EmptyModelRelationItem>?>()) {
+    if (t == _i1.getType<List<_i49.EmptyModelRelationItem>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i48.EmptyModelRelationItem>(e))
+              .map((e) => deserialize<_i49.EmptyModelRelationItem>(e))
               .toList()
           : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == _i1.getType<List<_i60.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i61.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i61.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i59.OrganizationWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i60.OrganizationWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i59.OrganizationWithLongTableName>(e))
+              .map((e) => deserialize<_i60.OrganizationWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i60.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i61.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i60.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i61.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i62.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i63.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i62.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i63.LongImplicitIdField>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i69.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i70.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i69.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i70.MultipleMaxFieldName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i65.UserNote>?>()) {
+    if (t == _i1.getType<List<_i66.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i65.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i66.UserNote>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i68.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i69.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i68.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i69.UserNoteWithALongName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i72.Person>?>()) {
+    if (t == _i1.getType<List<_i73.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i72.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i73.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i71.Organization>?>()) {
+    if (t == _i1.getType<List<_i72.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i71.Organization>(e))
+              .map((e) => deserialize<_i72.Organization>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i72.Person>?>()) {
+    if (t == _i1.getType<List<_i73.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i72.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i73.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i74.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i75.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i74.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i75.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i74.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i75.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i79.Player>?>()) {
+    if (t == _i1.getType<List<_i80.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i79.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i80.Player>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i83.Order>?>()) {
+    if (t == _i1.getType<List<_i84.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i83.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i84.Order>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i81.Comment>?>()) {
+    if (t == _i1.getType<List<_i82.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i81.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i82.Comment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i88.Blocking>?>()) {
+    if (t == _i1.getType<List<_i89.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i88.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i89.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i88.Blocking>?>()) {
+    if (t == _i1.getType<List<_i89.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i88.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i89.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i90.Cat>?>()) {
+    if (t == _i1.getType<List<_i91.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i90.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i91.Cat>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i129.ModuleClass>) {
+    if (t == List<_i130.ModuleClass>) {
       return (data as List)
-          .map((e) => deserialize<_i129.ModuleClass>(e))
+          .map((e) => deserialize<_i130.ModuleClass>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i129.ModuleClass>) {
+    if (t == Map<String, _i130.ModuleClass>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i129.ModuleClass>(v))) as T;
+          deserialize<String>(k), deserialize<_i130.ModuleClass>(v))) as T;
     }
-    if (t == _i1.getType<(_i129.ModuleClass,)?>()) {
+    if (t == _i1.getType<(_i130.ModuleClass,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i129.ModuleClass>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i130.ModuleClass>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == List<int>) {
@@ -1263,25 +1271,25 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i115.SimpleData>) {
+    if (t == List<_i116.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i115.SimpleData>(e))
+          .map((e) => deserialize<_i116.SimpleData>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i116.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i115.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i116.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i115.SimpleData?>) {
+    if (t == List<_i116.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i115.SimpleData?>(e))
+          .map((e) => deserialize<_i116.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i116.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i115.SimpleData?>(e))
+              .map((e) => deserialize<_i116.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -1301,22 +1309,22 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i130.ByteData>) {
-      return (data as List).map((e) => deserialize<_i130.ByteData>(e)).toList()
+    if (t == List<_i131.ByteData>) {
+      return (data as List).map((e) => deserialize<_i131.ByteData>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i130.ByteData>?>()) {
+    if (t == _i1.getType<List<_i131.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i130.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i131.ByteData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i130.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i130.ByteData?>(e)).toList()
+    if (t == List<_i131.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i131.ByteData?>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i130.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i131.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i130.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i131.ByteData?>(e)).toList()
           : null) as T;
     }
     if (t == List<Duration>) {
@@ -1374,32 +1382,32 @@ class Protocol extends _i1.SerializationManager {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as T;
     }
-    if (t == _i131.CustomClassWithoutProtocolSerialization) {
-      return _i131.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
+    if (t == _i132.CustomClassWithoutProtocolSerialization) {
+      return _i132.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i131.CustomClassWithProtocolSerialization) {
-      return _i131.CustomClassWithProtocolSerialization.fromJson(data) as T;
+    if (t == _i132.CustomClassWithProtocolSerialization) {
+      return _i132.CustomClassWithProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i131.CustomClassWithProtocolSerializationMethod) {
-      return _i131.CustomClassWithProtocolSerializationMethod.fromJson(data)
+    if (t == _i132.CustomClassWithProtocolSerializationMethod) {
+      return _i132.CustomClassWithProtocolSerializationMethod.fromJson(data)
           as T;
     }
-    if (t == List<_i120.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i120.TestEnum>(e)).toList()
+    if (t == List<_i121.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i121.TestEnum>(e)).toList()
           as T;
     }
-    if (t == List<_i120.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i120.TestEnum?>(e)).toList()
+    if (t == List<_i121.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i121.TestEnum?>(e)).toList()
           as T;
     }
-    if (t == List<List<_i120.TestEnum>>) {
+    if (t == List<List<_i121.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i120.TestEnum>>(e))
+          .map((e) => deserialize<List<_i121.TestEnum>>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i115.SimpleData>) {
+    if (t == Map<String, _i116.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i115.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i116.SimpleData>(v))) as T;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -1409,9 +1417,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime>(v))) as T;
     }
-    if (t == Map<String, _i130.ByteData>) {
+    if (t == Map<String, _i131.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i130.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i131.ByteData>(v)))
           as T;
     }
     if (t == Map<String, Duration>) {
@@ -1422,9 +1430,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v))) as T;
     }
-    if (t == Map<String, _i115.SimpleData?>) {
+    if (t == Map<String, _i116.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i115.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i116.SimpleData?>(v))) as T;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -1434,9 +1442,9 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i130.ByteData?>) {
+    if (t == Map<String, _i131.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i130.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i131.ByteData?>(v)))
           as T;
     }
     if (t == Map<String, Duration?>) {
@@ -1452,53 +1460,53 @@ class Protocol extends _i1.SerializationManager {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i116.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i115.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i116.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i115.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i116.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i115.SimpleData?>(e))
+              .map((e) => deserialize<_i116.SimpleData?>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<List<_i115.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i116.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i115.SimpleData>>(e))
+              .map((e) => deserialize<List<_i116.SimpleData>>(e))
               .toList()
           : null) as T;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i115.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i116.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i115.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i116.SimpleData>>?>>(v)))
           : null) as T;
     }
-    if (t == List<List<Map<int, _i115.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i116.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i115.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i116.SimpleData>>?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<Map<int, _i115.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i116.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i115.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i116.SimpleData>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<int, _i115.SimpleData>) {
+    if (t == Map<int, _i116.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i115.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i116.SimpleData>(e['v']))))
           as T;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i115.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i116.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i115.SimpleData>>(v)))
+              deserialize<Map<int, _i116.SimpleData>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -1552,9 +1560,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i130.ByteData>?>()) {
+    if (t == _i1.getType<List<_i131.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i130.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i131.ByteData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -1577,43 +1585,43 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i120.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i121.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i121.TestEnum>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i121.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i122.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i121.TestEnumStringified>(e))
+              .map((e) => deserialize<_i122.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i122.Types>?>()) {
+    if (t == _i1.getType<List<_i123.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i122.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i123.Types>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<Map<String, _i122.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i123.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i122.Types>>(e))
+              .map((e) => deserialize<Map<String, _i123.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<String, _i122.Types>) {
+    if (t == Map<String, _i123.Types>) {
       return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<_i122.Types>(v))) as T;
+          MapEntry(deserialize<String>(k), deserialize<_i123.Types>(v))) as T;
     }
-    if (t == _i1.getType<List<List<_i122.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i123.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i122.Types>>(e))
+              .map((e) => deserialize<List<_i123.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == List<_i122.Types>) {
-      return (data as List).map((e) => deserialize<_i122.Types>(e)).toList()
+    if (t == List<_i123.Types>) {
+      return (data as List).map((e) => deserialize<_i123.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<List<(int,)>?>()) {
@@ -1664,10 +1672,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i130.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i131.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i130.ByteData>(e['k']),
+              deserialize<_i131.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -1695,41 +1703,41 @@ class Protocol extends _i1.SerializationManager {
               deserialize<BigInt>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i120.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i121.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i120.TestEnum>(e['k']),
+              deserialize<_i121.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i121.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i122.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i121.TestEnumStringified>(e['k']),
+              deserialize<_i122.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i122.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i123.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i122.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i123.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<Map<_i122.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i123.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i122.Types, String>>(e['k']),
+              deserialize<Map<_i123.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == Map<_i122.Types, String>) {
+    if (t == Map<_i123.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i122.Types>(e['k']), deserialize<String>(e['v'])))) as T;
+          deserialize<_i123.Types>(e['k']), deserialize<String>(e['v'])))) as T;
     }
-    if (t == _i1.getType<Map<List<_i122.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i123.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i122.Types>>(e['k']),
+              deserialize<List<_i123.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -1772,10 +1780,10 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i130.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i131.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i130.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i131.ByteData>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -1802,34 +1810,34 @@ class Protocol extends _i1.SerializationManager {
               MapEntry(deserialize<String>(k), deserialize<BigInt>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i120.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i121.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i120.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i121.TestEnum>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i121.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i122.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i121.TestEnumStringified>(v)))
+              deserialize<_i122.TestEnumStringified>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i122.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i123.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i122.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i123.Types>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i122.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i123.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i122.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i123.Types>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, List<_i122.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i123.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i122.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i123.Types>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, (String,)>?>()) {
@@ -1888,10 +1896,10 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i130.ByteData,)?>()) {
+    if (t == _i1.getType<(_i131.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i130.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i131.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -1914,17 +1922,17 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i120.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i121.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i120.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i121.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<(_i121.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i122.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i121.TestEnumStringified>(
+              deserialize<_i122.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
@@ -1943,28 +1951,28 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i115.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i116.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i115.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i116.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i115.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i116.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i115.SimpleData>(
+              namedModel: deserialize<_i116.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i115.SimpleData, {_i115.SimpleData namedModel})?>()) {
+        _i1.getType<(_i116.SimpleData, {_i116.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i115.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i116.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i115.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i116.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -1980,21 +1988,21 @@ class Protocol extends _i1.SerializationManager {
     if (t ==
         _i1.getType<
             (
-              (List<(_i115.SimpleData,)>,), {
+              (List<(_i116.SimpleData,)>,), {
               (
-                _i115.SimpleData,
-                Map<String, _i115.SimpleData>
+                _i116.SimpleData,
+                Map<String, _i116.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i115.SimpleData,)>,)>(
+              deserialize<(List<(_i116.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i115.SimpleData,
-                    Map<String, _i115.SimpleData>
+                    _i116.SimpleData,
+                    Map<String, _i116.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
@@ -2023,9 +2031,9 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<String>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i130.ByteData>?>()) {
+    if (t == _i1.getType<Set<_i131.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i130.ByteData>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i131.ByteData>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<Duration>?>()) {
@@ -2043,33 +2051,33 @@ class Protocol extends _i1.SerializationManager {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i120.TestEnum>?>()) {
+    if (t == _i1.getType<Set<_i121.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.TestEnum>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i121.TestEnum>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i121.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Set<_i122.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i121.TestEnumStringified>(e))
+              .map((e) => deserialize<_i122.TestEnumStringified>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i122.Types>?>()) {
+    if (t == _i1.getType<Set<_i123.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i122.Types>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i123.Types>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<Map<String, _i122.Types>>?>()) {
+    if (t == _i1.getType<Set<Map<String, _i123.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i122.Types>>(e))
+              .map((e) => deserialize<Map<String, _i123.Types>>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<List<_i122.Types>>?>()) {
+    if (t == _i1.getType<Set<List<_i123.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i122.Types>>(e)).toSet()
+          ? (data as List).map((e) => deserialize<List<_i123.Types>>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -2098,9 +2106,9 @@ class Protocol extends _i1.SerializationManager {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == List<_i132.SimpleData>) {
+    if (t == List<_i133.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i132.SimpleData>(e))
+          .map((e) => deserialize<_i133.SimpleData>(e))
           .toList() as T;
     }
     if (t == List<int>) {
@@ -2157,28 +2165,28 @@ class Protocol extends _i1.SerializationManager {
     if (t == List<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
     }
-    if (t == List<_i130.ByteData>) {
-      return (data as List).map((e) => deserialize<_i130.ByteData>(e)).toList()
+    if (t == List<_i131.ByteData>) {
+      return (data as List).map((e) => deserialize<_i131.ByteData>(e)).toList()
           as T;
     }
-    if (t == List<_i130.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i130.ByteData?>(e)).toList()
+    if (t == List<_i131.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i131.ByteData?>(e)).toList()
           as T;
     }
-    if (t == List<_i132.SimpleData?>) {
+    if (t == List<_i133.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i132.SimpleData?>(e))
+          .map((e) => deserialize<_i133.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i132.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i133.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i132.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i133.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i132.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i133.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i132.SimpleData?>(e))
+              .map((e) => deserialize<_i133.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -2217,13 +2225,13 @@ class Protocol extends _i1.SerializationManager {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<_i133.TestEnum, int>) {
+    if (t == Map<_i134.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i133.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
+          deserialize<_i134.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<String, _i133.TestEnum>) {
+    if (t == Map<String, _i134.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i133.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i134.TestEnum>(v)))
           as T;
     }
     if (t == Map<String, double>) {
@@ -2260,34 +2268,34 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i130.ByteData>) {
+    if (t == Map<String, _i131.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i130.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i131.ByteData>(v)))
           as T;
     }
-    if (t == Map<String, _i130.ByteData?>) {
+    if (t == Map<String, _i131.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i130.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i131.ByteData?>(v)))
           as T;
     }
-    if (t == Map<String, _i132.SimpleData>) {
+    if (t == Map<String, _i133.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i132.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i133.SimpleData>(v))) as T;
     }
-    if (t == Map<String, _i132.SimpleData?>) {
+    if (t == Map<String, _i133.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i132.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i133.SimpleData?>(v))) as T;
     }
-    if (t == _i1.getType<Map<String, _i132.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i133.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i132.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i133.SimpleData>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i132.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i133.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i132.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i133.SimpleData?>(v)))
           : null) as T;
     }
     if (t == Map<String, Duration>) {
@@ -2298,20 +2306,20 @@ class Protocol extends _i1.SerializationManager {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<Duration?>(v))) as T;
     }
-    if (t == List<_i134.UserInfo>) {
-      return (data as List).map((e) => deserialize<_i134.UserInfo>(e)).toList()
+    if (t == List<_i135.UserInfo>) {
+      return (data as List).map((e) => deserialize<_i135.UserInfo>(e)).toList()
           as T;
     }
     if (t == Set<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
     }
-    if (t == Set<_i132.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i132.SimpleData>(e)).toSet()
+    if (t == Set<_i133.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i133.SimpleData>(e)).toSet()
           as T;
     }
-    if (t == List<Set<_i132.SimpleData>>) {
+    if (t == List<Set<_i133.SimpleData>>) {
       return (data as List)
-          .map((e) => deserialize<Set<_i132.SimpleData>>(e))
+          .map((e) => deserialize<Set<_i133.SimpleData>>(e))
           .toList() as T;
     }
     if (t == _i1.getType<(int,)>()) {
@@ -2352,18 +2360,18 @@ class Protocol extends _i1.SerializationManager {
               deserialize<String>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i132.SimpleData>(data['p'][1]),
+        deserialize<_i133.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i132.SimpleData>(data['p'][1]),
+              deserialize<_i133.SimpleData>(data['p'][1]),
             ) as T;
     }
     if (t == _i1.getType<({int number, String text})>()) {
@@ -2380,135 +2388,135 @@ class Protocol extends _i1.SerializationManager {
               text: deserialize<String>(data['n']['text']),
             ) as T;
     }
-    if (t == _i1.getType<({_i132.SimpleData data, int number})>()) {
+    if (t == _i1.getType<({_i133.SimpleData data, int number})>()) {
       return (
         data:
-            deserialize<_i132.SimpleData>(((data as Map)['n'] as Map)['data']),
+            deserialize<_i133.SimpleData>(((data as Map)['n'] as Map)['data']),
         number: deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<({_i132.SimpleData data, int number})?>()) {
+    if (t == _i1.getType<({_i133.SimpleData data, int number})?>()) {
       return (data == null)
           ? null as T
           : (
-              data: deserialize<_i132.SimpleData>(
+              data: deserialize<_i133.SimpleData>(
                   ((data as Map)['n'] as Map)['data']),
               number: deserialize<int>(data['n']['number']),
             ) as T;
     }
-    if (t == _i1.getType<({_i132.SimpleData? data, int? number})>()) {
+    if (t == _i1.getType<({_i133.SimpleData? data, int? number})>()) {
       return (
         data: ((data as Map)['n'] as Map)['data'] == null
             ? null
-            : deserialize<_i132.SimpleData>(data['n']['data']),
+            : deserialize<_i133.SimpleData>(data['n']['data']),
         number: ((data)['n'] as Map)['number'] == null
             ? null
             : deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i132.SimpleData data})>()) {
+    if (t == _i1.getType<(int, {_i133.SimpleData data})>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        data: deserialize<_i132.SimpleData>(data['n']['data']),
+        data: deserialize<_i133.SimpleData>(data['n']['data']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i132.SimpleData data})?>()) {
+    if (t == _i1.getType<(int, {_i133.SimpleData data})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              data: deserialize<_i132.SimpleData>(data['n']['data']),
+              data: deserialize<_i133.SimpleData>(data['n']['data']),
             ) as T;
     }
-    if (t == List<(int, _i132.SimpleData)>) {
+    if (t == List<(int, _i133.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i132.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i133.SimpleData)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i132.SimpleData>(data['p'][1]),
+        deserialize<_i133.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == List<(int, _i132.SimpleData)?>) {
+    if (t == List<(int, _i133.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i132.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i133.SimpleData)?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i132.SimpleData>(data['p'][1]),
+              deserialize<_i133.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Set<(int, _i132.SimpleData)>) {
+    if (t == Set<(int, _i133.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i132.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i133.SimpleData)>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i132.SimpleData>(data['p'][1]),
+        deserialize<_i133.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Set<(int, _i132.SimpleData)?>) {
+    if (t == Set<(int, _i133.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i132.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i133.SimpleData)?>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i132.SimpleData>(data['p'][1]),
+              deserialize<_i133.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<Set<(int, _i132.SimpleData)>?>()) {
+    if (t == _i1.getType<Set<(int, _i133.SimpleData)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(int, _i132.SimpleData)>(e))
+              .map((e) => deserialize<(int, _i133.SimpleData)>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i132.SimpleData>(data['p'][1]),
+        deserialize<_i133.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i132.SimpleData)>) {
+    if (t == Map<String, (int, _i133.SimpleData)>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i132.SimpleData)>(v)))
+              deserialize<String>(k), deserialize<(int, _i133.SimpleData)>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i132.SimpleData>(data['p'][1]),
+        deserialize<_i133.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i132.SimpleData)?>) {
+    if (t == Map<String, (int, _i133.SimpleData)?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i132.SimpleData)?>(v)))
+              deserialize<String>(k), deserialize<(int, _i133.SimpleData)?>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i132.SimpleData>(data['p'][1]),
+              deserialize<_i133.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Map<(String, int), (int, _i132.SimpleData)>) {
+    if (t == Map<(String, int), (int, _i133.SimpleData)>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
           deserialize<(String, int)>(e['k']),
-          deserialize<(int, _i132.SimpleData)>(e['v'])))) as T;
+          deserialize<(int, _i133.SimpleData)>(e['v'])))) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
       return (
@@ -2516,10 +2524,10 @@ class Protocol extends _i1.SerializationManager {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i132.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i133.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i132.SimpleData>(data['p'][1]),
+        deserialize<_i133.SimpleData>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
@@ -2571,56 +2579,56 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i1.getType<(int,)>()) {
       return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<({(_i132.SimpleData, double) namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i133.SimpleData, double) namedSubRecord})>()) {
       return (
-        namedSubRecord: deserialize<(_i132.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i133.SimpleData, double)>(
             ((data as Map)['n'] as Map)['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i132.SimpleData, double)>()) {
+    if (t == _i1.getType<(_i133.SimpleData, double)>()) {
       return (
-        deserialize<_i132.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<_i133.SimpleData>(((data as Map)['p'] as List)[0]),
         deserialize<double>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<({(_i132.SimpleData, double)? namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i133.SimpleData, double)? namedSubRecord})>()) {
       return (
         namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
             ? null
-            : deserialize<(_i132.SimpleData, double)>(
+            : deserialize<(_i133.SimpleData, double)>(
                 data['n']['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i132.SimpleData, double)?>()) {
+    if (t == _i1.getType<(_i133.SimpleData, double)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i132.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i133.SimpleData>(((data as Map)['p'] as List)[0]),
               deserialize<double>(data['p'][1]),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i132.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i133.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i132.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i133.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
     if (t ==
-        List<((int, String), {(_i132.SimpleData, double) namedSubRecord})>) {
+        List<((int, String), {(_i133.SimpleData, double) namedSubRecord})>) {
       return (data as List)
           .map((e) => deserialize<
-              ((int, String), {(_i132.SimpleData, double) namedSubRecord})>(e))
+              ((int, String), {(_i133.SimpleData, double) namedSubRecord})>(e))
           .toList() as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i132.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i133.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i132.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i133.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
@@ -2629,37 +2637,37 @@ class Protocol extends _i1.SerializationManager {
             List<
                 (
                   (int, String), {
-                  (_i132.SimpleData, double) namedSubRecord
+                  (_i133.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i132.SimpleData, double) namedSubRecord
+                    (_i133.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i132.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i133.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i132.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i133.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i132.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i133.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i132.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i133.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -2719,17 +2727,17 @@ class Protocol extends _i1.SerializationManager {
     if (t == Set<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
     }
-    if (t == Set<_i130.ByteData>) {
-      return (data as List).map((e) => deserialize<_i130.ByteData>(e)).toSet()
+    if (t == Set<_i131.ByteData>) {
+      return (data as List).map((e) => deserialize<_i131.ByteData>(e)).toSet()
           as T;
     }
-    if (t == Set<_i130.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i130.ByteData?>(e)).toSet()
+    if (t == Set<_i131.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i131.ByteData?>(e)).toSet()
           as T;
     }
-    if (t == Set<_i132.SimpleData?>) {
+    if (t == Set<_i133.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i132.SimpleData?>(e))
+          .map((e) => deserialize<_i133.SimpleData?>(e))
           .toSet() as T;
     }
     if (t == Set<Duration>) {
@@ -2738,8 +2746,8 @@ class Protocol extends _i1.SerializationManager {
     if (t == Set<Duration?>) {
       return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
     }
-    if (t == List<_i135.Types>) {
-      return (data as List).map((e) => deserialize<_i135.Types>(e)).toList()
+    if (t == List<_i136.Types>) {
+      return (data as List).map((e) => deserialize<_i136.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<(String, (int, bool))>()) {
@@ -2769,7 +2777,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -2777,17 +2785,17 @@ class Protocol extends _i1.SerializationManager {
             (
               Map<String, int>, {
               bool flag,
-              _i132.SimpleData simpleData
+              _i133.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
     if (t ==
         _i1.getType<
-            (Map<String, int>, {bool flag, _i132.SimpleData simpleData})>()) {
+            (Map<String, int>, {bool flag, _i133.SimpleData simpleData})>()) {
       return (
         deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
         flag: deserialize<bool>(data['n']['flag']),
-        simpleData: deserialize<_i132.SimpleData>(data['n']['simpleData']),
+        simpleData: deserialize<_i133.SimpleData>(data['n']['simpleData']),
       ) as T;
     }
     if (t == List<(String, int)>) {
@@ -2804,7 +2812,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -2814,7 +2822,7 @@ class Protocol extends _i1.SerializationManager {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i132.SimpleData simpleData
+                    _i133.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -2829,10 +2837,10 @@ class Protocol extends _i1.SerializationManager {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(_i129.ModuleClass,)?>()) {
+    if (t == _i1.getType<(_i130.ModuleClass,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i129.ModuleClass>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i130.ModuleClass>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(String, {Uri? optionalUri})?>()) {
@@ -2926,10 +2934,10 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i130.ByteData,)?>()) {
+    if (t == _i1.getType<(_i131.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i130.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i131.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -2952,17 +2960,17 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i120.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i121.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i120.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i121.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<(_i121.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i122.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i121.TestEnumStringified>(
+              deserialize<_i122.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
@@ -2981,28 +2989,28 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i115.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i116.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i115.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i116.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i115.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i116.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i115.SimpleData>(
+              namedModel: deserialize<_i116.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i115.SimpleData, {_i115.SimpleData namedModel})?>()) {
+        _i1.getType<(_i116.SimpleData, {_i116.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i115.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i116.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i115.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i116.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -3024,46 +3032,46 @@ class Protocol extends _i1.SerializationManager {
     if (t ==
         _i1.getType<
             (
-              (List<(_i115.SimpleData,)>,), {
+              (List<(_i116.SimpleData,)>,), {
               (
-                _i115.SimpleData,
-                Map<String, _i115.SimpleData>
+                _i116.SimpleData,
+                Map<String, _i116.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i115.SimpleData,)>,)>(
+              deserialize<(List<(_i116.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i115.SimpleData,
-                    Map<String, _i115.SimpleData>
+                    _i116.SimpleData,
+                    Map<String, _i116.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
-    if (t == _i1.getType<(List<(_i115.SimpleData,)>,)>()) {
+    if (t == _i1.getType<(List<(_i116.SimpleData,)>,)>()) {
       return (
-        deserialize<List<(_i115.SimpleData,)>>(((data as Map)['p'] as List)[0]),
+        deserialize<List<(_i116.SimpleData,)>>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == List<(_i115.SimpleData,)>) {
+    if (t == List<(_i116.SimpleData,)>) {
       return (data as List)
-          .map((e) => deserialize<(_i115.SimpleData,)>(e))
+          .map((e) => deserialize<(_i116.SimpleData,)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(_i115.SimpleData,)>()) {
-      return (deserialize<_i115.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i116.SimpleData,)>()) {
+      return (deserialize<_i116.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i115.SimpleData,)>()) {
-      return (deserialize<_i115.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i116.SimpleData,)>()) {
+      return (deserialize<_i116.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i115.SimpleData, Map<String, _i115.SimpleData>)>()) {
+    if (t == _i1.getType<(_i116.SimpleData, Map<String, _i116.SimpleData>)>()) {
       return (
-        deserialize<_i115.SimpleData>(((data as Map)['p'] as List)[0]),
-        deserialize<Map<String, _i115.SimpleData>>(data['p'][1]),
+        deserialize<_i116.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<Map<String, _i116.SimpleData>>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -3084,57 +3092,57 @@ class Protocol extends _i1.SerializationManager {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i131.CustomClass) {
-      return _i131.CustomClass.fromJson(data) as T;
+    if (t == _i132.CustomClass) {
+      return _i132.CustomClass.fromJson(data) as T;
     }
-    if (t == _i131.CustomClass2) {
-      return _i131.CustomClass2.fromJson(data) as T;
+    if (t == _i132.CustomClass2) {
+      return _i132.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i131.ProtocolCustomClass) {
-      return _i131.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i132.ProtocolCustomClass) {
+      return _i132.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i131.ExternalCustomClass) {
-      return _i131.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i132.ExternalCustomClass) {
+      return _i132.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i131.FreezedCustomClass) {
-      return _i131.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i132.FreezedCustomClass) {
+      return _i132.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i131.CustomClass?>()) {
-      return (data != null ? _i131.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i132.CustomClass?>()) {
+      return (data != null ? _i132.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i131.CustomClass2?>()) {
-      return (data != null ? _i131.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i132.CustomClass2?>()) {
+      return (data != null ? _i132.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i131.CustomClassWithoutProtocolSerialization?>()) {
+    if (t == _i1.getType<_i132.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? _i131.CustomClassWithoutProtocolSerialization.fromJson(data)
+          ? _i132.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i131.CustomClassWithProtocolSerialization?>()) {
+    if (t == _i1.getType<_i132.CustomClassWithProtocolSerialization?>()) {
       return (data != null
-          ? _i131.CustomClassWithProtocolSerialization.fromJson(data)
+          ? _i132.CustomClassWithProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i131.CustomClassWithProtocolSerializationMethod?>()) {
+    if (t == _i1.getType<_i132.CustomClassWithProtocolSerializationMethod?>()) {
       return (data != null
-          ? _i131.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          ? _i132.CustomClassWithProtocolSerializationMethod.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i131.ProtocolCustomClass?>()) {
-      return (data != null ? _i131.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i132.ProtocolCustomClass?>()) {
+      return (data != null ? _i132.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i131.ExternalCustomClass?>()) {
-      return (data != null ? _i131.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i132.ExternalCustomClass?>()) {
+      return (data != null ? _i132.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i131.FreezedCustomClass?>()) {
-      return (data != null ? _i131.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i132.FreezedCustomClass?>()) {
+      return (data != null ? _i132.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<List<_i132.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i133.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i132.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i133.SimpleData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<(int?,)?>()) {
@@ -3151,26 +3159,26 @@ class Protocol extends _i1.SerializationManager {
             List<
                 (
                   (int, String), {
-                  (_i132.SimpleData, double) namedSubRecord
+                  (_i133.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i132.SimpleData, double) namedSubRecord
+                    (_i133.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i132.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i133.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i132.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i133.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -3178,7 +3186,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -3186,7 +3194,7 @@ class Protocol extends _i1.SerializationManager {
             (
               Map<String, int>, {
               bool flag,
-              _i132.SimpleData simpleData
+              _i133.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
@@ -3200,7 +3208,7 @@ class Protocol extends _i1.SerializationManager {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -3210,7 +3218,7 @@ class Protocol extends _i1.SerializationManager {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i132.SimpleData simpleData
+                    _i133.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -3226,10 +3234,10 @@ class Protocol extends _i1.SerializationManager {
       ) as T;
     }
     try {
-      return _i134.Protocol().deserialize<T>(data, t);
+      return _i135.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     try {
-      return _i129.Protocol().deserialize<T>(data, t);
+      return _i130.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -3238,28 +3246,28 @@ class Protocol extends _i1.SerializationManager {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i131.CustomClass) {
+    if (data is _i132.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i131.CustomClass2) {
+    if (data is _i132.CustomClass2) {
       return 'CustomClass2';
     }
-    if (data is _i131.CustomClassWithoutProtocolSerialization) {
+    if (data is _i132.CustomClassWithoutProtocolSerialization) {
       return 'CustomClassWithoutProtocolSerialization';
     }
-    if (data is _i131.CustomClassWithProtocolSerialization) {
+    if (data is _i132.CustomClassWithProtocolSerialization) {
       return 'CustomClassWithProtocolSerialization';
     }
-    if (data is _i131.CustomClassWithProtocolSerializationMethod) {
+    if (data is _i132.CustomClassWithProtocolSerializationMethod) {
       return 'CustomClassWithProtocolSerializationMethod';
     }
-    if (data is _i131.ProtocolCustomClass) {
+    if (data is _i132.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
     }
-    if (data is _i131.ExternalCustomClass) {
+    if (data is _i132.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i131.FreezedCustomClass) {
+    if (data is _i132.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i2.ByIndexEnumWithNameValue) {
@@ -3346,351 +3354,354 @@ class Protocol extends _i1.SerializationManager {
     if (data is _i29.ByNameEnum) {
       return 'ByNameEnum';
     }
-    if (data is _i30.DefaultException) {
+    if (data is _i30.DefaultValueEnum) {
+      return 'DefaultValueEnum';
+    }
+    if (data is _i31.DefaultException) {
       return 'DefaultException';
     }
-    if (data is _i31.IntDefault) {
+    if (data is _i32.IntDefault) {
       return 'IntDefault';
     }
-    if (data is _i32.IntDefaultMix) {
+    if (data is _i33.IntDefaultMix) {
       return 'IntDefaultMix';
     }
-    if (data is _i33.IntDefaultModel) {
+    if (data is _i34.IntDefaultModel) {
       return 'IntDefaultModel';
     }
-    if (data is _i34.IntDefaultPersist) {
+    if (data is _i35.IntDefaultPersist) {
       return 'IntDefaultPersist';
     }
-    if (data is _i35.StringDefault) {
+    if (data is _i36.StringDefault) {
       return 'StringDefault';
     }
-    if (data is _i36.StringDefaultMix) {
+    if (data is _i37.StringDefaultMix) {
       return 'StringDefaultMix';
     }
-    if (data is _i37.StringDefaultModel) {
+    if (data is _i38.StringDefaultModel) {
       return 'StringDefaultModel';
     }
-    if (data is _i38.StringDefaultPersist) {
+    if (data is _i39.StringDefaultPersist) {
       return 'StringDefaultPersist';
     }
-    if (data is _i39.UriDefault) {
+    if (data is _i40.UriDefault) {
       return 'UriDefault';
     }
-    if (data is _i40.UriDefaultMix) {
+    if (data is _i41.UriDefaultMix) {
       return 'UriDefaultMix';
     }
-    if (data is _i41.UriDefaultModel) {
+    if (data is _i42.UriDefaultModel) {
       return 'UriDefaultModel';
     }
-    if (data is _i42.UriDefaultPersist) {
+    if (data is _i43.UriDefaultPersist) {
       return 'UriDefaultPersist';
     }
-    if (data is _i43.UuidDefault) {
+    if (data is _i44.UuidDefault) {
       return 'UuidDefault';
     }
-    if (data is _i44.UuidDefaultMix) {
+    if (data is _i45.UuidDefaultMix) {
       return 'UuidDefaultMix';
     }
-    if (data is _i45.UuidDefaultModel) {
+    if (data is _i46.UuidDefaultModel) {
       return 'UuidDefaultModel';
     }
-    if (data is _i46.UuidDefaultPersist) {
+    if (data is _i47.UuidDefaultPersist) {
       return 'UuidDefaultPersist';
     }
-    if (data is _i47.EmptyModel) {
+    if (data is _i48.EmptyModel) {
       return 'EmptyModel';
     }
-    if (data is _i48.EmptyModelRelationItem) {
+    if (data is _i49.EmptyModelRelationItem) {
       return 'EmptyModelRelationItem';
     }
-    if (data is _i49.EmptyModelWithTable) {
+    if (data is _i50.EmptyModelWithTable) {
       return 'EmptyModelWithTable';
     }
-    if (data is _i50.RelationEmptyModel) {
+    if (data is _i51.RelationEmptyModel) {
       return 'RelationEmptyModel';
     }
-    if (data is _i51.ExceptionWithData) {
+    if (data is _i52.ExceptionWithData) {
       return 'ExceptionWithData';
     }
-    if (data is _i52.ChildClass) {
+    if (data is _i53.ChildClass) {
       return 'ChildClass';
     }
-    if (data is _i53.ChildWithDefault) {
+    if (data is _i54.ChildWithDefault) {
       return 'ChildWithDefault';
     }
-    if (data is _i54.GrandparentClass) {
+    if (data is _i55.GrandparentClass) {
       return 'GrandparentClass';
     }
-    if (data is _i55.ParentClass) {
+    if (data is _i56.ParentClass) {
       return 'ParentClass';
     }
-    if (data is _i56.ParentWithDefault) {
+    if (data is _i57.ParentWithDefault) {
       return 'ParentWithDefault';
     }
-    if (data is _i57.SealedChild) {
+    if (data is _i58.SealedChild) {
       return 'SealedChild';
     }
-    if (data is _i57.SealedGrandChild) {
+    if (data is _i58.SealedGrandChild) {
       return 'SealedGrandChild';
     }
-    if (data is _i57.SealedOtherChild) {
+    if (data is _i58.SealedOtherChild) {
       return 'SealedOtherChild';
     }
-    if (data is _i58.CityWithLongTableName) {
+    if (data is _i59.CityWithLongTableName) {
       return 'CityWithLongTableName';
     }
-    if (data is _i59.OrganizationWithLongTableName) {
+    if (data is _i60.OrganizationWithLongTableName) {
       return 'OrganizationWithLongTableName';
     }
-    if (data is _i60.PersonWithLongTableName) {
+    if (data is _i61.PersonWithLongTableName) {
       return 'PersonWithLongTableName';
     }
-    if (data is _i61.MaxFieldName) {
+    if (data is _i62.MaxFieldName) {
       return 'MaxFieldName';
     }
-    if (data is _i62.LongImplicitIdField) {
+    if (data is _i63.LongImplicitIdField) {
       return 'LongImplicitIdField';
     }
-    if (data is _i63.LongImplicitIdFieldCollection) {
+    if (data is _i64.LongImplicitIdFieldCollection) {
       return 'LongImplicitIdFieldCollection';
     }
-    if (data is _i64.RelationToMultipleMaxFieldName) {
+    if (data is _i65.RelationToMultipleMaxFieldName) {
       return 'RelationToMultipleMaxFieldName';
     }
-    if (data is _i65.UserNote) {
+    if (data is _i66.UserNote) {
       return 'UserNote';
     }
-    if (data is _i66.UserNoteCollection) {
+    if (data is _i67.UserNoteCollection) {
       return 'UserNoteCollection';
     }
-    if (data is _i67.UserNoteCollectionWithALongName) {
+    if (data is _i68.UserNoteCollectionWithALongName) {
       return 'UserNoteCollectionWithALongName';
     }
-    if (data is _i68.UserNoteWithALongName) {
+    if (data is _i69.UserNoteWithALongName) {
       return 'UserNoteWithALongName';
     }
-    if (data is _i69.MultipleMaxFieldName) {
+    if (data is _i70.MultipleMaxFieldName) {
       return 'MultipleMaxFieldName';
     }
-    if (data is _i70.City) {
+    if (data is _i71.City) {
       return 'City';
     }
-    if (data is _i71.Organization) {
+    if (data is _i72.Organization) {
       return 'Organization';
     }
-    if (data is _i72.Person) {
+    if (data is _i73.Person) {
       return 'Person';
     }
-    if (data is _i73.Course) {
+    if (data is _i74.Course) {
       return 'Course';
     }
-    if (data is _i74.Enrollment) {
+    if (data is _i75.Enrollment) {
       return 'Enrollment';
     }
-    if (data is _i75.Student) {
+    if (data is _i76.Student) {
       return 'Student';
     }
-    if (data is _i76.ObjectUser) {
+    if (data is _i77.ObjectUser) {
       return 'ObjectUser';
     }
-    if (data is _i77.ParentUser) {
+    if (data is _i78.ParentUser) {
       return 'ParentUser';
     }
-    if (data is _i78.Arena) {
+    if (data is _i79.Arena) {
       return 'Arena';
     }
-    if (data is _i79.Player) {
+    if (data is _i80.Player) {
       return 'Player';
     }
-    if (data is _i80.Team) {
+    if (data is _i81.Team) {
       return 'Team';
     }
-    if (data is _i81.Comment) {
+    if (data is _i82.Comment) {
       return 'Comment';
     }
-    if (data is _i82.Customer) {
+    if (data is _i83.Customer) {
       return 'Customer';
     }
-    if (data is _i83.Order) {
+    if (data is _i84.Order) {
       return 'Order';
     }
-    if (data is _i84.Address) {
+    if (data is _i85.Address) {
       return 'Address';
     }
-    if (data is _i85.Citizen) {
+    if (data is _i86.Citizen) {
       return 'Citizen';
     }
-    if (data is _i86.Company) {
+    if (data is _i87.Company) {
       return 'Company';
     }
-    if (data is _i87.Town) {
+    if (data is _i88.Town) {
       return 'Town';
     }
-    if (data is _i88.Blocking) {
+    if (data is _i89.Blocking) {
       return 'Blocking';
     }
-    if (data is _i89.Member) {
+    if (data is _i90.Member) {
       return 'Member';
     }
-    if (data is _i90.Cat) {
+    if (data is _i91.Cat) {
       return 'Cat';
     }
-    if (data is _i91.Post) {
+    if (data is _i92.Post) {
       return 'Post';
     }
-    if (data is _i92.ModuleDatatype) {
+    if (data is _i93.ModuleDatatype) {
       return 'ModuleDatatype';
     }
-    if (data is _i93.Nullability) {
+    if (data is _i94.Nullability) {
       return 'Nullability';
     }
-    if (data is _i94.ObjectFieldPersist) {
+    if (data is _i95.ObjectFieldPersist) {
       return 'ObjectFieldPersist';
     }
-    if (data is _i95.ObjectFieldScopes) {
+    if (data is _i96.ObjectFieldScopes) {
       return 'ObjectFieldScopes';
     }
-    if (data is _i96.ObjectWithByteData) {
+    if (data is _i97.ObjectWithByteData) {
       return 'ObjectWithByteData';
     }
-    if (data is _i97.ObjectWithCustomClass) {
+    if (data is _i98.ObjectWithCustomClass) {
       return 'ObjectWithCustomClass';
     }
-    if (data is _i98.ObjectWithDuration) {
+    if (data is _i99.ObjectWithDuration) {
       return 'ObjectWithDuration';
     }
-    if (data is _i99.ObjectWithEnum) {
+    if (data is _i100.ObjectWithEnum) {
       return 'ObjectWithEnum';
     }
-    if (data is _i100.ObjectWithIndex) {
+    if (data is _i101.ObjectWithIndex) {
       return 'ObjectWithIndex';
     }
-    if (data is _i101.ObjectWithMaps) {
+    if (data is _i102.ObjectWithMaps) {
       return 'ObjectWithMaps';
     }
-    if (data is _i102.ObjectWithObject) {
+    if (data is _i103.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i103.ObjectWithParent) {
+    if (data is _i104.ObjectWithParent) {
       return 'ObjectWithParent';
     }
-    if (data is _i104.ObjectWithSelfParent) {
+    if (data is _i105.ObjectWithSelfParent) {
       return 'ObjectWithSelfParent';
     }
-    if (data is _i105.ObjectWithUuid) {
+    if (data is _i106.ObjectWithUuid) {
       return 'ObjectWithUuid';
     }
-    if (data is _i106.RelatedUniqueData) {
+    if (data is _i107.RelatedUniqueData) {
       return 'RelatedUniqueData';
     }
-    if (data is _i107.ScopeNoneFields) {
+    if (data is _i108.ScopeNoneFields) {
       return 'ScopeNoneFields';
     }
-    if (data is _i108.ScopeServerOnlyField) {
+    if (data is _i109.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i109.ScopeServerOnlyFieldChild) {
+    if (data is _i110.ScopeServerOnlyFieldChild) {
       return 'ScopeServerOnlyFieldChild';
     }
-    if (data is _i110.DefaultServerOnlyClass) {
+    if (data is _i111.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i111.DefaultServerOnlyEnum) {
+    if (data is _i112.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i112.NotServerOnlyClass) {
+    if (data is _i113.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i113.NotServerOnlyEnum) {
+    if (data is _i114.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i114.ServerOnlyClassField) {
+    if (data is _i115.ServerOnlyClassField) {
       return 'ServerOnlyClassField';
     }
-    if (data is _i115.SimpleData) {
+    if (data is _i116.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i116.SimpleDataList) {
+    if (data is _i117.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i117.SimpleDataMap) {
+    if (data is _i118.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i118.SimpleDataObject) {
+    if (data is _i119.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i119.SimpleDateTime) {
+    if (data is _i120.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i120.TestEnum) {
+    if (data is _i121.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i121.TestEnumStringified) {
+    if (data is _i122.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i122.Types) {
+    if (data is _i123.Types) {
       return 'Types';
     }
-    if (data is _i123.TypesList) {
+    if (data is _i124.TypesList) {
       return 'TypesList';
     }
-    if (data is _i124.TypesMap) {
+    if (data is _i125.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i125.TypesRecord) {
+    if (data is _i126.TypesRecord) {
       return 'TypesRecord';
     }
-    if (data is _i126.TypesSet) {
+    if (data is _i127.TypesSet) {
       return 'TypesSet';
     }
-    if (data is _i127.UniqueData) {
+    if (data is _i128.UniqueData) {
       return 'UniqueData';
     }
-    if (data is _i128.MyFeatureModel) {
+    if (data is _i129.MyFeatureModel) {
       return 'MyFeatureModel';
     }
-    className = _i134.Protocol().getClassNameForObject(data);
+    className = _i135.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_auth.$className';
     }
-    className = _i129.Protocol().getClassNameForObject(data);
+    className = _i130.Protocol().getClassNameForObject(data);
     if (className != null) {
       return 'serverpod_test_module.$className';
     }
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i132.SimpleData>) {
+    if (data is List<_i133.SimpleData>) {
       return 'List<SimpleData>';
     }
-    if (data is List<_i134.UserInfo>) {
+    if (data is List<_i135.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i132.SimpleData>?) {
+    if (data is List<_i133.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i132.SimpleData?>) {
+    if (data is List<_i133.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i132.SimpleData>) {
+    if (data is Set<_i133.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i132.SimpleData>>) {
+    if (data is List<Set<_i133.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
     if (data is (int?,)?) {
       return '(int?,)?';
     }
     if (data is List<
-        ((int, String), {(_i132.SimpleData, double) namedSubRecord})?>?) {
+        ((int, String), {(_i133.SimpleData, double) namedSubRecord})?>?) {
       return 'List<((int,String),{(SimpleData,double) namedSubRecord})?>?';
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
     )) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))';
     }
@@ -3699,7 +3710,7 @@ class Protocol extends _i1.SerializationManager {
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
     )?) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?';
     }
@@ -3716,31 +3727,31 @@ class Protocol extends _i1.SerializationManager {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CustomClass') {
-      return deserialize<_i131.CustomClass>(data['data']);
+      return deserialize<_i132.CustomClass>(data['data']);
     }
     if (dataClassName == 'CustomClass2') {
-      return deserialize<_i131.CustomClass2>(data['data']);
+      return deserialize<_i132.CustomClass2>(data['data']);
     }
     if (dataClassName == 'CustomClassWithoutProtocolSerialization') {
-      return deserialize<_i131.CustomClassWithoutProtocolSerialization>(
+      return deserialize<_i132.CustomClassWithoutProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerialization') {
-      return deserialize<_i131.CustomClassWithProtocolSerialization>(
+      return deserialize<_i132.CustomClassWithProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerializationMethod') {
-      return deserialize<_i131.CustomClassWithProtocolSerializationMethod>(
+      return deserialize<_i132.CustomClassWithProtocolSerializationMethod>(
           data['data']);
     }
     if (dataClassName == 'ProtocolCustomClass') {
-      return deserialize<_i131.ProtocolCustomClass>(data['data']);
+      return deserialize<_i132.ProtocolCustomClass>(data['data']);
     }
     if (dataClassName == 'ExternalCustomClass') {
-      return deserialize<_i131.ExternalCustomClass>(data['data']);
+      return deserialize<_i132.ExternalCustomClass>(data['data']);
     }
     if (dataClassName == 'FreezedCustomClass') {
-      return deserialize<_i131.FreezedCustomClass>(data['data']);
+      return deserialize<_i132.FreezedCustomClass>(data['data']);
     }
     if (dataClassName == 'ByIndexEnumWithNameValue') {
       return deserialize<_i2.ByIndexEnumWithNameValue>(data['data']);
@@ -3826,340 +3837,343 @@ class Protocol extends _i1.SerializationManager {
     if (dataClassName == 'ByNameEnum') {
       return deserialize<_i29.ByNameEnum>(data['data']);
     }
+    if (dataClassName == 'DefaultValueEnum') {
+      return deserialize<_i30.DefaultValueEnum>(data['data']);
+    }
     if (dataClassName == 'DefaultException') {
-      return deserialize<_i30.DefaultException>(data['data']);
+      return deserialize<_i31.DefaultException>(data['data']);
     }
     if (dataClassName == 'IntDefault') {
-      return deserialize<_i31.IntDefault>(data['data']);
+      return deserialize<_i32.IntDefault>(data['data']);
     }
     if (dataClassName == 'IntDefaultMix') {
-      return deserialize<_i32.IntDefaultMix>(data['data']);
+      return deserialize<_i33.IntDefaultMix>(data['data']);
     }
     if (dataClassName == 'IntDefaultModel') {
-      return deserialize<_i33.IntDefaultModel>(data['data']);
+      return deserialize<_i34.IntDefaultModel>(data['data']);
     }
     if (dataClassName == 'IntDefaultPersist') {
-      return deserialize<_i34.IntDefaultPersist>(data['data']);
+      return deserialize<_i35.IntDefaultPersist>(data['data']);
     }
     if (dataClassName == 'StringDefault') {
-      return deserialize<_i35.StringDefault>(data['data']);
+      return deserialize<_i36.StringDefault>(data['data']);
     }
     if (dataClassName == 'StringDefaultMix') {
-      return deserialize<_i36.StringDefaultMix>(data['data']);
+      return deserialize<_i37.StringDefaultMix>(data['data']);
     }
     if (dataClassName == 'StringDefaultModel') {
-      return deserialize<_i37.StringDefaultModel>(data['data']);
+      return deserialize<_i38.StringDefaultModel>(data['data']);
     }
     if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i38.StringDefaultPersist>(data['data']);
+      return deserialize<_i39.StringDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UriDefault') {
-      return deserialize<_i39.UriDefault>(data['data']);
+      return deserialize<_i40.UriDefault>(data['data']);
     }
     if (dataClassName == 'UriDefaultMix') {
-      return deserialize<_i40.UriDefaultMix>(data['data']);
+      return deserialize<_i41.UriDefaultMix>(data['data']);
     }
     if (dataClassName == 'UriDefaultModel') {
-      return deserialize<_i41.UriDefaultModel>(data['data']);
+      return deserialize<_i42.UriDefaultModel>(data['data']);
     }
     if (dataClassName == 'UriDefaultPersist') {
-      return deserialize<_i42.UriDefaultPersist>(data['data']);
+      return deserialize<_i43.UriDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UuidDefault') {
-      return deserialize<_i43.UuidDefault>(data['data']);
+      return deserialize<_i44.UuidDefault>(data['data']);
     }
     if (dataClassName == 'UuidDefaultMix') {
-      return deserialize<_i44.UuidDefaultMix>(data['data']);
+      return deserialize<_i45.UuidDefaultMix>(data['data']);
     }
     if (dataClassName == 'UuidDefaultModel') {
-      return deserialize<_i45.UuidDefaultModel>(data['data']);
+      return deserialize<_i46.UuidDefaultModel>(data['data']);
     }
     if (dataClassName == 'UuidDefaultPersist') {
-      return deserialize<_i46.UuidDefaultPersist>(data['data']);
+      return deserialize<_i47.UuidDefaultPersist>(data['data']);
     }
     if (dataClassName == 'EmptyModel') {
-      return deserialize<_i47.EmptyModel>(data['data']);
+      return deserialize<_i48.EmptyModel>(data['data']);
     }
     if (dataClassName == 'EmptyModelRelationItem') {
-      return deserialize<_i48.EmptyModelRelationItem>(data['data']);
+      return deserialize<_i49.EmptyModelRelationItem>(data['data']);
     }
     if (dataClassName == 'EmptyModelWithTable') {
-      return deserialize<_i49.EmptyModelWithTable>(data['data']);
+      return deserialize<_i50.EmptyModelWithTable>(data['data']);
     }
     if (dataClassName == 'RelationEmptyModel') {
-      return deserialize<_i50.RelationEmptyModel>(data['data']);
+      return deserialize<_i51.RelationEmptyModel>(data['data']);
     }
     if (dataClassName == 'ExceptionWithData') {
-      return deserialize<_i51.ExceptionWithData>(data['data']);
+      return deserialize<_i52.ExceptionWithData>(data['data']);
     }
     if (dataClassName == 'ChildClass') {
-      return deserialize<_i52.ChildClass>(data['data']);
+      return deserialize<_i53.ChildClass>(data['data']);
     }
     if (dataClassName == 'ChildWithDefault') {
-      return deserialize<_i53.ChildWithDefault>(data['data']);
+      return deserialize<_i54.ChildWithDefault>(data['data']);
     }
     if (dataClassName == 'GrandparentClass') {
-      return deserialize<_i54.GrandparentClass>(data['data']);
+      return deserialize<_i55.GrandparentClass>(data['data']);
     }
     if (dataClassName == 'ParentClass') {
-      return deserialize<_i55.ParentClass>(data['data']);
+      return deserialize<_i56.ParentClass>(data['data']);
     }
     if (dataClassName == 'ParentWithDefault') {
-      return deserialize<_i56.ParentWithDefault>(data['data']);
+      return deserialize<_i57.ParentWithDefault>(data['data']);
     }
     if (dataClassName == 'SealedChild') {
-      return deserialize<_i57.SealedChild>(data['data']);
+      return deserialize<_i58.SealedChild>(data['data']);
     }
     if (dataClassName == 'SealedGrandChild') {
-      return deserialize<_i57.SealedGrandChild>(data['data']);
+      return deserialize<_i58.SealedGrandChild>(data['data']);
     }
     if (dataClassName == 'SealedOtherChild') {
-      return deserialize<_i57.SealedOtherChild>(data['data']);
+      return deserialize<_i58.SealedOtherChild>(data['data']);
     }
     if (dataClassName == 'CityWithLongTableName') {
-      return deserialize<_i58.CityWithLongTableName>(data['data']);
+      return deserialize<_i59.CityWithLongTableName>(data['data']);
     }
     if (dataClassName == 'OrganizationWithLongTableName') {
-      return deserialize<_i59.OrganizationWithLongTableName>(data['data']);
+      return deserialize<_i60.OrganizationWithLongTableName>(data['data']);
     }
     if (dataClassName == 'PersonWithLongTableName') {
-      return deserialize<_i60.PersonWithLongTableName>(data['data']);
+      return deserialize<_i61.PersonWithLongTableName>(data['data']);
     }
     if (dataClassName == 'MaxFieldName') {
-      return deserialize<_i61.MaxFieldName>(data['data']);
+      return deserialize<_i62.MaxFieldName>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdField') {
-      return deserialize<_i62.LongImplicitIdField>(data['data']);
+      return deserialize<_i63.LongImplicitIdField>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdFieldCollection') {
-      return deserialize<_i63.LongImplicitIdFieldCollection>(data['data']);
+      return deserialize<_i64.LongImplicitIdFieldCollection>(data['data']);
     }
     if (dataClassName == 'RelationToMultipleMaxFieldName') {
-      return deserialize<_i64.RelationToMultipleMaxFieldName>(data['data']);
+      return deserialize<_i65.RelationToMultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'UserNote') {
-      return deserialize<_i65.UserNote>(data['data']);
+      return deserialize<_i66.UserNote>(data['data']);
     }
     if (dataClassName == 'UserNoteCollection') {
-      return deserialize<_i66.UserNoteCollection>(data['data']);
+      return deserialize<_i67.UserNoteCollection>(data['data']);
     }
     if (dataClassName == 'UserNoteCollectionWithALongName') {
-      return deserialize<_i67.UserNoteCollectionWithALongName>(data['data']);
+      return deserialize<_i68.UserNoteCollectionWithALongName>(data['data']);
     }
     if (dataClassName == 'UserNoteWithALongName') {
-      return deserialize<_i68.UserNoteWithALongName>(data['data']);
+      return deserialize<_i69.UserNoteWithALongName>(data['data']);
     }
     if (dataClassName == 'MultipleMaxFieldName') {
-      return deserialize<_i69.MultipleMaxFieldName>(data['data']);
+      return deserialize<_i70.MultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'City') {
-      return deserialize<_i70.City>(data['data']);
+      return deserialize<_i71.City>(data['data']);
     }
     if (dataClassName == 'Organization') {
-      return deserialize<_i71.Organization>(data['data']);
+      return deserialize<_i72.Organization>(data['data']);
     }
     if (dataClassName == 'Person') {
-      return deserialize<_i72.Person>(data['data']);
+      return deserialize<_i73.Person>(data['data']);
     }
     if (dataClassName == 'Course') {
-      return deserialize<_i73.Course>(data['data']);
+      return deserialize<_i74.Course>(data['data']);
     }
     if (dataClassName == 'Enrollment') {
-      return deserialize<_i74.Enrollment>(data['data']);
+      return deserialize<_i75.Enrollment>(data['data']);
     }
     if (dataClassName == 'Student') {
-      return deserialize<_i75.Student>(data['data']);
+      return deserialize<_i76.Student>(data['data']);
     }
     if (dataClassName == 'ObjectUser') {
-      return deserialize<_i76.ObjectUser>(data['data']);
+      return deserialize<_i77.ObjectUser>(data['data']);
     }
     if (dataClassName == 'ParentUser') {
-      return deserialize<_i77.ParentUser>(data['data']);
+      return deserialize<_i78.ParentUser>(data['data']);
     }
     if (dataClassName == 'Arena') {
-      return deserialize<_i78.Arena>(data['data']);
+      return deserialize<_i79.Arena>(data['data']);
     }
     if (dataClassName == 'Player') {
-      return deserialize<_i79.Player>(data['data']);
+      return deserialize<_i80.Player>(data['data']);
     }
     if (dataClassName == 'Team') {
-      return deserialize<_i80.Team>(data['data']);
+      return deserialize<_i81.Team>(data['data']);
     }
     if (dataClassName == 'Comment') {
-      return deserialize<_i81.Comment>(data['data']);
+      return deserialize<_i82.Comment>(data['data']);
     }
     if (dataClassName == 'Customer') {
-      return deserialize<_i82.Customer>(data['data']);
+      return deserialize<_i83.Customer>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i83.Order>(data['data']);
+      return deserialize<_i84.Order>(data['data']);
     }
     if (dataClassName == 'Address') {
-      return deserialize<_i84.Address>(data['data']);
+      return deserialize<_i85.Address>(data['data']);
     }
     if (dataClassName == 'Citizen') {
-      return deserialize<_i85.Citizen>(data['data']);
+      return deserialize<_i86.Citizen>(data['data']);
     }
     if (dataClassName == 'Company') {
-      return deserialize<_i86.Company>(data['data']);
+      return deserialize<_i87.Company>(data['data']);
     }
     if (dataClassName == 'Town') {
-      return deserialize<_i87.Town>(data['data']);
+      return deserialize<_i88.Town>(data['data']);
     }
     if (dataClassName == 'Blocking') {
-      return deserialize<_i88.Blocking>(data['data']);
+      return deserialize<_i89.Blocking>(data['data']);
     }
     if (dataClassName == 'Member') {
-      return deserialize<_i89.Member>(data['data']);
+      return deserialize<_i90.Member>(data['data']);
     }
     if (dataClassName == 'Cat') {
-      return deserialize<_i90.Cat>(data['data']);
+      return deserialize<_i91.Cat>(data['data']);
     }
     if (dataClassName == 'Post') {
-      return deserialize<_i91.Post>(data['data']);
+      return deserialize<_i92.Post>(data['data']);
     }
     if (dataClassName == 'ModuleDatatype') {
-      return deserialize<_i92.ModuleDatatype>(data['data']);
+      return deserialize<_i93.ModuleDatatype>(data['data']);
     }
     if (dataClassName == 'Nullability') {
-      return deserialize<_i93.Nullability>(data['data']);
+      return deserialize<_i94.Nullability>(data['data']);
     }
     if (dataClassName == 'ObjectFieldPersist') {
-      return deserialize<_i94.ObjectFieldPersist>(data['data']);
+      return deserialize<_i95.ObjectFieldPersist>(data['data']);
     }
     if (dataClassName == 'ObjectFieldScopes') {
-      return deserialize<_i95.ObjectFieldScopes>(data['data']);
+      return deserialize<_i96.ObjectFieldScopes>(data['data']);
     }
     if (dataClassName == 'ObjectWithByteData') {
-      return deserialize<_i96.ObjectWithByteData>(data['data']);
+      return deserialize<_i97.ObjectWithByteData>(data['data']);
     }
     if (dataClassName == 'ObjectWithCustomClass') {
-      return deserialize<_i97.ObjectWithCustomClass>(data['data']);
+      return deserialize<_i98.ObjectWithCustomClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithDuration') {
-      return deserialize<_i98.ObjectWithDuration>(data['data']);
+      return deserialize<_i99.ObjectWithDuration>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnum') {
-      return deserialize<_i99.ObjectWithEnum>(data['data']);
+      return deserialize<_i100.ObjectWithEnum>(data['data']);
     }
     if (dataClassName == 'ObjectWithIndex') {
-      return deserialize<_i100.ObjectWithIndex>(data['data']);
+      return deserialize<_i101.ObjectWithIndex>(data['data']);
     }
     if (dataClassName == 'ObjectWithMaps') {
-      return deserialize<_i101.ObjectWithMaps>(data['data']);
+      return deserialize<_i102.ObjectWithMaps>(data['data']);
     }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i102.ObjectWithObject>(data['data']);
+      return deserialize<_i103.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i103.ObjectWithParent>(data['data']);
+      return deserialize<_i104.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i104.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i105.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i105.ObjectWithUuid>(data['data']);
+      return deserialize<_i106.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i106.RelatedUniqueData>(data['data']);
+      return deserialize<_i107.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ScopeNoneFields') {
-      return deserialize<_i107.ScopeNoneFields>(data['data']);
+      return deserialize<_i108.ScopeNoneFields>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyField') {
-      return deserialize<_i108.ScopeServerOnlyField>(data['data']);
+      return deserialize<_i109.ScopeServerOnlyField>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyFieldChild') {
-      return deserialize<_i109.ScopeServerOnlyFieldChild>(data['data']);
+      return deserialize<_i110.ScopeServerOnlyFieldChild>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
-      return deserialize<_i110.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i111.DefaultServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyEnum') {
-      return deserialize<_i111.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i112.DefaultServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyClass') {
-      return deserialize<_i112.NotServerOnlyClass>(data['data']);
+      return deserialize<_i113.NotServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyEnum') {
-      return deserialize<_i113.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i114.NotServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClassField') {
-      return deserialize<_i114.ServerOnlyClassField>(data['data']);
+      return deserialize<_i115.ServerOnlyClassField>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i115.SimpleData>(data['data']);
+      return deserialize<_i116.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDataList') {
-      return deserialize<_i116.SimpleDataList>(data['data']);
+      return deserialize<_i117.SimpleDataList>(data['data']);
     }
     if (dataClassName == 'SimpleDataMap') {
-      return deserialize<_i117.SimpleDataMap>(data['data']);
+      return deserialize<_i118.SimpleDataMap>(data['data']);
     }
     if (dataClassName == 'SimpleDataObject') {
-      return deserialize<_i118.SimpleDataObject>(data['data']);
+      return deserialize<_i119.SimpleDataObject>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i119.SimpleDateTime>(data['data']);
+      return deserialize<_i120.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i120.TestEnum>(data['data']);
+      return deserialize<_i121.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i121.TestEnumStringified>(data['data']);
+      return deserialize<_i122.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i122.Types>(data['data']);
+      return deserialize<_i123.Types>(data['data']);
     }
     if (dataClassName == 'TypesList') {
-      return deserialize<_i123.TypesList>(data['data']);
+      return deserialize<_i124.TypesList>(data['data']);
     }
     if (dataClassName == 'TypesMap') {
-      return deserialize<_i124.TypesMap>(data['data']);
+      return deserialize<_i125.TypesMap>(data['data']);
     }
     if (dataClassName == 'TypesRecord') {
-      return deserialize<_i125.TypesRecord>(data['data']);
+      return deserialize<_i126.TypesRecord>(data['data']);
     }
     if (dataClassName == 'TypesSet') {
-      return deserialize<_i126.TypesSet>(data['data']);
+      return deserialize<_i127.TypesSet>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i127.UniqueData>(data['data']);
+      return deserialize<_i128.UniqueData>(data['data']);
     }
     if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i128.MyFeatureModel>(data['data']);
+      return deserialize<_i129.MyFeatureModel>(data['data']);
     }
     if (dataClassName.startsWith('serverpod_auth.')) {
       data['className'] = dataClassName.substring(15);
-      return _i134.Protocol().deserializeByClassName(data);
+      return _i135.Protocol().deserializeByClassName(data);
     }
     if (dataClassName.startsWith('serverpod_test_module.')) {
       data['className'] = dataClassName.substring(22);
-      return _i129.Protocol().deserializeByClassName(data);
+      return _i130.Protocol().deserializeByClassName(data);
     }
     if (dataClassName == 'List<int>') {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i132.SimpleData>>(data['data']);
+      return deserialize<List<_i133.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
-      return deserialize<List<_i134.UserInfo>>(data['data']);
+      return deserialize<List<_i135.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i132.SimpleData>?>(data['data']);
+      return deserialize<List<_i133.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i132.SimpleData?>>(data['data']);
+      return deserialize<List<_i133.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i132.SimpleData>>(data['data']);
+      return deserialize<Set<_i133.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i132.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i133.SimpleData>>>(data['data']);
     }
     if (dataClassName == '(int?,)?') {
       return deserialize<(int?,)?>(data['data']);
@@ -4170,7 +4184,7 @@ class Protocol extends _i1.SerializationManager {
           List<
               (
                 (int, String), {
-                (_i132.SimpleData, double) namedSubRecord
+                (_i133.SimpleData, double) namedSubRecord
               })?>?>(data['data']);
     }
     if (dataClassName ==
@@ -4178,7 +4192,7 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
           )>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>') {
@@ -4189,7 +4203,7 @@ class Protocol extends _i1.SerializationManager {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
           )?>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>?') {
@@ -4252,7 +4266,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, _i132.SimpleData)) {
+  if (record is (int, _i133.SimpleData)) {
     return {
       "p": [
         record.$1,
@@ -4268,7 +4282,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i132.SimpleData data, int number})) {
+  if (record is ({_i133.SimpleData data, int number})) {
     return {
       "n": {
         "data": record.data,
@@ -4276,7 +4290,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i132.SimpleData? data, int? number})) {
+  if (record is ({_i133.SimpleData? data, int? number})) {
     return {
       "n": {
         "data": record.data,
@@ -4284,7 +4298,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (int, {_i132.SimpleData data})) {
+  if (record is (int, {_i133.SimpleData data})) {
     return {
       "p": [
         record.$1,
@@ -4302,14 +4316,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i132.SimpleData, double) namedSubRecord})) {
+  if (record is ({(_i133.SimpleData, double) namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is (_i132.SimpleData, double)) {
+  if (record is (_i133.SimpleData, double)) {
     return {
       "p": [
         record.$1,
@@ -4317,14 +4331,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i132.SimpleData, double)? namedSubRecord})) {
+  if (record is ({(_i133.SimpleData, double)? namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is ((int, String), {(_i132.SimpleData, double) namedSubRecord})) {
+  if (record is ((int, String), {(_i133.SimpleData, double) namedSubRecord})) {
     return {
       "p": [
         mapRecordToJson(record.$1),
@@ -4352,7 +4366,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
   }
   if (record is (
     String,
-    (Map<String, int>, {bool flag, _i132.SimpleData simpleData})
+    (Map<String, int>, {bool flag, _i133.SimpleData simpleData})
   )) {
     return {
       "p": [
@@ -4361,7 +4375,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (Map<String, int>, {bool flag, _i132.SimpleData simpleData})) {
+  if (record is (Map<String, int>, {bool flag, _i133.SimpleData simpleData})) {
     return {
       "p": [
         record.$1,
@@ -4372,7 +4386,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (_i129.ModuleClass,)) {
+  if (record is (_i130.ModuleClass,)) {
     return {
       "p": [
         record.$1,
@@ -4417,7 +4431,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i130.ByteData,)) {
+  if (record is (_i131.ByteData,)) {
     return {
       "p": [
         record.$1,
@@ -4452,14 +4466,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i120.TestEnum,)) {
+  if (record is (_i121.TestEnum,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is (_i121.TestEnumStringified,)) {
+  if (record is (_i122.TestEnumStringified,)) {
     return {
       "p": [
         record.$1,
@@ -4487,21 +4501,21 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i115.SimpleData,)) {
+  if (record is (_i116.SimpleData,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is ({_i115.SimpleData namedModel})) {
+  if (record is ({_i116.SimpleData namedModel})) {
     return {
       "n": {
         "namedModel": record.namedModel,
       },
     };
   }
-  if (record is (_i115.SimpleData, {_i115.SimpleData namedModel})) {
+  if (record is (_i116.SimpleData, {_i116.SimpleData namedModel})) {
     return {
       "p": [
         record.$1,
@@ -4530,8 +4544,8 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
     };
   }
   if (record is (
-    (List<(_i115.SimpleData,)>,), {
-    (_i115.SimpleData, Map<String, _i115.SimpleData>) namedNestedRecord
+    (List<(_i116.SimpleData,)>,), {
+    (_i116.SimpleData, Map<String, _i116.SimpleData>) namedNestedRecord
   })) {
     return {
       "p": [
@@ -4542,14 +4556,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (List<(_i115.SimpleData,)>,)) {
+  if (record is (List<(_i116.SimpleData,)>,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is (_i115.SimpleData, Map<String, _i115.SimpleData>)) {
+  if (record is (_i116.SimpleData, Map<String, _i116.SimpleData>)) {
     return {
       "p": [
         record.$1,

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/default_value_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enums/default_value_enum.dart
@@ -1,0 +1,33 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+enum DefaultValueEnum implements _i1.SerializableModel {
+  value1,
+  value2;
+
+  static DefaultValueEnum fromJson(int index) {
+    switch (index) {
+      case 0:
+        return DefaultValueEnum.value1;
+      case 1:
+        return DefaultValueEnum.value2;
+      default:
+        return DefaultValueEnum.value2;
+    }
+  }
+
+  @override
+  int toJson() => index;
+  @override
+  String toString() => name;
+}

--- a/tests/serverpod_test_server/lib/src/generated/protocol.dart
+++ b/tests/serverpod_test_server/lib/src/generated/protocol.dart
@@ -42,120 +42,121 @@ import 'defaults/enum/enum_default_model.dart' as _i29;
 import 'defaults/enum/enum_default_persist.dart' as _i30;
 import 'defaults/enum/enums/by_index_enum.dart' as _i31;
 import 'defaults/enum/enums/by_name_enum.dart' as _i32;
-import 'defaults/exception/default_exception.dart' as _i33;
-import 'defaults/integer/int_default.dart' as _i34;
-import 'defaults/integer/int_default_mix.dart' as _i35;
-import 'defaults/integer/int_default_model.dart' as _i36;
-import 'defaults/integer/int_default_persist.dart' as _i37;
-import 'defaults/string/string_default.dart' as _i38;
-import 'defaults/string/string_default_mix.dart' as _i39;
-import 'defaults/string/string_default_model.dart' as _i40;
-import 'defaults/string/string_default_persist.dart' as _i41;
-import 'defaults/uri/uri_default.dart' as _i42;
-import 'defaults/uri/uri_default_mix.dart' as _i43;
-import 'defaults/uri/uri_default_model.dart' as _i44;
-import 'defaults/uri/uri_default_persist.dart' as _i45;
-import 'defaults/uuid/uuid_default.dart' as _i46;
-import 'defaults/uuid/uuid_default_mix.dart' as _i47;
-import 'defaults/uuid/uuid_default_model.dart' as _i48;
-import 'defaults/uuid/uuid_default_persist.dart' as _i49;
-import 'empty_model/empty_model.dart' as _i50;
-import 'empty_model/empty_model_relation_item.dart' as _i51;
-import 'empty_model/empty_model_with_table.dart' as _i52;
-import 'empty_model/relation_empy_model.dart' as _i53;
-import 'exception_with_data.dart' as _i54;
-import 'inheritance/child_class.dart' as _i55;
-import 'inheritance/child_with_default.dart' as _i56;
-import 'inheritance/grandparent_class.dart' as _i57;
-import 'inheritance/parent_class.dart' as _i58;
-import 'inheritance/parent_with_default.dart' as _i59;
-import 'inheritance/sealed_parent.dart' as _i60;
-import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i61;
+import 'defaults/enum/enums/default_value_enum.dart' as _i33;
+import 'defaults/exception/default_exception.dart' as _i34;
+import 'defaults/integer/int_default.dart' as _i35;
+import 'defaults/integer/int_default_mix.dart' as _i36;
+import 'defaults/integer/int_default_model.dart' as _i37;
+import 'defaults/integer/int_default_persist.dart' as _i38;
+import 'defaults/string/string_default.dart' as _i39;
+import 'defaults/string/string_default_mix.dart' as _i40;
+import 'defaults/string/string_default_model.dart' as _i41;
+import 'defaults/string/string_default_persist.dart' as _i42;
+import 'defaults/uri/uri_default.dart' as _i43;
+import 'defaults/uri/uri_default_mix.dart' as _i44;
+import 'defaults/uri/uri_default_model.dart' as _i45;
+import 'defaults/uri/uri_default_persist.dart' as _i46;
+import 'defaults/uuid/uuid_default.dart' as _i47;
+import 'defaults/uuid/uuid_default_mix.dart' as _i48;
+import 'defaults/uuid/uuid_default_model.dart' as _i49;
+import 'defaults/uuid/uuid_default_persist.dart' as _i50;
+import 'empty_model/empty_model.dart' as _i51;
+import 'empty_model/empty_model_relation_item.dart' as _i52;
+import 'empty_model/empty_model_with_table.dart' as _i53;
+import 'empty_model/relation_empy_model.dart' as _i54;
+import 'exception_with_data.dart' as _i55;
+import 'inheritance/child_class.dart' as _i56;
+import 'inheritance/child_with_default.dart' as _i57;
+import 'inheritance/grandparent_class.dart' as _i58;
+import 'inheritance/parent_class.dart' as _i59;
+import 'inheritance/parent_with_default.dart' as _i60;
+import 'inheritance/sealed_parent.dart' as _i61;
+import 'long_identifiers/deep_includes/city_with_long_table_name.dart' as _i62;
 import 'long_identifiers/deep_includes/organization_with_long_table_name.dart'
-    as _i62;
-import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
     as _i63;
-import 'long_identifiers/max_field_name.dart' as _i64;
+import 'long_identifiers/deep_includes/person_with_long_table_name.dart'
+    as _i64;
+import 'long_identifiers/max_field_name.dart' as _i65;
 import 'long_identifiers/models_with_relations/long_implicit_id_field.dart'
-    as _i65;
-import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
     as _i66;
-import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
+import 'long_identifiers/models_with_relations/long_implicit_id_field_collection.dart'
     as _i67;
-import 'long_identifiers/models_with_relations/user_note.dart' as _i68;
+import 'long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart'
+    as _i68;
+import 'long_identifiers/models_with_relations/user_note.dart' as _i69;
 import 'long_identifiers/models_with_relations/user_note_collection.dart'
-    as _i69;
-import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
     as _i70;
-import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
+import 'long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart'
     as _i71;
-import 'long_identifiers/multiple_max_field_name.dart' as _i72;
-import 'models_with_list_relations/city.dart' as _i73;
-import 'models_with_list_relations/organization.dart' as _i74;
-import 'models_with_list_relations/person.dart' as _i75;
-import 'models_with_relations/many_to_many/course.dart' as _i76;
-import 'models_with_relations/many_to_many/enrollment.dart' as _i77;
-import 'models_with_relations/many_to_many/student.dart' as _i78;
-import 'models_with_relations/module/object_user.dart' as _i79;
-import 'models_with_relations/module/parent_user.dart' as _i80;
-import 'models_with_relations/nested_one_to_many/arena.dart' as _i81;
-import 'models_with_relations/nested_one_to_many/player.dart' as _i82;
-import 'models_with_relations/nested_one_to_many/team.dart' as _i83;
-import 'models_with_relations/one_to_many/comment.dart' as _i84;
-import 'models_with_relations/one_to_many/customer.dart' as _i85;
-import 'models_with_relations/one_to_many/order.dart' as _i86;
-import 'models_with_relations/one_to_one/address.dart' as _i87;
-import 'models_with_relations/one_to_one/citizen.dart' as _i88;
-import 'models_with_relations/one_to_one/company.dart' as _i89;
-import 'models_with_relations/one_to_one/town.dart' as _i90;
-import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i91;
-import 'models_with_relations/self_relation/many_to_many/member.dart' as _i92;
-import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i93;
-import 'models_with_relations/self_relation/one_to_one/post.dart' as _i94;
-import 'module_datatype.dart' as _i95;
-import 'nullability.dart' as _i96;
-import 'object_field_persist.dart' as _i97;
-import 'object_field_scopes.dart' as _i98;
-import 'object_with_bytedata.dart' as _i99;
-import 'object_with_custom_class.dart' as _i100;
-import 'object_with_duration.dart' as _i101;
-import 'object_with_enum.dart' as _i102;
-import 'object_with_index.dart' as _i103;
-import 'object_with_maps.dart' as _i104;
-import 'object_with_object.dart' as _i105;
-import 'object_with_parent.dart' as _i106;
-import 'object_with_self_parent.dart' as _i107;
-import 'object_with_uuid.dart' as _i108;
-import 'related_unique_data.dart' as _i109;
-import 'scopes/scope_none_fields.dart' as _i110;
-import 'scopes/scope_server_only_field.dart' as _i111;
-import 'scopes/scope_server_only_field_child.dart' as _i112;
-import 'scopes/serverOnly/default_server_only_class.dart' as _i113;
-import 'scopes/serverOnly/default_server_only_enum.dart' as _i114;
-import 'scopes/serverOnly/not_server_only_class.dart' as _i115;
-import 'scopes/serverOnly/not_server_only_enum.dart' as _i116;
-import 'scopes/serverOnly/server_only_class.dart' as _i117;
-import 'scopes/serverOnly/server_only_enum.dart' as _i118;
-import 'scopes/server_only_class_field.dart' as _i119;
-import 'simple_data.dart' as _i120;
-import 'simple_data_list.dart' as _i121;
-import 'simple_data_map.dart' as _i122;
-import 'simple_data_object.dart' as _i123;
-import 'simple_date_time.dart' as _i124;
-import 'test_enum.dart' as _i125;
-import 'test_enum_stringified.dart' as _i126;
-import 'types.dart' as _i127;
-import 'types_list.dart' as _i128;
-import 'types_map.dart' as _i129;
-import 'types_record.dart' as _i130;
-import 'types_set.dart' as _i131;
-import 'unique_data.dart' as _i132;
-import 'my_feature/models/my_feature_model.dart' as _i133;
-import 'dart:typed_data' as _i134;
-import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i135;
-import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i136;
-import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i137;
-import 'package:serverpod_test_server/src/generated/types.dart' as _i138;
+import 'long_identifiers/models_with_relations/user_note_with_a_long_name.dart'
+    as _i72;
+import 'long_identifiers/multiple_max_field_name.dart' as _i73;
+import 'models_with_list_relations/city.dart' as _i74;
+import 'models_with_list_relations/organization.dart' as _i75;
+import 'models_with_list_relations/person.dart' as _i76;
+import 'models_with_relations/many_to_many/course.dart' as _i77;
+import 'models_with_relations/many_to_many/enrollment.dart' as _i78;
+import 'models_with_relations/many_to_many/student.dart' as _i79;
+import 'models_with_relations/module/object_user.dart' as _i80;
+import 'models_with_relations/module/parent_user.dart' as _i81;
+import 'models_with_relations/nested_one_to_many/arena.dart' as _i82;
+import 'models_with_relations/nested_one_to_many/player.dart' as _i83;
+import 'models_with_relations/nested_one_to_many/team.dart' as _i84;
+import 'models_with_relations/one_to_many/comment.dart' as _i85;
+import 'models_with_relations/one_to_many/customer.dart' as _i86;
+import 'models_with_relations/one_to_many/order.dart' as _i87;
+import 'models_with_relations/one_to_one/address.dart' as _i88;
+import 'models_with_relations/one_to_one/citizen.dart' as _i89;
+import 'models_with_relations/one_to_one/company.dart' as _i90;
+import 'models_with_relations/one_to_one/town.dart' as _i91;
+import 'models_with_relations/self_relation/many_to_many/blocking.dart' as _i92;
+import 'models_with_relations/self_relation/many_to_many/member.dart' as _i93;
+import 'models_with_relations/self_relation/one_to_many/cat.dart' as _i94;
+import 'models_with_relations/self_relation/one_to_one/post.dart' as _i95;
+import 'module_datatype.dart' as _i96;
+import 'nullability.dart' as _i97;
+import 'object_field_persist.dart' as _i98;
+import 'object_field_scopes.dart' as _i99;
+import 'object_with_bytedata.dart' as _i100;
+import 'object_with_custom_class.dart' as _i101;
+import 'object_with_duration.dart' as _i102;
+import 'object_with_enum.dart' as _i103;
+import 'object_with_index.dart' as _i104;
+import 'object_with_maps.dart' as _i105;
+import 'object_with_object.dart' as _i106;
+import 'object_with_parent.dart' as _i107;
+import 'object_with_self_parent.dart' as _i108;
+import 'object_with_uuid.dart' as _i109;
+import 'related_unique_data.dart' as _i110;
+import 'scopes/scope_none_fields.dart' as _i111;
+import 'scopes/scope_server_only_field.dart' as _i112;
+import 'scopes/scope_server_only_field_child.dart' as _i113;
+import 'scopes/serverOnly/default_server_only_class.dart' as _i114;
+import 'scopes/serverOnly/default_server_only_enum.dart' as _i115;
+import 'scopes/serverOnly/not_server_only_class.dart' as _i116;
+import 'scopes/serverOnly/not_server_only_enum.dart' as _i117;
+import 'scopes/serverOnly/server_only_class.dart' as _i118;
+import 'scopes/serverOnly/server_only_enum.dart' as _i119;
+import 'scopes/server_only_class_field.dart' as _i120;
+import 'simple_data.dart' as _i121;
+import 'simple_data_list.dart' as _i122;
+import 'simple_data_map.dart' as _i123;
+import 'simple_data_object.dart' as _i124;
+import 'simple_date_time.dart' as _i125;
+import 'test_enum.dart' as _i126;
+import 'test_enum_stringified.dart' as _i127;
+import 'types.dart' as _i128;
+import 'types_list.dart' as _i129;
+import 'types_map.dart' as _i130;
+import 'types_record.dart' as _i131;
+import 'types_set.dart' as _i132;
+import 'unique_data.dart' as _i133;
+import 'my_feature/models/my_feature_model.dart' as _i134;
+import 'dart:typed_data' as _i135;
+import 'package:serverpod_test_shared/serverpod_test_shared.dart' as _i136;
+import 'package:serverpod_test_server/src/generated/simple_data.dart' as _i137;
+import 'package:serverpod_test_server/src/generated/test_enum.dart' as _i138;
+import 'package:serverpod_test_server/src/generated/types.dart' as _i139;
 export 'by_index_enum_with_name_value.dart';
 export 'by_name_enum_with_name_value.dart';
 export 'defaults/bigint/bigint_default.dart';
@@ -184,6 +185,7 @@ export 'defaults/enum/enum_default_model.dart';
 export 'defaults/enum/enum_default_persist.dart';
 export 'defaults/enum/enums/by_index_enum.dart';
 export 'defaults/enum/enums/by_name_enum.dart';
+export 'defaults/enum/enums/default_value_enum.dart';
 export 'defaults/exception/default_exception.dart';
 export 'defaults/integer/int_default.dart';
 export 'defaults/integer/int_default_mix.dart';
@@ -5243,314 +5245,317 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i32.ByNameEnum) {
       return _i32.ByNameEnum.fromJson(data) as T;
     }
-    if (t == _i33.DefaultException) {
-      return _i33.DefaultException.fromJson(data) as T;
+    if (t == _i33.DefaultValueEnum) {
+      return _i33.DefaultValueEnum.fromJson(data) as T;
     }
-    if (t == _i34.IntDefault) {
-      return _i34.IntDefault.fromJson(data) as T;
+    if (t == _i34.DefaultException) {
+      return _i34.DefaultException.fromJson(data) as T;
     }
-    if (t == _i35.IntDefaultMix) {
-      return _i35.IntDefaultMix.fromJson(data) as T;
+    if (t == _i35.IntDefault) {
+      return _i35.IntDefault.fromJson(data) as T;
     }
-    if (t == _i36.IntDefaultModel) {
-      return _i36.IntDefaultModel.fromJson(data) as T;
+    if (t == _i36.IntDefaultMix) {
+      return _i36.IntDefaultMix.fromJson(data) as T;
     }
-    if (t == _i37.IntDefaultPersist) {
-      return _i37.IntDefaultPersist.fromJson(data) as T;
+    if (t == _i37.IntDefaultModel) {
+      return _i37.IntDefaultModel.fromJson(data) as T;
     }
-    if (t == _i38.StringDefault) {
-      return _i38.StringDefault.fromJson(data) as T;
+    if (t == _i38.IntDefaultPersist) {
+      return _i38.IntDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i39.StringDefaultMix) {
-      return _i39.StringDefaultMix.fromJson(data) as T;
+    if (t == _i39.StringDefault) {
+      return _i39.StringDefault.fromJson(data) as T;
     }
-    if (t == _i40.StringDefaultModel) {
-      return _i40.StringDefaultModel.fromJson(data) as T;
+    if (t == _i40.StringDefaultMix) {
+      return _i40.StringDefaultMix.fromJson(data) as T;
     }
-    if (t == _i41.StringDefaultPersist) {
-      return _i41.StringDefaultPersist.fromJson(data) as T;
+    if (t == _i41.StringDefaultModel) {
+      return _i41.StringDefaultModel.fromJson(data) as T;
     }
-    if (t == _i42.UriDefault) {
-      return _i42.UriDefault.fromJson(data) as T;
+    if (t == _i42.StringDefaultPersist) {
+      return _i42.StringDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i43.UriDefaultMix) {
-      return _i43.UriDefaultMix.fromJson(data) as T;
+    if (t == _i43.UriDefault) {
+      return _i43.UriDefault.fromJson(data) as T;
     }
-    if (t == _i44.UriDefaultModel) {
-      return _i44.UriDefaultModel.fromJson(data) as T;
+    if (t == _i44.UriDefaultMix) {
+      return _i44.UriDefaultMix.fromJson(data) as T;
     }
-    if (t == _i45.UriDefaultPersist) {
-      return _i45.UriDefaultPersist.fromJson(data) as T;
+    if (t == _i45.UriDefaultModel) {
+      return _i45.UriDefaultModel.fromJson(data) as T;
     }
-    if (t == _i46.UuidDefault) {
-      return _i46.UuidDefault.fromJson(data) as T;
+    if (t == _i46.UriDefaultPersist) {
+      return _i46.UriDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i47.UuidDefaultMix) {
-      return _i47.UuidDefaultMix.fromJson(data) as T;
+    if (t == _i47.UuidDefault) {
+      return _i47.UuidDefault.fromJson(data) as T;
     }
-    if (t == _i48.UuidDefaultModel) {
-      return _i48.UuidDefaultModel.fromJson(data) as T;
+    if (t == _i48.UuidDefaultMix) {
+      return _i48.UuidDefaultMix.fromJson(data) as T;
     }
-    if (t == _i49.UuidDefaultPersist) {
-      return _i49.UuidDefaultPersist.fromJson(data) as T;
+    if (t == _i49.UuidDefaultModel) {
+      return _i49.UuidDefaultModel.fromJson(data) as T;
     }
-    if (t == _i50.EmptyModel) {
-      return _i50.EmptyModel.fromJson(data) as T;
+    if (t == _i50.UuidDefaultPersist) {
+      return _i50.UuidDefaultPersist.fromJson(data) as T;
     }
-    if (t == _i51.EmptyModelRelationItem) {
-      return _i51.EmptyModelRelationItem.fromJson(data) as T;
+    if (t == _i51.EmptyModel) {
+      return _i51.EmptyModel.fromJson(data) as T;
     }
-    if (t == _i52.EmptyModelWithTable) {
-      return _i52.EmptyModelWithTable.fromJson(data) as T;
+    if (t == _i52.EmptyModelRelationItem) {
+      return _i52.EmptyModelRelationItem.fromJson(data) as T;
     }
-    if (t == _i53.RelationEmptyModel) {
-      return _i53.RelationEmptyModel.fromJson(data) as T;
+    if (t == _i53.EmptyModelWithTable) {
+      return _i53.EmptyModelWithTable.fromJson(data) as T;
     }
-    if (t == _i54.ExceptionWithData) {
-      return _i54.ExceptionWithData.fromJson(data) as T;
+    if (t == _i54.RelationEmptyModel) {
+      return _i54.RelationEmptyModel.fromJson(data) as T;
     }
-    if (t == _i55.ChildClass) {
-      return _i55.ChildClass.fromJson(data) as T;
+    if (t == _i55.ExceptionWithData) {
+      return _i55.ExceptionWithData.fromJson(data) as T;
     }
-    if (t == _i56.ChildWithDefault) {
-      return _i56.ChildWithDefault.fromJson(data) as T;
+    if (t == _i56.ChildClass) {
+      return _i56.ChildClass.fromJson(data) as T;
     }
-    if (t == _i57.GrandparentClass) {
-      return _i57.GrandparentClass.fromJson(data) as T;
+    if (t == _i57.ChildWithDefault) {
+      return _i57.ChildWithDefault.fromJson(data) as T;
     }
-    if (t == _i58.ParentClass) {
-      return _i58.ParentClass.fromJson(data) as T;
+    if (t == _i58.GrandparentClass) {
+      return _i58.GrandparentClass.fromJson(data) as T;
     }
-    if (t == _i59.ParentWithDefault) {
-      return _i59.ParentWithDefault.fromJson(data) as T;
+    if (t == _i59.ParentClass) {
+      return _i59.ParentClass.fromJson(data) as T;
     }
-    if (t == _i60.SealedChild) {
-      return _i60.SealedChild.fromJson(data) as T;
+    if (t == _i60.ParentWithDefault) {
+      return _i60.ParentWithDefault.fromJson(data) as T;
     }
-    if (t == _i60.SealedGrandChild) {
-      return _i60.SealedGrandChild.fromJson(data) as T;
+    if (t == _i61.SealedChild) {
+      return _i61.SealedChild.fromJson(data) as T;
     }
-    if (t == _i60.SealedOtherChild) {
-      return _i60.SealedOtherChild.fromJson(data) as T;
+    if (t == _i61.SealedGrandChild) {
+      return _i61.SealedGrandChild.fromJson(data) as T;
     }
-    if (t == _i61.CityWithLongTableName) {
-      return _i61.CityWithLongTableName.fromJson(data) as T;
+    if (t == _i61.SealedOtherChild) {
+      return _i61.SealedOtherChild.fromJson(data) as T;
     }
-    if (t == _i62.OrganizationWithLongTableName) {
-      return _i62.OrganizationWithLongTableName.fromJson(data) as T;
+    if (t == _i62.CityWithLongTableName) {
+      return _i62.CityWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i63.PersonWithLongTableName) {
-      return _i63.PersonWithLongTableName.fromJson(data) as T;
+    if (t == _i63.OrganizationWithLongTableName) {
+      return _i63.OrganizationWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i64.MaxFieldName) {
-      return _i64.MaxFieldName.fromJson(data) as T;
+    if (t == _i64.PersonWithLongTableName) {
+      return _i64.PersonWithLongTableName.fromJson(data) as T;
     }
-    if (t == _i65.LongImplicitIdField) {
-      return _i65.LongImplicitIdField.fromJson(data) as T;
+    if (t == _i65.MaxFieldName) {
+      return _i65.MaxFieldName.fromJson(data) as T;
     }
-    if (t == _i66.LongImplicitIdFieldCollection) {
-      return _i66.LongImplicitIdFieldCollection.fromJson(data) as T;
+    if (t == _i66.LongImplicitIdField) {
+      return _i66.LongImplicitIdField.fromJson(data) as T;
     }
-    if (t == _i67.RelationToMultipleMaxFieldName) {
-      return _i67.RelationToMultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i67.LongImplicitIdFieldCollection) {
+      return _i67.LongImplicitIdFieldCollection.fromJson(data) as T;
     }
-    if (t == _i68.UserNote) {
-      return _i68.UserNote.fromJson(data) as T;
+    if (t == _i68.RelationToMultipleMaxFieldName) {
+      return _i68.RelationToMultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i69.UserNoteCollection) {
-      return _i69.UserNoteCollection.fromJson(data) as T;
+    if (t == _i69.UserNote) {
+      return _i69.UserNote.fromJson(data) as T;
     }
-    if (t == _i70.UserNoteCollectionWithALongName) {
-      return _i70.UserNoteCollectionWithALongName.fromJson(data) as T;
+    if (t == _i70.UserNoteCollection) {
+      return _i70.UserNoteCollection.fromJson(data) as T;
     }
-    if (t == _i71.UserNoteWithALongName) {
-      return _i71.UserNoteWithALongName.fromJson(data) as T;
+    if (t == _i71.UserNoteCollectionWithALongName) {
+      return _i71.UserNoteCollectionWithALongName.fromJson(data) as T;
     }
-    if (t == _i72.MultipleMaxFieldName) {
-      return _i72.MultipleMaxFieldName.fromJson(data) as T;
+    if (t == _i72.UserNoteWithALongName) {
+      return _i72.UserNoteWithALongName.fromJson(data) as T;
     }
-    if (t == _i73.City) {
-      return _i73.City.fromJson(data) as T;
+    if (t == _i73.MultipleMaxFieldName) {
+      return _i73.MultipleMaxFieldName.fromJson(data) as T;
     }
-    if (t == _i74.Organization) {
-      return _i74.Organization.fromJson(data) as T;
+    if (t == _i74.City) {
+      return _i74.City.fromJson(data) as T;
     }
-    if (t == _i75.Person) {
-      return _i75.Person.fromJson(data) as T;
+    if (t == _i75.Organization) {
+      return _i75.Organization.fromJson(data) as T;
     }
-    if (t == _i76.Course) {
-      return _i76.Course.fromJson(data) as T;
+    if (t == _i76.Person) {
+      return _i76.Person.fromJson(data) as T;
     }
-    if (t == _i77.Enrollment) {
-      return _i77.Enrollment.fromJson(data) as T;
+    if (t == _i77.Course) {
+      return _i77.Course.fromJson(data) as T;
     }
-    if (t == _i78.Student) {
-      return _i78.Student.fromJson(data) as T;
+    if (t == _i78.Enrollment) {
+      return _i78.Enrollment.fromJson(data) as T;
     }
-    if (t == _i79.ObjectUser) {
-      return _i79.ObjectUser.fromJson(data) as T;
+    if (t == _i79.Student) {
+      return _i79.Student.fromJson(data) as T;
     }
-    if (t == _i80.ParentUser) {
-      return _i80.ParentUser.fromJson(data) as T;
+    if (t == _i80.ObjectUser) {
+      return _i80.ObjectUser.fromJson(data) as T;
     }
-    if (t == _i81.Arena) {
-      return _i81.Arena.fromJson(data) as T;
+    if (t == _i81.ParentUser) {
+      return _i81.ParentUser.fromJson(data) as T;
     }
-    if (t == _i82.Player) {
-      return _i82.Player.fromJson(data) as T;
+    if (t == _i82.Arena) {
+      return _i82.Arena.fromJson(data) as T;
     }
-    if (t == _i83.Team) {
-      return _i83.Team.fromJson(data) as T;
+    if (t == _i83.Player) {
+      return _i83.Player.fromJson(data) as T;
     }
-    if (t == _i84.Comment) {
-      return _i84.Comment.fromJson(data) as T;
+    if (t == _i84.Team) {
+      return _i84.Team.fromJson(data) as T;
     }
-    if (t == _i85.Customer) {
-      return _i85.Customer.fromJson(data) as T;
+    if (t == _i85.Comment) {
+      return _i85.Comment.fromJson(data) as T;
     }
-    if (t == _i86.Order) {
-      return _i86.Order.fromJson(data) as T;
+    if (t == _i86.Customer) {
+      return _i86.Customer.fromJson(data) as T;
     }
-    if (t == _i87.Address) {
-      return _i87.Address.fromJson(data) as T;
+    if (t == _i87.Order) {
+      return _i87.Order.fromJson(data) as T;
     }
-    if (t == _i88.Citizen) {
-      return _i88.Citizen.fromJson(data) as T;
+    if (t == _i88.Address) {
+      return _i88.Address.fromJson(data) as T;
     }
-    if (t == _i89.Company) {
-      return _i89.Company.fromJson(data) as T;
+    if (t == _i89.Citizen) {
+      return _i89.Citizen.fromJson(data) as T;
     }
-    if (t == _i90.Town) {
-      return _i90.Town.fromJson(data) as T;
+    if (t == _i90.Company) {
+      return _i90.Company.fromJson(data) as T;
     }
-    if (t == _i91.Blocking) {
-      return _i91.Blocking.fromJson(data) as T;
+    if (t == _i91.Town) {
+      return _i91.Town.fromJson(data) as T;
     }
-    if (t == _i92.Member) {
-      return _i92.Member.fromJson(data) as T;
+    if (t == _i92.Blocking) {
+      return _i92.Blocking.fromJson(data) as T;
     }
-    if (t == _i93.Cat) {
-      return _i93.Cat.fromJson(data) as T;
+    if (t == _i93.Member) {
+      return _i93.Member.fromJson(data) as T;
     }
-    if (t == _i94.Post) {
-      return _i94.Post.fromJson(data) as T;
+    if (t == _i94.Cat) {
+      return _i94.Cat.fromJson(data) as T;
     }
-    if (t == _i95.ModuleDatatype) {
-      return _i95.ModuleDatatype.fromJson(data) as T;
+    if (t == _i95.Post) {
+      return _i95.Post.fromJson(data) as T;
     }
-    if (t == _i96.Nullability) {
-      return _i96.Nullability.fromJson(data) as T;
+    if (t == _i96.ModuleDatatype) {
+      return _i96.ModuleDatatype.fromJson(data) as T;
     }
-    if (t == _i97.ObjectFieldPersist) {
-      return _i97.ObjectFieldPersist.fromJson(data) as T;
+    if (t == _i97.Nullability) {
+      return _i97.Nullability.fromJson(data) as T;
     }
-    if (t == _i98.ObjectFieldScopes) {
-      return _i98.ObjectFieldScopes.fromJson(data) as T;
+    if (t == _i98.ObjectFieldPersist) {
+      return _i98.ObjectFieldPersist.fromJson(data) as T;
     }
-    if (t == _i99.ObjectWithByteData) {
-      return _i99.ObjectWithByteData.fromJson(data) as T;
+    if (t == _i99.ObjectFieldScopes) {
+      return _i99.ObjectFieldScopes.fromJson(data) as T;
     }
-    if (t == _i100.ObjectWithCustomClass) {
-      return _i100.ObjectWithCustomClass.fromJson(data) as T;
+    if (t == _i100.ObjectWithByteData) {
+      return _i100.ObjectWithByteData.fromJson(data) as T;
     }
-    if (t == _i101.ObjectWithDuration) {
-      return _i101.ObjectWithDuration.fromJson(data) as T;
+    if (t == _i101.ObjectWithCustomClass) {
+      return _i101.ObjectWithCustomClass.fromJson(data) as T;
     }
-    if (t == _i102.ObjectWithEnum) {
-      return _i102.ObjectWithEnum.fromJson(data) as T;
+    if (t == _i102.ObjectWithDuration) {
+      return _i102.ObjectWithDuration.fromJson(data) as T;
     }
-    if (t == _i103.ObjectWithIndex) {
-      return _i103.ObjectWithIndex.fromJson(data) as T;
+    if (t == _i103.ObjectWithEnum) {
+      return _i103.ObjectWithEnum.fromJson(data) as T;
     }
-    if (t == _i104.ObjectWithMaps) {
-      return _i104.ObjectWithMaps.fromJson(data) as T;
+    if (t == _i104.ObjectWithIndex) {
+      return _i104.ObjectWithIndex.fromJson(data) as T;
     }
-    if (t == _i105.ObjectWithObject) {
-      return _i105.ObjectWithObject.fromJson(data) as T;
+    if (t == _i105.ObjectWithMaps) {
+      return _i105.ObjectWithMaps.fromJson(data) as T;
     }
-    if (t == _i106.ObjectWithParent) {
-      return _i106.ObjectWithParent.fromJson(data) as T;
+    if (t == _i106.ObjectWithObject) {
+      return _i106.ObjectWithObject.fromJson(data) as T;
     }
-    if (t == _i107.ObjectWithSelfParent) {
-      return _i107.ObjectWithSelfParent.fromJson(data) as T;
+    if (t == _i107.ObjectWithParent) {
+      return _i107.ObjectWithParent.fromJson(data) as T;
     }
-    if (t == _i108.ObjectWithUuid) {
-      return _i108.ObjectWithUuid.fromJson(data) as T;
+    if (t == _i108.ObjectWithSelfParent) {
+      return _i108.ObjectWithSelfParent.fromJson(data) as T;
     }
-    if (t == _i109.RelatedUniqueData) {
-      return _i109.RelatedUniqueData.fromJson(data) as T;
+    if (t == _i109.ObjectWithUuid) {
+      return _i109.ObjectWithUuid.fromJson(data) as T;
     }
-    if (t == _i110.ScopeNoneFields) {
-      return _i110.ScopeNoneFields.fromJson(data) as T;
+    if (t == _i110.RelatedUniqueData) {
+      return _i110.RelatedUniqueData.fromJson(data) as T;
     }
-    if (t == _i111.ScopeServerOnlyField) {
-      return _i111.ScopeServerOnlyField.fromJson(data) as T;
+    if (t == _i111.ScopeNoneFields) {
+      return _i111.ScopeNoneFields.fromJson(data) as T;
     }
-    if (t == _i112.ScopeServerOnlyFieldChild) {
-      return _i112.ScopeServerOnlyFieldChild.fromJson(data) as T;
+    if (t == _i112.ScopeServerOnlyField) {
+      return _i112.ScopeServerOnlyField.fromJson(data) as T;
     }
-    if (t == _i113.DefaultServerOnlyClass) {
-      return _i113.DefaultServerOnlyClass.fromJson(data) as T;
+    if (t == _i113.ScopeServerOnlyFieldChild) {
+      return _i113.ScopeServerOnlyFieldChild.fromJson(data) as T;
     }
-    if (t == _i114.DefaultServerOnlyEnum) {
-      return _i114.DefaultServerOnlyEnum.fromJson(data) as T;
+    if (t == _i114.DefaultServerOnlyClass) {
+      return _i114.DefaultServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i115.NotServerOnlyClass) {
-      return _i115.NotServerOnlyClass.fromJson(data) as T;
+    if (t == _i115.DefaultServerOnlyEnum) {
+      return _i115.DefaultServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i116.NotServerOnlyEnum) {
-      return _i116.NotServerOnlyEnum.fromJson(data) as T;
+    if (t == _i116.NotServerOnlyClass) {
+      return _i116.NotServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i117.ServerOnlyClass) {
-      return _i117.ServerOnlyClass.fromJson(data) as T;
+    if (t == _i117.NotServerOnlyEnum) {
+      return _i117.NotServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i118.ServerOnlyEnum) {
-      return _i118.ServerOnlyEnum.fromJson(data) as T;
+    if (t == _i118.ServerOnlyClass) {
+      return _i118.ServerOnlyClass.fromJson(data) as T;
     }
-    if (t == _i119.ServerOnlyClassField) {
-      return _i119.ServerOnlyClassField.fromJson(data) as T;
+    if (t == _i119.ServerOnlyEnum) {
+      return _i119.ServerOnlyEnum.fromJson(data) as T;
     }
-    if (t == _i120.SimpleData) {
-      return _i120.SimpleData.fromJson(data) as T;
+    if (t == _i120.ServerOnlyClassField) {
+      return _i120.ServerOnlyClassField.fromJson(data) as T;
     }
-    if (t == _i121.SimpleDataList) {
-      return _i121.SimpleDataList.fromJson(data) as T;
+    if (t == _i121.SimpleData) {
+      return _i121.SimpleData.fromJson(data) as T;
     }
-    if (t == _i122.SimpleDataMap) {
-      return _i122.SimpleDataMap.fromJson(data) as T;
+    if (t == _i122.SimpleDataList) {
+      return _i122.SimpleDataList.fromJson(data) as T;
     }
-    if (t == _i123.SimpleDataObject) {
-      return _i123.SimpleDataObject.fromJson(data) as T;
+    if (t == _i123.SimpleDataMap) {
+      return _i123.SimpleDataMap.fromJson(data) as T;
     }
-    if (t == _i124.SimpleDateTime) {
-      return _i124.SimpleDateTime.fromJson(data) as T;
+    if (t == _i124.SimpleDataObject) {
+      return _i124.SimpleDataObject.fromJson(data) as T;
     }
-    if (t == _i125.TestEnum) {
-      return _i125.TestEnum.fromJson(data) as T;
+    if (t == _i125.SimpleDateTime) {
+      return _i125.SimpleDateTime.fromJson(data) as T;
     }
-    if (t == _i126.TestEnumStringified) {
-      return _i126.TestEnumStringified.fromJson(data) as T;
+    if (t == _i126.TestEnum) {
+      return _i126.TestEnum.fromJson(data) as T;
     }
-    if (t == _i127.Types) {
-      return _i127.Types.fromJson(data) as T;
+    if (t == _i127.TestEnumStringified) {
+      return _i127.TestEnumStringified.fromJson(data) as T;
     }
-    if (t == _i128.TypesList) {
-      return _i128.TypesList.fromJson(data) as T;
+    if (t == _i128.Types) {
+      return _i128.Types.fromJson(data) as T;
     }
-    if (t == _i129.TypesMap) {
-      return _i129.TypesMap.fromJson(data) as T;
+    if (t == _i129.TypesList) {
+      return _i129.TypesList.fromJson(data) as T;
     }
-    if (t == _i130.TypesRecord) {
-      return _i130.TypesRecord.fromJson(data) as T;
+    if (t == _i130.TypesMap) {
+      return _i130.TypesMap.fromJson(data) as T;
     }
-    if (t == _i131.TypesSet) {
-      return _i131.TypesSet.fromJson(data) as T;
+    if (t == _i131.TypesRecord) {
+      return _i131.TypesRecord.fromJson(data) as T;
     }
-    if (t == _i132.UniqueData) {
-      return _i132.UniqueData.fromJson(data) as T;
+    if (t == _i132.TypesSet) {
+      return _i132.TypesSet.fromJson(data) as T;
     }
-    if (t == _i133.MyFeatureModel) {
-      return _i133.MyFeatureModel.fromJson(data) as T;
+    if (t == _i133.UniqueData) {
+      return _i133.UniqueData.fromJson(data) as T;
+    }
+    if (t == _i134.MyFeatureModel) {
+      return _i134.MyFeatureModel.fromJson(data) as T;
     }
     if (t == _i1.getType<_i5.ByIndexEnumWithNameValue?>()) {
       return (data != null ? _i5.ByIndexEnumWithNameValue.fromJson(data) : null)
@@ -5649,462 +5654,465 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<_i32.ByNameEnum?>()) {
       return (data != null ? _i32.ByNameEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i33.DefaultException?>()) {
-      return (data != null ? _i33.DefaultException.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i33.DefaultValueEnum?>()) {
+      return (data != null ? _i33.DefaultValueEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i34.IntDefault?>()) {
-      return (data != null ? _i34.IntDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i34.DefaultException?>()) {
+      return (data != null ? _i34.DefaultException.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i35.IntDefaultMix?>()) {
-      return (data != null ? _i35.IntDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i35.IntDefault?>()) {
+      return (data != null ? _i35.IntDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i36.IntDefaultModel?>()) {
-      return (data != null ? _i36.IntDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i36.IntDefaultMix?>()) {
+      return (data != null ? _i36.IntDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i37.IntDefaultPersist?>()) {
-      return (data != null ? _i37.IntDefaultPersist.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i37.IntDefaultModel?>()) {
+      return (data != null ? _i37.IntDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i38.StringDefault?>()) {
-      return (data != null ? _i38.StringDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i38.IntDefaultPersist?>()) {
+      return (data != null ? _i38.IntDefaultPersist.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i39.StringDefaultMix?>()) {
-      return (data != null ? _i39.StringDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i39.StringDefault?>()) {
+      return (data != null ? _i39.StringDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i40.StringDefaultModel?>()) {
-      return (data != null ? _i40.StringDefaultModel.fromJson(data) : null)
+    if (t == _i1.getType<_i40.StringDefaultMix?>()) {
+      return (data != null ? _i40.StringDefaultMix.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i41.StringDefaultModel?>()) {
+      return (data != null ? _i41.StringDefaultModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i41.StringDefaultPersist?>()) {
-      return (data != null ? _i41.StringDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i42.StringDefaultPersist?>()) {
+      return (data != null ? _i42.StringDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i42.UriDefault?>()) {
-      return (data != null ? _i42.UriDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i43.UriDefault?>()) {
+      return (data != null ? _i43.UriDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i43.UriDefaultMix?>()) {
-      return (data != null ? _i43.UriDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i44.UriDefaultMix?>()) {
+      return (data != null ? _i44.UriDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i44.UriDefaultModel?>()) {
-      return (data != null ? _i44.UriDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i45.UriDefaultModel?>()) {
+      return (data != null ? _i45.UriDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i45.UriDefaultPersist?>()) {
-      return (data != null ? _i45.UriDefaultPersist.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i46.UriDefaultPersist?>()) {
+      return (data != null ? _i46.UriDefaultPersist.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i46.UuidDefault?>()) {
-      return (data != null ? _i46.UuidDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i47.UuidDefault?>()) {
+      return (data != null ? _i47.UuidDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i47.UuidDefaultMix?>()) {
-      return (data != null ? _i47.UuidDefaultMix.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i48.UuidDefaultMix?>()) {
+      return (data != null ? _i48.UuidDefaultMix.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i48.UuidDefaultModel?>()) {
-      return (data != null ? _i48.UuidDefaultModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i49.UuidDefaultModel?>()) {
+      return (data != null ? _i49.UuidDefaultModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i49.UuidDefaultPersist?>()) {
-      return (data != null ? _i49.UuidDefaultPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i50.UuidDefaultPersist?>()) {
+      return (data != null ? _i50.UuidDefaultPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i50.EmptyModel?>()) {
-      return (data != null ? _i50.EmptyModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i51.EmptyModel?>()) {
+      return (data != null ? _i51.EmptyModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i51.EmptyModelRelationItem?>()) {
-      return (data != null ? _i51.EmptyModelRelationItem.fromJson(data) : null)
+    if (t == _i1.getType<_i52.EmptyModelRelationItem?>()) {
+      return (data != null ? _i52.EmptyModelRelationItem.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i52.EmptyModelWithTable?>()) {
-      return (data != null ? _i52.EmptyModelWithTable.fromJson(data) : null)
+    if (t == _i1.getType<_i53.EmptyModelWithTable?>()) {
+      return (data != null ? _i53.EmptyModelWithTable.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i53.RelationEmptyModel?>()) {
-      return (data != null ? _i53.RelationEmptyModel.fromJson(data) : null)
+    if (t == _i1.getType<_i54.RelationEmptyModel?>()) {
+      return (data != null ? _i54.RelationEmptyModel.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i54.ExceptionWithData?>()) {
-      return (data != null ? _i54.ExceptionWithData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i55.ExceptionWithData?>()) {
+      return (data != null ? _i55.ExceptionWithData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i55.ChildClass?>()) {
-      return (data != null ? _i55.ChildClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i56.ChildClass?>()) {
+      return (data != null ? _i56.ChildClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i56.ChildWithDefault?>()) {
-      return (data != null ? _i56.ChildWithDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i57.ChildWithDefault?>()) {
+      return (data != null ? _i57.ChildWithDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i57.GrandparentClass?>()) {
-      return (data != null ? _i57.GrandparentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i58.GrandparentClass?>()) {
+      return (data != null ? _i58.GrandparentClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i58.ParentClass?>()) {
-      return (data != null ? _i58.ParentClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i59.ParentClass?>()) {
+      return (data != null ? _i59.ParentClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i59.ParentWithDefault?>()) {
-      return (data != null ? _i59.ParentWithDefault.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i60.ParentWithDefault?>()) {
+      return (data != null ? _i60.ParentWithDefault.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i60.SealedChild?>()) {
-      return (data != null ? _i60.SealedChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i61.SealedChild?>()) {
+      return (data != null ? _i61.SealedChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i60.SealedGrandChild?>()) {
-      return (data != null ? _i60.SealedGrandChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i61.SealedGrandChild?>()) {
+      return (data != null ? _i61.SealedGrandChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i60.SealedOtherChild?>()) {
-      return (data != null ? _i60.SealedOtherChild.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i61.SealedOtherChild?>()) {
+      return (data != null ? _i61.SealedOtherChild.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i61.CityWithLongTableName?>()) {
-      return (data != null ? _i61.CityWithLongTableName.fromJson(data) : null)
+    if (t == _i1.getType<_i62.CityWithLongTableName?>()) {
+      return (data != null ? _i62.CityWithLongTableName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i62.OrganizationWithLongTableName?>()) {
+    if (t == _i1.getType<_i63.OrganizationWithLongTableName?>()) {
       return (data != null
-          ? _i62.OrganizationWithLongTableName.fromJson(data)
+          ? _i63.OrganizationWithLongTableName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i63.PersonWithLongTableName?>()) {
-      return (data != null ? _i63.PersonWithLongTableName.fromJson(data) : null)
+    if (t == _i1.getType<_i64.PersonWithLongTableName?>()) {
+      return (data != null ? _i64.PersonWithLongTableName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i64.MaxFieldName?>()) {
-      return (data != null ? _i64.MaxFieldName.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i65.MaxFieldName?>()) {
+      return (data != null ? _i65.MaxFieldName.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i65.LongImplicitIdField?>()) {
-      return (data != null ? _i65.LongImplicitIdField.fromJson(data) : null)
+    if (t == _i1.getType<_i66.LongImplicitIdField?>()) {
+      return (data != null ? _i66.LongImplicitIdField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i66.LongImplicitIdFieldCollection?>()) {
+    if (t == _i1.getType<_i67.LongImplicitIdFieldCollection?>()) {
       return (data != null
-          ? _i66.LongImplicitIdFieldCollection.fromJson(data)
+          ? _i67.LongImplicitIdFieldCollection.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i67.RelationToMultipleMaxFieldName?>()) {
+    if (t == _i1.getType<_i68.RelationToMultipleMaxFieldName?>()) {
       return (data != null
-          ? _i67.RelationToMultipleMaxFieldName.fromJson(data)
+          ? _i68.RelationToMultipleMaxFieldName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i68.UserNote?>()) {
-      return (data != null ? _i68.UserNote.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i69.UserNote?>()) {
+      return (data != null ? _i69.UserNote.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i69.UserNoteCollection?>()) {
-      return (data != null ? _i69.UserNoteCollection.fromJson(data) : null)
+    if (t == _i1.getType<_i70.UserNoteCollection?>()) {
+      return (data != null ? _i70.UserNoteCollection.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i70.UserNoteCollectionWithALongName?>()) {
+    if (t == _i1.getType<_i71.UserNoteCollectionWithALongName?>()) {
       return (data != null
-          ? _i70.UserNoteCollectionWithALongName.fromJson(data)
+          ? _i71.UserNoteCollectionWithALongName.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i71.UserNoteWithALongName?>()) {
-      return (data != null ? _i71.UserNoteWithALongName.fromJson(data) : null)
+    if (t == _i1.getType<_i72.UserNoteWithALongName?>()) {
+      return (data != null ? _i72.UserNoteWithALongName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i72.MultipleMaxFieldName?>()) {
-      return (data != null ? _i72.MultipleMaxFieldName.fromJson(data) : null)
+    if (t == _i1.getType<_i73.MultipleMaxFieldName?>()) {
+      return (data != null ? _i73.MultipleMaxFieldName.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i73.City?>()) {
-      return (data != null ? _i73.City.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i74.City?>()) {
+      return (data != null ? _i74.City.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i74.Organization?>()) {
-      return (data != null ? _i74.Organization.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i75.Organization?>()) {
+      return (data != null ? _i75.Organization.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i75.Person?>()) {
-      return (data != null ? _i75.Person.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i76.Person?>()) {
+      return (data != null ? _i76.Person.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i76.Course?>()) {
-      return (data != null ? _i76.Course.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i77.Course?>()) {
+      return (data != null ? _i77.Course.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i77.Enrollment?>()) {
-      return (data != null ? _i77.Enrollment.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i78.Enrollment?>()) {
+      return (data != null ? _i78.Enrollment.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i78.Student?>()) {
-      return (data != null ? _i78.Student.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i79.Student?>()) {
+      return (data != null ? _i79.Student.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i79.ObjectUser?>()) {
-      return (data != null ? _i79.ObjectUser.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i80.ObjectUser?>()) {
+      return (data != null ? _i80.ObjectUser.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i80.ParentUser?>()) {
-      return (data != null ? _i80.ParentUser.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i81.ParentUser?>()) {
+      return (data != null ? _i81.ParentUser.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i81.Arena?>()) {
-      return (data != null ? _i81.Arena.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i82.Arena?>()) {
+      return (data != null ? _i82.Arena.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i82.Player?>()) {
-      return (data != null ? _i82.Player.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i83.Player?>()) {
+      return (data != null ? _i83.Player.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i83.Team?>()) {
-      return (data != null ? _i83.Team.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i84.Team?>()) {
+      return (data != null ? _i84.Team.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i84.Comment?>()) {
-      return (data != null ? _i84.Comment.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i85.Comment?>()) {
+      return (data != null ? _i85.Comment.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i85.Customer?>()) {
-      return (data != null ? _i85.Customer.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i86.Customer?>()) {
+      return (data != null ? _i86.Customer.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i86.Order?>()) {
-      return (data != null ? _i86.Order.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i87.Order?>()) {
+      return (data != null ? _i87.Order.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i87.Address?>()) {
-      return (data != null ? _i87.Address.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i88.Address?>()) {
+      return (data != null ? _i88.Address.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i88.Citizen?>()) {
-      return (data != null ? _i88.Citizen.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i89.Citizen?>()) {
+      return (data != null ? _i89.Citizen.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i89.Company?>()) {
-      return (data != null ? _i89.Company.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i90.Company?>()) {
+      return (data != null ? _i90.Company.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i90.Town?>()) {
-      return (data != null ? _i90.Town.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i91.Town?>()) {
+      return (data != null ? _i91.Town.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i91.Blocking?>()) {
-      return (data != null ? _i91.Blocking.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i92.Blocking?>()) {
+      return (data != null ? _i92.Blocking.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i92.Member?>()) {
-      return (data != null ? _i92.Member.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i93.Member?>()) {
+      return (data != null ? _i93.Member.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i93.Cat?>()) {
-      return (data != null ? _i93.Cat.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i94.Cat?>()) {
+      return (data != null ? _i94.Cat.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i94.Post?>()) {
-      return (data != null ? _i94.Post.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i95.Post?>()) {
+      return (data != null ? _i95.Post.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i95.ModuleDatatype?>()) {
-      return (data != null ? _i95.ModuleDatatype.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i96.ModuleDatatype?>()) {
+      return (data != null ? _i96.ModuleDatatype.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i96.Nullability?>()) {
-      return (data != null ? _i96.Nullability.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i97.Nullability?>()) {
+      return (data != null ? _i97.Nullability.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i97.ObjectFieldPersist?>()) {
-      return (data != null ? _i97.ObjectFieldPersist.fromJson(data) : null)
+    if (t == _i1.getType<_i98.ObjectFieldPersist?>()) {
+      return (data != null ? _i98.ObjectFieldPersist.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i98.ObjectFieldScopes?>()) {
-      return (data != null ? _i98.ObjectFieldScopes.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i99.ObjectFieldScopes?>()) {
+      return (data != null ? _i99.ObjectFieldScopes.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i99.ObjectWithByteData?>()) {
-      return (data != null ? _i99.ObjectWithByteData.fromJson(data) : null)
+    if (t == _i1.getType<_i100.ObjectWithByteData?>()) {
+      return (data != null ? _i100.ObjectWithByteData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i100.ObjectWithCustomClass?>()) {
-      return (data != null ? _i100.ObjectWithCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i101.ObjectWithCustomClass?>()) {
+      return (data != null ? _i101.ObjectWithCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i101.ObjectWithDuration?>()) {
-      return (data != null ? _i101.ObjectWithDuration.fromJson(data) : null)
+    if (t == _i1.getType<_i102.ObjectWithDuration?>()) {
+      return (data != null ? _i102.ObjectWithDuration.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i102.ObjectWithEnum?>()) {
-      return (data != null ? _i102.ObjectWithEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i103.ObjectWithEnum?>()) {
+      return (data != null ? _i103.ObjectWithEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i103.ObjectWithIndex?>()) {
-      return (data != null ? _i103.ObjectWithIndex.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i104.ObjectWithIndex?>()) {
+      return (data != null ? _i104.ObjectWithIndex.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i104.ObjectWithMaps?>()) {
-      return (data != null ? _i104.ObjectWithMaps.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i105.ObjectWithMaps?>()) {
+      return (data != null ? _i105.ObjectWithMaps.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i105.ObjectWithObject?>()) {
-      return (data != null ? _i105.ObjectWithObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i106.ObjectWithObject?>()) {
+      return (data != null ? _i106.ObjectWithObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i106.ObjectWithParent?>()) {
-      return (data != null ? _i106.ObjectWithParent.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i107.ObjectWithParent?>()) {
+      return (data != null ? _i107.ObjectWithParent.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i107.ObjectWithSelfParent?>()) {
-      return (data != null ? _i107.ObjectWithSelfParent.fromJson(data) : null)
+    if (t == _i1.getType<_i108.ObjectWithSelfParent?>()) {
+      return (data != null ? _i108.ObjectWithSelfParent.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i108.ObjectWithUuid?>()) {
-      return (data != null ? _i108.ObjectWithUuid.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i109.ObjectWithUuid?>()) {
+      return (data != null ? _i109.ObjectWithUuid.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i109.RelatedUniqueData?>()) {
-      return (data != null ? _i109.RelatedUniqueData.fromJson(data) : null)
+    if (t == _i1.getType<_i110.RelatedUniqueData?>()) {
+      return (data != null ? _i110.RelatedUniqueData.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i110.ScopeNoneFields?>()) {
-      return (data != null ? _i110.ScopeNoneFields.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i111.ScopeNoneFields?>()) {
+      return (data != null ? _i111.ScopeNoneFields.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i111.ScopeServerOnlyField?>()) {
-      return (data != null ? _i111.ScopeServerOnlyField.fromJson(data) : null)
+    if (t == _i1.getType<_i112.ScopeServerOnlyField?>()) {
+      return (data != null ? _i112.ScopeServerOnlyField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i112.ScopeServerOnlyFieldChild?>()) {
+    if (t == _i1.getType<_i113.ScopeServerOnlyFieldChild?>()) {
       return (data != null
-          ? _i112.ScopeServerOnlyFieldChild.fromJson(data)
+          ? _i113.ScopeServerOnlyFieldChild.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i113.DefaultServerOnlyClass?>()) {
-      return (data != null ? _i113.DefaultServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i114.DefaultServerOnlyClass?>()) {
+      return (data != null ? _i114.DefaultServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i114.DefaultServerOnlyEnum?>()) {
-      return (data != null ? _i114.DefaultServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i115.DefaultServerOnlyEnum?>()) {
+      return (data != null ? _i115.DefaultServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i115.NotServerOnlyClass?>()) {
-      return (data != null ? _i115.NotServerOnlyClass.fromJson(data) : null)
+    if (t == _i1.getType<_i116.NotServerOnlyClass?>()) {
+      return (data != null ? _i116.NotServerOnlyClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i116.NotServerOnlyEnum?>()) {
-      return (data != null ? _i116.NotServerOnlyEnum.fromJson(data) : null)
+    if (t == _i1.getType<_i117.NotServerOnlyEnum?>()) {
+      return (data != null ? _i117.NotServerOnlyEnum.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i117.ServerOnlyClass?>()) {
-      return (data != null ? _i117.ServerOnlyClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i118.ServerOnlyClass?>()) {
+      return (data != null ? _i118.ServerOnlyClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i118.ServerOnlyEnum?>()) {
-      return (data != null ? _i118.ServerOnlyEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i119.ServerOnlyEnum?>()) {
+      return (data != null ? _i119.ServerOnlyEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i119.ServerOnlyClassField?>()) {
-      return (data != null ? _i119.ServerOnlyClassField.fromJson(data) : null)
+    if (t == _i1.getType<_i120.ServerOnlyClassField?>()) {
+      return (data != null ? _i120.ServerOnlyClassField.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i120.SimpleData?>()) {
-      return (data != null ? _i120.SimpleData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i121.SimpleData?>()) {
+      return (data != null ? _i121.SimpleData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i121.SimpleDataList?>()) {
-      return (data != null ? _i121.SimpleDataList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i122.SimpleDataList?>()) {
+      return (data != null ? _i122.SimpleDataList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i122.SimpleDataMap?>()) {
-      return (data != null ? _i122.SimpleDataMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i123.SimpleDataMap?>()) {
+      return (data != null ? _i123.SimpleDataMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i123.SimpleDataObject?>()) {
-      return (data != null ? _i123.SimpleDataObject.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i124.SimpleDataObject?>()) {
+      return (data != null ? _i124.SimpleDataObject.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i124.SimpleDateTime?>()) {
-      return (data != null ? _i124.SimpleDateTime.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i125.SimpleDateTime?>()) {
+      return (data != null ? _i125.SimpleDateTime.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i125.TestEnum?>()) {
-      return (data != null ? _i125.TestEnum.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i126.TestEnum?>()) {
+      return (data != null ? _i126.TestEnum.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i126.TestEnumStringified?>()) {
-      return (data != null ? _i126.TestEnumStringified.fromJson(data) : null)
+    if (t == _i1.getType<_i127.TestEnumStringified?>()) {
+      return (data != null ? _i127.TestEnumStringified.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i127.Types?>()) {
-      return (data != null ? _i127.Types.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i128.Types?>()) {
+      return (data != null ? _i128.Types.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i128.TypesList?>()) {
-      return (data != null ? _i128.TypesList.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i129.TypesList?>()) {
+      return (data != null ? _i129.TypesList.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i129.TypesMap?>()) {
-      return (data != null ? _i129.TypesMap.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i130.TypesMap?>()) {
+      return (data != null ? _i130.TypesMap.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i130.TypesRecord?>()) {
-      return (data != null ? _i130.TypesRecord.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i131.TypesRecord?>()) {
+      return (data != null ? _i131.TypesRecord.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i131.TypesSet?>()) {
-      return (data != null ? _i131.TypesSet.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i132.TypesSet?>()) {
+      return (data != null ? _i132.TypesSet.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i132.UniqueData?>()) {
-      return (data != null ? _i132.UniqueData.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i133.UniqueData?>()) {
+      return (data != null ? _i133.UniqueData.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i133.MyFeatureModel?>()) {
-      return (data != null ? _i133.MyFeatureModel.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i134.MyFeatureModel?>()) {
+      return (data != null ? _i134.MyFeatureModel.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<List<_i51.EmptyModelRelationItem>?>()) {
+    if (t == _i1.getType<List<_i52.EmptyModelRelationItem>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i51.EmptyModelRelationItem>(e))
+              .map((e) => deserialize<_i52.EmptyModelRelationItem>(e))
               .toList()
           : null) as T;
     }
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == _i1.getType<List<_i63.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i64.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i64.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i62.OrganizationWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i63.OrganizationWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i62.OrganizationWithLongTableName>(e))
+              .map((e) => deserialize<_i63.OrganizationWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i63.PersonWithLongTableName>?>()) {
+    if (t == _i1.getType<List<_i64.PersonWithLongTableName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i63.PersonWithLongTableName>(e))
+              .map((e) => deserialize<_i64.PersonWithLongTableName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i65.LongImplicitIdField>?>()) {
+    if (t == _i1.getType<List<_i66.LongImplicitIdField>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i65.LongImplicitIdField>(e))
+              .map((e) => deserialize<_i66.LongImplicitIdField>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i72.MultipleMaxFieldName>?>()) {
+    if (t == _i1.getType<List<_i73.MultipleMaxFieldName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i72.MultipleMaxFieldName>(e))
+              .map((e) => deserialize<_i73.MultipleMaxFieldName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i68.UserNote>?>()) {
+    if (t == _i1.getType<List<_i69.UserNote>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i68.UserNote>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i69.UserNote>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i71.UserNoteWithALongName>?>()) {
+    if (t == _i1.getType<List<_i72.UserNoteWithALongName>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i71.UserNoteWithALongName>(e))
+              .map((e) => deserialize<_i72.UserNoteWithALongName>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i75.Person>?>()) {
+    if (t == _i1.getType<List<_i76.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i75.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i76.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i74.Organization>?>()) {
+    if (t == _i1.getType<List<_i75.Organization>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i74.Organization>(e))
+              .map((e) => deserialize<_i75.Organization>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i75.Person>?>()) {
+    if (t == _i1.getType<List<_i76.Person>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i75.Person>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i76.Person>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i77.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i78.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i77.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i78.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i77.Enrollment>?>()) {
+    if (t == _i1.getType<List<_i78.Enrollment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i77.Enrollment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i78.Enrollment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i82.Player>?>()) {
+    if (t == _i1.getType<List<_i83.Player>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i82.Player>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i83.Player>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i86.Order>?>()) {
+    if (t == _i1.getType<List<_i87.Order>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i86.Order>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i87.Order>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i84.Comment>?>()) {
+    if (t == _i1.getType<List<_i85.Comment>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i84.Comment>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i85.Comment>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i91.Blocking>?>()) {
+    if (t == _i1.getType<List<_i92.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i91.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i92.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i91.Blocking>?>()) {
+    if (t == _i1.getType<List<_i92.Blocking>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i91.Blocking>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i92.Blocking>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i93.Cat>?>()) {
+    if (t == _i1.getType<List<_i94.Cat>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i93.Cat>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i94.Cat>(e)).toList()
           : null) as T;
     }
     if (t == List<_i4.ModuleClass>) {
@@ -6138,25 +6146,25 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<int?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i120.SimpleData>) {
+    if (t == List<_i121.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i120.SimpleData>(e))
+          .map((e) => deserialize<_i121.SimpleData>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i121.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i120.SimpleData?>) {
+    if (t == List<_i121.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i120.SimpleData?>(e))
+          .map((e) => deserialize<_i121.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i120.SimpleData?>(e))
+              .map((e) => deserialize<_i121.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -6176,22 +6184,22 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<DateTime?>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i134.ByteData>) {
-      return (data as List).map((e) => deserialize<_i134.ByteData>(e)).toList()
+    if (t == List<_i135.ByteData>) {
+      return (data as List).map((e) => deserialize<_i135.ByteData>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i134.ByteData>?>()) {
+    if (t == _i1.getType<List<_i135.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i134.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i135.ByteData>(e)).toList()
           : null) as T;
     }
-    if (t == List<_i134.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i134.ByteData?>(e)).toList()
+    if (t == List<_i135.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i135.ByteData?>(e)).toList()
           as T;
     }
-    if (t == _i1.getType<List<_i134.ByteData?>?>()) {
+    if (t == _i1.getType<List<_i135.ByteData?>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i134.ByteData?>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i135.ByteData?>(e)).toList()
           : null) as T;
     }
     if (t == List<Duration>) {
@@ -6249,32 +6257,32 @@ class Protocol extends _i1.SerializationManagerServer {
               (k, v) => MapEntry(deserialize<String>(k), deserialize<int?>(v)))
           : null) as T;
     }
-    if (t == _i135.CustomClassWithoutProtocolSerialization) {
-      return _i135.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
+    if (t == _i136.CustomClassWithoutProtocolSerialization) {
+      return _i136.CustomClassWithoutProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i135.CustomClassWithProtocolSerialization) {
-      return _i135.CustomClassWithProtocolSerialization.fromJson(data) as T;
+    if (t == _i136.CustomClassWithProtocolSerialization) {
+      return _i136.CustomClassWithProtocolSerialization.fromJson(data) as T;
     }
-    if (t == _i135.CustomClassWithProtocolSerializationMethod) {
-      return _i135.CustomClassWithProtocolSerializationMethod.fromJson(data)
+    if (t == _i136.CustomClassWithProtocolSerializationMethod) {
+      return _i136.CustomClassWithProtocolSerializationMethod.fromJson(data)
           as T;
     }
-    if (t == List<_i125.TestEnum>) {
-      return (data as List).map((e) => deserialize<_i125.TestEnum>(e)).toList()
+    if (t == List<_i126.TestEnum>) {
+      return (data as List).map((e) => deserialize<_i126.TestEnum>(e)).toList()
           as T;
     }
-    if (t == List<_i125.TestEnum?>) {
-      return (data as List).map((e) => deserialize<_i125.TestEnum?>(e)).toList()
+    if (t == List<_i126.TestEnum?>) {
+      return (data as List).map((e) => deserialize<_i126.TestEnum?>(e)).toList()
           as T;
     }
-    if (t == List<List<_i125.TestEnum>>) {
+    if (t == List<List<_i126.TestEnum>>) {
       return (data as List)
-          .map((e) => deserialize<List<_i125.TestEnum>>(e))
+          .map((e) => deserialize<List<_i126.TestEnum>>(e))
           .toList() as T;
     }
-    if (t == Map<String, _i120.SimpleData>) {
+    if (t == Map<String, _i121.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i120.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i121.SimpleData>(v))) as T;
     }
     if (t == Map<String, String>) {
       return (data as Map).map((k, v) =>
@@ -6284,9 +6292,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime>(v))) as T;
     }
-    if (t == Map<String, _i134.ByteData>) {
+    if (t == Map<String, _i135.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i134.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i135.ByteData>(v)))
           as T;
     }
     if (t == Map<String, Duration>) {
@@ -6297,9 +6305,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<_i1.UuidValue>(v))) as T;
     }
-    if (t == Map<String, _i120.SimpleData?>) {
+    if (t == Map<String, _i121.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i120.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i121.SimpleData?>(v))) as T;
     }
     if (t == Map<String, String?>) {
       return (data as Map).map((k, v) =>
@@ -6309,9 +6317,9 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i134.ByteData?>) {
+    if (t == Map<String, _i135.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i134.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i135.ByteData?>(v)))
           as T;
     }
     if (t == Map<String, Duration?>) {
@@ -6327,66 +6335,66 @@ class Protocol extends _i1.SerializationManagerServer {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i120.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i121.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i120.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i121.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i120.SimpleData?>(e))
+              .map((e) => deserialize<_i121.SimpleData?>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<List<_i120.SimpleData>>?>()) {
+    if (t == _i1.getType<List<List<_i121.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i120.SimpleData>>(e))
+              .map((e) => deserialize<List<_i121.SimpleData>>(e))
               .toList()
           : null) as T;
     }
     if (t ==
-        _i1.getType<Map<String, List<List<Map<int, _i120.SimpleData>>?>>?>()) {
+        _i1.getType<Map<String, List<List<Map<int, _i121.SimpleData>>?>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<List<List<Map<int, _i120.SimpleData>>?>>(v)))
+              deserialize<List<List<Map<int, _i121.SimpleData>>?>>(v)))
           : null) as T;
     }
-    if (t == List<List<Map<int, _i120.SimpleData>>?>) {
+    if (t == List<List<Map<int, _i121.SimpleData>>?>) {
       return (data as List)
-          .map((e) => deserialize<List<Map<int, _i120.SimpleData>>?>(e))
+          .map((e) => deserialize<List<Map<int, _i121.SimpleData>>?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<Map<int, _i120.SimpleData>>?>()) {
+    if (t == _i1.getType<List<Map<int, _i121.SimpleData>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<int, _i120.SimpleData>>(e))
+              .map((e) => deserialize<Map<int, _i121.SimpleData>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<int, _i120.SimpleData>) {
+    if (t == Map<int, _i121.SimpleData>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<int>(e['k']), deserialize<_i120.SimpleData>(e['v']))))
+              deserialize<int>(e['k']), deserialize<_i121.SimpleData>(e['v']))))
           as T;
     }
-    if (t == _i1.getType<Map<String, Map<int, _i120.SimpleData>>?>()) {
+    if (t == _i1.getType<Map<String, Map<int, _i121.SimpleData>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<Map<int, _i120.SimpleData>>(v)))
+              deserialize<Map<int, _i121.SimpleData>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<List<_i117.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<List<_i118.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i117.ServerOnlyClass>(e))
+              .map((e) => deserialize<_i118.ServerOnlyClass>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i117.ServerOnlyClass>?>()) {
+    if (t == _i1.getType<Map<String, _i118.ServerOnlyClass>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i117.ServerOnlyClass>(v)))
+              deserialize<String>(k), deserialize<_i118.ServerOnlyClass>(v)))
           : null) as T;
     }
     if (t == _i1.getType<List<int>?>()) {
@@ -6440,9 +6448,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i134.ByteData>?>()) {
+    if (t == _i1.getType<List<_i135.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i134.ByteData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i135.ByteData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<List<Duration>?>()) {
@@ -6465,43 +6473,43 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i125.TestEnum>?>()) {
+    if (t == _i1.getType<List<_i126.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i125.TestEnum>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i126.TestEnum>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i126.TestEnumStringified>?>()) {
+    if (t == _i1.getType<List<_i127.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i126.TestEnumStringified>(e))
+              .map((e) => deserialize<_i127.TestEnumStringified>(e))
               .toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i127.Types>?>()) {
+    if (t == _i1.getType<List<_i128.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i127.Types>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i128.Types>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<Map<String, _i127.Types>>?>()) {
+    if (t == _i1.getType<List<Map<String, _i128.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i127.Types>>(e))
+              .map((e) => deserialize<Map<String, _i128.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == Map<String, _i127.Types>) {
+    if (t == Map<String, _i128.Types>) {
       return (data as Map).map((k, v) =>
-          MapEntry(deserialize<String>(k), deserialize<_i127.Types>(v))) as T;
+          MapEntry(deserialize<String>(k), deserialize<_i128.Types>(v))) as T;
     }
-    if (t == _i1.getType<List<List<_i127.Types>>?>()) {
+    if (t == _i1.getType<List<List<_i128.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<List<_i127.Types>>(e))
+              .map((e) => deserialize<List<_i128.Types>>(e))
               .toList()
           : null) as T;
     }
-    if (t == List<_i127.Types>) {
-      return (data as List).map((e) => deserialize<_i127.Types>(e)).toList()
+    if (t == List<_i128.Types>) {
+      return (data as List).map((e) => deserialize<_i128.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<List<(int,)>?>()) {
@@ -6552,10 +6560,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i134.ByteData, String>?>()) {
+    if (t == _i1.getType<Map<_i135.ByteData, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i134.ByteData>(e['k']),
+              deserialize<_i135.ByteData>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -6583,41 +6591,41 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<BigInt>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i125.TestEnum, String>?>()) {
+    if (t == _i1.getType<Map<_i126.TestEnum, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i125.TestEnum>(e['k']),
+              deserialize<_i126.TestEnum>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i126.TestEnumStringified, String>?>()) {
+    if (t == _i1.getType<Map<_i127.TestEnumStringified, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i126.TestEnumStringified>(e['k']),
+              deserialize<_i127.TestEnumStringified>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<_i127.Types, String>?>()) {
+    if (t == _i1.getType<Map<_i128.Types, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<_i127.Types>(e['k']), deserialize<String>(e['v']))))
+              deserialize<_i128.Types>(e['k']), deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == _i1.getType<Map<Map<_i127.Types, String>, String>?>()) {
+    if (t == _i1.getType<Map<Map<_i128.Types, String>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<Map<_i127.Types, String>>(e['k']),
+              deserialize<Map<_i128.Types, String>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
-    if (t == Map<_i127.Types, String>) {
+    if (t == Map<_i128.Types, String>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i127.Types>(e['k']), deserialize<String>(e['v'])))) as T;
+          deserialize<_i128.Types>(e['k']), deserialize<String>(e['v'])))) as T;
     }
-    if (t == _i1.getType<Map<List<_i127.Types>, String>?>()) {
+    if (t == _i1.getType<Map<List<_i128.Types>, String>?>()) {
       return (data != null
           ? Map.fromEntries((data as List).map((e) => MapEntry(
-              deserialize<List<_i127.Types>>(e['k']),
+              deserialize<List<_i128.Types>>(e['k']),
               deserialize<String>(e['v']))))
           : null) as T;
     }
@@ -6660,10 +6668,10 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<String>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i134.ByteData>?>()) {
+    if (t == _i1.getType<Map<String, _i135.ByteData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i134.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i135.ByteData>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, Duration>?>()) {
@@ -6690,34 +6698,34 @@ class Protocol extends _i1.SerializationManagerServer {
               MapEntry(deserialize<String>(k), deserialize<BigInt>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i125.TestEnum>?>()) {
+    if (t == _i1.getType<Map<String, _i126.TestEnum>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i125.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i126.TestEnum>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i126.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Map<String, _i127.TestEnumStringified>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(deserialize<String>(k),
-              deserialize<_i126.TestEnumStringified>(v)))
+              deserialize<_i127.TestEnumStringified>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i127.Types>?>()) {
+    if (t == _i1.getType<Map<String, _i128.Types>?>()) {
       return (data != null
           ? (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i127.Types>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i128.Types>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, Map<String, _i127.Types>>?>()) {
+    if (t == _i1.getType<Map<String, Map<String, _i128.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<Map<String, _i127.Types>>(v)))
+              deserialize<String>(k), deserialize<Map<String, _i128.Types>>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, List<_i127.Types>>?>()) {
+    if (t == _i1.getType<Map<String, List<_i128.Types>>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<List<_i127.Types>>(v)))
+              deserialize<String>(k), deserialize<List<_i128.Types>>(v)))
           : null) as T;
     }
     if (t == _i1.getType<Map<String, (String,)>?>()) {
@@ -6776,10 +6784,10 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<String>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i134.ByteData,)?>()) {
+    if (t == _i1.getType<(_i135.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i134.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i135.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -6802,17 +6810,17 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i125.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i126.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i125.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i126.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<(_i126.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i127.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i126.TestEnumStringified>(
+              deserialize<_i127.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
@@ -6831,28 +6839,28 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i120.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i121.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i120.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i121.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i120.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i121.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i120.SimpleData>(
+              namedModel: deserialize<_i121.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i120.SimpleData, {_i120.SimpleData namedModel})?>()) {
+        _i1.getType<(_i121.SimpleData, {_i121.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i120.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i121.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i120.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i121.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -6868,21 +6876,21 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t ==
         _i1.getType<
             (
-              (List<(_i120.SimpleData,)>,), {
+              (List<(_i121.SimpleData,)>,), {
               (
-                _i120.SimpleData,
-                Map<String, _i120.SimpleData>
+                _i121.SimpleData,
+                Map<String, _i121.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i120.SimpleData,)>,)>(
+              deserialize<(List<(_i121.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i120.SimpleData,
-                    Map<String, _i120.SimpleData>
+                    _i121.SimpleData,
+                    Map<String, _i121.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
@@ -6911,9 +6919,9 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<String>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i134.ByteData>?>()) {
+    if (t == _i1.getType<Set<_i135.ByteData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i134.ByteData>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i135.ByteData>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<Duration>?>()) {
@@ -6931,33 +6939,33 @@ class Protocol extends _i1.SerializationManagerServer {
           ? (data as List).map((e) => deserialize<BigInt>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i125.TestEnum>?>()) {
+    if (t == _i1.getType<Set<_i126.TestEnum>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i125.TestEnum>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i126.TestEnum>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i126.TestEnumStringified>?>()) {
+    if (t == _i1.getType<Set<_i127.TestEnumStringified>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i126.TestEnumStringified>(e))
+              .map((e) => deserialize<_i127.TestEnumStringified>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<_i127.Types>?>()) {
+    if (t == _i1.getType<Set<_i128.Types>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i127.Types>(e)).toSet()
+          ? (data as List).map((e) => deserialize<_i128.Types>(e)).toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<Map<String, _i127.Types>>?>()) {
+    if (t == _i1.getType<Set<Map<String, _i128.Types>>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<Map<String, _i127.Types>>(e))
+              .map((e) => deserialize<Map<String, _i128.Types>>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<Set<List<_i127.Types>>?>()) {
+    if (t == _i1.getType<Set<List<_i128.Types>>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<List<_i127.Types>>(e)).toSet()
+          ? (data as List).map((e) => deserialize<List<_i128.Types>>(e)).toSet()
           : null) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -6986,9 +6994,9 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == List<String>) {
       return (data as List).map((e) => deserialize<String>(e)).toList() as T;
     }
-    if (t == List<_i136.SimpleData>) {
+    if (t == List<_i137.SimpleData>) {
       return (data as List)
-          .map((e) => deserialize<_i136.SimpleData>(e))
+          .map((e) => deserialize<_i137.SimpleData>(e))
           .toList() as T;
     }
     if (t == List<int>) {
@@ -7045,28 +7053,28 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == List<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toList() as T;
     }
-    if (t == List<_i134.ByteData>) {
-      return (data as List).map((e) => deserialize<_i134.ByteData>(e)).toList()
+    if (t == List<_i135.ByteData>) {
+      return (data as List).map((e) => deserialize<_i135.ByteData>(e)).toList()
           as T;
     }
-    if (t == List<_i134.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i134.ByteData?>(e)).toList()
+    if (t == List<_i135.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i135.ByteData?>(e)).toList()
           as T;
     }
-    if (t == List<_i136.SimpleData?>) {
+    if (t == List<_i137.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i136.SimpleData?>(e))
+          .map((e) => deserialize<_i137.SimpleData?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<List<_i136.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i137.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i136.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i137.SimpleData>(e)).toList()
           : null) as T;
     }
-    if (t == _i1.getType<List<_i136.SimpleData?>?>()) {
+    if (t == _i1.getType<List<_i137.SimpleData?>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<_i136.SimpleData?>(e))
+              .map((e) => deserialize<_i137.SimpleData?>(e))
               .toList()
           : null) as T;
     }
@@ -7105,13 +7113,13 @@ class Protocol extends _i1.SerializationManagerServer {
       return Map.fromEntries((data as List).map((e) =>
           MapEntry(deserialize<int>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<_i137.TestEnum, int>) {
+    if (t == Map<_i138.TestEnum, int>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
-          deserialize<_i137.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
+          deserialize<_i138.TestEnum>(e['k']), deserialize<int>(e['v'])))) as T;
     }
-    if (t == Map<String, _i137.TestEnum>) {
+    if (t == Map<String, _i138.TestEnum>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i137.TestEnum>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i138.TestEnum>(v)))
           as T;
     }
     if (t == Map<String, double>) {
@@ -7148,34 +7156,34 @@ class Protocol extends _i1.SerializationManagerServer {
       return (data as Map).map((k, v) =>
           MapEntry(deserialize<String>(k), deserialize<DateTime?>(v))) as T;
     }
-    if (t == Map<String, _i134.ByteData>) {
+    if (t == Map<String, _i135.ByteData>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i134.ByteData>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i135.ByteData>(v)))
           as T;
     }
-    if (t == Map<String, _i134.ByteData?>) {
+    if (t == Map<String, _i135.ByteData?>) {
       return (data as Map).map((k, v) =>
-              MapEntry(deserialize<String>(k), deserialize<_i134.ByteData?>(v)))
+              MapEntry(deserialize<String>(k), deserialize<_i135.ByteData?>(v)))
           as T;
     }
-    if (t == Map<String, _i136.SimpleData>) {
+    if (t == Map<String, _i137.SimpleData>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i136.SimpleData>(v))) as T;
+          deserialize<String>(k), deserialize<_i137.SimpleData>(v))) as T;
     }
-    if (t == Map<String, _i136.SimpleData?>) {
+    if (t == Map<String, _i137.SimpleData?>) {
       return (data as Map).map((k, v) => MapEntry(
-          deserialize<String>(k), deserialize<_i136.SimpleData?>(v))) as T;
+          deserialize<String>(k), deserialize<_i137.SimpleData?>(v))) as T;
     }
-    if (t == _i1.getType<Map<String, _i136.SimpleData>?>()) {
+    if (t == _i1.getType<Map<String, _i137.SimpleData>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i136.SimpleData>(v)))
+              deserialize<String>(k), deserialize<_i137.SimpleData>(v)))
           : null) as T;
     }
-    if (t == _i1.getType<Map<String, _i136.SimpleData?>?>()) {
+    if (t == _i1.getType<Map<String, _i137.SimpleData?>?>()) {
       return (data != null
           ? (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<_i136.SimpleData?>(v)))
+              deserialize<String>(k), deserialize<_i137.SimpleData?>(v)))
           : null) as T;
     }
     if (t == Map<String, Duration>) {
@@ -7193,13 +7201,13 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<int>) {
       return (data as List).map((e) => deserialize<int>(e)).toSet() as T;
     }
-    if (t == Set<_i136.SimpleData>) {
-      return (data as List).map((e) => deserialize<_i136.SimpleData>(e)).toSet()
+    if (t == Set<_i137.SimpleData>) {
+      return (data as List).map((e) => deserialize<_i137.SimpleData>(e)).toSet()
           as T;
     }
-    if (t == List<Set<_i136.SimpleData>>) {
+    if (t == List<Set<_i137.SimpleData>>) {
       return (data as List)
-          .map((e) => deserialize<Set<_i136.SimpleData>>(e))
+          .map((e) => deserialize<Set<_i137.SimpleData>>(e))
           .toList() as T;
     }
     if (t == _i1.getType<(int,)>()) {
@@ -7240,18 +7248,18 @@ class Protocol extends _i1.SerializationManagerServer {
               deserialize<String>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i136.SimpleData>(data['p'][1]),
+        deserialize<_i137.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i136.SimpleData>(data['p'][1]),
+              deserialize<_i137.SimpleData>(data['p'][1]),
             ) as T;
     }
     if (t == _i1.getType<({int number, String text})>()) {
@@ -7268,135 +7276,135 @@ class Protocol extends _i1.SerializationManagerServer {
               text: deserialize<String>(data['n']['text']),
             ) as T;
     }
-    if (t == _i1.getType<({_i136.SimpleData data, int number})>()) {
+    if (t == _i1.getType<({_i137.SimpleData data, int number})>()) {
       return (
         data:
-            deserialize<_i136.SimpleData>(((data as Map)['n'] as Map)['data']),
+            deserialize<_i137.SimpleData>(((data as Map)['n'] as Map)['data']),
         number: deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<({_i136.SimpleData data, int number})?>()) {
+    if (t == _i1.getType<({_i137.SimpleData data, int number})?>()) {
       return (data == null)
           ? null as T
           : (
-              data: deserialize<_i136.SimpleData>(
+              data: deserialize<_i137.SimpleData>(
                   ((data as Map)['n'] as Map)['data']),
               number: deserialize<int>(data['n']['number']),
             ) as T;
     }
-    if (t == _i1.getType<({_i136.SimpleData? data, int? number})>()) {
+    if (t == _i1.getType<({_i137.SimpleData? data, int? number})>()) {
       return (
         data: ((data as Map)['n'] as Map)['data'] == null
             ? null
-            : deserialize<_i136.SimpleData>(data['n']['data']),
+            : deserialize<_i137.SimpleData>(data['n']['data']),
         number: ((data)['n'] as Map)['number'] == null
             ? null
             : deserialize<int>(data['n']['number']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i136.SimpleData data})>()) {
+    if (t == _i1.getType<(int, {_i137.SimpleData data})>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        data: deserialize<_i136.SimpleData>(data['n']['data']),
+        data: deserialize<_i137.SimpleData>(data['n']['data']),
       ) as T;
     }
-    if (t == _i1.getType<(int, {_i136.SimpleData data})?>()) {
+    if (t == _i1.getType<(int, {_i137.SimpleData data})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              data: deserialize<_i136.SimpleData>(data['n']['data']),
+              data: deserialize<_i137.SimpleData>(data['n']['data']),
             ) as T;
     }
-    if (t == List<(int, _i136.SimpleData)>) {
+    if (t == List<(int, _i137.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i136.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i137.SimpleData)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i136.SimpleData>(data['p'][1]),
+        deserialize<_i137.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == List<(int, _i136.SimpleData)?>) {
+    if (t == List<(int, _i137.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i136.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i137.SimpleData)?>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i136.SimpleData>(data['p'][1]),
+              deserialize<_i137.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Set<(int, _i136.SimpleData)>) {
+    if (t == Set<(int, _i137.SimpleData)>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i136.SimpleData)>(e))
+          .map((e) => deserialize<(int, _i137.SimpleData)>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i136.SimpleData>(data['p'][1]),
+        deserialize<_i137.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Set<(int, _i136.SimpleData)?>) {
+    if (t == Set<(int, _i137.SimpleData)?>) {
       return (data as List)
-          .map((e) => deserialize<(int, _i136.SimpleData)?>(e))
+          .map((e) => deserialize<(int, _i137.SimpleData)?>(e))
           .toSet() as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i136.SimpleData>(data['p'][1]),
+              deserialize<_i137.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == _i1.getType<Set<(int, _i136.SimpleData)>?>()) {
+    if (t == _i1.getType<Set<(int, _i137.SimpleData)>?>()) {
       return (data != null
           ? (data as List)
-              .map((e) => deserialize<(int, _i136.SimpleData)>(e))
+              .map((e) => deserialize<(int, _i137.SimpleData)>(e))
               .toSet()
           : null) as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i136.SimpleData>(data['p'][1]),
+        deserialize<_i137.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i136.SimpleData)>) {
+    if (t == Map<String, (int, _i137.SimpleData)>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i136.SimpleData)>(v)))
+              deserialize<String>(k), deserialize<(int, _i137.SimpleData)>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i136.SimpleData>(data['p'][1]),
+        deserialize<_i137.SimpleData>(data['p'][1]),
       ) as T;
     }
-    if (t == Map<String, (int, _i136.SimpleData)?>) {
+    if (t == Map<String, (int, _i137.SimpleData)?>) {
       return (data as Map).map((k, v) => MapEntry(
-              deserialize<String>(k), deserialize<(int, _i136.SimpleData)?>(v)))
+              deserialize<String>(k), deserialize<(int, _i137.SimpleData)?>(v)))
           as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)?>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<int>(((data as Map)['p'] as List)[0]),
-              deserialize<_i136.SimpleData>(data['p'][1]),
+              deserialize<_i137.SimpleData>(data['p'][1]),
             ) as T;
     }
-    if (t == Map<(String, int), (int, _i136.SimpleData)>) {
+    if (t == Map<(String, int), (int, _i137.SimpleData)>) {
       return Map.fromEntries((data as List).map((e) => MapEntry(
           deserialize<(String, int)>(e['k']),
-          deserialize<(int, _i136.SimpleData)>(e['v'])))) as T;
+          deserialize<(int, _i137.SimpleData)>(e['v'])))) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
       return (
@@ -7404,10 +7412,10 @@ class Protocol extends _i1.SerializationManagerServer {
         deserialize<int>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<(int, _i136.SimpleData)>()) {
+    if (t == _i1.getType<(int, _i137.SimpleData)>()) {
       return (
         deserialize<int>(((data as Map)['p'] as List)[0]),
-        deserialize<_i136.SimpleData>(data['p'][1]),
+        deserialize<_i137.SimpleData>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<(String, int)>()) {
@@ -7459,56 +7467,56 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == _i1.getType<(int,)>()) {
       return (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<({(_i136.SimpleData, double) namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i137.SimpleData, double) namedSubRecord})>()) {
       return (
-        namedSubRecord: deserialize<(_i136.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i137.SimpleData, double)>(
             ((data as Map)['n'] as Map)['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i136.SimpleData, double)>()) {
+    if (t == _i1.getType<(_i137.SimpleData, double)>()) {
       return (
-        deserialize<_i136.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<_i137.SimpleData>(((data as Map)['p'] as List)[0]),
         deserialize<double>(data['p'][1]),
       ) as T;
     }
-    if (t == _i1.getType<({(_i136.SimpleData, double)? namedSubRecord})>()) {
+    if (t == _i1.getType<({(_i137.SimpleData, double)? namedSubRecord})>()) {
       return (
         namedSubRecord: ((data as Map)['n'] as Map)['namedSubRecord'] == null
             ? null
-            : deserialize<(_i136.SimpleData, double)>(
+            : deserialize<(_i137.SimpleData, double)>(
                 data['n']['namedSubRecord']),
       ) as T;
     }
-    if (t == _i1.getType<(_i136.SimpleData, double)?>()) {
+    if (t == _i1.getType<(_i137.SimpleData, double)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i136.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i137.SimpleData>(((data as Map)['p'] as List)[0]),
               deserialize<double>(data['p'][1]),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i136.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i137.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i136.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i137.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
     if (t ==
-        List<((int, String), {(_i136.SimpleData, double) namedSubRecord})>) {
+        List<((int, String), {(_i137.SimpleData, double) namedSubRecord})>) {
       return (data as List)
           .map((e) => deserialize<
-              ((int, String), {(_i136.SimpleData, double) namedSubRecord})>(e))
+              ((int, String), {(_i137.SimpleData, double) namedSubRecord})>(e))
           .toList() as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i136.SimpleData, double) namedSubRecord})>()) {
+            ((int, String), {(_i137.SimpleData, double) namedSubRecord})>()) {
       return (
         deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-        namedSubRecord: deserialize<(_i136.SimpleData, double)>(
+        namedSubRecord: deserialize<(_i137.SimpleData, double)>(
             data['n']['namedSubRecord']),
       ) as T;
     }
@@ -7517,37 +7525,37 @@ class Protocol extends _i1.SerializationManagerServer {
             List<
                 (
                   (int, String), {
-                  (_i136.SimpleData, double) namedSubRecord
+                  (_i137.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i136.SimpleData, double) namedSubRecord
+                    (_i137.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i136.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i137.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i136.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i137.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i136.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i137.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i136.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i137.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -7607,17 +7615,17 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<DateTime?>) {
       return (data as List).map((e) => deserialize<DateTime?>(e)).toSet() as T;
     }
-    if (t == Set<_i134.ByteData>) {
-      return (data as List).map((e) => deserialize<_i134.ByteData>(e)).toSet()
+    if (t == Set<_i135.ByteData>) {
+      return (data as List).map((e) => deserialize<_i135.ByteData>(e)).toSet()
           as T;
     }
-    if (t == Set<_i134.ByteData?>) {
-      return (data as List).map((e) => deserialize<_i134.ByteData?>(e)).toSet()
+    if (t == Set<_i135.ByteData?>) {
+      return (data as List).map((e) => deserialize<_i135.ByteData?>(e)).toSet()
           as T;
     }
-    if (t == Set<_i136.SimpleData?>) {
+    if (t == Set<_i137.SimpleData?>) {
       return (data as List)
-          .map((e) => deserialize<_i136.SimpleData?>(e))
+          .map((e) => deserialize<_i137.SimpleData?>(e))
           .toSet() as T;
     }
     if (t == Set<Duration>) {
@@ -7626,8 +7634,8 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t == Set<Duration?>) {
       return (data as List).map((e) => deserialize<Duration?>(e)).toSet() as T;
     }
-    if (t == List<_i138.Types>) {
-      return (data as List).map((e) => deserialize<_i138.Types>(e)).toList()
+    if (t == List<_i139.Types>) {
+      return (data as List).map((e) => deserialize<_i139.Types>(e)).toList()
           as T;
     }
     if (t == _i1.getType<(String, (int, bool))>()) {
@@ -7657,7 +7665,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -7665,17 +7673,17 @@ class Protocol extends _i1.SerializationManagerServer {
             (
               Map<String, int>, {
               bool flag,
-              _i136.SimpleData simpleData
+              _i137.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
     if (t ==
         _i1.getType<
-            (Map<String, int>, {bool flag, _i136.SimpleData simpleData})>()) {
+            (Map<String, int>, {bool flag, _i137.SimpleData simpleData})>()) {
       return (
         deserialize<Map<String, int>>(((data as Map)['p'] as List)[0]),
         flag: deserialize<bool>(data['n']['flag']),
-        simpleData: deserialize<_i136.SimpleData>(data['n']['simpleData']),
+        simpleData: deserialize<_i137.SimpleData>(data['n']['simpleData']),
       ) as T;
     }
     if (t == List<(String, int)>) {
@@ -7692,7 +7700,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -7702,7 +7710,7 @@ class Protocol extends _i1.SerializationManagerServer {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i136.SimpleData simpleData
+                    _i137.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -7814,10 +7822,10 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<DateTime>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i134.ByteData,)?>()) {
+    if (t == _i1.getType<(_i135.ByteData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i134.ByteData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i135.ByteData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
     if (t == _i1.getType<(Duration,)?>()) {
@@ -7840,17 +7848,17 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<BigInt>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i125.TestEnum,)?>()) {
+    if (t == _i1.getType<(_i126.TestEnum,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i125.TestEnum>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i126.TestEnum>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<(_i126.TestEnumStringified,)?>()) {
+    if (t == _i1.getType<(_i127.TestEnumStringified,)?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i126.TestEnumStringified>(
+              deserialize<_i127.TestEnumStringified>(
                   ((data as Map)['p'] as List)[0]),
             ) as T;
     }
@@ -7869,28 +7877,28 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<Set<int>>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i1.getType<(_i120.SimpleData,)?>()) {
+    if (t == _i1.getType<(_i121.SimpleData,)?>()) {
       return (data == null)
           ? null as T
-          : (deserialize<_i120.SimpleData>(((data as Map)['p'] as List)[0]),)
+          : (deserialize<_i121.SimpleData>(((data as Map)['p'] as List)[0]),)
               as T;
     }
-    if (t == _i1.getType<({_i120.SimpleData namedModel})?>()) {
+    if (t == _i1.getType<({_i121.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              namedModel: deserialize<_i120.SimpleData>(
+              namedModel: deserialize<_i121.SimpleData>(
                   ((data as Map)['n'] as Map)['namedModel']),
             ) as T;
     }
     if (t ==
-        _i1.getType<(_i120.SimpleData, {_i120.SimpleData namedModel})?>()) {
+        _i1.getType<(_i121.SimpleData, {_i121.SimpleData namedModel})?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<_i120.SimpleData>(((data as Map)['p'] as List)[0]),
+              deserialize<_i121.SimpleData>(((data as Map)['p'] as List)[0]),
               namedModel:
-                  deserialize<_i120.SimpleData>(data['n']['namedModel']),
+                  deserialize<_i121.SimpleData>(data['n']['namedModel']),
             ) as T;
     }
     if (t ==
@@ -7912,46 +7920,46 @@ class Protocol extends _i1.SerializationManagerServer {
     if (t ==
         _i1.getType<
             (
-              (List<(_i120.SimpleData,)>,), {
+              (List<(_i121.SimpleData,)>,), {
               (
-                _i120.SimpleData,
-                Map<String, _i120.SimpleData>
+                _i121.SimpleData,
+                Map<String, _i121.SimpleData>
               ) namedNestedRecord
             })?>()) {
       return (data == null)
           ? null as T
           : (
-              deserialize<(List<(_i120.SimpleData,)>,)>(
+              deserialize<(List<(_i121.SimpleData,)>,)>(
                   ((data as Map)['p'] as List)[0]),
               namedNestedRecord: deserialize<
                   (
-                    _i120.SimpleData,
-                    Map<String, _i120.SimpleData>
+                    _i121.SimpleData,
+                    Map<String, _i121.SimpleData>
                   )>(data['n']['namedNestedRecord']),
             ) as T;
     }
-    if (t == _i1.getType<(List<(_i120.SimpleData,)>,)>()) {
+    if (t == _i1.getType<(List<(_i121.SimpleData,)>,)>()) {
       return (
-        deserialize<List<(_i120.SimpleData,)>>(((data as Map)['p'] as List)[0]),
+        deserialize<List<(_i121.SimpleData,)>>(((data as Map)['p'] as List)[0]),
       ) as T;
     }
-    if (t == List<(_i120.SimpleData,)>) {
+    if (t == List<(_i121.SimpleData,)>) {
       return (data as List)
-          .map((e) => deserialize<(_i120.SimpleData,)>(e))
+          .map((e) => deserialize<(_i121.SimpleData,)>(e))
           .toList() as T;
     }
-    if (t == _i1.getType<(_i120.SimpleData,)>()) {
-      return (deserialize<_i120.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i121.SimpleData,)>()) {
+      return (deserialize<_i121.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i120.SimpleData,)>()) {
-      return (deserialize<_i120.SimpleData>(((data as Map)['p'] as List)[0]),)
+    if (t == _i1.getType<(_i121.SimpleData,)>()) {
+      return (deserialize<_i121.SimpleData>(((data as Map)['p'] as List)[0]),)
           as T;
     }
-    if (t == _i1.getType<(_i120.SimpleData, Map<String, _i120.SimpleData>)>()) {
+    if (t == _i1.getType<(_i121.SimpleData, Map<String, _i121.SimpleData>)>()) {
       return (
-        deserialize<_i120.SimpleData>(((data as Map)['p'] as List)[0]),
-        deserialize<Map<String, _i120.SimpleData>>(data['p'][1]),
+        deserialize<_i121.SimpleData>(((data as Map)['p'] as List)[0]),
+        deserialize<Map<String, _i121.SimpleData>>(data['p'][1]),
       ) as T;
     }
     if (t == _i1.getType<Set<(int,)>?>()) {
@@ -7972,57 +7980,57 @@ class Protocol extends _i1.SerializationManagerServer {
           ? null as T
           : (deserialize<int>(((data as Map)['p'] as List)[0]),) as T;
     }
-    if (t == _i135.CustomClass) {
-      return _i135.CustomClass.fromJson(data) as T;
+    if (t == _i136.CustomClass) {
+      return _i136.CustomClass.fromJson(data) as T;
     }
-    if (t == _i135.CustomClass2) {
-      return _i135.CustomClass2.fromJson(data) as T;
+    if (t == _i136.CustomClass2) {
+      return _i136.CustomClass2.fromJson(data) as T;
     }
-    if (t == _i135.ProtocolCustomClass) {
-      return _i135.ProtocolCustomClass.fromJson(data) as T;
+    if (t == _i136.ProtocolCustomClass) {
+      return _i136.ProtocolCustomClass.fromJson(data) as T;
     }
-    if (t == _i135.ExternalCustomClass) {
-      return _i135.ExternalCustomClass.fromJson(data) as T;
+    if (t == _i136.ExternalCustomClass) {
+      return _i136.ExternalCustomClass.fromJson(data) as T;
     }
-    if (t == _i135.FreezedCustomClass) {
-      return _i135.FreezedCustomClass.fromJson(data) as T;
+    if (t == _i136.FreezedCustomClass) {
+      return _i136.FreezedCustomClass.fromJson(data) as T;
     }
-    if (t == _i1.getType<_i135.CustomClass?>()) {
-      return (data != null ? _i135.CustomClass.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i136.CustomClass?>()) {
+      return (data != null ? _i136.CustomClass.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i135.CustomClass2?>()) {
-      return (data != null ? _i135.CustomClass2.fromJson(data) : null) as T;
+    if (t == _i1.getType<_i136.CustomClass2?>()) {
+      return (data != null ? _i136.CustomClass2.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i135.CustomClassWithoutProtocolSerialization?>()) {
+    if (t == _i1.getType<_i136.CustomClassWithoutProtocolSerialization?>()) {
       return (data != null
-          ? _i135.CustomClassWithoutProtocolSerialization.fromJson(data)
+          ? _i136.CustomClassWithoutProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i135.CustomClassWithProtocolSerialization?>()) {
+    if (t == _i1.getType<_i136.CustomClassWithProtocolSerialization?>()) {
       return (data != null
-          ? _i135.CustomClassWithProtocolSerialization.fromJson(data)
+          ? _i136.CustomClassWithProtocolSerialization.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i135.CustomClassWithProtocolSerializationMethod?>()) {
+    if (t == _i1.getType<_i136.CustomClassWithProtocolSerializationMethod?>()) {
       return (data != null
-          ? _i135.CustomClassWithProtocolSerializationMethod.fromJson(data)
+          ? _i136.CustomClassWithProtocolSerializationMethod.fromJson(data)
           : null) as T;
     }
-    if (t == _i1.getType<_i135.ProtocolCustomClass?>()) {
-      return (data != null ? _i135.ProtocolCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i136.ProtocolCustomClass?>()) {
+      return (data != null ? _i136.ProtocolCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i135.ExternalCustomClass?>()) {
-      return (data != null ? _i135.ExternalCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i136.ExternalCustomClass?>()) {
+      return (data != null ? _i136.ExternalCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<_i135.FreezedCustomClass?>()) {
-      return (data != null ? _i135.FreezedCustomClass.fromJson(data) : null)
+    if (t == _i1.getType<_i136.FreezedCustomClass?>()) {
+      return (data != null ? _i136.FreezedCustomClass.fromJson(data) : null)
           as T;
     }
-    if (t == _i1.getType<List<_i136.SimpleData>?>()) {
+    if (t == _i1.getType<List<_i137.SimpleData>?>()) {
       return (data != null
-          ? (data as List).map((e) => deserialize<_i136.SimpleData>(e)).toList()
+          ? (data as List).map((e) => deserialize<_i137.SimpleData>(e)).toList()
           : null) as T;
     }
     if (t == _i1.getType<(int?,)?>()) {
@@ -8039,26 +8047,26 @@ class Protocol extends _i1.SerializationManagerServer {
             List<
                 (
                   (int, String), {
-                  (_i136.SimpleData, double) namedSubRecord
+                  (_i137.SimpleData, double) namedSubRecord
                 })?>?>()) {
       return (data != null
           ? (data as List)
               .map((e) => deserialize<
                   (
                     (int, String), {
-                    (_i136.SimpleData, double) namedSubRecord
+                    (_i137.SimpleData, double) namedSubRecord
                   })?>(e))
               .toList()
           : null) as T;
     }
     if (t ==
         _i1.getType<
-            ((int, String), {(_i136.SimpleData, double) namedSubRecord})?>()) {
+            ((int, String), {(_i137.SimpleData, double) namedSubRecord})?>()) {
       return (data == null)
           ? null as T
           : (
               deserialize<(int, String)>(((data as Map)['p'] as List)[0]),
-              namedSubRecord: deserialize<(_i136.SimpleData, double)>(
+              namedSubRecord: deserialize<(_i137.SimpleData, double)>(
                   data['n']['namedSubRecord']),
             ) as T;
     }
@@ -8066,7 +8074,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
             )>()) {
       return (
         deserialize<String>(((data as Map)['p'] as List)[0]),
@@ -8074,7 +8082,7 @@ class Protocol extends _i1.SerializationManagerServer {
             (
               Map<String, int>, {
               bool flag,
-              _i136.SimpleData simpleData
+              _i137.SimpleData simpleData
             })>(data['p'][1]),
       ) as T;
     }
@@ -8088,7 +8096,7 @@ class Protocol extends _i1.SerializationManagerServer {
         _i1.getType<
             (
               String,
-              (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+              (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
             )?>()) {
       return (data == null)
           ? null as T
@@ -8098,7 +8106,7 @@ class Protocol extends _i1.SerializationManagerServer {
                   (
                     Map<String, int>, {
                     bool flag,
-                    _i136.SimpleData simpleData
+                    _i137.SimpleData simpleData
                   })>(data['p'][1]),
             ) as T;
     }
@@ -8129,28 +8137,28 @@ class Protocol extends _i1.SerializationManagerServer {
   String? getClassNameForObject(Object? data) {
     String? className = super.getClassNameForObject(data);
     if (className != null) return className;
-    if (data is _i135.CustomClass) {
+    if (data is _i136.CustomClass) {
       return 'CustomClass';
     }
-    if (data is _i135.CustomClass2) {
+    if (data is _i136.CustomClass2) {
       return 'CustomClass2';
     }
-    if (data is _i135.CustomClassWithoutProtocolSerialization) {
+    if (data is _i136.CustomClassWithoutProtocolSerialization) {
       return 'CustomClassWithoutProtocolSerialization';
     }
-    if (data is _i135.CustomClassWithProtocolSerialization) {
+    if (data is _i136.CustomClassWithProtocolSerialization) {
       return 'CustomClassWithProtocolSerialization';
     }
-    if (data is _i135.CustomClassWithProtocolSerializationMethod) {
+    if (data is _i136.CustomClassWithProtocolSerializationMethod) {
       return 'CustomClassWithProtocolSerializationMethod';
     }
-    if (data is _i135.ProtocolCustomClass) {
+    if (data is _i136.ProtocolCustomClass) {
       return 'ProtocolCustomClass';
     }
-    if (data is _i135.ExternalCustomClass) {
+    if (data is _i136.ExternalCustomClass) {
       return 'ExternalCustomClass';
     }
-    if (data is _i135.FreezedCustomClass) {
+    if (data is _i136.FreezedCustomClass) {
       return 'FreezedCustomClass';
     }
     if (data is _i5.ByIndexEnumWithNameValue) {
@@ -8237,313 +8245,316 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is _i32.ByNameEnum) {
       return 'ByNameEnum';
     }
-    if (data is _i33.DefaultException) {
+    if (data is _i33.DefaultValueEnum) {
+      return 'DefaultValueEnum';
+    }
+    if (data is _i34.DefaultException) {
       return 'DefaultException';
     }
-    if (data is _i34.IntDefault) {
+    if (data is _i35.IntDefault) {
       return 'IntDefault';
     }
-    if (data is _i35.IntDefaultMix) {
+    if (data is _i36.IntDefaultMix) {
       return 'IntDefaultMix';
     }
-    if (data is _i36.IntDefaultModel) {
+    if (data is _i37.IntDefaultModel) {
       return 'IntDefaultModel';
     }
-    if (data is _i37.IntDefaultPersist) {
+    if (data is _i38.IntDefaultPersist) {
       return 'IntDefaultPersist';
     }
-    if (data is _i38.StringDefault) {
+    if (data is _i39.StringDefault) {
       return 'StringDefault';
     }
-    if (data is _i39.StringDefaultMix) {
+    if (data is _i40.StringDefaultMix) {
       return 'StringDefaultMix';
     }
-    if (data is _i40.StringDefaultModel) {
+    if (data is _i41.StringDefaultModel) {
       return 'StringDefaultModel';
     }
-    if (data is _i41.StringDefaultPersist) {
+    if (data is _i42.StringDefaultPersist) {
       return 'StringDefaultPersist';
     }
-    if (data is _i42.UriDefault) {
+    if (data is _i43.UriDefault) {
       return 'UriDefault';
     }
-    if (data is _i43.UriDefaultMix) {
+    if (data is _i44.UriDefaultMix) {
       return 'UriDefaultMix';
     }
-    if (data is _i44.UriDefaultModel) {
+    if (data is _i45.UriDefaultModel) {
       return 'UriDefaultModel';
     }
-    if (data is _i45.UriDefaultPersist) {
+    if (data is _i46.UriDefaultPersist) {
       return 'UriDefaultPersist';
     }
-    if (data is _i46.UuidDefault) {
+    if (data is _i47.UuidDefault) {
       return 'UuidDefault';
     }
-    if (data is _i47.UuidDefaultMix) {
+    if (data is _i48.UuidDefaultMix) {
       return 'UuidDefaultMix';
     }
-    if (data is _i48.UuidDefaultModel) {
+    if (data is _i49.UuidDefaultModel) {
       return 'UuidDefaultModel';
     }
-    if (data is _i49.UuidDefaultPersist) {
+    if (data is _i50.UuidDefaultPersist) {
       return 'UuidDefaultPersist';
     }
-    if (data is _i50.EmptyModel) {
+    if (data is _i51.EmptyModel) {
       return 'EmptyModel';
     }
-    if (data is _i51.EmptyModelRelationItem) {
+    if (data is _i52.EmptyModelRelationItem) {
       return 'EmptyModelRelationItem';
     }
-    if (data is _i52.EmptyModelWithTable) {
+    if (data is _i53.EmptyModelWithTable) {
       return 'EmptyModelWithTable';
     }
-    if (data is _i53.RelationEmptyModel) {
+    if (data is _i54.RelationEmptyModel) {
       return 'RelationEmptyModel';
     }
-    if (data is _i54.ExceptionWithData) {
+    if (data is _i55.ExceptionWithData) {
       return 'ExceptionWithData';
     }
-    if (data is _i55.ChildClass) {
+    if (data is _i56.ChildClass) {
       return 'ChildClass';
     }
-    if (data is _i56.ChildWithDefault) {
+    if (data is _i57.ChildWithDefault) {
       return 'ChildWithDefault';
     }
-    if (data is _i57.GrandparentClass) {
+    if (data is _i58.GrandparentClass) {
       return 'GrandparentClass';
     }
-    if (data is _i58.ParentClass) {
+    if (data is _i59.ParentClass) {
       return 'ParentClass';
     }
-    if (data is _i59.ParentWithDefault) {
+    if (data is _i60.ParentWithDefault) {
       return 'ParentWithDefault';
     }
-    if (data is _i60.SealedChild) {
+    if (data is _i61.SealedChild) {
       return 'SealedChild';
     }
-    if (data is _i60.SealedGrandChild) {
+    if (data is _i61.SealedGrandChild) {
       return 'SealedGrandChild';
     }
-    if (data is _i60.SealedOtherChild) {
+    if (data is _i61.SealedOtherChild) {
       return 'SealedOtherChild';
     }
-    if (data is _i61.CityWithLongTableName) {
+    if (data is _i62.CityWithLongTableName) {
       return 'CityWithLongTableName';
     }
-    if (data is _i62.OrganizationWithLongTableName) {
+    if (data is _i63.OrganizationWithLongTableName) {
       return 'OrganizationWithLongTableName';
     }
-    if (data is _i63.PersonWithLongTableName) {
+    if (data is _i64.PersonWithLongTableName) {
       return 'PersonWithLongTableName';
     }
-    if (data is _i64.MaxFieldName) {
+    if (data is _i65.MaxFieldName) {
       return 'MaxFieldName';
     }
-    if (data is _i65.LongImplicitIdField) {
+    if (data is _i66.LongImplicitIdField) {
       return 'LongImplicitIdField';
     }
-    if (data is _i66.LongImplicitIdFieldCollection) {
+    if (data is _i67.LongImplicitIdFieldCollection) {
       return 'LongImplicitIdFieldCollection';
     }
-    if (data is _i67.RelationToMultipleMaxFieldName) {
+    if (data is _i68.RelationToMultipleMaxFieldName) {
       return 'RelationToMultipleMaxFieldName';
     }
-    if (data is _i68.UserNote) {
+    if (data is _i69.UserNote) {
       return 'UserNote';
     }
-    if (data is _i69.UserNoteCollection) {
+    if (data is _i70.UserNoteCollection) {
       return 'UserNoteCollection';
     }
-    if (data is _i70.UserNoteCollectionWithALongName) {
+    if (data is _i71.UserNoteCollectionWithALongName) {
       return 'UserNoteCollectionWithALongName';
     }
-    if (data is _i71.UserNoteWithALongName) {
+    if (data is _i72.UserNoteWithALongName) {
       return 'UserNoteWithALongName';
     }
-    if (data is _i72.MultipleMaxFieldName) {
+    if (data is _i73.MultipleMaxFieldName) {
       return 'MultipleMaxFieldName';
     }
-    if (data is _i73.City) {
+    if (data is _i74.City) {
       return 'City';
     }
-    if (data is _i74.Organization) {
+    if (data is _i75.Organization) {
       return 'Organization';
     }
-    if (data is _i75.Person) {
+    if (data is _i76.Person) {
       return 'Person';
     }
-    if (data is _i76.Course) {
+    if (data is _i77.Course) {
       return 'Course';
     }
-    if (data is _i77.Enrollment) {
+    if (data is _i78.Enrollment) {
       return 'Enrollment';
     }
-    if (data is _i78.Student) {
+    if (data is _i79.Student) {
       return 'Student';
     }
-    if (data is _i79.ObjectUser) {
+    if (data is _i80.ObjectUser) {
       return 'ObjectUser';
     }
-    if (data is _i80.ParentUser) {
+    if (data is _i81.ParentUser) {
       return 'ParentUser';
     }
-    if (data is _i81.Arena) {
+    if (data is _i82.Arena) {
       return 'Arena';
     }
-    if (data is _i82.Player) {
+    if (data is _i83.Player) {
       return 'Player';
     }
-    if (data is _i83.Team) {
+    if (data is _i84.Team) {
       return 'Team';
     }
-    if (data is _i84.Comment) {
+    if (data is _i85.Comment) {
       return 'Comment';
     }
-    if (data is _i85.Customer) {
+    if (data is _i86.Customer) {
       return 'Customer';
     }
-    if (data is _i86.Order) {
+    if (data is _i87.Order) {
       return 'Order';
     }
-    if (data is _i87.Address) {
+    if (data is _i88.Address) {
       return 'Address';
     }
-    if (data is _i88.Citizen) {
+    if (data is _i89.Citizen) {
       return 'Citizen';
     }
-    if (data is _i89.Company) {
+    if (data is _i90.Company) {
       return 'Company';
     }
-    if (data is _i90.Town) {
+    if (data is _i91.Town) {
       return 'Town';
     }
-    if (data is _i91.Blocking) {
+    if (data is _i92.Blocking) {
       return 'Blocking';
     }
-    if (data is _i92.Member) {
+    if (data is _i93.Member) {
       return 'Member';
     }
-    if (data is _i93.Cat) {
+    if (data is _i94.Cat) {
       return 'Cat';
     }
-    if (data is _i94.Post) {
+    if (data is _i95.Post) {
       return 'Post';
     }
-    if (data is _i95.ModuleDatatype) {
+    if (data is _i96.ModuleDatatype) {
       return 'ModuleDatatype';
     }
-    if (data is _i96.Nullability) {
+    if (data is _i97.Nullability) {
       return 'Nullability';
     }
-    if (data is _i97.ObjectFieldPersist) {
+    if (data is _i98.ObjectFieldPersist) {
       return 'ObjectFieldPersist';
     }
-    if (data is _i98.ObjectFieldScopes) {
+    if (data is _i99.ObjectFieldScopes) {
       return 'ObjectFieldScopes';
     }
-    if (data is _i99.ObjectWithByteData) {
+    if (data is _i100.ObjectWithByteData) {
       return 'ObjectWithByteData';
     }
-    if (data is _i100.ObjectWithCustomClass) {
+    if (data is _i101.ObjectWithCustomClass) {
       return 'ObjectWithCustomClass';
     }
-    if (data is _i101.ObjectWithDuration) {
+    if (data is _i102.ObjectWithDuration) {
       return 'ObjectWithDuration';
     }
-    if (data is _i102.ObjectWithEnum) {
+    if (data is _i103.ObjectWithEnum) {
       return 'ObjectWithEnum';
     }
-    if (data is _i103.ObjectWithIndex) {
+    if (data is _i104.ObjectWithIndex) {
       return 'ObjectWithIndex';
     }
-    if (data is _i104.ObjectWithMaps) {
+    if (data is _i105.ObjectWithMaps) {
       return 'ObjectWithMaps';
     }
-    if (data is _i105.ObjectWithObject) {
+    if (data is _i106.ObjectWithObject) {
       return 'ObjectWithObject';
     }
-    if (data is _i106.ObjectWithParent) {
+    if (data is _i107.ObjectWithParent) {
       return 'ObjectWithParent';
     }
-    if (data is _i107.ObjectWithSelfParent) {
+    if (data is _i108.ObjectWithSelfParent) {
       return 'ObjectWithSelfParent';
     }
-    if (data is _i108.ObjectWithUuid) {
+    if (data is _i109.ObjectWithUuid) {
       return 'ObjectWithUuid';
     }
-    if (data is _i109.RelatedUniqueData) {
+    if (data is _i110.RelatedUniqueData) {
       return 'RelatedUniqueData';
     }
-    if (data is _i110.ScopeNoneFields) {
+    if (data is _i111.ScopeNoneFields) {
       return 'ScopeNoneFields';
     }
-    if (data is _i111.ScopeServerOnlyField) {
+    if (data is _i112.ScopeServerOnlyField) {
       return 'ScopeServerOnlyField';
     }
-    if (data is _i112.ScopeServerOnlyFieldChild) {
+    if (data is _i113.ScopeServerOnlyFieldChild) {
       return 'ScopeServerOnlyFieldChild';
     }
-    if (data is _i113.DefaultServerOnlyClass) {
+    if (data is _i114.DefaultServerOnlyClass) {
       return 'DefaultServerOnlyClass';
     }
-    if (data is _i114.DefaultServerOnlyEnum) {
+    if (data is _i115.DefaultServerOnlyEnum) {
       return 'DefaultServerOnlyEnum';
     }
-    if (data is _i115.NotServerOnlyClass) {
+    if (data is _i116.NotServerOnlyClass) {
       return 'NotServerOnlyClass';
     }
-    if (data is _i116.NotServerOnlyEnum) {
+    if (data is _i117.NotServerOnlyEnum) {
       return 'NotServerOnlyEnum';
     }
-    if (data is _i117.ServerOnlyClass) {
+    if (data is _i118.ServerOnlyClass) {
       return 'ServerOnlyClass';
     }
-    if (data is _i118.ServerOnlyEnum) {
+    if (data is _i119.ServerOnlyEnum) {
       return 'ServerOnlyEnum';
     }
-    if (data is _i119.ServerOnlyClassField) {
+    if (data is _i120.ServerOnlyClassField) {
       return 'ServerOnlyClassField';
     }
-    if (data is _i120.SimpleData) {
+    if (data is _i121.SimpleData) {
       return 'SimpleData';
     }
-    if (data is _i121.SimpleDataList) {
+    if (data is _i122.SimpleDataList) {
       return 'SimpleDataList';
     }
-    if (data is _i122.SimpleDataMap) {
+    if (data is _i123.SimpleDataMap) {
       return 'SimpleDataMap';
     }
-    if (data is _i123.SimpleDataObject) {
+    if (data is _i124.SimpleDataObject) {
       return 'SimpleDataObject';
     }
-    if (data is _i124.SimpleDateTime) {
+    if (data is _i125.SimpleDateTime) {
       return 'SimpleDateTime';
     }
-    if (data is _i125.TestEnum) {
+    if (data is _i126.TestEnum) {
       return 'TestEnum';
     }
-    if (data is _i126.TestEnumStringified) {
+    if (data is _i127.TestEnumStringified) {
       return 'TestEnumStringified';
     }
-    if (data is _i127.Types) {
+    if (data is _i128.Types) {
       return 'Types';
     }
-    if (data is _i128.TypesList) {
+    if (data is _i129.TypesList) {
       return 'TypesList';
     }
-    if (data is _i129.TypesMap) {
+    if (data is _i130.TypesMap) {
       return 'TypesMap';
     }
-    if (data is _i130.TypesRecord) {
+    if (data is _i131.TypesRecord) {
       return 'TypesRecord';
     }
-    if (data is _i131.TypesSet) {
+    if (data is _i132.TypesSet) {
       return 'TypesSet';
     }
-    if (data is _i132.UniqueData) {
+    if (data is _i133.UniqueData) {
       return 'UniqueData';
     }
-    if (data is _i133.MyFeatureModel) {
+    if (data is _i134.MyFeatureModel) {
       return 'MyFeatureModel';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -8561,37 +8572,37 @@ class Protocol extends _i1.SerializationManagerServer {
     if (data is List<int>) {
       return 'List<int>';
     }
-    if (data is List<_i136.SimpleData>) {
+    if (data is List<_i137.SimpleData>) {
       return 'List<SimpleData>';
     }
     if (data is List<_i3.UserInfo>) {
       return 'List<serverpod_auth.UserInfo>';
     }
-    if (data is List<_i136.SimpleData>?) {
+    if (data is List<_i137.SimpleData>?) {
       return 'List<SimpleData>?';
     }
-    if (data is List<_i136.SimpleData?>) {
+    if (data is List<_i137.SimpleData?>) {
       return 'List<SimpleData?>';
     }
     if (data is Set<int>) {
       return 'Set<int>';
     }
-    if (data is Set<_i136.SimpleData>) {
+    if (data is Set<_i137.SimpleData>) {
       return 'Set<SimpleData>';
     }
-    if (data is List<Set<_i136.SimpleData>>) {
+    if (data is List<Set<_i137.SimpleData>>) {
       return 'List<Set<SimpleData>>';
     }
     if (data is (int?,)?) {
       return '(int?,)?';
     }
     if (data is List<
-        ((int, String), {(_i136.SimpleData, double) namedSubRecord})?>?) {
+        ((int, String), {(_i137.SimpleData, double) namedSubRecord})?>?) {
       return 'List<((int,String),{(SimpleData,double) namedSubRecord})?>?';
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
     )) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))';
     }
@@ -8600,7 +8611,7 @@ class Protocol extends _i1.SerializationManagerServer {
     }
     if (data is (
       String,
-      (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+      (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
     )?) {
       return '(String,(Map<String,int>,{bool flag,SimpleData simpleData}))?';
     }
@@ -8617,31 +8628,31 @@ class Protocol extends _i1.SerializationManagerServer {
       return super.deserializeByClassName(data);
     }
     if (dataClassName == 'CustomClass') {
-      return deserialize<_i135.CustomClass>(data['data']);
+      return deserialize<_i136.CustomClass>(data['data']);
     }
     if (dataClassName == 'CustomClass2') {
-      return deserialize<_i135.CustomClass2>(data['data']);
+      return deserialize<_i136.CustomClass2>(data['data']);
     }
     if (dataClassName == 'CustomClassWithoutProtocolSerialization') {
-      return deserialize<_i135.CustomClassWithoutProtocolSerialization>(
+      return deserialize<_i136.CustomClassWithoutProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerialization') {
-      return deserialize<_i135.CustomClassWithProtocolSerialization>(
+      return deserialize<_i136.CustomClassWithProtocolSerialization>(
           data['data']);
     }
     if (dataClassName == 'CustomClassWithProtocolSerializationMethod') {
-      return deserialize<_i135.CustomClassWithProtocolSerializationMethod>(
+      return deserialize<_i136.CustomClassWithProtocolSerializationMethod>(
           data['data']);
     }
     if (dataClassName == 'ProtocolCustomClass') {
-      return deserialize<_i135.ProtocolCustomClass>(data['data']);
+      return deserialize<_i136.ProtocolCustomClass>(data['data']);
     }
     if (dataClassName == 'ExternalCustomClass') {
-      return deserialize<_i135.ExternalCustomClass>(data['data']);
+      return deserialize<_i136.ExternalCustomClass>(data['data']);
     }
     if (dataClassName == 'FreezedCustomClass') {
-      return deserialize<_i135.FreezedCustomClass>(data['data']);
+      return deserialize<_i136.FreezedCustomClass>(data['data']);
     }
     if (dataClassName == 'ByIndexEnumWithNameValue') {
       return deserialize<_i5.ByIndexEnumWithNameValue>(data['data']);
@@ -8727,314 +8738,317 @@ class Protocol extends _i1.SerializationManagerServer {
     if (dataClassName == 'ByNameEnum') {
       return deserialize<_i32.ByNameEnum>(data['data']);
     }
+    if (dataClassName == 'DefaultValueEnum') {
+      return deserialize<_i33.DefaultValueEnum>(data['data']);
+    }
     if (dataClassName == 'DefaultException') {
-      return deserialize<_i33.DefaultException>(data['data']);
+      return deserialize<_i34.DefaultException>(data['data']);
     }
     if (dataClassName == 'IntDefault') {
-      return deserialize<_i34.IntDefault>(data['data']);
+      return deserialize<_i35.IntDefault>(data['data']);
     }
     if (dataClassName == 'IntDefaultMix') {
-      return deserialize<_i35.IntDefaultMix>(data['data']);
+      return deserialize<_i36.IntDefaultMix>(data['data']);
     }
     if (dataClassName == 'IntDefaultModel') {
-      return deserialize<_i36.IntDefaultModel>(data['data']);
+      return deserialize<_i37.IntDefaultModel>(data['data']);
     }
     if (dataClassName == 'IntDefaultPersist') {
-      return deserialize<_i37.IntDefaultPersist>(data['data']);
+      return deserialize<_i38.IntDefaultPersist>(data['data']);
     }
     if (dataClassName == 'StringDefault') {
-      return deserialize<_i38.StringDefault>(data['data']);
+      return deserialize<_i39.StringDefault>(data['data']);
     }
     if (dataClassName == 'StringDefaultMix') {
-      return deserialize<_i39.StringDefaultMix>(data['data']);
+      return deserialize<_i40.StringDefaultMix>(data['data']);
     }
     if (dataClassName == 'StringDefaultModel') {
-      return deserialize<_i40.StringDefaultModel>(data['data']);
+      return deserialize<_i41.StringDefaultModel>(data['data']);
     }
     if (dataClassName == 'StringDefaultPersist') {
-      return deserialize<_i41.StringDefaultPersist>(data['data']);
+      return deserialize<_i42.StringDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UriDefault') {
-      return deserialize<_i42.UriDefault>(data['data']);
+      return deserialize<_i43.UriDefault>(data['data']);
     }
     if (dataClassName == 'UriDefaultMix') {
-      return deserialize<_i43.UriDefaultMix>(data['data']);
+      return deserialize<_i44.UriDefaultMix>(data['data']);
     }
     if (dataClassName == 'UriDefaultModel') {
-      return deserialize<_i44.UriDefaultModel>(data['data']);
+      return deserialize<_i45.UriDefaultModel>(data['data']);
     }
     if (dataClassName == 'UriDefaultPersist') {
-      return deserialize<_i45.UriDefaultPersist>(data['data']);
+      return deserialize<_i46.UriDefaultPersist>(data['data']);
     }
     if (dataClassName == 'UuidDefault') {
-      return deserialize<_i46.UuidDefault>(data['data']);
+      return deserialize<_i47.UuidDefault>(data['data']);
     }
     if (dataClassName == 'UuidDefaultMix') {
-      return deserialize<_i47.UuidDefaultMix>(data['data']);
+      return deserialize<_i48.UuidDefaultMix>(data['data']);
     }
     if (dataClassName == 'UuidDefaultModel') {
-      return deserialize<_i48.UuidDefaultModel>(data['data']);
+      return deserialize<_i49.UuidDefaultModel>(data['data']);
     }
     if (dataClassName == 'UuidDefaultPersist') {
-      return deserialize<_i49.UuidDefaultPersist>(data['data']);
+      return deserialize<_i50.UuidDefaultPersist>(data['data']);
     }
     if (dataClassName == 'EmptyModel') {
-      return deserialize<_i50.EmptyModel>(data['data']);
+      return deserialize<_i51.EmptyModel>(data['data']);
     }
     if (dataClassName == 'EmptyModelRelationItem') {
-      return deserialize<_i51.EmptyModelRelationItem>(data['data']);
+      return deserialize<_i52.EmptyModelRelationItem>(data['data']);
     }
     if (dataClassName == 'EmptyModelWithTable') {
-      return deserialize<_i52.EmptyModelWithTable>(data['data']);
+      return deserialize<_i53.EmptyModelWithTable>(data['data']);
     }
     if (dataClassName == 'RelationEmptyModel') {
-      return deserialize<_i53.RelationEmptyModel>(data['data']);
+      return deserialize<_i54.RelationEmptyModel>(data['data']);
     }
     if (dataClassName == 'ExceptionWithData') {
-      return deserialize<_i54.ExceptionWithData>(data['data']);
+      return deserialize<_i55.ExceptionWithData>(data['data']);
     }
     if (dataClassName == 'ChildClass') {
-      return deserialize<_i55.ChildClass>(data['data']);
+      return deserialize<_i56.ChildClass>(data['data']);
     }
     if (dataClassName == 'ChildWithDefault') {
-      return deserialize<_i56.ChildWithDefault>(data['data']);
+      return deserialize<_i57.ChildWithDefault>(data['data']);
     }
     if (dataClassName == 'GrandparentClass') {
-      return deserialize<_i57.GrandparentClass>(data['data']);
+      return deserialize<_i58.GrandparentClass>(data['data']);
     }
     if (dataClassName == 'ParentClass') {
-      return deserialize<_i58.ParentClass>(data['data']);
+      return deserialize<_i59.ParentClass>(data['data']);
     }
     if (dataClassName == 'ParentWithDefault') {
-      return deserialize<_i59.ParentWithDefault>(data['data']);
+      return deserialize<_i60.ParentWithDefault>(data['data']);
     }
     if (dataClassName == 'SealedChild') {
-      return deserialize<_i60.SealedChild>(data['data']);
+      return deserialize<_i61.SealedChild>(data['data']);
     }
     if (dataClassName == 'SealedGrandChild') {
-      return deserialize<_i60.SealedGrandChild>(data['data']);
+      return deserialize<_i61.SealedGrandChild>(data['data']);
     }
     if (dataClassName == 'SealedOtherChild') {
-      return deserialize<_i60.SealedOtherChild>(data['data']);
+      return deserialize<_i61.SealedOtherChild>(data['data']);
     }
     if (dataClassName == 'CityWithLongTableName') {
-      return deserialize<_i61.CityWithLongTableName>(data['data']);
+      return deserialize<_i62.CityWithLongTableName>(data['data']);
     }
     if (dataClassName == 'OrganizationWithLongTableName') {
-      return deserialize<_i62.OrganizationWithLongTableName>(data['data']);
+      return deserialize<_i63.OrganizationWithLongTableName>(data['data']);
     }
     if (dataClassName == 'PersonWithLongTableName') {
-      return deserialize<_i63.PersonWithLongTableName>(data['data']);
+      return deserialize<_i64.PersonWithLongTableName>(data['data']);
     }
     if (dataClassName == 'MaxFieldName') {
-      return deserialize<_i64.MaxFieldName>(data['data']);
+      return deserialize<_i65.MaxFieldName>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdField') {
-      return deserialize<_i65.LongImplicitIdField>(data['data']);
+      return deserialize<_i66.LongImplicitIdField>(data['data']);
     }
     if (dataClassName == 'LongImplicitIdFieldCollection') {
-      return deserialize<_i66.LongImplicitIdFieldCollection>(data['data']);
+      return deserialize<_i67.LongImplicitIdFieldCollection>(data['data']);
     }
     if (dataClassName == 'RelationToMultipleMaxFieldName') {
-      return deserialize<_i67.RelationToMultipleMaxFieldName>(data['data']);
+      return deserialize<_i68.RelationToMultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'UserNote') {
-      return deserialize<_i68.UserNote>(data['data']);
+      return deserialize<_i69.UserNote>(data['data']);
     }
     if (dataClassName == 'UserNoteCollection') {
-      return deserialize<_i69.UserNoteCollection>(data['data']);
+      return deserialize<_i70.UserNoteCollection>(data['data']);
     }
     if (dataClassName == 'UserNoteCollectionWithALongName') {
-      return deserialize<_i70.UserNoteCollectionWithALongName>(data['data']);
+      return deserialize<_i71.UserNoteCollectionWithALongName>(data['data']);
     }
     if (dataClassName == 'UserNoteWithALongName') {
-      return deserialize<_i71.UserNoteWithALongName>(data['data']);
+      return deserialize<_i72.UserNoteWithALongName>(data['data']);
     }
     if (dataClassName == 'MultipleMaxFieldName') {
-      return deserialize<_i72.MultipleMaxFieldName>(data['data']);
+      return deserialize<_i73.MultipleMaxFieldName>(data['data']);
     }
     if (dataClassName == 'City') {
-      return deserialize<_i73.City>(data['data']);
+      return deserialize<_i74.City>(data['data']);
     }
     if (dataClassName == 'Organization') {
-      return deserialize<_i74.Organization>(data['data']);
+      return deserialize<_i75.Organization>(data['data']);
     }
     if (dataClassName == 'Person') {
-      return deserialize<_i75.Person>(data['data']);
+      return deserialize<_i76.Person>(data['data']);
     }
     if (dataClassName == 'Course') {
-      return deserialize<_i76.Course>(data['data']);
+      return deserialize<_i77.Course>(data['data']);
     }
     if (dataClassName == 'Enrollment') {
-      return deserialize<_i77.Enrollment>(data['data']);
+      return deserialize<_i78.Enrollment>(data['data']);
     }
     if (dataClassName == 'Student') {
-      return deserialize<_i78.Student>(data['data']);
+      return deserialize<_i79.Student>(data['data']);
     }
     if (dataClassName == 'ObjectUser') {
-      return deserialize<_i79.ObjectUser>(data['data']);
+      return deserialize<_i80.ObjectUser>(data['data']);
     }
     if (dataClassName == 'ParentUser') {
-      return deserialize<_i80.ParentUser>(data['data']);
+      return deserialize<_i81.ParentUser>(data['data']);
     }
     if (dataClassName == 'Arena') {
-      return deserialize<_i81.Arena>(data['data']);
+      return deserialize<_i82.Arena>(data['data']);
     }
     if (dataClassName == 'Player') {
-      return deserialize<_i82.Player>(data['data']);
+      return deserialize<_i83.Player>(data['data']);
     }
     if (dataClassName == 'Team') {
-      return deserialize<_i83.Team>(data['data']);
+      return deserialize<_i84.Team>(data['data']);
     }
     if (dataClassName == 'Comment') {
-      return deserialize<_i84.Comment>(data['data']);
+      return deserialize<_i85.Comment>(data['data']);
     }
     if (dataClassName == 'Customer') {
-      return deserialize<_i85.Customer>(data['data']);
+      return deserialize<_i86.Customer>(data['data']);
     }
     if (dataClassName == 'Order') {
-      return deserialize<_i86.Order>(data['data']);
+      return deserialize<_i87.Order>(data['data']);
     }
     if (dataClassName == 'Address') {
-      return deserialize<_i87.Address>(data['data']);
+      return deserialize<_i88.Address>(data['data']);
     }
     if (dataClassName == 'Citizen') {
-      return deserialize<_i88.Citizen>(data['data']);
+      return deserialize<_i89.Citizen>(data['data']);
     }
     if (dataClassName == 'Company') {
-      return deserialize<_i89.Company>(data['data']);
+      return deserialize<_i90.Company>(data['data']);
     }
     if (dataClassName == 'Town') {
-      return deserialize<_i90.Town>(data['data']);
+      return deserialize<_i91.Town>(data['data']);
     }
     if (dataClassName == 'Blocking') {
-      return deserialize<_i91.Blocking>(data['data']);
+      return deserialize<_i92.Blocking>(data['data']);
     }
     if (dataClassName == 'Member') {
-      return deserialize<_i92.Member>(data['data']);
+      return deserialize<_i93.Member>(data['data']);
     }
     if (dataClassName == 'Cat') {
-      return deserialize<_i93.Cat>(data['data']);
+      return deserialize<_i94.Cat>(data['data']);
     }
     if (dataClassName == 'Post') {
-      return deserialize<_i94.Post>(data['data']);
+      return deserialize<_i95.Post>(data['data']);
     }
     if (dataClassName == 'ModuleDatatype') {
-      return deserialize<_i95.ModuleDatatype>(data['data']);
+      return deserialize<_i96.ModuleDatatype>(data['data']);
     }
     if (dataClassName == 'Nullability') {
-      return deserialize<_i96.Nullability>(data['data']);
+      return deserialize<_i97.Nullability>(data['data']);
     }
     if (dataClassName == 'ObjectFieldPersist') {
-      return deserialize<_i97.ObjectFieldPersist>(data['data']);
+      return deserialize<_i98.ObjectFieldPersist>(data['data']);
     }
     if (dataClassName == 'ObjectFieldScopes') {
-      return deserialize<_i98.ObjectFieldScopes>(data['data']);
+      return deserialize<_i99.ObjectFieldScopes>(data['data']);
     }
     if (dataClassName == 'ObjectWithByteData') {
-      return deserialize<_i99.ObjectWithByteData>(data['data']);
+      return deserialize<_i100.ObjectWithByteData>(data['data']);
     }
     if (dataClassName == 'ObjectWithCustomClass') {
-      return deserialize<_i100.ObjectWithCustomClass>(data['data']);
+      return deserialize<_i101.ObjectWithCustomClass>(data['data']);
     }
     if (dataClassName == 'ObjectWithDuration') {
-      return deserialize<_i101.ObjectWithDuration>(data['data']);
+      return deserialize<_i102.ObjectWithDuration>(data['data']);
     }
     if (dataClassName == 'ObjectWithEnum') {
-      return deserialize<_i102.ObjectWithEnum>(data['data']);
+      return deserialize<_i103.ObjectWithEnum>(data['data']);
     }
     if (dataClassName == 'ObjectWithIndex') {
-      return deserialize<_i103.ObjectWithIndex>(data['data']);
+      return deserialize<_i104.ObjectWithIndex>(data['data']);
     }
     if (dataClassName == 'ObjectWithMaps') {
-      return deserialize<_i104.ObjectWithMaps>(data['data']);
+      return deserialize<_i105.ObjectWithMaps>(data['data']);
     }
     if (dataClassName == 'ObjectWithObject') {
-      return deserialize<_i105.ObjectWithObject>(data['data']);
+      return deserialize<_i106.ObjectWithObject>(data['data']);
     }
     if (dataClassName == 'ObjectWithParent') {
-      return deserialize<_i106.ObjectWithParent>(data['data']);
+      return deserialize<_i107.ObjectWithParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithSelfParent') {
-      return deserialize<_i107.ObjectWithSelfParent>(data['data']);
+      return deserialize<_i108.ObjectWithSelfParent>(data['data']);
     }
     if (dataClassName == 'ObjectWithUuid') {
-      return deserialize<_i108.ObjectWithUuid>(data['data']);
+      return deserialize<_i109.ObjectWithUuid>(data['data']);
     }
     if (dataClassName == 'RelatedUniqueData') {
-      return deserialize<_i109.RelatedUniqueData>(data['data']);
+      return deserialize<_i110.RelatedUniqueData>(data['data']);
     }
     if (dataClassName == 'ScopeNoneFields') {
-      return deserialize<_i110.ScopeNoneFields>(data['data']);
+      return deserialize<_i111.ScopeNoneFields>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyField') {
-      return deserialize<_i111.ScopeServerOnlyField>(data['data']);
+      return deserialize<_i112.ScopeServerOnlyField>(data['data']);
     }
     if (dataClassName == 'ScopeServerOnlyFieldChild') {
-      return deserialize<_i112.ScopeServerOnlyFieldChild>(data['data']);
+      return deserialize<_i113.ScopeServerOnlyFieldChild>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyClass') {
-      return deserialize<_i113.DefaultServerOnlyClass>(data['data']);
+      return deserialize<_i114.DefaultServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'DefaultServerOnlyEnum') {
-      return deserialize<_i114.DefaultServerOnlyEnum>(data['data']);
+      return deserialize<_i115.DefaultServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyClass') {
-      return deserialize<_i115.NotServerOnlyClass>(data['data']);
+      return deserialize<_i116.NotServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'NotServerOnlyEnum') {
-      return deserialize<_i116.NotServerOnlyEnum>(data['data']);
+      return deserialize<_i117.NotServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClass') {
-      return deserialize<_i117.ServerOnlyClass>(data['data']);
+      return deserialize<_i118.ServerOnlyClass>(data['data']);
     }
     if (dataClassName == 'ServerOnlyEnum') {
-      return deserialize<_i118.ServerOnlyEnum>(data['data']);
+      return deserialize<_i119.ServerOnlyEnum>(data['data']);
     }
     if (dataClassName == 'ServerOnlyClassField') {
-      return deserialize<_i119.ServerOnlyClassField>(data['data']);
+      return deserialize<_i120.ServerOnlyClassField>(data['data']);
     }
     if (dataClassName == 'SimpleData') {
-      return deserialize<_i120.SimpleData>(data['data']);
+      return deserialize<_i121.SimpleData>(data['data']);
     }
     if (dataClassName == 'SimpleDataList') {
-      return deserialize<_i121.SimpleDataList>(data['data']);
+      return deserialize<_i122.SimpleDataList>(data['data']);
     }
     if (dataClassName == 'SimpleDataMap') {
-      return deserialize<_i122.SimpleDataMap>(data['data']);
+      return deserialize<_i123.SimpleDataMap>(data['data']);
     }
     if (dataClassName == 'SimpleDataObject') {
-      return deserialize<_i123.SimpleDataObject>(data['data']);
+      return deserialize<_i124.SimpleDataObject>(data['data']);
     }
     if (dataClassName == 'SimpleDateTime') {
-      return deserialize<_i124.SimpleDateTime>(data['data']);
+      return deserialize<_i125.SimpleDateTime>(data['data']);
     }
     if (dataClassName == 'TestEnum') {
-      return deserialize<_i125.TestEnum>(data['data']);
+      return deserialize<_i126.TestEnum>(data['data']);
     }
     if (dataClassName == 'TestEnumStringified') {
-      return deserialize<_i126.TestEnumStringified>(data['data']);
+      return deserialize<_i127.TestEnumStringified>(data['data']);
     }
     if (dataClassName == 'Types') {
-      return deserialize<_i127.Types>(data['data']);
+      return deserialize<_i128.Types>(data['data']);
     }
     if (dataClassName == 'TypesList') {
-      return deserialize<_i128.TypesList>(data['data']);
+      return deserialize<_i129.TypesList>(data['data']);
     }
     if (dataClassName == 'TypesMap') {
-      return deserialize<_i129.TypesMap>(data['data']);
+      return deserialize<_i130.TypesMap>(data['data']);
     }
     if (dataClassName == 'TypesRecord') {
-      return deserialize<_i130.TypesRecord>(data['data']);
+      return deserialize<_i131.TypesRecord>(data['data']);
     }
     if (dataClassName == 'TypesSet') {
-      return deserialize<_i131.TypesSet>(data['data']);
+      return deserialize<_i132.TypesSet>(data['data']);
     }
     if (dataClassName == 'UniqueData') {
-      return deserialize<_i132.UniqueData>(data['data']);
+      return deserialize<_i133.UniqueData>(data['data']);
     }
     if (dataClassName == 'MyFeatureModel') {
-      return deserialize<_i133.MyFeatureModel>(data['data']);
+      return deserialize<_i134.MyFeatureModel>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -9052,25 +9066,25 @@ class Protocol extends _i1.SerializationManagerServer {
       return deserialize<List<int>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>') {
-      return deserialize<List<_i136.SimpleData>>(data['data']);
+      return deserialize<List<_i137.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<serverpod_auth.UserInfo>') {
       return deserialize<List<_i3.UserInfo>>(data['data']);
     }
     if (dataClassName == 'List<SimpleData>?') {
-      return deserialize<List<_i136.SimpleData>?>(data['data']);
+      return deserialize<List<_i137.SimpleData>?>(data['data']);
     }
     if (dataClassName == 'List<SimpleData?>') {
-      return deserialize<List<_i136.SimpleData?>>(data['data']);
+      return deserialize<List<_i137.SimpleData?>>(data['data']);
     }
     if (dataClassName == 'Set<int>') {
       return deserialize<Set<int>>(data['data']);
     }
     if (dataClassName == 'Set<SimpleData>') {
-      return deserialize<Set<_i136.SimpleData>>(data['data']);
+      return deserialize<Set<_i137.SimpleData>>(data['data']);
     }
     if (dataClassName == 'List<Set<SimpleData>>') {
-      return deserialize<List<Set<_i136.SimpleData>>>(data['data']);
+      return deserialize<List<Set<_i137.SimpleData>>>(data['data']);
     }
     if (dataClassName == '(int?,)?') {
       return deserialize<(int?,)?>(data['data']);
@@ -9081,7 +9095,7 @@ class Protocol extends _i1.SerializationManagerServer {
           List<
               (
                 (int, String), {
-                (_i136.SimpleData, double) namedSubRecord
+                (_i137.SimpleData, double) namedSubRecord
               })?>?>(data['data']);
     }
     if (dataClassName ==
@@ -9089,7 +9103,7 @@ class Protocol extends _i1.SerializationManagerServer {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
           )>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>') {
@@ -9100,7 +9114,7 @@ class Protocol extends _i1.SerializationManagerServer {
       return deserialize<
           (
             String,
-            (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+            (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
           )?>(data['data']);
     }
     if (dataClassName == 'List<(String,int)>?') {
@@ -9178,146 +9192,146 @@ class Protocol extends _i1.SerializationManagerServer {
         return _i29.EnumDefaultModel.t;
       case _i30.EnumDefaultPersist:
         return _i30.EnumDefaultPersist.t;
-      case _i34.IntDefault:
-        return _i34.IntDefault.t;
-      case _i35.IntDefaultMix:
-        return _i35.IntDefaultMix.t;
-      case _i36.IntDefaultModel:
-        return _i36.IntDefaultModel.t;
-      case _i37.IntDefaultPersist:
-        return _i37.IntDefaultPersist.t;
-      case _i38.StringDefault:
-        return _i38.StringDefault.t;
-      case _i39.StringDefaultMix:
-        return _i39.StringDefaultMix.t;
-      case _i40.StringDefaultModel:
-        return _i40.StringDefaultModel.t;
-      case _i41.StringDefaultPersist:
-        return _i41.StringDefaultPersist.t;
-      case _i42.UriDefault:
-        return _i42.UriDefault.t;
-      case _i43.UriDefaultMix:
-        return _i43.UriDefaultMix.t;
-      case _i44.UriDefaultModel:
-        return _i44.UriDefaultModel.t;
-      case _i45.UriDefaultPersist:
-        return _i45.UriDefaultPersist.t;
-      case _i46.UuidDefault:
-        return _i46.UuidDefault.t;
-      case _i47.UuidDefaultMix:
-        return _i47.UuidDefaultMix.t;
-      case _i48.UuidDefaultModel:
-        return _i48.UuidDefaultModel.t;
-      case _i49.UuidDefaultPersist:
-        return _i49.UuidDefaultPersist.t;
-      case _i51.EmptyModelRelationItem:
-        return _i51.EmptyModelRelationItem.t;
-      case _i52.EmptyModelWithTable:
-        return _i52.EmptyModelWithTable.t;
-      case _i53.RelationEmptyModel:
-        return _i53.RelationEmptyModel.t;
-      case _i58.ParentClass:
-        return _i58.ParentClass.t;
-      case _i61.CityWithLongTableName:
-        return _i61.CityWithLongTableName.t;
-      case _i62.OrganizationWithLongTableName:
-        return _i62.OrganizationWithLongTableName.t;
-      case _i63.PersonWithLongTableName:
-        return _i63.PersonWithLongTableName.t;
-      case _i64.MaxFieldName:
-        return _i64.MaxFieldName.t;
-      case _i65.LongImplicitIdField:
-        return _i65.LongImplicitIdField.t;
-      case _i66.LongImplicitIdFieldCollection:
-        return _i66.LongImplicitIdFieldCollection.t;
-      case _i67.RelationToMultipleMaxFieldName:
-        return _i67.RelationToMultipleMaxFieldName.t;
-      case _i68.UserNote:
-        return _i68.UserNote.t;
-      case _i69.UserNoteCollection:
-        return _i69.UserNoteCollection.t;
-      case _i70.UserNoteCollectionWithALongName:
-        return _i70.UserNoteCollectionWithALongName.t;
-      case _i71.UserNoteWithALongName:
-        return _i71.UserNoteWithALongName.t;
-      case _i72.MultipleMaxFieldName:
-        return _i72.MultipleMaxFieldName.t;
-      case _i73.City:
-        return _i73.City.t;
-      case _i74.Organization:
-        return _i74.Organization.t;
-      case _i75.Person:
-        return _i75.Person.t;
-      case _i76.Course:
-        return _i76.Course.t;
-      case _i77.Enrollment:
-        return _i77.Enrollment.t;
-      case _i78.Student:
-        return _i78.Student.t;
-      case _i79.ObjectUser:
-        return _i79.ObjectUser.t;
-      case _i80.ParentUser:
-        return _i80.ParentUser.t;
-      case _i81.Arena:
-        return _i81.Arena.t;
-      case _i82.Player:
-        return _i82.Player.t;
-      case _i83.Team:
-        return _i83.Team.t;
-      case _i84.Comment:
-        return _i84.Comment.t;
-      case _i85.Customer:
-        return _i85.Customer.t;
-      case _i86.Order:
-        return _i86.Order.t;
-      case _i87.Address:
-        return _i87.Address.t;
-      case _i88.Citizen:
-        return _i88.Citizen.t;
-      case _i89.Company:
-        return _i89.Company.t;
-      case _i90.Town:
-        return _i90.Town.t;
-      case _i91.Blocking:
-        return _i91.Blocking.t;
-      case _i92.Member:
-        return _i92.Member.t;
-      case _i93.Cat:
-        return _i93.Cat.t;
-      case _i94.Post:
-        return _i94.Post.t;
-      case _i97.ObjectFieldPersist:
-        return _i97.ObjectFieldPersist.t;
-      case _i98.ObjectFieldScopes:
-        return _i98.ObjectFieldScopes.t;
-      case _i99.ObjectWithByteData:
-        return _i99.ObjectWithByteData.t;
-      case _i101.ObjectWithDuration:
-        return _i101.ObjectWithDuration.t;
-      case _i102.ObjectWithEnum:
-        return _i102.ObjectWithEnum.t;
-      case _i103.ObjectWithIndex:
-        return _i103.ObjectWithIndex.t;
-      case _i105.ObjectWithObject:
-        return _i105.ObjectWithObject.t;
-      case _i106.ObjectWithParent:
-        return _i106.ObjectWithParent.t;
-      case _i107.ObjectWithSelfParent:
-        return _i107.ObjectWithSelfParent.t;
-      case _i108.ObjectWithUuid:
-        return _i108.ObjectWithUuid.t;
-      case _i109.RelatedUniqueData:
-        return _i109.RelatedUniqueData.t;
-      case _i110.ScopeNoneFields:
-        return _i110.ScopeNoneFields.t;
-      case _i120.SimpleData:
-        return _i120.SimpleData.t;
-      case _i124.SimpleDateTime:
-        return _i124.SimpleDateTime.t;
-      case _i127.Types:
-        return _i127.Types.t;
-      case _i132.UniqueData:
-        return _i132.UniqueData.t;
+      case _i35.IntDefault:
+        return _i35.IntDefault.t;
+      case _i36.IntDefaultMix:
+        return _i36.IntDefaultMix.t;
+      case _i37.IntDefaultModel:
+        return _i37.IntDefaultModel.t;
+      case _i38.IntDefaultPersist:
+        return _i38.IntDefaultPersist.t;
+      case _i39.StringDefault:
+        return _i39.StringDefault.t;
+      case _i40.StringDefaultMix:
+        return _i40.StringDefaultMix.t;
+      case _i41.StringDefaultModel:
+        return _i41.StringDefaultModel.t;
+      case _i42.StringDefaultPersist:
+        return _i42.StringDefaultPersist.t;
+      case _i43.UriDefault:
+        return _i43.UriDefault.t;
+      case _i44.UriDefaultMix:
+        return _i44.UriDefaultMix.t;
+      case _i45.UriDefaultModel:
+        return _i45.UriDefaultModel.t;
+      case _i46.UriDefaultPersist:
+        return _i46.UriDefaultPersist.t;
+      case _i47.UuidDefault:
+        return _i47.UuidDefault.t;
+      case _i48.UuidDefaultMix:
+        return _i48.UuidDefaultMix.t;
+      case _i49.UuidDefaultModel:
+        return _i49.UuidDefaultModel.t;
+      case _i50.UuidDefaultPersist:
+        return _i50.UuidDefaultPersist.t;
+      case _i52.EmptyModelRelationItem:
+        return _i52.EmptyModelRelationItem.t;
+      case _i53.EmptyModelWithTable:
+        return _i53.EmptyModelWithTable.t;
+      case _i54.RelationEmptyModel:
+        return _i54.RelationEmptyModel.t;
+      case _i59.ParentClass:
+        return _i59.ParentClass.t;
+      case _i62.CityWithLongTableName:
+        return _i62.CityWithLongTableName.t;
+      case _i63.OrganizationWithLongTableName:
+        return _i63.OrganizationWithLongTableName.t;
+      case _i64.PersonWithLongTableName:
+        return _i64.PersonWithLongTableName.t;
+      case _i65.MaxFieldName:
+        return _i65.MaxFieldName.t;
+      case _i66.LongImplicitIdField:
+        return _i66.LongImplicitIdField.t;
+      case _i67.LongImplicitIdFieldCollection:
+        return _i67.LongImplicitIdFieldCollection.t;
+      case _i68.RelationToMultipleMaxFieldName:
+        return _i68.RelationToMultipleMaxFieldName.t;
+      case _i69.UserNote:
+        return _i69.UserNote.t;
+      case _i70.UserNoteCollection:
+        return _i70.UserNoteCollection.t;
+      case _i71.UserNoteCollectionWithALongName:
+        return _i71.UserNoteCollectionWithALongName.t;
+      case _i72.UserNoteWithALongName:
+        return _i72.UserNoteWithALongName.t;
+      case _i73.MultipleMaxFieldName:
+        return _i73.MultipleMaxFieldName.t;
+      case _i74.City:
+        return _i74.City.t;
+      case _i75.Organization:
+        return _i75.Organization.t;
+      case _i76.Person:
+        return _i76.Person.t;
+      case _i77.Course:
+        return _i77.Course.t;
+      case _i78.Enrollment:
+        return _i78.Enrollment.t;
+      case _i79.Student:
+        return _i79.Student.t;
+      case _i80.ObjectUser:
+        return _i80.ObjectUser.t;
+      case _i81.ParentUser:
+        return _i81.ParentUser.t;
+      case _i82.Arena:
+        return _i82.Arena.t;
+      case _i83.Player:
+        return _i83.Player.t;
+      case _i84.Team:
+        return _i84.Team.t;
+      case _i85.Comment:
+        return _i85.Comment.t;
+      case _i86.Customer:
+        return _i86.Customer.t;
+      case _i87.Order:
+        return _i87.Order.t;
+      case _i88.Address:
+        return _i88.Address.t;
+      case _i89.Citizen:
+        return _i89.Citizen.t;
+      case _i90.Company:
+        return _i90.Company.t;
+      case _i91.Town:
+        return _i91.Town.t;
+      case _i92.Blocking:
+        return _i92.Blocking.t;
+      case _i93.Member:
+        return _i93.Member.t;
+      case _i94.Cat:
+        return _i94.Cat.t;
+      case _i95.Post:
+        return _i95.Post.t;
+      case _i98.ObjectFieldPersist:
+        return _i98.ObjectFieldPersist.t;
+      case _i99.ObjectFieldScopes:
+        return _i99.ObjectFieldScopes.t;
+      case _i100.ObjectWithByteData:
+        return _i100.ObjectWithByteData.t;
+      case _i102.ObjectWithDuration:
+        return _i102.ObjectWithDuration.t;
+      case _i103.ObjectWithEnum:
+        return _i103.ObjectWithEnum.t;
+      case _i104.ObjectWithIndex:
+        return _i104.ObjectWithIndex.t;
+      case _i106.ObjectWithObject:
+        return _i106.ObjectWithObject.t;
+      case _i107.ObjectWithParent:
+        return _i107.ObjectWithParent.t;
+      case _i108.ObjectWithSelfParent:
+        return _i108.ObjectWithSelfParent.t;
+      case _i109.ObjectWithUuid:
+        return _i109.ObjectWithUuid.t;
+      case _i110.RelatedUniqueData:
+        return _i110.RelatedUniqueData.t;
+      case _i111.ScopeNoneFields:
+        return _i111.ScopeNoneFields.t;
+      case _i121.SimpleData:
+        return _i121.SimpleData.t;
+      case _i125.SimpleDateTime:
+        return _i125.SimpleDateTime.t;
+      case _i128.Types:
+        return _i128.Types.t;
+      case _i133.UniqueData:
+        return _i133.UniqueData.t;
     }
     return null;
   }
@@ -9383,7 +9397,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (int, _i136.SimpleData)) {
+  if (record is (int, _i137.SimpleData)) {
     return {
       "p": [
         record.$1,
@@ -9399,7 +9413,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i136.SimpleData data, int number})) {
+  if (record is ({_i137.SimpleData data, int number})) {
     return {
       "n": {
         "data": record.data,
@@ -9407,7 +9421,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is ({_i136.SimpleData? data, int? number})) {
+  if (record is ({_i137.SimpleData? data, int? number})) {
     return {
       "n": {
         "data": record.data,
@@ -9415,7 +9429,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (int, {_i136.SimpleData data})) {
+  if (record is (int, {_i137.SimpleData data})) {
     return {
       "p": [
         record.$1,
@@ -9433,14 +9447,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i136.SimpleData, double) namedSubRecord})) {
+  if (record is ({(_i137.SimpleData, double) namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is (_i136.SimpleData, double)) {
+  if (record is (_i137.SimpleData, double)) {
     return {
       "p": [
         record.$1,
@@ -9448,14 +9462,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is ({(_i136.SimpleData, double)? namedSubRecord})) {
+  if (record is ({(_i137.SimpleData, double)? namedSubRecord})) {
     return {
       "n": {
         "namedSubRecord": mapRecordToJson(record.namedSubRecord),
       },
     };
   }
-  if (record is ((int, String), {(_i136.SimpleData, double) namedSubRecord})) {
+  if (record is ((int, String), {(_i137.SimpleData, double) namedSubRecord})) {
     return {
       "p": [
         mapRecordToJson(record.$1),
@@ -9483,7 +9497,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
   }
   if (record is (
     String,
-    (Map<String, int>, {bool flag, _i136.SimpleData simpleData})
+    (Map<String, int>, {bool flag, _i137.SimpleData simpleData})
   )) {
     return {
       "p": [
@@ -9492,7 +9506,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (Map<String, int>, {bool flag, _i136.SimpleData simpleData})) {
+  if (record is (Map<String, int>, {bool flag, _i137.SimpleData simpleData})) {
     return {
       "p": [
         record.$1,
@@ -9548,7 +9562,7 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i134.ByteData,)) {
+  if (record is (_i135.ByteData,)) {
     return {
       "p": [
         record.$1,
@@ -9583,14 +9597,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i125.TestEnum,)) {
+  if (record is (_i126.TestEnum,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is (_i126.TestEnumStringified,)) {
+  if (record is (_i127.TestEnumStringified,)) {
     return {
       "p": [
         record.$1,
@@ -9618,21 +9632,21 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       ],
     };
   }
-  if (record is (_i120.SimpleData,)) {
+  if (record is (_i121.SimpleData,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is ({_i120.SimpleData namedModel})) {
+  if (record is ({_i121.SimpleData namedModel})) {
     return {
       "n": {
         "namedModel": record.namedModel,
       },
     };
   }
-  if (record is (_i120.SimpleData, {_i120.SimpleData namedModel})) {
+  if (record is (_i121.SimpleData, {_i121.SimpleData namedModel})) {
     return {
       "p": [
         record.$1,
@@ -9661,8 +9675,8 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
     };
   }
   if (record is (
-    (List<(_i120.SimpleData,)>,), {
-    (_i120.SimpleData, Map<String, _i120.SimpleData>) namedNestedRecord
+    (List<(_i121.SimpleData,)>,), {
+    (_i121.SimpleData, Map<String, _i121.SimpleData>) namedNestedRecord
   })) {
     return {
       "p": [
@@ -9673,14 +9687,14 @@ Map<String, dynamic>? mapRecordToJson(Record? record) {
       },
     };
   }
-  if (record is (List<(_i120.SimpleData,)>,)) {
+  if (record is (List<(_i121.SimpleData,)>,)) {
     return {
       "p": [
         record.$1,
       ],
     };
   }
-  if (record is (_i120.SimpleData, Map<String, _i120.SimpleData>)) {
+  if (record is (_i121.SimpleData, Map<String, _i121.SimpleData>)) {
     return {
       "p": [
         record.$1,

--- a/tests/serverpod_test_server/lib/src/models/defaults/enum/enums/default_value_enum.spy.yaml
+++ b/tests/serverpod_test_server/lib/src/models/defaults/enum/enums/default_value_enum.spy.yaml
@@ -1,0 +1,5 @@
+enum: DefaultValueEnum
+default: value2
+values:
+  - value1
+  - value2

--- a/tests/serverpod_test_server/test_integration/database_operations/default/enum/enum_default_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/default/enum/enum_default_test.dart
@@ -139,5 +139,41 @@ void main() async {
         );
       },
     );
+
+    group('Given a class with "default" enum fields,', () {
+      test(
+        'when deserializing an invalid index for DefaultValueEnum, it should default to value2',
+        () async {
+          var object = DefaultValueEnum.fromJson(-1);
+          expect(DefaultValueEnum.values.length, 2);
+          expect(object, DefaultValueEnum.value2);
+        },
+      );
+
+      test(
+        'when deserializing an invalid index for ByIndexEnum, it should throw an ArgumentError',
+        () async {
+          expect(
+            () => ByIndexEnum.fromJson(-1),
+            throwsA(predicate((e) =>
+                e is ArgumentError &&
+                e.message == 'Value "2" cannot be converted to "ByIndexEnum"')),
+          );
+        },
+      );
+
+      test(
+        'when deserializing an invalid name for ByNameEnum, it should throw an ArgumentError',
+        () async {
+          expect(
+            () => ByNameEnum.fromJson('Invalid'),
+            throwsA(predicate((e) =>
+                e is ArgumentError &&
+                e.message ==
+                    'Value "Invalid" cannot be converted to "ByNameEnum"')),
+          );
+        },
+      );
+    });
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/default/enum/enum_default_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/default/enum/enum_default_test.dart
@@ -157,7 +157,8 @@ void main() async {
             () => ByIndexEnum.fromJson(-1),
             throwsA(predicate((e) =>
                 e is ArgumentError &&
-                e.message == 'Value "2" cannot be converted to "ByIndexEnum"')),
+                e.message ==
+                    'Value "-1" cannot be converted to "ByIndexEnum"')),
           );
         },
       );

--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -342,6 +342,9 @@ class EnumDefinition extends SerializableModelDefinition {
   /// The type of serialization this enum should use.
   final EnumSerialization serialized;
 
+  /// The default value of the enum when parsing of the enum fails.
+  final ProtocolEnumValueDefinition? defaultValue;
+
   /// All the values of the enum.
   /// This also contains possible documentation for them.
   List<ProtocolEnumValueDefinition> values;
@@ -355,6 +358,7 @@ class EnumDefinition extends SerializableModelDefinition {
     required super.sourceFileName,
     required super.className,
     required this.serialized,
+    required this.defaultValue,
     required this.values,
     required super.serverOnly,
     required super.type,

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -614,7 +614,7 @@ class ModelParser {
   ) {
     final defaultValue =
         _parseDefaultValue(documentContents, Keyword.defaultKey);
-    return values.where((value) => value.name == defaultValue).firstOrNull;
+    return ProtocolEnumValueDefinition(defaultValue);
   }
 
   static List<ProtocolEnumValueDefinition> _parseEnumValues(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -614,9 +614,7 @@ class ModelParser {
   ) {
     final defaultValue =
         _parseDefaultValue(documentContents, Keyword.defaultKey);
-    if (defaultValue == null) return null;
-    if (defaultValue is! String) return null;
-    return ProtocolEnumValueDefinition(defaultValue);
+    return values.where((value) => value.name == defaultValue).firstOrNull;
   }
 
   static List<ProtocolEnumValueDefinition> _parseEnumValues(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -182,10 +182,8 @@ class ModelParser {
       extraClasses: [],
     );
     var defaultValue = _parseDefaultValue(documentContents, Keyword.defaultKey);
-    print(defaultValue);
     var defaultEnumDefinitionValue =
         values.where((value) => value.name == defaultValue).firstOrNull;
-    print(defaultEnumDefinitionValue);
 
     var enumDef = EnumDefinition(
       fileName: outFileName,

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -181,6 +181,11 @@ class ModelParser {
       '${protocolSource.moduleAlias}:$className',
       extraClasses: [],
     );
+    var defaultValue = _parseDefaultValue(documentContents, Keyword.defaultKey);
+    var defaultEnumDefinitionValue =
+        values.where((value) => value.name == defaultValue).firstOrNull;
+    print(defaultValue);
+    print(defaultEnumDefinitionValue);
 
     var enumDef = EnumDefinition(
       fileName: outFileName,
@@ -189,6 +194,7 @@ class ModelParser {
       values: values,
       serialized: serializeAs,
       documentation: enumDocumentation,
+      defaultValue: defaultEnumDefinitionValue,
       subDirParts: protocolSource.subDirPathParts,
       serverOnly: serverOnly,
       type: enumType,

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -615,6 +615,7 @@ class ModelParser {
     final defaultValue =
         _parseDefaultValue(documentContents, Keyword.defaultKey);
     if (defaultValue == null) return null;
+    if (defaultValue is! String) return null;
     return ProtocolEnumValueDefinition(defaultValue);
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -614,6 +614,7 @@ class ModelParser {
   ) {
     final defaultValue =
         _parseDefaultValue(documentContents, Keyword.defaultKey);
+    if (defaultValue == null) return null;
     return ProtocolEnumValueDefinition(defaultValue);
   }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -182,9 +182,9 @@ class ModelParser {
       extraClasses: [],
     );
     var defaultValue = _parseDefaultValue(documentContents, Keyword.defaultKey);
+    print(defaultValue);
     var defaultEnumDefinitionValue =
         values.where((value) => value.name == defaultValue).firstOrNull;
-    print(defaultValue);
     print(defaultEnumDefinitionValue);
 
     var enumDef = EnumDefinition(

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -181,9 +181,8 @@ class ModelParser {
       '${protocolSource.moduleAlias}:$className',
       extraClasses: [],
     );
-    var defaultValue = _parseDefaultValue(documentContents, Keyword.defaultKey);
     var defaultEnumDefinitionValue =
-        values.where((value) => value.name == defaultValue).firstOrNull;
+        _parseEnumDefaultValue(documentContents, values);
 
     var enumDef = EnumDefinition(
       fileName: outFileName,
@@ -607,6 +606,15 @@ class ModelParser {
     var node = documentContents.nodes[Keyword.unique];
     var nodeValue = node?.value;
     return nodeValue is bool ? nodeValue : false;
+  }
+
+  static ProtocolEnumValueDefinition? _parseEnumDefaultValue(
+    YamlMap documentContents,
+    List<ProtocolEnumValueDefinition> values,
+  ) {
+    final defaultValue =
+        _parseDefaultValue(documentContents, Keyword.defaultKey);
+    return values.where((value) => value.name == defaultValue).firstOrNull;
   }
 
   static List<ProtocolEnumValueDefinition> _parseEnumValues(

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -1233,6 +1233,37 @@ class Restrictions {
     return [];
   }
 
+  List<SourceSpanSeverityException> validateEnumDefaultValue(
+    String parentNodeName,
+    dynamic content,
+    SourceSpan? span,
+  ) {
+    if (content is! String) {
+      return [
+        SourceSpanSeverityException(
+          'The "default" property must be a String.',
+          span,
+        )
+      ];
+    }
+
+    var definition = documentDefinition;
+    if (definition is! EnumDefinition) return [];
+    final values = definition.values;
+    var defaultEnumDsefinitionValue =
+        values.where((value) => value.name == content).firstOrNull;
+    if (defaultEnumDsefinitionValue == null) {
+      return [
+        SourceSpanSeverityException(
+          '"$content" is not a valid default value. Allowed values are: ${values.map((e) => e.name).join(', ')}.',
+          span,
+        )
+      ];
+    }
+
+    return [];
+  }
+
   List<SourceSpanSeverityException> validateEnumValues(
     String parentNodeName,
     dynamic content,

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -1250,18 +1250,13 @@ class Restrictions {
     var definition = documentDefinition;
     if (definition is! EnumDefinition) return [];
     final values = definition.values;
-    var defaultEnumDsefinitionValue =
-        values.where((value) => value.name == content).firstOrNull;
-    if (defaultEnumDsefinitionValue == null) {
-      return [
-        SourceSpanSeverityException(
-          '"$content" is not a valid default value. Allowed values are: ${values.map((e) => e.name).join(', ')}.',
-          span,
-        )
-      ];
-    }
-
-    return [];
+    if (values.any((value) => value.name == content)) return [];
+    return [
+      SourceSpanSeverityException(
+        '"$content" is not a valid default value. Allowed values are: ${values.map((e) => e.name).join(', ')}.',
+        span,
+      )
+    ];
   }
 
   List<SourceSpanSeverityException> validateEnumValues(

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart
@@ -21,6 +21,7 @@ class EnumYamlDefinition {
       ),
       ValidateNode(
         Keyword.defaultKey,
+        valueRestriction: restrictions.validateEnumDefaultValue,
       ),
       ValidateNode(
         Keyword.serverOnly,

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/enum_yaml_definition.dart
@@ -20,6 +20,9 @@ class EnumYamlDefinition {
             EnumValueRestriction(enums: EnumSerialization.values).validate,
       ),
       ValidateNode(
+        Keyword.defaultKey,
+      ),
+      ValidateNode(
         Keyword.serverOnly,
         valueRestriction: BooleanValueRestriction().validate,
       ),

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -2389,20 +2389,11 @@ class SerializableModelLibraryGenerator {
         ..body = (BlockBuilder()
               ..statements.addAll([
                 const Code('switch(index){'),
-                for (int i = 0; i < enumDefinition.values.length; i++) ...[
+                for (int i = 0; i < enumDefinition.values.length; i++)
                   Code(
                     'case $i: return ${enumDefinition.className}.${enumDefinition.values[i].name};',
                   ),
-                ],
-                if (enumDefinition.defaultValue == null) ...[
-                  Code(
-                    'default: throw ArgumentError(\'Value "\$index" cannot be converted to "${enumDefinition.className}"\');',
-                  ),
-                ] else ...[
-                  Code(
-                    'default: return ${enumDefinition.className}.${enumDefinition.defaultValue!.name};',
-                  ),
-                ],
+                _buildDefaultSwitchCase(enumDefinition, 'index'),
                 const Code('}'),
               ]))
             .build()),
@@ -2436,15 +2427,7 @@ class SerializableModelLibraryGenerator {
                   Code(
                     "case '${value.name}': return ${enumDefinition.className}.${value.name};",
                   ),
-                if (enumDefinition.defaultValue == null) ...[
-                  Code(
-                    'default: throw ArgumentError(\'Value "\$name" cannot be converted to "${enumDefinition.className}"\');',
-                  ),
-                ] else ...[
-                  Code(
-                    'default: return ${enumDefinition.className}.${enumDefinition.defaultValue!.name};',
-                  ),
-                ],
+                _buildDefaultSwitchCase(enumDefinition, 'name'),
                 const Code('}'),
               ]))
             .build()),
@@ -2488,6 +2471,18 @@ class SerializableModelLibraryGenerator {
     }
 
     return refer(field.name);
+  }
+
+  Code _buildDefaultSwitchCase(
+      EnumDefinition enumDefinition, String valueFieldName) {
+    if (enumDefinition.defaultValue == null) {
+      return Code(
+        'default: throw ArgumentError(\'Value "\$$valueFieldName" cannot be converted to "${enumDefinition.className}"\');',
+      );
+    }
+    return Code(
+      'default: return ${enumDefinition.className}.${enumDefinition.defaultValue!.name};',
+    );
   }
 }
 

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -2389,13 +2389,20 @@ class SerializableModelLibraryGenerator {
         ..body = (BlockBuilder()
               ..statements.addAll([
                 const Code('switch(index){'),
-                for (int i = 0; i < enumDefinition.values.length; i++)
+                for (int i = 0; i < enumDefinition.values.length; i++) ...[
                   Code(
                     'case $i: return ${enumDefinition.className}.${enumDefinition.values[i].name};',
                   ),
-                Code(
-                  'default: throw ArgumentError(\'Value "\$index" cannot be converted to "${enumDefinition.className}"\');',
-                ),
+                ],
+                if (enumDefinition.defaultValue == null) ...[
+                  Code(
+                    'default: throw ArgumentError(\'Value "\$index" cannot be converted to "${enumDefinition.className}"\');',
+                  ),
+                ] else ...[
+                  Code(
+                    'default: return ${enumDefinition.className}.${enumDefinition.defaultValue!.name};',
+                  ),
+                ],
                 const Code('}'),
               ]))
             .build()),
@@ -2429,9 +2436,15 @@ class SerializableModelLibraryGenerator {
                   Code(
                     "case '${value.name}': return ${enumDefinition.className}.${value.name};",
                   ),
-                Code(
-                  'default: throw ArgumentError(\'Value "\$name" cannot be converted to "${enumDefinition.className}"\');',
-                ),
+                if (enumDefinition.defaultValue == null) ...[
+                  Code(
+                    'default: throw ArgumentError(\'Value "\$name" cannot be converted to "${enumDefinition.className}"\');',
+                  ),
+                ] else ...[
+                  Code(
+                    'default: return ${enumDefinition.className}.${enumDefinition.defaultValue!.name};',
+                  ),
+                ],
                 const Code('}'),
               ]))
             .build()),

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_type_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/class_type_test.dart
@@ -1,6 +1,7 @@
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
 import 'package:test/test.dart';
 
 import '../../../../test_util/builders/generator_config_builder.dart';
@@ -54,6 +55,8 @@ void main() {
 
     expect(model.type.className, model.className);
     expect(model.type.enumDefinition, model);
+    expect(model.defaultValue, isNull);
+    expect(model.serialized, EnumSerialization.byIndex);
   });
 
   test(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_default_value_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_default_value_test.dart
@@ -1,0 +1,102 @@
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/builders/model_source_builder.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  group('Given a valid enum definition when validating', () {
+    var modelSources = [
+      ModelSourceBuilder().withYaml(
+        '''
+        enum: ExampleEnum
+        values:
+          - first
+          - second
+        ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
+
+    var definitions = analyzer.validateAll();
+
+    var definition = definitions.first as EnumDefinition;
+
+    test('then no errors are collected', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then defaultValue is set to null.', () {
+      expect(definition.defaultValue, isNull);
+    });
+  });
+
+  group(
+      'Given a valid enum definition with default value set to valid value when validating',
+      () {
+    var modelSources = [
+      ModelSourceBuilder().withYaml(
+        '''
+        enum: ExampleEnum
+        default: first
+        values:
+          - first
+          - second
+        ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
+
+    var definitions = analyzer.validateAll();
+    var definition = definitions.first as EnumDefinition;
+
+    test('then no errors are collected', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then defaultValue is set to valid value.', () {
+      expect(definition.defaultValue, definition.values.first);
+    });
+  });
+
+  group(
+      'Given a valid enum definition with default value set to an invalid value when validating',
+      () {
+    var modelSources = [
+      ModelSourceBuilder().withYaml(
+        '''
+        enum: ExampleEnum
+        values:
+          - first
+          - second
+        ''',
+      ).build()
+    ];
+
+    var collector = CodeGenerationCollector();
+    var analyzer =
+        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
+
+    var definitions = analyzer.validateAll();
+
+    var definition = definitions.first as EnumDefinition;
+
+    test('then no errors are collected', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then defaultValue is set to valid value.', () {
+      expect(definition.defaultValue, isNull);
+    });
+  });
+}

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_default_value_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/enum_default_value_test.dart
@@ -12,31 +12,36 @@ void main() {
   group(
       'Given a valid enum definition with default value set to valid value when validating',
       () {
-    var modelSources = [
-      ModelSourceBuilder().withYaml(
-        '''
+    late CodeGenerationCollector collector;
+    late EnumDefinition definition;
+    setUp(() {
+      var modelSources = [
+        ModelSourceBuilder().withYaml(
+          '''
         enum: ExampleEnum
         default: first
         values:
           - first
           - second
         ''',
-      ).build()
-    ];
+        ).build()
+      ];
 
-    var collector = CodeGenerationCollector();
-    var analyzer =
-        StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
+      collector = CodeGenerationCollector();
+      var analyzer =
+          StatefulAnalyzer(config, modelSources, onErrorsCollector(collector));
 
-    var definitions = analyzer.validateAll();
-    var definition = definitions.first as EnumDefinition;
+      var definitions = analyzer.validateAll();
+      definition = definitions.first as EnumDefinition;
+    });
 
     test('then no errors are collected', () {
       expect(collector.errors, isEmpty);
     });
 
     test('then defaultValue is set to valid value.', () {
-      expect(definition.defaultValue, definition.values.first);
+      expect(definition.defaultValue, isNotNull);
+      expect(definition.defaultValue!.name, definition.values.first.name);
     });
   });
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/extra_properties_test.dart
@@ -442,7 +442,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'The "table" property is not allowed for enum type. Valid keys are {enum, serialized, serverOnly, values}.',
+          'The "table" property is not allowed for enum type. Valid keys are {enum, serialized, default, serverOnly, values}.',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_validation_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_validation_test.dart
@@ -171,7 +171,7 @@ void main() {
       var error = collector.errors.first;
       expect(
         error.message,
-        'The "fields" property is not allowed for enum type. Valid keys are {enum, serialized, serverOnly, values}.',
+        'The "fields" property is not allowed for enum type. Valid keys are {enum, serialized, default, serverOnly, values}.',
       );
     });
   });

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
@@ -50,6 +50,13 @@ void main() {
     test('then generated enum has toJson method', () {
       expect(codeMap[expectedFileName], contains('int toJson() => index;'));
     });
+
+    test('then generated enum has throw ArgumentError', () {
+      expect(
+          codeMap[expectedFileName],
+          contains(
+              'default:\n        throw ArgumentError(\'Value "\$index" cannot be converted to "Example"\');'));
+    });
   });
 
   group('Given an enum named Example serialized by name when generating code',
@@ -80,6 +87,13 @@ void main() {
         codeMap[expectedFileName],
         contains('String toString() => name;'),
       );
+    });
+
+    test('then generated enum has throw ArgumentError', () {
+      expect(
+          codeMap[expectedFileName],
+          contains(
+              'default:\n        throw ArgumentError(\'Value "\$name" cannot be converted to "Example"\');'));
     });
   });
 
@@ -170,6 +184,32 @@ void main() {
     test('then generated enum includes second value', () {
       expect(codeMap[expectedFileName],
           contains('// This is a comment for the second value'));
+    });
+  });
+
+  group('Given an enum with a default value when generating code', () {
+    var models = [
+      EnumDefinitionBuilder()
+          .withClassName('Example')
+          .withFileName('example')
+          .withValues([
+            ProtocolEnumValueDefinition('one', []),
+            ProtocolEnumValueDefinition('two', []),
+          ])
+          .withDefaultValue(
+            ProtocolEnumValueDefinition('one', []),
+          )
+          .build()
+    ];
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    test('then generated enum has the correct default value', () {
+      expect(codeMap[expectedFileName],
+          contains('default:\n        return Example.one;'));
     });
   });
 }

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/enum_field_test.dart
@@ -50,13 +50,6 @@ void main() {
     test('then generated enum has toJson method', () {
       expect(codeMap[expectedFileName], contains('int toJson() => index;'));
     });
-
-    test('then generated enum has throw ArgumentError', () {
-      expect(
-          codeMap[expectedFileName],
-          contains(
-              'default:\n        throw ArgumentError(\'Value "\$index" cannot be converted to "Example"\');'));
-    });
   });
 
   group('Given an enum named Example serialized by name when generating code',
@@ -87,13 +80,6 @@ void main() {
         codeMap[expectedFileName],
         contains('String toString() => name;'),
       );
-    });
-
-    test('then generated enum has throw ArgumentError', () {
-      expect(
-          codeMap[expectedFileName],
-          contains(
-              'default:\n        throw ArgumentError(\'Value "\$name" cannot be converted to "Example"\');'));
     });
   });
 
@@ -184,32 +170,6 @@ void main() {
     test('then generated enum includes second value', () {
       expect(codeMap[expectedFileName],
           contains('// This is a comment for the second value'));
-    });
-  });
-
-  group('Given an enum with a default value when generating code', () {
-    var models = [
-      EnumDefinitionBuilder()
-          .withClassName('Example')
-          .withFileName('example')
-          .withValues([
-            ProtocolEnumValueDefinition('one', []),
-            ProtocolEnumValueDefinition('two', []),
-          ])
-          .withDefaultValue(
-            ProtocolEnumValueDefinition('one', []),
-          )
-          .build()
-    ];
-
-    var codeMap = generator.generateSerializableModelsCode(
-      models: models,
-      config: config,
-    );
-
-    test('then generated enum has the correct default value', () {
-      expect(codeMap[expectedFileName],
-          contains('default:\n        return Example.one;'));
     });
   });
 }

--- a/tools/serverpod_cli/test/test_util/builders/enum_definition_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/enum_definition_builder.dart
@@ -8,7 +8,7 @@ class EnumDefinitionBuilder {
   String _sourceFileName;
   String _className;
   EnumSerialization _serialized;
-  ProtocolEnumValueDefinition? defaultValue;
+  ProtocolEnumValueDefinition? _defaultValue;
   List<String> _subDirParts;
   bool _serverOnly;
 
@@ -22,7 +22,7 @@ class EnumDefinitionBuilder {
         _serialized = EnumSerialization.byIndex,
         _subDirParts = [],
         _serverOnly = false,
-        defaultValue = ProtocolEnumValueDefinition('A'),
+        _defaultValue = null,
         _values = [
           ProtocolEnumValueDefinition('A'),
           ProtocolEnumValueDefinition('B'),
@@ -37,7 +37,7 @@ class EnumDefinitionBuilder {
       className: _className,
       serialized: _serialized,
       values: _values,
-      defaultValue: defaultValue,
+      defaultValue: _defaultValue,
       subDirParts: _subDirParts,
       serverOnly: _serverOnly,
       documentation: _documentation,
@@ -74,6 +74,12 @@ class EnumDefinitionBuilder {
 
   EnumDefinitionBuilder withSerialized(EnumSerialization serialized) {
     _serialized = serialized;
+    return this;
+  }
+
+  EnumDefinitionBuilder withDefaultValue(
+      ProtocolEnumValueDefinition defaultValue) {
+    _defaultValue = defaultValue;
     return this;
   }
 

--- a/tools/serverpod_cli/test/test_util/builders/enum_definition_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/enum_definition_builder.dart
@@ -8,6 +8,7 @@ class EnumDefinitionBuilder {
   String _sourceFileName;
   String _className;
   EnumSerialization _serialized;
+  ProtocolEnumValueDefinition? defaultValue;
   List<String> _subDirParts;
   bool _serverOnly;
 
@@ -21,6 +22,7 @@ class EnumDefinitionBuilder {
         _serialized = EnumSerialization.byIndex,
         _subDirParts = [],
         _serverOnly = false,
+        defaultValue = ProtocolEnumValueDefinition('A'),
         _values = [
           ProtocolEnumValueDefinition('A'),
           ProtocolEnumValueDefinition('B'),
@@ -35,6 +37,7 @@ class EnumDefinitionBuilder {
       className: _className,
       serialized: _serialized,
       values: _values,
+      defaultValue: defaultValue,
       subDirParts: _subDirParts,
       serverOnly: _serverOnly,
       documentation: _documentation,


### PR DESCRIPTION
Implements https://github.com/serverpod/serverpod/issues/3338 

By adding a new property in the enum fields

Just use the value name
```
enum: Example
serialized: byName
default: unknown
values:
  - unknown
  - customValue1
  - customValue2
```

With byIndex you still use the value name
```
enum: Example
serialized: byIndex
default: unknown
values:
  - unknown
  - customValue1
  - customValue2
```

## Pre-launch Checklist

- [X] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [X] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [X] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [X] I added new tests to check the change I am making.
- [X] All existing and new tests are passing.
- [X] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._

Everything is backwards compatible