### PR TITLE
chore: Bump sign_in_with_apple dependency.

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   material_design_icons_flutter: ">=6.0.0 < 8.0.0"
   serverpod_auth_client: 2.5.0
   serverpod_auth_shared_flutter: 2.5.0
-  sign_in_with_apple: '>=5.0.0 <7.0.0'
+  sign_in_with_apple: '>=6.0.0 <8.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_apple_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   material_design_icons_flutter: ">=6.0.0 < 8.0.0"
   serverpod_auth_client: SERVERPOD_VERSION
   serverpod_auth_shared_flutter: SERVERPOD_VERSION
-  sign_in_with_apple: '>=5.0.0 <7.0.0'
+  sign_in_with_apple: '>=6.0.0 <8.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Bumps the minimum version to `6.0.0` since that is the first version that is supported by Dart `3.3` which is Serverpods minimum required version.

Bumps that max version to `<8.0.0` to allow the new `7.x.x` major version.

None of the features mentioned in the changelog are used by the authentication method.

Changelog: https://pub.dev/packages/sign_in_with_apple/changelog
Version and SDK: https://pub.dev/packages/sign_in_with_apple/versions

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._