### PR TITLE
fix: Avoid unnecessary stacktrace in windows when performing health checks

### DIFF
--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -7,8 +7,8 @@ import 'package:serverpod/src/database/database_pool_manager.dart';
 import 'package:serverpod/src/server/command_line_args.dart';
 import 'package:serverpod/src/server/health_check.dart';
 import 'package:serverpod/src/server/serverpod.dart';
-import 'package:system_resources/system_resources.dart';
 import 'package:serverpod/src/util/date_time_extension.dart';
+import 'package:system_resources/system_resources.dart';
 
 /// Performs health checks on the server once a minute, typically this class
 /// is managed internally by Serverpod. Writes results to the database.
@@ -31,21 +31,14 @@ class HealthCheckManager {
   /// Starts the health check manager.
   Future<void> start() async {
     _running = true;
+
     try {
       await SystemResources.init();
-    } catch (e, stackTrace) {
-      if (!Platform.isWindows) {
-        _reportException(
-          e,
-          stackTrace,
-          message:
-              'CPU and memory usage metrics are not supported on this platform.',
-        );
-      } else {
-        stderr.writeln(
-            'WARNING: CPU and memory usage metrics are not supported on this platform.');
-      }
+    } catch (e) {
+      stderr.writeln(
+          'WARNING: CPU and memory usage metrics are not supported on this platform.');
     }
+
     _scheduleNextCheck();
   }
 

--- a/packages/serverpod/lib/src/server/health_check_manager.dart
+++ b/packages/serverpod/lib/src/server/health_check_manager.dart
@@ -34,12 +34,17 @@ class HealthCheckManager {
     try {
       await SystemResources.init();
     } catch (e, stackTrace) {
-      _reportException(
-        e,
-        stackTrace,
-        message:
-            'CPU and memory usage metrics are not supported on this platform.',
-      );
+      if (!Platform.isWindows) {
+        _reportException(
+          e,
+          stackTrace,
+          message:
+              'CPU and memory usage metrics are not supported on this platform.',
+        );
+      } else {
+        stderr.writeln(
+            'WARNING: CPU and memory usage metrics are not supported on this platform.');
+      }
     }
     _scheduleNextCheck();
   }


### PR DESCRIPTION
Fixes https://github.com/serverpod/serverpod/issues/3394

Avoid debug console pollution with unnecessary stackstrace because the used package does not support windows. (https://github.com/jonasroussel/system_resources/issues/3).


Fixes https://github.com/serverpod/serverpod/issues/3394

## Pre-launch Checklist

- [x ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x ] I listed at least one issue that this PR fixes in the description above.
- [x ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.