### PR TITLE
chore: Bump googleapis_auth to allow 2.0.0 release.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   openid_client: ^0.4.8
   meta: ^1.8.0
   googleapis: '>=11.0.0 <15.0.0'
-  googleapis_auth: ^1.6.0
+  googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.0.0 <2.0.0'
   image: ^4.0.15
   jose: ^0.3.3

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   openid_client: ^0.4.8
   meta: ^1.8.0
   googleapis: '>=11.0.0 <15.0.0'
-  googleapis_auth: ^1.6.0
+  googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.0.0 <2.0.0'
   image: ^4.0.15
   jose: ^0.3.3


### PR DESCRIPTION
Adds a span for `googleapis_auth` to allow then new `2.0.0` release.

The deprecated `auth.dart` and `RefreshFailedException` are not used by Serverpod internally so the version range should be OK.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - simple dependency widening.