### PR TITLE
fix: Report exceptions during database start and healthcheck operations

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -235,7 +235,9 @@ class Serverpod {
       if (settings != null) {
         _updateLogSettings(settings);
       }
-    } catch (_) {
+    } catch (e, stackTrace) {
+      const message = 'Failed to reload runtime settings.';
+      _reportException(e, stackTrace, message: message);
       return;
     }
   }
@@ -252,9 +254,12 @@ class Serverpod {
         settings.id = oldRuntimeSettings.id;
         await internal.RuntimeSettings.db.updateRow(internalSession, settings);
       }
-    } catch (error, stackTrace) {
-      logVerbose(error.toString());
-      logVerbose(stackTrace.toString());
+    } catch (e, stackTrace) {
+      _reportException(
+        e,
+        stackTrace,
+        message: 'Failed to store runtime settings',
+      );
     }
   }
 
@@ -612,8 +617,10 @@ class Serverpod {
         session: internalSession,
         maxAttempts: maxAttempts,
       );
-    } catch (e) {
-      throw ExitException(1, 'Failed to connect to the database: $e');
+    } catch (e, stackTrace) {
+      const message = 'Failed to connect to the database.';
+      _reportException(e, stackTrace, message: message);
+      throw ExitException(1, '$message: $e');
     }
 
     try {
@@ -654,22 +661,20 @@ class Serverpod {
 
       logVerbose('Verifying database integrity.');
       await migrationManager.verifyDatabaseIntegrity(internalSession);
-    } catch (e) {
+    } catch (e, stackTrace) {
       _exitCode = 1;
-      stderr.writeln(
-        'Failed to apply database migrations. $e',
-      );
+      const message = 'Failed to apply database migrations.';
+      _reportException(e, stackTrace, message: message);
     }
 
     logVerbose('Loading runtime settings.');
     try {
       _runtimeSettings =
           await internal.RuntimeSettings.db.findFirstRow(internalSession);
-    } catch (e) {
+    } catch (e, stackTrace) {
       _exitCode = 1;
-      stderr.writeln(
-        'Failed to load runtime settings. $e',
-      );
+      const message = 'Failed to load runtime settings.';
+      _reportException(e, stackTrace, message: message);
     }
 
     if (_runtimeSettings == null) {
@@ -677,11 +682,10 @@ class Serverpod {
       try {
         _runtimeSettings = await RuntimeSettings.db
             .insertRow(internalSession, _defaultRuntimeSettings);
-      } catch (e) {
+      } catch (e, stackTrace) {
         _exitCode = 1;
-        stderr.writeln(
-          'Failed to store runtime settings. $e',
-        );
+        const message = 'Failed to store runtime settings.';
+        _reportException(e, stackTrace, message: message);
       }
     } else {
       logVerbose('Runtime settings loaded.');
@@ -942,11 +946,11 @@ class Serverpod {
     StackTrace stackTrace, {
     String? message,
   }) {
+    var now = DateTime.now().toUtc();
     if (message != null) {
-      message = '${DateTime.now().toUtc()} $message';
-      stderr.writeln(message);
+      stderr.writeln('$now ERROR: $message');
     }
-    stderr.writeln('$e');
+    stderr.writeln('$now ERROR: $e');
     stderr.writeln('$stackTrace');
 
     internalSubmitEvent(
@@ -973,11 +977,11 @@ class Serverpod {
       try {
         await session.db.testConnection();
         return session;
-      } catch (e) {
-        // Write connection error to stderr.
-        stderr.writeln(
-          'Failed to connect to the database. Retrying in 10 seconds. $e',
-        );
+      } catch (e, stackTrace) {
+        const message = 'Failed to connect to the database.';
+        _reportException(e, stackTrace, message: message);
+
+        stderr.writeln('Retrying to connect to the database in 10 seconds.');
         if (!printedDatabaseConnectionError) {
           stderr.writeln('Database configuration:');
           stderr.writeln(config.database.toString());

--- a/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
+++ b/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
@@ -283,7 +283,7 @@ void main() {
   });
 
   group(
-      'Given a serverpod server with a missing database and a diagnostic event handler, '
+      'Given a serverpod server with a diagnostic event handler and a missing database, '
       'when starting serverpod', () {
     var exceptionHandler = TestExceptionHandler();
     late Serverpod pod;

--- a/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
+++ b/tests/serverpod_test_server/test_integration/diagnostics/diagnostic_events_test.dart
@@ -281,4 +281,83 @@ void main() {
       expect(record.context, isA<WebCallOpContext>());
     });
   });
+
+  group(
+      'Given a serverpod server with a missing database and a diagnostic event handler, '
+      'when starting serverpod', () {
+    var exceptionHandler = TestExceptionHandler();
+    late Serverpod pod;
+    late DiagnosticEventRecord<ExceptionEvent> record;
+
+    setUpAll(() async {
+      exceptionHandler = TestExceptionHandler();
+
+      final config = ServerpodConfig(
+        database: DatabaseConfig(
+          host: 'localhost',
+          port: 9999,
+          user: 'postgres',
+          password: 'postgres',
+          name: 'postgres',
+        ),
+        apiServer: ServerConfig(
+          port: 8080,
+          publicHost: 'localhost',
+          publicPort: 8080,
+          publicScheme: 'http',
+        ),
+      );
+      pod = IntegrationTestServer.create(
+        config: config,
+        experimentalFeatures: ExperimentalFeatures(
+          diagnosticEventHandlers: [exceptionHandler],
+        ),
+      );
+      final result = pod
+          .start(runInGuardedZone: false)
+          .timeout(const Duration(seconds: 2));
+      await expectLater(result, throwsA(isA<TimeoutException>()));
+      record = await exceptionHandler.events.first.timeout(timeout);
+    });
+
+    tearDownAll(() async {
+      await pod.shutdown(exitProcess: false);
+      exceptionHandler.eventsStreamController.close();
+    });
+
+    test('then the diagnostic event handler gets called with a Exception',
+        () async {
+      expect(record.event.exception, isA<SocketException>());
+    });
+
+    test('then the diagnostic event exception message is correct', () async {
+      expect((record.event.exception as SocketException).message,
+          contains('Connection refused'));
+    });
+
+    test('then the diagnostic event message is correct', () async {
+      expect(record.event.message,
+          startsWith('Failed to connect to the database'));
+    });
+
+    test('then the diagnostic event space is framework', () async {
+      expect(record.space, equals(OriginSpace.framework));
+    });
+
+    test('then the diagnostic event context is a DiagnosticEventContext',
+        () async {
+      expect(record.context.runtimeType, DiagnosticEventContext);
+    });
+
+    test('then the diagnostic event context has the expected content',
+        () async {
+      expect(
+          record.context.toJson(),
+          allOf([
+            containsPair('serverId', 'default'),
+            containsPair('serverName', ''),
+            containsPair('serverRunMode', 'production'),
+          ]));
+    });
+  });
 }


### PR DESCRIPTION
Report exception events during database startup and health-check operations via the diagnostics handler. These areas were not covered before as reported in issue #3294.

Closes #3294 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

n/a