### PR TITLE
fix: Restrict version check to serverpod, and serverpod_client packages

### DIFF
--- a/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
+++ b/tools/serverpod_cli/lib/src/serverpod_packages_version_check/serverpod_packages_version_check.dart
@@ -17,7 +17,10 @@ class ServerpodPackagesVersionCheckWarnings {
 
 extension on PubspecPlus {
   Iterable<HostedDep> get serverpodDeps =>
-      deps.whereType<HostedDep>().where((d) => d.name.startsWith('serverpod'));
+      deps.whereType<HostedDep>().where((d) => const [
+            'serverpod',
+            'serverpod_client',
+          ].contains(d.name));
 }
 
 List<SourceSpanSeverityException> validateServerpodPackagesVersion(

--- a/tools/serverpod_cli/test/integration/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
+++ b/tools/serverpod_cli/test/integration/serverpod_packages_version_check/serverpod_packages_version_check_test.dart
@@ -16,7 +16,8 @@ void main() {
       late final explicitVersion = PubspecPlus.parse('''
 name: x
 dependencies:
-  serverpod_shared: 1.1.0
+  serverpod_cloud_lints: 0.9.0 # ignored as this dependency is not relevant for codegen
+  serverpod_client: 1.1.0
 ''');
 
       test(
@@ -89,7 +90,8 @@ dependencies:
       late final approximateVersion = PubspecPlus.parse('''
 name: x
 dependencies:
-  serverpod_shared: ^1.1.0
+  serverpod_cloud_lints: 0.9.0 # ignored as this dependency is not relevant for codegen
+  serverpod_client: ^1.1.0
 ''');
 
       group('when calling validateServerpodPackagesVersion matching version',


### PR DESCRIPTION
Restrict the packages that must match the version of `serverpod_cli`, when running the generate command.

Now we only check `serverpod_client` and `serverpod` which matches the imports used in the generated code.

Fixes: #3397

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make mulxiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [daxt format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as othxr Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None.
