### PR TITLE
feat(tests): Extend the compilation unit class matchers.

### DIFF
--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
@@ -196,7 +196,7 @@ abstract interface class ParameterMatcher {}
 /// A chainable matcher that matches a super initializer in a compilation unit.
 abstract interface class SuperInitializerMatcher {
   /// Chains an [ArgumentMatcher] that checks if the super initializer is called
-  /// with a specific argument.
+  /// with a specific literal argument.
   ArgumentMatcher withArgument(String value);
 
   /// Chains an [ArgumentMatcher] that checks if the super initializer is called

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
@@ -8,6 +8,7 @@ import 'compilation_unit_matcher/chainable_matcher.dart';
 part 'compilation_unit_matcher/argument_matcher/argument_matcher.dart';
 part 'compilation_unit_matcher/class_matcher/class_matcher.dart';
 part 'compilation_unit_matcher/constructor_matcher/constructor_matcher.dart';
+part 'compilation_unit_matcher/extends_matcher/extends_matcher.dart';
 part 'compilation_unit_matcher/field_matcher/field_matcher.dart';
 part 'compilation_unit_matcher/method_matcher/method_matcher.dart';
 part 'compilation_unit_matcher/parameter_matcher/parameter_matcher.dart';
@@ -28,8 +29,10 @@ part 'compilation_unit_matcher/super_initializer_matcher/super_initializer_match
 ///   │   ├── SuperInitializerMatcher
 ///   │   │   └── ArgumentMatcher
 ///   │   └── ParameterMatcher
-///   └── MethodMatcher
-///       └── ParameterMatcher
+///   ├── MethodMatcher
+///   │   └── ParameterMatcher
+///   └── ExtendsMatcher
+///
 ClassMatcher containsClass(String className) => _ClassMatcherImpl._(className);
 
 /// Parses a string of Dart code into a FormattedCompilationUnit.
@@ -42,6 +45,9 @@ abstract interface class ArgumentMatcher {}
 /// A matcher that checks if a CompilationUnit contains a class that matches
 /// certain criteria.
 abstract interface class ClassMatcher {
+  /// Chains a [ExtendsMatcher] that checks if the class extends a specific class.
+  ExtendsMatcher thatExtends(String className);
+
   /// Chains a [FieldMatcher] that checks if the class contains a field with a
   /// specific name.
   ///
@@ -138,6 +144,9 @@ abstract interface class ConstructorMatcher {
     bool? isRequired,
   });
 }
+
+/// A chainable matcher that matches the extension in a compilation unit.
+abstract interface class ExtendsMatcher {}
 
 /// A chainable matcher that matches a field in a compilation unit.
 abstract interface class FieldMatcher {}

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
@@ -10,6 +10,7 @@ part 'compilation_unit_matcher/class_matcher/class_matcher.dart';
 part 'compilation_unit_matcher/constructor_matcher/constructor_matcher.dart';
 part 'compilation_unit_matcher/extends_matcher/extends_matcher.dart';
 part 'compilation_unit_matcher/field_matcher/field_matcher.dart';
+part 'compilation_unit_matcher/generic_matcher/generic_matcher.dart';
 part 'compilation_unit_matcher/method_matcher/method_matcher.dart';
 part 'compilation_unit_matcher/parameter_matcher/parameter_matcher.dart';
 part 'compilation_unit_matcher/super_initializer_matcher/super_initializer_matcher.dart';
@@ -146,7 +147,9 @@ abstract interface class ConstructorMatcher {
 }
 
 /// A chainable matcher that matches the extension in a compilation unit.
-abstract interface class ExtendsMatcher {}
+abstract interface class ExtendsMatcher {
+  GenericMatcher withGeneric(String genericType);
+}
 
 /// A chainable matcher that matches a field in a compilation unit.
 abstract interface class FieldMatcher {}
@@ -161,6 +164,9 @@ class FormattedCompilationUnit {
     return DartFormatter().format(compilationUnit.toSource());
   }
 }
+
+/// A chainable matcher that matches a generic type in a compilation unit.
+abstract interface class GenericMatcher {}
 
 /// Initializer types for parameters.
 enum Initializer {

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
@@ -63,7 +63,10 @@ abstract interface class ClassMatcher {
   ///
   /// Use [isNullable] to match field nullability. If the value is not set, the
   /// matcher will ignore the nullability of the field.
-  FieldMatcher withField(String fieldName, {bool? isNullable});
+  ///
+  /// Use [isFinal] to match final fields. If the value is not set, the matcher
+  /// will ignore the final status of the field
+  FieldMatcher withField(String fieldName, {bool? isNullable, bool? isFinal});
 
   /// Chains a [MethodMatcher] that checks if the class contains a method with a
   /// specific name.

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher.dart
@@ -66,7 +66,15 @@ abstract interface class ClassMatcher {
   ///
   /// Use [isFinal] to match final fields. If the value is not set, the matcher
   /// will ignore the final status of the field
-  FieldMatcher withField(String fieldName, {bool? isNullable, bool? isFinal});
+  ///
+  /// Use [isLate] to match late fields. If the value is not set, the matcher
+  /// will ignore the late status of the field
+  FieldMatcher withField(
+    String fieldName, {
+    bool? isNullable,
+    bool? isFinal,
+    bool? isLate,
+  });
 
   /// Chains a [MethodMatcher] that checks if the class contains a method with a
   /// specific name.

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher.dart
@@ -47,7 +47,7 @@ class _ArgumentMatcherImpl extends Matcher implements ArgumentMatcher {
         'does not contain argument "$_value" in super initializer. Found arguments: [',
       );
       output.writeAll(
-        arguments.map((e) => e.toSource()),
+        arguments.value.map((e) => e.toSource()),
         ', ',
       );
       output.write(']');
@@ -89,10 +89,10 @@ class _ArgumentMatcherImpl extends Matcher implements ArgumentMatcher {
   }
 
   Iterable<Expression>? _featureValueOf(actual) {
-    var superInitializer = _parent.matchedFeatureValueOf(actual);
-    if (superInitializer == null) return null;
+    var match = _parent.matchedFeatureValueOf(actual);
+    if (match == null) return null;
 
-    return superInitializer.where((e) => e._hasMatchingValue(_value));
+    return match.value.where((e) => e._hasMatchingValue(_value));
   }
 }
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher.dart
@@ -134,8 +134,6 @@ extension on Expression {
       return resolvedThis.expression._hasMatchingValue(name);
     }
 
-    if (resolvedThis is! SimpleIdentifier) return false;
-
-    return resolvedThis.name == name;
+    return resolvedThis.toSource() == name;
   }
 }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/argument_matcher/argument_matcher_test.dart
@@ -191,4 +191,51 @@ void main() {
       );
     });
   });
+
+  group(
+      'Given compilation unit with class with super initializer with literal argument',
+      () {
+    late final compilationUnit = parseCode(
+      '''
+      class User extends Super {
+        User() : super('name');
+      }
+    ''',
+    );
+
+    test(
+        'when matching class, constructor, super initializer and argument then test passes',
+        () {
+      expect(
+        compilationUnit,
+        containsClass('User')
+            .withUnnamedConstructor()
+            .withSuperInitializer()
+            .withArgument("'name'"),
+      );
+    });
+  });
+
+  group(
+      'Given compilation unit with class with super initializer with identifier argument',
+      () {
+    late final compilationUnit = parseCode(
+      '''
+      class User extends Super {
+        User() : super(name);
+      }
+    ''',
+    );
+    test(
+        'when matching class, constructor, super initializer and argument then test passes',
+        () {
+      expect(
+        compilationUnit,
+        containsClass('User')
+            .withUnnamedConstructor()
+            .withSuperInitializer()
+            .withArgument('name'),
+      );
+    });
+  });
 }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/chainable_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/chainable_matcher.dart
@@ -1,13 +1,53 @@
 import 'package:test/test.dart';
 
-typedef MatchedFeatureValueOf<T> = T? Function(dynamic actual);
+/// Helper method to construct a [Match] object.
+///
+/// In order to construct a [Match] object, the [matchedItem] must be non-null.
+/// If the [matchedItem] is null, this method will return null.
+///
+/// [extractValue] is used to extract the value from the [matchedItem]
+/// that is then stored in the constructed [Match] object.
+Match<T>? _createMatch<T, V>({
+  required V? Function() resolveMatch,
+  required T Function(V value) extractValue,
+}) {
+  var matchedItem = resolveMatch();
+  if (matchedItem == null) return null;
+
+  return Match(extractValue(matchedItem));
+}
+
+typedef MatchedFeatureValueOf<T> = Match<T>? Function(dynamic actual);
 
 /// A matcher that can be chained with other matchers.
 class ChainableMatcher<T> {
   final Matcher _matcher;
   final MatchedFeatureValueOf<T> _matchedFeatureValueOf;
 
-  ChainableMatcher(this._matcher, this._matchedFeatureValueOf);
+  ChainableMatcher._(this._matcher, this._matchedFeatureValueOf);
+
+  /// Creates a matcher that can be chained with other matchers.
+  /// The [matcher] is the matcher that is chained.
+  ///
+  /// The [resolveMatch] function is used to determine if the contained matcher
+  /// matches the [actual] value. If the matcher matches, this should return the
+  /// resolved match. If the matcher does not match, this should return null.
+  ///
+  /// The [extractValue] function is used to extract the value from the resolved
+  /// match. This value is then stored in the [Match] object.
+  static ChainableMatcher<T> createMatcher<T, V>(
+    Matcher matcher, {
+    required V? Function(dynamic item) resolveMatch,
+    required T Function(V value) extractValue,
+  }) {
+    return ChainableMatcher<T>._(
+      matcher,
+      (actual) => _createMatch<T, V>(
+        resolveMatch: () => resolveMatch(actual),
+        extractValue: extractValue,
+      ),
+    );
+  }
 
   /// Describes the contained matcher. This is used to describe the matcher in
   /// the context of the chain.
@@ -31,7 +71,15 @@ class ChainableMatcher<T> {
 
   /// Checks if the matcher matches the given [actual] value.
   ///
-  /// If null is returned, this means that the contained matcher did not match
-  /// and the call to describeMismatch should be delegated to the matcher.
-  T? matchedFeatureValueOf(dynamic actual) => _matchedFeatureValueOf(actual);
+  /// Returns a [Match] object if the matcher matches the [actual] value.
+  /// If the matcher does not match, this method should return null and the call
+  /// to describeMismatch should be delegated to the matcher.
+  Match<T>? matchedFeatureValueOf(dynamic actual) =>
+      _matchedFeatureValueOf(actual);
+}
+
+/// A match that contains the value requested by the matcher.
+class Match<T> {
+  final T value;
+  Match(this.value);
 }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
@@ -42,6 +42,18 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
   }
 
   @override
+  ExtendsMatcher thatExtends(String className) {
+    return _ExtendsMatcherImpl._(
+      ChainableMatcher.createMatcher(
+        this,
+        resolveMatch: _matchedFeatureValueOf,
+        extractValue: (classDeclaration) => classDeclaration.extendsClause,
+      ),
+      name: className,
+    );
+  }
+
+  @override
   FieldMatcher withField(String fieldName, {bool? isNullable}) {
     return _FieldMatcherImpl._(
       ChainableMatcher.createMatcher(

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
@@ -1,12 +1,13 @@
 part of '../../compilation_unit_matcher.dart';
 
 class _ClassMatcherImpl implements Matcher, ClassMatcher {
-  final String className;
-  _ClassMatcherImpl._(this.className);
+  final String _className;
+
+  _ClassMatcherImpl._(this._className);
 
   @override
   Description describe(Description description) {
-    return description.add('a CompilationUnit containing class "$className"');
+    return description.add('a CompilationUnit containing class "$_className"');
   }
 
   @override
@@ -32,7 +33,7 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
         .join(', ');
 
     return mismatchDescription.add(
-        'does not contain class "$className". Found classes: [$classNames]');
+        'does not contain class "$_className". Found classes: [$classNames]');
   }
 
   @override
@@ -102,7 +103,7 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
 
     return resolvedActual.declarations
         .whereType<ClassDeclaration>()
-        .where((d) => d._hasMatchingClass(className))
+        .where((d) => d._hasMatchingClass(_className))
         .firstOrNull;
   }
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
@@ -54,17 +54,24 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
   }
 
   @override
-  FieldMatcher withField(String fieldName, {bool? isNullable, bool? isFinal}) {
+  FieldMatcher withField(
+    String fieldName, {
+    bool? isNullable,
+    bool? isFinal,
+    bool? isLate,
+  }) {
     return _FieldMatcherImpl._(
-        ChainableMatcher.createMatcher(
-          this,
-          resolveMatch: _matchedFeatureValueOf,
-          extractValue: (classDeclaration) =>
-              classDeclaration.members.whereType<FieldDeclaration>(),
-        ),
-        fieldName,
-        isNullable: isNullable,
-        isFinal: isFinal);
+      ChainableMatcher.createMatcher(
+        this,
+        resolveMatch: _matchedFeatureValueOf,
+        extractValue: (classDeclaration) =>
+            classDeclaration.members.whereType<FieldDeclaration>(),
+      ),
+      fieldName,
+      isNullable: isNullable,
+      isFinal: isFinal,
+      isLate: isLate,
+    );
   }
 
   @override

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
@@ -54,17 +54,17 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
   }
 
   @override
-  FieldMatcher withField(String fieldName, {bool? isNullable}) {
+  FieldMatcher withField(String fieldName, {bool? isNullable, bool? isFinal}) {
     return _FieldMatcherImpl._(
-      ChainableMatcher.createMatcher(
-        this,
-        resolveMatch: _matchedFeatureValueOf,
-        extractValue: (classDeclaration) =>
-            classDeclaration.members.whereType<FieldDeclaration>(),
-      ),
-      fieldName,
-      isNullable: isNullable,
-    );
+        ChainableMatcher.createMatcher(
+          this,
+          resolveMatch: _matchedFeatureValueOf,
+          extractValue: (classDeclaration) =>
+              classDeclaration.members.whereType<FieldDeclaration>(),
+        ),
+        fieldName,
+        isNullable: isNullable,
+        isFinal: isFinal);
   }
 
   @override

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/class_matcher/class_matcher.dart
@@ -44,11 +44,11 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
   @override
   FieldMatcher withField(String fieldName, {bool? isNullable}) {
     return _FieldMatcherImpl._(
-      ChainableMatcher(
+      ChainableMatcher.createMatcher(
         this,
-        (actual) => _matchedFeatureValueOf(actual)
-            ?.members
-            .whereType<FieldDeclaration>(),
+        resolveMatch: _matchedFeatureValueOf,
+        extractValue: (classDeclaration) =>
+            classDeclaration.members.whereType<FieldDeclaration>(),
       ),
       fieldName,
       isNullable: isNullable,
@@ -62,11 +62,11 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
     String? returnType,
   }) {
     return _MethodMatcherImpl._(
-      ChainableMatcher(
+      ChainableMatcher.createMatcher(
         this,
-        (actual) => _matchedFeatureValueOf(actual)
-            ?.members
-            .whereType<MethodDeclaration>(),
+        resolveMatch: _matchedFeatureValueOf,
+        extractValue: (classDeclaration) =>
+            classDeclaration.members.whereType<MethodDeclaration>(),
       ),
       methodName,
       isOverride: isOverride,
@@ -125,11 +125,11 @@ class _ClassMatcherImpl implements Matcher, ClassMatcher {
     bool? isFactory,
   }) {
     return _ConstructorMatcherImpl._(
-      ChainableMatcher(
+      ChainableMatcher.createMatcher(
         this,
-        (actual) => _matchedFeatureValueOf(actual)
-            ?.members
-            .whereType<ConstructorDeclaration>(),
+        resolveMatch: _matchedFeatureValueOf,
+        extractValue: (classDeclaration) =>
+            classDeclaration.members.whereType<ConstructorDeclaration>(),
       ),
       name: constructorName,
       isFactory: isFactory,

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher.dart
@@ -41,9 +41,7 @@ class _ExtendsMatcherImpl implements Matcher, ExtendsMatcher {
   @override
   bool matches(item, Map matchState) {
     var extendsClause = _featureValueOf(item);
-    if (extendsClause is! ExtendsClause) return false;
-
-    return extendsClause._hasMatchingClassName(_name);
+    return _matches(extendsClause);
   }
 
   ExtendsClause? _featureValueOf(actual) {
@@ -51,6 +49,34 @@ class _ExtendsMatcherImpl implements Matcher, ExtendsMatcher {
     if (match == null) return null;
 
     return match.value;
+  }
+
+  ExtendsClause? _matchedFeatureValueOf(dynamic actual) {
+    var extendsDeclaration = _featureValueOf(actual);
+    if (extendsDeclaration == null) return null;
+
+    if (!_matches(extendsDeclaration)) return null;
+
+    return extendsDeclaration;
+  }
+
+  bool _matches(ExtendsClause? extendsClause) {
+    if (extendsClause == null) return false;
+
+    return extendsClause._hasMatchingClassName(_name);
+  }
+
+  @override
+  GenericMatcher withGeneric(String genericType) {
+    return _GenericMatcherImpl._(
+      ChainableMatcher.createMatcher(
+        this,
+        resolveMatch: _matchedFeatureValueOf,
+        extractValue: (extendsClause) =>
+            extendsClause.superclass.typeArguments?.arguments ?? [],
+      ),
+      genericType,
+    );
   }
 }
 

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher.dart
@@ -1,0 +1,65 @@
+part of '../../compilation_unit_matcher.dart';
+
+class _ExtendsMatcherImpl implements Matcher, ExtendsMatcher {
+  final ChainableMatcher<ExtendsClause?> _parent;
+  final String _name;
+
+  _ExtendsMatcherImpl._(this._parent, {required String name}) : _name = name;
+
+  @override
+  Description describe(Description description) {
+    return _parent.describe(description).add(' that extends "$_name"');
+  }
+
+  @override
+  Description describeMismatch(
+    item,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
+    var match = _parent.matchedFeatureValueOf(item);
+    if (match == null) {
+      return _parent.describeMismatch(
+        item,
+        mismatchDescription,
+        matchState,
+        verbose,
+      );
+    }
+
+    var extendsClause = match.value;
+    if (extendsClause == null) {
+      return mismatchDescription.add('does not extend any class');
+    }
+
+    return mismatchDescription.add(
+      'extends the class "${extendsClause._getExtendedTypeName()}"',
+    );
+  }
+
+  @override
+  bool matches(item, Map matchState) {
+    var extendsClause = _featureValueOf(item);
+    if (extendsClause is! ExtendsClause) return false;
+
+    return extendsClause._hasMatchingClassName(_name);
+  }
+
+  ExtendsClause? _featureValueOf(actual) {
+    var match = _parent.matchedFeatureValueOf(actual);
+    if (match == null) return null;
+
+    return match.value;
+  }
+}
+
+extension on ExtendsClause {
+  String? _getExtendedTypeName() {
+    return superclass.name2.lexeme;
+  }
+
+  bool _hasMatchingClassName(String className) {
+    return _getExtendedTypeName() == className;
+  }
+}

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/extends_matcher/extends_matcher_test.dart
@@ -1,0 +1,89 @@
+import 'package:test/test.dart';
+
+import '../../compilation_unit_matcher.dart';
+
+void main() {
+  group('Given compilation unit with class that does not extend another class',
+      () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {}
+      ''',
+    );
+
+    test('when negate matching class and extention then test passes', () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').thatExtends('Parent')),
+      );
+    });
+
+    test(
+        'when matching with class name and non-existent extends then test fails',
+        () {
+      final matcher =
+          containsClass('User').thatExtends('NonExistentParent') as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        equals(
+          'does not extend any class',
+        ),
+      );
+    });
+  });
+
+  group('Given compilation unit with class that extends another class', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User extends Parent {}
+      ''',
+    );
+
+    test('when matching class and extention then test passes', () {
+      expect(
+        compilationUnit,
+        containsClass('User').thatExtends('Parent'),
+      );
+    });
+
+    test('when negate matching class and invalid extention then test passes',
+        () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').thatExtends('InvalidParent')),
+      );
+    });
+
+    test(
+        'when matching with class name and incorrect extends clause then test fails',
+        () {
+      final matcher =
+          containsClass('User').thatExtends('InvalidParent') as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        equals(
+          'extends the class "Parent"',
+        ),
+      );
+    });
+  });
+
+  test(
+      'Given matcher for class extending another class when fetching description then description is correct',
+      () {
+    final matcher = containsClass('User').thatExtends('Parent') as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      equals('a CompilationUnit containing class "User" that extends "Parent"'),
+    );
+  });
+}

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher.dart
@@ -23,8 +23,8 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
     Map matchState,
     bool verbose,
   ) {
-    var fieldDeclarations = parent.matchedFeatureValueOf(item);
-    if (fieldDeclarations == null) {
+    var match = parent.matchedFeatureValueOf(item);
+    if (match == null) {
       return parent.describeMismatch(
         item,
         mismatchDescription,
@@ -35,7 +35,7 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
 
     var fieldDecl = _featureValueOf(item);
     if (fieldDecl is! FieldDeclaration) {
-      final fieldNames = fieldDeclarations
+      final fieldNames = match.value
           .expand((f) => f.fields.variables)
           .map((v) => v.name.lexeme)
           .join(', ');
@@ -57,10 +57,10 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
   }
 
   FieldDeclaration? _featureValueOf(actual) {
-    var fieldDeclarations = parent.matchedFeatureValueOf(actual);
-    if (fieldDeclarations == null) return null;
+    var match = parent.matchedFeatureValueOf(actual);
+    if (match == null) return null;
 
-    return fieldDeclarations
+    return match.value
         .where((f) => f._hasMatchingVariable(fieldName))
         .firstOrNull;
   }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher.dart
@@ -5,11 +5,13 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
   final String fieldName;
   final bool? isNullable;
   final bool? isFinal;
+  final bool? isLate;
   _FieldMatcherImpl._(
     this.parent,
     this.fieldName, {
     required this.isNullable,
     required this.isFinal,
+    required this.isLate,
   });
 
   @override
@@ -17,6 +19,7 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
     var output = StringBuffer(' with a ');
     output.writeAll([
       if (isNullable != null) isNullable == true ? 'nullable' : 'non-nullable',
+      if (isLate != null) isLate == true ? 'late' : 'non-late',
       if (isFinal != null) isFinal == true ? 'final' : 'non-final',
       'field "$fieldName"',
     ], ' ');
@@ -56,10 +59,12 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
     var output = StringBuffer('contains field "$fieldName" but the field is ');
     output.writeAll(
       [
-        if (!fieldDecl._hasMatchingFinal(isFinal))
-          isFinal == true ? 'non-final' : 'final',
         if (!fieldDecl._hasMatchingNullable(isNullable))
           isNullable == true ? 'non-nullable' : 'nullable',
+        if (!fieldDecl._hasMatchingLate(isLate))
+          isLate == true ? 'non-late' : 'late',
+        if (!fieldDecl._hasMatchingFinal(isFinal))
+          isFinal == true ? 'non-final' : 'final',
       ],
       ' and ',
     );
@@ -74,6 +79,7 @@ class _FieldMatcherImpl extends Matcher implements FieldMatcher {
 
     if (!field._hasMatchingNullable(isNullable)) return false;
     if (!field._hasMatchingFinal(isFinal)) return false;
+    if (!field._hasMatchingLate(isLate)) return false;
     return true;
   }
 
@@ -98,6 +104,12 @@ extension on FieldDeclaration {
     if (isFinal == null) return true;
 
     return fields.isFinal == isFinal;
+  }
+
+  bool _hasMatchingLate(bool? isLate) {
+    if (isLate == null) return true;
+
+    return fields.isLate == isLate;
   }
 
   bool _hasMatchingVariable(String name) {

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_description_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_description_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+
+import '../../compilation_unit_matcher.dart';
+
+void main() {
+  test(
+      'Given field matcher when describing matcher then description is correct',
+      () {
+    final matcher = containsClass('User').withField('name') as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains('a CompilationUnit containing class "User" with a field "name"'),
+    );
+  });
+
+  test(
+      'Given field matcher for nullable field when describing matcher then description is correct',
+      () {
+    final matcher =
+        containsClass('User').withField('name', isNullable: true) as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains(
+          'a CompilationUnit containing class "User" with a nullable field "name"'),
+    );
+  });
+
+  test(
+      'Given field matcher for non-nullable field when describing matcher then description is correct',
+      () {
+    final matcher =
+        containsClass('User').withField('name', isNullable: false) as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains(
+          'a CompilationUnit containing class "User" with a non-nullable field "name"'),
+    );
+  });
+}

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_description_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_description_test.dart
@@ -45,4 +45,49 @@ void main() {
           'a CompilationUnit containing class "User" with a non-nullable field "name"'),
     );
   });
+
+  test(
+      'Given field matcher for final field when describing matcher then description is correct',
+      () {
+    final matcher =
+        containsClass('User').withField('name', isFinal: true) as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains(
+          'a CompilationUnit containing class "User" with a final field "name"'),
+    );
+  });
+
+  test(
+      'Given field matcher for non-final field when describing matcher then description is correct',
+      () {
+    final matcher =
+        containsClass('User').withField('name', isFinal: false) as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains(
+          'a CompilationUnit containing class "User" with a non-final field "name"'),
+    );
+  });
+
+  test(
+      'Given field matcher for nullable non-final field when describing matcher then description is correct',
+      () {
+    final matcher = containsClass('User')
+        .withField('name', isFinal: false, isNullable: true) as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains(
+          'a CompilationUnit containing class "User" with a nullable non-final field "name"'),
+    );
+  });
 }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_description_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_description_test.dart
@@ -77,17 +77,47 @@ void main() {
   });
 
   test(
-      'Given field matcher for nullable non-final field when describing matcher then description is correct',
+      'Given field matcher for late field when describing matcher then description is correct',
       () {
-    final matcher = containsClass('User')
-        .withField('name', isFinal: false, isNullable: true) as Matcher;
+    final matcher =
+        containsClass('User').withField('name', isLate: true) as Matcher;
     final description = StringDescription();
     matcher.describe(description);
 
     expect(
       description.toString(),
       contains(
-          'a CompilationUnit containing class "User" with a nullable non-final field "name"'),
+          'a CompilationUnit containing class "User" with a late field "name"'),
+    );
+  });
+
+  test(
+      'Given field matcher for non-late field when describing matcher then description is correct',
+      () {
+    final matcher =
+        containsClass('User').withField('name', isLate: false) as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains(
+          'a CompilationUnit containing class "User" with a non-late field "name"'),
+    );
+  });
+
+  test(
+      'Given field matcher for nullable late non-final field when describing matcher then description is correct',
+      () {
+    final matcher = containsClass('User').withField('name',
+        isFinal: false, isNullable: true, isLate: true) as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      contains(
+          'a CompilationUnit containing class "User" with a nullable late non-final field "name"'),
     );
   });
 }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_mismatch_description_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_mismatch_description_test.dart
@@ -1,0 +1,91 @@
+import 'package:test/test.dart';
+
+import '../../compilation_unit_matcher.dart';
+
+void main() {
+  group('Given compilation unit with class and no fields ', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {}
+      ''',
+    );
+    test(
+        'when matching with non-existent class then mismatch description is correct',
+        () {
+      final matcher =
+          containsClass('NonExistentClass').withField('name') as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        equals(
+          'does not contain class "NonExistentClass". Found classes: [User]',
+        ),
+      );
+    });
+  });
+
+  group('Given compilation unit with class and non-nullable field', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {
+        final String name;
+      }
+    ''',
+    );
+
+    test(
+        'when matching with non-existent field then mismatch description is correct',
+        () {
+      final matcher =
+          containsClass('User').withField('nonExistentField') as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains(
+            'does not contain field "nonExistentField". Found fields: [name]'),
+      );
+    });
+
+    test(
+        'when matching with nullable field then mismatch description is correct',
+        () {
+      final matcher =
+          containsClass('User').withField('name', isNullable: true) as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains('contains field "name" but the field is non-nullable'),
+      );
+    });
+  });
+
+  group('Given compilation unit with class and nullable field', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {
+        final String? name;
+      }
+    ''',
+    );
+
+    test(
+        'when matching with non-nullable field then mismatch description is correct',
+        () {
+      final matcher =
+          containsClass('User').withField('name', isNullable: false) as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains('contains field "name" but the field is nullable'),
+      );
+    });
+  });
+}

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_mismatch_description_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_mismatch_description_test.dart
@@ -26,7 +26,7 @@ void main() {
     });
   });
 
-  group('Given compilation unit with class and non-nullable field', () {
+  group('Given compilation unit with class and non-nullable final field', () {
     late final compilationUnit = parseCode(
       '''
       class User {
@@ -63,6 +63,35 @@ void main() {
         contains('contains field "name" but the field is non-nullable'),
       );
     });
+
+    test(
+        'when matching with non-final field then mismatch description is correct',
+        () {
+      final matcher =
+          containsClass('User').withField('name', isFinal: false) as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains('contains field "name" but the field is final'),
+      );
+    });
+
+    test(
+        'when matching with nullable non-final field then mismatch description is correct',
+        () {
+      final matcher = containsClass('User')
+          .withField('name', isFinal: false, isNullable: true) as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains(
+            'contains field "name" but the field is final and non-nullable'),
+      );
+    });
   });
 
   group('Given compilation unit with class and nullable field', () {
@@ -85,6 +114,29 @@ void main() {
       expect(
         description.toString(),
         contains('contains field "name" but the field is nullable'),
+      );
+    });
+  });
+
+  group('Given compilation unit with class and non-final field', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {
+        String name;
+      }
+    ''',
+    );
+
+    test('when matching with final field then mismatch description is correct',
+        () {
+      final matcher =
+          containsClass('User').withField('name', isFinal: true) as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains('contains field "name" but the field is non-final'),
       );
     });
   });

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_mismatch_description_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_mismatch_description_test.dart
@@ -26,7 +26,9 @@ void main() {
     });
   });
 
-  group('Given compilation unit with class and non-nullable final field', () {
+  group(
+      'Given compilation unit with class and non-nullable non-late final field',
+      () {
     late final compilationUnit = parseCode(
       '''
       class User {
@@ -78,18 +80,31 @@ void main() {
       );
     });
 
-    test(
-        'when matching with nullable non-final field then mismatch description is correct',
+    test('when matching with late field then mismatch description is correct',
         () {
-      final matcher = containsClass('User')
-          .withField('name', isFinal: false, isNullable: true) as Matcher;
+      final matcher =
+          containsClass('User').withField('name', isLate: true) as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains('contains field "name" but the field is non-late'),
+      );
+    });
+
+    test(
+        'when matching with nullable late non-final field then mismatch description is correct',
+        () {
+      final matcher = containsClass('User').withField('name',
+          isFinal: false, isNullable: true, isLate: true) as Matcher;
       final description = StringDescription();
       matcher.describeMismatch(compilationUnit, description, {}, false);
 
       expect(
         description.toString(),
         contains(
-            'contains field "name" but the field is final and non-nullable'),
+            'contains field "name" but the field is non-nullable and non-late and final'),
       );
     });
   });
@@ -137,6 +152,30 @@ void main() {
       expect(
         description.toString(),
         contains('contains field "name" but the field is non-final'),
+      );
+    });
+  });
+
+  group('Given compilation unit with class and late field', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {
+        late String name;
+      }
+    ''',
+    );
+
+    test(
+        'when matching with non-late field then mismatch description is correct',
+        () {
+      final matcher =
+          containsClass('User').withField('name', isLate: false) as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        contains('contains field "name" but the field is late'),
       );
     });
   });

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_test.dart
@@ -17,22 +17,6 @@ void main() {
         isNot(containsClass('User').withField('nonExistentField')),
       );
     });
-
-    test(
-        'when matching with non-existent class then mismatch description is correct',
-        () {
-      final matcher =
-          containsClass('NonExistentClass').withField('name') as Matcher;
-      final description = StringDescription();
-      matcher.describeMismatch(compilationUnit, description, {}, false);
-
-      expect(
-        description.toString(),
-        equals(
-          'does not contain class "NonExistentClass". Found classes: [User]',
-        ),
-      );
-    });
   });
 
   group('Given compilation unit with class and non-nullable field', () {
@@ -73,77 +57,6 @@ void main() {
         isNot(containsClass('NonExistentClass').withField('name')),
       );
     });
-
-    test(
-        'when matching with non-existent field then mismatch description is correct',
-        () {
-      final matcher =
-          containsClass('User').withField('nonExistentField') as Matcher;
-      final description = StringDescription();
-      matcher.describeMismatch(compilationUnit, description, {}, false);
-
-      expect(
-        description.toString(),
-        contains(
-            'does not contain field "nonExistentField". Found fields: [name]'),
-      );
-    });
-
-    test(
-        'when matching with nullable field then mismatch description is correct',
-        () {
-      final matcher =
-          containsClass('User').withField('name', isNullable: true) as Matcher;
-      final description = StringDescription();
-      matcher.describeMismatch(compilationUnit, description, {}, false);
-
-      expect(
-        description.toString(),
-        contains('contains field "name" but the field is non-nullable'),
-      );
-    });
-
-    test('when describing matcher then description is correct', () {
-      final matcher = containsClass('User').withField('name') as Matcher;
-      final description = StringDescription();
-      matcher.describe(description);
-
-      expect(
-        description.toString(),
-        contains(
-            'a CompilationUnit containing class "User" with a field "name"'),
-      );
-    });
-
-    test(
-        'when describing matcher with nullable field then description is correct',
-        () {
-      final matcher =
-          containsClass('User').withField('name', isNullable: true) as Matcher;
-      final description = StringDescription();
-      matcher.describe(description);
-
-      expect(
-        description.toString(),
-        contains(
-            'a CompilationUnit containing class "User" with a nullable field "name"'),
-      );
-    });
-
-    test(
-        'when describing matcher with non-nullable field then description is correct',
-        () {
-      final matcher =
-          containsClass('User').withField('name', isNullable: false) as Matcher;
-      final description = StringDescription();
-      matcher.describe(description);
-
-      expect(
-        description.toString(),
-        contains(
-            'a CompilationUnit containing class "User" with a non-nullable field "name"'),
-      );
-    });
   });
 
   group('Given compilation unit with class and nullable field', () {
@@ -174,62 +87,6 @@ void main() {
       expect(
         compilationUnit,
         isNot(containsClass('User').withField('name', isNullable: false)),
-      );
-    });
-
-    test(
-        'when matching with non-nullable field then mismatch description is correct',
-        () {
-      final matcher =
-          containsClass('User').withField('name', isNullable: false) as Matcher;
-      final description = StringDescription();
-      matcher.describeMismatch(compilationUnit, description, {}, false);
-
-      expect(
-        description.toString(),
-        contains('contains field "name" but the field is nullable'),
-      );
-    });
-
-    test('when describing matcher then description is correct', () {
-      final matcher = containsClass('User').withField('name') as Matcher;
-      final description = StringDescription();
-      matcher.describe(description);
-
-      expect(
-        description.toString(),
-        contains(
-            'a CompilationUnit containing class "User" with a field "name"'),
-      );
-    });
-
-    test(
-        'when describing matcher with nullable field then description is correct',
-        () {
-      final matcher =
-          containsClass('User').withField('name', isNullable: true) as Matcher;
-      final description = StringDescription();
-      matcher.describe(description);
-
-      expect(
-        description.toString(),
-        contains(
-            'a CompilationUnit containing class "User" with a nullable field "name"'),
-      );
-    });
-
-    test(
-        'when describing matcher with non-nullable field then description is correct',
-        () {
-      final matcher =
-          containsClass('User').withField('name', isNullable: false) as Matcher;
-      final description = StringDescription();
-      matcher.describe(description);
-
-      expect(
-        description.toString(),
-        contains(
-            'a CompilationUnit containing class "User" with a non-nullable field "name"'),
       );
     });
   });

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_test.dart
@@ -19,7 +19,7 @@ void main() {
     });
   });
 
-  group('Given compilation unit with class and non-nullable field', () {
+  group('Given compilation unit with class and non-nullable final field', () {
     late final compilationUnit = parseCode(
       '''
       class User {
@@ -42,10 +42,33 @@ void main() {
       );
     });
 
+    test('when matching class and final field then test passes', () {
+      expect(
+        compilationUnit,
+        containsClass('User').withField('name', isFinal: true),
+      );
+    });
+
+    test('when matching class and non-nullable final field then test passes',
+        () {
+      expect(
+        compilationUnit,
+        containsClass('User')
+            .withField('name', isNullable: false, isFinal: true),
+      );
+    });
+
     test('when negate matching class and nullable field then test passes', () {
       expect(
         compilationUnit,
         isNot(containsClass('User').withField('name', isNullable: true)),
+      );
+    });
+
+    test('when negate matching class and non-final field then test passes', () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').withField('name', isFinal: false)),
       );
     });
 
@@ -87,6 +110,30 @@ void main() {
       expect(
         compilationUnit,
         isNot(containsClass('User').withField('name', isNullable: false)),
+      );
+    });
+  });
+
+  group('Given compilation unit with class and non-final field', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {
+        String name;
+      }
+    ''',
+    );
+
+    test('when matching class and non-final field then test passes', () {
+      expect(
+        compilationUnit,
+        containsClass('User').withField('name', isFinal: false),
+      );
+    });
+
+    test('when negate matching class and final field then test passes', () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').withField('name', isFinal: true)),
       );
     });
   });

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/field_matcher/field_matcher_test.dart
@@ -19,7 +19,9 @@ void main() {
     });
   });
 
-  group('Given compilation unit with class and non-nullable final field', () {
+  group(
+      'Given compilation unit with class and non-nullable non-late final field',
+      () {
     late final compilationUnit = parseCode(
       '''
       class User {
@@ -49,12 +51,20 @@ void main() {
       );
     });
 
-    test('when matching class and non-nullable final field then test passes',
+    test('when matching class and non-late field then test passes', () {
+      expect(
+        compilationUnit,
+        containsClass('User').withField('name', isLate: false),
+      );
+    });
+
+    test(
+        'when matching class and non-nullable non-late final field then test passes',
         () {
       expect(
         compilationUnit,
         containsClass('User')
-            .withField('name', isNullable: false, isFinal: true),
+            .withField('name', isNullable: false, isFinal: true, isLate: false),
       );
     });
 
@@ -69,6 +79,13 @@ void main() {
       expect(
         compilationUnit,
         isNot(containsClass('User').withField('name', isFinal: false)),
+      );
+    });
+
+    test('when negate matching class and late field then test passes', () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').withField('name', isLate: true)),
       );
     });
 
@@ -134,6 +151,31 @@ void main() {
       expect(
         compilationUnit,
         isNot(containsClass('User').withField('name', isFinal: true)),
+      );
+    });
+  });
+
+  group('Given compilation unit with class and late final field', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User {
+        late final String name;
+      }
+    ''',
+    );
+
+    test('when matching class and late final field then test passes', () {
+      expect(
+        compilationUnit,
+        containsClass('User').withField('name', isLate: true),
+      );
+    });
+
+    test('when negate matching class and non-late final field then test passes',
+        () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').withField('name', isLate: false)),
       );
     });
   });

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/generic_matcher/generic_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/generic_matcher/generic_matcher.dart
@@ -1,0 +1,55 @@
+part of '../../compilation_unit_matcher.dart';
+
+class _GenericMatcherImpl implements Matcher, GenericMatcher {
+  final ChainableMatcher<Iterable<TypeAnnotation>> _parent;
+  final String _generic;
+
+  _GenericMatcherImpl._(this._parent, this._generic);
+
+  @override
+  Description describe(Description description) {
+    return _parent.describe(description).add(' with generic "$_generic"');
+  }
+
+  @override
+  Description describeMismatch(
+    item,
+    Description mismatchDescription,
+    Map matchState,
+    bool verbose,
+  ) {
+    var match = _parent.matchedFeatureValueOf(item);
+    if (match == null) {
+      return _parent.describeMismatch(
+        item,
+        mismatchDescription,
+        matchState,
+        verbose,
+      );
+    }
+
+    var typeParameters = match.value;
+    if (typeParameters.isEmpty) {
+      return mismatchDescription.add('does not have any generics');
+    }
+
+    return mismatchDescription.add(
+      'does not have the generic "$_generic". Found generics: [${typeParameters.map((e) => e.toSource()).join(', ')}]',
+    );
+  }
+
+  @override
+  bool matches(item, Map matchState) {
+    var typeParameters = _featureValueOf(item);
+    if (typeParameters == null) return false;
+
+    return typeParameters.where((e) => e.toSource() == _generic).isNotEmpty;
+  }
+
+  Iterable<TypeAnnotation>? _featureValueOf(actual) {
+    var match = _parent.matchedFeatureValueOf(actual);
+    if (match == null) return null;
+
+    return match.value;
+  }
+}

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/generic_matcher/generic_matcher_test.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/generic_matcher/generic_matcher_test.dart
@@ -1,0 +1,134 @@
+import 'package:test/test.dart';
+
+import '../../compilation_unit_matcher.dart';
+
+void main() {
+  group('Given a class with an extends clause that has no generics', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User extends Parent {}
+      ''',
+    );
+
+    test(
+        'when negate matching with non-existent generic on the extended class then test passes',
+        () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').thatExtends('Parent').withGeneric('T')),
+      );
+    });
+
+    test(
+        'when matching with non-existent generic on the extended class then mismatch description is correct',
+        () {
+      final matcher = containsClass('User')
+          .thatExtends('Parent')
+          .withGeneric('T') as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        equals('does not have any generics'),
+      );
+    });
+  });
+
+  group('Given a class with an extends clause that has generics', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User extends Parent<T> {}
+      ''',
+    );
+
+    test('when matching generic on the extended class then test passes', () {
+      expect(
+        compilationUnit,
+        containsClass('User').thatExtends('Parent').withGeneric('T'),
+      );
+    });
+
+    test(
+        'when negate matching non-existent generic on the extended class then test passes',
+        () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').thatExtends('Parent').withGeneric('X')),
+      );
+    });
+
+    test(
+        'when matching incorrect generic on the extended class then test fails',
+        () {
+      final matcher = containsClass('User')
+          .thatExtends('Parent')
+          .withGeneric('X') as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        equals(
+          'does not have the generic "X". Found generics: [T]',
+        ),
+      );
+    });
+  });
+
+  group('Given a class with an extends clause that with multiple generics', () {
+    late final compilationUnit = parseCode(
+      '''
+      class User extends Parent<T, V> {}
+      ''',
+    );
+
+    test('when matching generic on the extended class then test passes', () {
+      expect(
+        compilationUnit,
+        containsClass('User').thatExtends('Parent').withGeneric('V'),
+      );
+    });
+
+    test(
+        'when negate matching non-existent generic on the extended class then test passes',
+        () {
+      expect(
+        compilationUnit,
+        isNot(containsClass('User').thatExtends('Parent').withGeneric('X')),
+      );
+    });
+
+    test(
+        'when matching incorrect generic on the extended class then test fails',
+        () {
+      final matcher = containsClass('User')
+          .thatExtends('Parent')
+          .withGeneric('X') as Matcher;
+      final description = StringDescription();
+      matcher.describeMismatch(compilationUnit, description, {}, false);
+
+      expect(
+        description.toString(),
+        equals(
+          'does not have the generic "X". Found generics: [T, V]',
+        ),
+      );
+    });
+  });
+
+  test(
+      'Given generics matcher with when describing matcher then description is correct',
+      () {
+    final matcher =
+        containsClass('User').thatExtends('Parent').withGeneric('T') as Matcher;
+    final description = StringDescription();
+    matcher.describe(description);
+
+    expect(
+      description.toString(),
+      equals(
+          'a CompilationUnit containing class "User" that extends "Parent" with generic "T"'),
+    );
+  });
+}

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/method_matcher/method_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/method_matcher/method_matcher.dart
@@ -38,8 +38,8 @@ class _MethodMatcherImpl extends Matcher implements MethodMatcher {
     Map matchState,
     bool verbose,
   ) {
-    var methodDeclarations = _parent.matchedFeatureValueOf(item);
-    if (methodDeclarations == null) {
+    var match = _parent.matchedFeatureValueOf(item);
+    if (match == null) {
       return _parent.describeMismatch(
         item,
         mismatchDescription,
@@ -53,7 +53,7 @@ class _MethodMatcherImpl extends Matcher implements MethodMatcher {
     if (methodDecl == null) {
       output.write('does not contain method "$_name". Found methods: [');
       output.writeAll(
-        methodDeclarations.map((m) => m.name.lexeme),
+        match.value.map((m) => m.name.lexeme),
         ', ',
       );
       output.write(']');
@@ -84,8 +84,12 @@ class _MethodMatcherImpl extends Matcher implements MethodMatcher {
     bool? isRequired,
   }) {
     return _ParameterMatcherImpl._(
-      ChainableMatcher(this,
-          (actual) => _matchedFeatureValueOf(actual)?.parameters?.parameters),
+      ChainableMatcher.createMatcher(
+        this,
+        resolveMatch: _matchedFeatureValueOf,
+        extractValue: (methodDeclaration) =>
+            methodDeclaration.parameters?.parameters ?? [],
+      ),
       parameterName,
       type: type,
       isRequired: isRequired,
@@ -93,10 +97,10 @@ class _MethodMatcherImpl extends Matcher implements MethodMatcher {
   }
 
   MethodDeclaration? _featureValueOf(actual) {
-    var methodDeclarations = _parent.matchedFeatureValueOf(actual);
-    if (methodDeclarations == null) return null;
+    var match = _parent.matchedFeatureValueOf(actual);
+    if (match == null) return null;
 
-    return methodDeclarations.where((m) => m.name.lexeme == _name).firstOrNull;
+    return match.value.where((m) => m.name.lexeme == _name).firstOrNull;
   }
 
   MethodDeclaration? _matchedFeatureValueOf(dynamic actual) {

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/parameter_matcher/parameter_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/parameter_matcher/parameter_matcher.dart
@@ -43,8 +43,8 @@ class _ParameterMatcherImpl extends Matcher implements ParameterMatcher {
     Map matchState,
     bool verbose,
   ) {
-    var formalParameters = parent.matchedFeatureValueOf(item);
-    if (formalParameters == null) {
+    var match = parent.matchedFeatureValueOf(item);
+    if (match == null) {
       return parent.describeMismatch(
         item,
         mismatchDescription,
@@ -55,7 +55,7 @@ class _ParameterMatcherImpl extends Matcher implements ParameterMatcher {
 
     var parameterDecl = _featureValueOf(item);
     if (parameterDecl is! FormalParameter) {
-      final parameterNames = formalParameters
+      final parameterNames = match.value
           .map((p) => p.name?.lexeme)
           .where((e) => e != null)
           .join(', ');
@@ -109,10 +109,10 @@ class _ParameterMatcherImpl extends Matcher implements ParameterMatcher {
   }
 
   FormalParameter? _featureValueOf(actual) {
-    var constructorDecl = parent.matchedFeatureValueOf(actual);
-    if (constructorDecl == null) return null;
+    var match = parent.matchedFeatureValueOf(actual);
+    if (match == null) return null;
 
-    return constructorDecl
+    return match.value
         .where((p) => p.name?.lexeme == parameterName)
         .firstOrNull;
   }

--- a/tools/serverpod_cli/test/test_util/compilation_unit_matcher/super_initializer_matcher/super_initializer_matcher.dart
+++ b/tools/serverpod_cli/test/test_util/compilation_unit_matcher/super_initializer_matcher/super_initializer_matcher.dart
@@ -1,7 +1,7 @@
 part of '../../compilation_unit_matcher.dart';
 
 class _SuperInitializerMatcherImpl implements Matcher, SuperInitializerMatcher {
-  final ChainableMatcher<Iterable<SuperConstructorInvocation>> parent;
+  final ChainableMatcher<SuperConstructorInvocation?> parent;
 
   _SuperInitializerMatcherImpl._(this.parent);
 
@@ -55,10 +55,10 @@ class _SuperInitializerMatcherImpl implements Matcher, SuperInitializerMatcher {
   }
 
   SuperConstructorInvocation? _featureValueOf(actual) {
-    var superConstructorInvocations = parent.matchedFeatureValueOf(actual);
-    if (superConstructorInvocations == null) return null;
+    var match = parent.matchedFeatureValueOf(actual);
+    if (match == null) return null;
 
-    return superConstructorInvocations.firstOrNull;
+    return match.value;
   }
 
   SuperConstructorInvocation? _matchedFeatureValueOf(actual) {
@@ -76,9 +76,11 @@ class _SuperInitializerMatcherImpl implements Matcher, SuperInitializerMatcher {
 
   ArgumentMatcher _withArgument(String name, {_ParameterType? parameterType}) {
     return _ArgumentMatcherImpl._(
-        ChainableMatcher(
+        ChainableMatcher.createMatcher(
           this,
-          (actual) => _matchedFeatureValueOf(actual)?.argumentList.arguments,
+          resolveMatch: _matchedFeatureValueOf,
+          extractValue: (superInitializer) =>
+              superInitializer.argumentList.arguments,
         ),
         name,
         parameterType);


### PR DESCRIPTION
Extends the compilation unit class matchers.

The goal was to migrate the class `table_class_test.dart`, but become of time limitations I wasn't able to finish the port.

The extensions to the class matches implemented here are part of that work and can be added to the framework to enable more concurrent migrations directly on the main.

This PR also contains a minor fix.
- Ensures that argument matches also match against literal values such as `bool` or `String.`

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - These are simple test matcher additions.