### PR TITLE
fix: Make serverpod generate compatible with workspaces.

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0
-  pubspec_parse: ^1.2.2
+  pubspec_parse: ^1.4.0
   source_span: ^1.10.0
   super_string: ^1.0.3
   watcher: ^1.0.2

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -43,6 +43,7 @@ dev_dependencies:
   serverpod_lints: SERVERPOD_VERSION
   term_glyph: ^1.2.2
   test: ^1.24.2
+  test_descriptor: ^2.0.2
 
 dependency_overrides:
   serverpod_shared:

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -337,6 +337,7 @@ class GeneratorConfig implements ModelLoadConfig {
 
     var modules = loadModuleConfigs(
       packageConfig: packageConfig,
+      projectPubspec: pubspec,
       nickNameOverrides: manualModules,
     );
 

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -103,7 +103,7 @@ List<ModuleConfig> _loadModuleConfigs({
       var packageSrcRoot = packageInfo.root;
 
       var generatorConfigUri =
-          packageInfo.root.resolve(path.joinAll(['config', 'generator.yaml']));
+          packageSrcRoot.resolve(path.joinAll(['config', 'generator.yaml']));
 
       var generatorConfigFile = File.fromUri(generatorConfigUri);
       if (!generatorConfigFile.existsSync()) {

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -100,29 +100,18 @@ List<ModuleConfig> _loadModuleConfigs({
     try {
       var packageName = packageInfo.name;
 
-      var packageSrcRoot = packageInfo.packageUriRoot;
-      var moduleProjectRoot = List<String>.from(packageSrcRoot.pathSegments)
-        ..removeLast()
-        ..removeLast();
-      var generatorConfigSegments = path
-          .joinAll([...moduleProjectRoot, 'config', 'generator.yaml']).split(
-              path.separator);
+      var packageSrcRoot = packageInfo.root;
 
-      var generatorConfigUri = packageSrcRoot.replace(
-        pathSegments: generatorConfigSegments,
-      );
+      var generatorConfigUri =
+          packageInfo.root.resolve(path.joinAll(['config', 'generator.yaml']));
 
       var generatorConfigFile = File.fromUri(generatorConfigUri);
       if (!generatorConfigFile.existsSync()) {
         continue;
       }
 
-      var moduleProjectUri = packageSrcRoot.replace(
-        pathSegments: moduleProjectRoot,
-      );
-
       var migrationVersions = findAllMigrationVersionsSync(
-        directory: Directory.fromUri(moduleProjectUri),
+        directory: Directory.fromUri(packageSrcRoot),
       );
 
       var moduleInfo = loadConfigFile(generatorConfigFile);
@@ -137,7 +126,7 @@ List<ModuleConfig> _loadModuleConfigs({
           name: moduleName,
           nickname: nickname,
           migrationVersions: migrationVersions,
-          serverPackageDirectoryPathParts: moduleProjectRoot,
+          serverPackageDirectoryPathParts: packageSrcRoot.pathSegments,
         ),
       );
     } catch (e) {

--- a/tools/serverpod_cli/lib/src/util/locate_modules.dart
+++ b/tools/serverpod_cli/lib/src/util/locate_modules.dart
@@ -1,26 +1,104 @@
+import 'dart:collection';
 import 'dart:io';
 
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as path;
+import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:yaml/yaml.dart';
 
 const _serverSuffix = '_server';
 
+bool _isServerpodModule(String packageName) {
+  return packageName.endsWith(_serverSuffix) || packageName == 'serverpod';
+}
+
 List<ModuleConfig> loadModuleConfigs({
+  required Pubspec projectPubspec,
   required PackageConfig packageConfig,
   Map<String, String?> nickNameOverrides = const {},
 }) {
-  var modules = <ModuleConfig>[];
+  var projectModuleDependencies = _listModuleDependencies(
+    projectPubspec: projectPubspec,
+    packageConfig: packageConfig,
+  );
 
-  for (var packageInfo in packageConfig.packages) {
-    try {
-      var packageName = packageInfo.name;
+  var moduleConfigs = _loadModuleConfigs(
+    modules: projectModuleDependencies,
+    nickNameOverrides: nickNameOverrides,
+  );
 
-      if (!packageName.endsWith(_serverSuffix) && packageName != 'serverpod') {
+  return moduleConfigs;
+}
+
+Set<Package> _listModuleDependencies({
+  required Pubspec projectPubspec,
+  required PackageConfig packageConfig,
+}) {
+  var projectModuleDependencies = <Package>{};
+  var visitedModules = <String>{};
+  var foundModules = Queue<String>();
+
+  void queueModulesInPubspec(Pubspec projectPubspec) {
+    for (var dependencyName in projectPubspec.dependencies.keys) {
+      if (!_isServerpodModule(dependencyName)) {
         continue;
       }
+
+      foundModules.add(dependencyName);
+    }
+  }
+
+  queueModulesInPubspec(projectPubspec);
+
+  while (foundModules.isNotEmpty) {
+    var moduleName = foundModules.removeFirst();
+    if (visitedModules.contains(moduleName)) {
+      continue;
+    }
+
+    visitedModules.add(moduleName);
+
+    var packageInfo = packageConfig.packages
+        .where((pkg) => pkg.name == moduleName)
+        .firstOrNull;
+
+    if (packageInfo == null) {
+      throw ServerpodModulesNotFoundException(
+        'Failed to locate module dependency path in package config for '
+        'dependency: $moduleName',
+      );
+    }
+
+    projectModuleDependencies.add(packageInfo);
+
+    Pubspec modulePubspec;
+    try {
+      var modulePubspecFile = File.fromUri(
+        packageInfo.root.resolve('pubspec.yaml'),
+      );
+      modulePubspec = parsePubspec(modulePubspecFile);
+    } catch (_) {
+      continue;
+    }
+
+    queueModulesInPubspec(modulePubspec);
+  }
+
+  return projectModuleDependencies;
+}
+
+List<ModuleConfig> _loadModuleConfigs({
+  required Set<Package> modules,
+  Map<String, String?> nickNameOverrides = const {},
+}) {
+  var moduleConfigs = <ModuleConfig>[];
+
+  for (var packageInfo in modules) {
+    try {
+      var packageName = packageInfo.name;
 
       var packageSrcRoot = packageInfo.packageUriRoot;
       var moduleProjectRoot = List<String>.from(packageSrcRoot.pathSegments)
@@ -53,7 +131,7 @@ List<ModuleConfig> loadModuleConfigs({
       var manualNickname = nickNameOverrides[moduleName];
       var nickname = manualNickname ?? moduleInfo['nickname'] ?? moduleName;
 
-      modules.add(
+      moduleConfigs.add(
         ModuleConfig(
           type: GeneratorConfig.getPackageType(moduleInfo),
           name: moduleName,
@@ -67,7 +145,7 @@ List<ModuleConfig> loadModuleConfigs({
     }
   }
 
-  return modules;
+  return moduleConfigs;
 }
 
 Map<dynamic, dynamic> loadConfigFile(File file) {

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   recase: ^4.1.0
   built_collection: ^5.1.1
   package_config: ^2.1.0
-  pubspec_parse: ^1.2.2
+  pubspec_parse: ^1.4.0
   source_span: ^1.10.0
   super_string: ^1.0.3
   watcher: ^1.0.2

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -44,6 +44,7 @@ dev_dependencies:
   serverpod_lints: 2.5.0
   term_glyph: ^1.2.2
   test: ^1.24.2
+  test_descriptor: ^2.0.2
 
 dependency_overrides:
   serverpod_shared:

--- a/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
+++ b/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
@@ -160,4 +160,24 @@ void main() {
 
     expect(moduleConfigs, isEmpty);
   });
+
+  test(
+      'Given no serverpod module dependencies but one exists in package config when loading modules then no module configuration is loaded',
+      () async {
+    const moduleName = 'module_server';
+
+    var ProjectDependencyContext(
+      :packageConfig,
+      :projectPubspec
+    ) = await ProjectDependencyStructureFactory()
+        .addModuleProject(ModuleProjectBuilder().withName(moduleName).build())
+        .addPackageToPackageConfig(moduleName)
+        .construct();
+
+    var moduleConfigs = loadModuleConfigs(
+      packageConfig: packageConfig,
+    );
+
+    expect(moduleConfigs, isEmpty);
+  });
 }

--- a/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
+++ b/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
@@ -1,0 +1,163 @@
+import 'package:serverpod_cli/src/util/locate_modules.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/builders/project_dependency_factory.dart';
+
+void main() {
+  test(
+      'Given serverpod module dependency when loading modules then module configuration is loaded',
+      () async {
+    const moduleName = 'module_server';
+
+    var ProjectDependencyContext(
+      :packageConfig,
+      :projectPubspec
+    ) = await ProjectDependencyStructureFactory()
+        .addProjectDependency(moduleName)
+        .addModuleProject(ModuleProjectBuilder().withName(moduleName).build())
+        .addPackageToPackageConfig(moduleName)
+        .construct();
+
+    var moduleConfigs = loadModuleConfigs(
+      packageConfig: packageConfig,
+    );
+
+    expect(moduleConfigs, hasLength(1));
+    expect(moduleConfigs.first.serverPackage, moduleName);
+  });
+
+  test(
+      'Given serverpod module dependency with transitive serverpod module dependency when loading modules then module configuration for both modules are loaded',
+      () async {
+    const moduleName = 'module_server';
+    const transitiveModuleName = 'transitive_module_server';
+
+    var ProjectDependencyContext(:packageConfig, :projectPubspec) =
+        await ProjectDependencyStructureFactory()
+            .addProjectDependency(moduleName)
+            .withModuleProjects([
+              ModuleProjectBuilder()
+                  .withName(moduleName)
+                  .withPubspecDependencies([transitiveModuleName]).build(),
+              ModuleProjectBuilder().withName(transitiveModuleName).build(),
+            ])
+            .addPackageToPackageConfig(moduleName)
+            .addPackageToPackageConfig(transitiveModuleName)
+            .construct();
+
+    var moduleConfigs = loadModuleConfigs(
+      packageConfig: packageConfig,
+    );
+
+    expect(moduleConfigs, hasLength(2));
+    expect(moduleConfigs.first.serverPackage, moduleName);
+    expect(moduleConfigs.last.serverPackage, transitiveModuleName);
+  });
+
+  test(
+      'Given serverpod module dependency with deeply nested transitive serverpod module dependency when loading modules then module configuration for all modules are loaded',
+      () async {
+    const moduleName = 'module_server';
+    const firstTransitiveModuleName = 'first_transitive_module_server';
+    const secondTransitiveModuleName = 'second_transitive_module_server';
+
+    var ProjectDependencyContext(
+      :packageConfig,
+      :projectPubspec
+    ) = await ProjectDependencyStructureFactory()
+        .addProjectDependency(moduleName)
+        .withModuleProjects([
+          ModuleProjectBuilder()
+              .withName(moduleName)
+              .withPubspecDependencies([firstTransitiveModuleName]).build(),
+          ModuleProjectBuilder()
+              .withName(firstTransitiveModuleName)
+              .withPubspecDependencies([secondTransitiveModuleName]).build(),
+          ModuleProjectBuilder().withName(secondTransitiveModuleName).build(),
+        ])
+        .addPackageToPackageConfig(moduleName)
+        .addPackageToPackageConfig(firstTransitiveModuleName)
+        .addPackageToPackageConfig(secondTransitiveModuleName)
+        .construct();
+
+    var moduleConfigs = loadModuleConfigs(
+      packageConfig: packageConfig,
+    );
+
+    expect(moduleConfigs, hasLength(3));
+    var moduleConfigServerPackageNames =
+        moduleConfigs.map((config) => config.serverPackage).toList();
+    expect(
+      moduleConfigServerPackageNames,
+      containsAll([
+        moduleName,
+        firstTransitiveModuleName,
+        secondTransitiveModuleName,
+      ]),
+    );
+  });
+
+  test(
+      'Given multiple serverpod module dependencies when loading modules then module configurations are loaded',
+      () async {
+    const firstModule = 'first_module_server';
+    const secondModule = 'second_module_server';
+
+    var ProjectDependencyContext(:packageConfig, :projectPubspec) =
+        await ProjectDependencyStructureFactory()
+            .addProjectDependency(firstModule)
+            .addProjectDependency(secondModule)
+            .withModuleProjects([
+              ModuleProjectBuilder().withName(firstModule).build(),
+              ModuleProjectBuilder().withName(secondModule).build(),
+            ])
+            .addPackageToPackageConfig(firstModule)
+            .addPackageToPackageConfig(secondModule)
+            .construct();
+
+    var moduleConfigs = loadModuleConfigs(
+      packageConfig: packageConfig,
+    );
+
+    expect(moduleConfigs, hasLength(2));
+    expect(moduleConfigs.first.serverPackage, firstModule);
+    expect(moduleConfigs.last.serverPackage, secondModule);
+  });
+
+  test(
+      'Given no serverpod module dependencies when loading modules then no module configuration is loaded',
+      () async {
+    var ProjectDependencyContext(:packageConfig, :projectPubspec) =
+        await ProjectDependencyStructureFactory().construct();
+
+    var moduleConfigs = loadModuleConfigs(
+      packageConfig: packageConfig,
+    );
+
+    expect(moduleConfigs, isEmpty);
+  });
+
+  test(
+      'Given serverpod module dependency that is missing generator config when loading modules then no module configuration is loaded',
+      () async {
+    const moduleName = 'module_server';
+
+    var ProjectDependencyContext(:packageConfig, :projectPubspec) =
+        await ProjectDependencyStructureFactory()
+            .addProjectDependency(moduleName)
+            .addModuleProject(
+              ModuleProjectBuilder()
+                  .withName(moduleName)
+                  .withIncludeGeneratorConfig(false)
+                  .build(),
+            )
+            .addPackageToPackageConfig(moduleName)
+            .construct();
+
+    var moduleConfigs = loadModuleConfigs(
+      packageConfig: packageConfig,
+    );
+
+    expect(moduleConfigs, isEmpty);
+  });
+}

--- a/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
+++ b/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
@@ -159,7 +159,12 @@ void main() {
               projectPubspec: projectPubspec,
               packageConfig: packageConfig,
             ),
-        throwsA(isA<ServerpodModulesNotFoundException>()));
+        throwsA(isA<ServerpodModulesNotFoundException>().having(
+            (e) => e.message,
+            'message',
+            equals(
+                'Failed to locate module dependency path in package config for '
+                'dependency: module_server'))));
   });
 
   test(
@@ -185,7 +190,13 @@ void main() {
               projectPubspec: projectPubspec,
               packageConfig: packageConfig,
             ),
-        throwsA(isA<ServerpodModulesNotFoundException>()));
+        throwsA(isA<ServerpodModulesNotFoundException>().having(
+          (e) => e.message,
+          'message',
+          equals(
+              'Failed to locate module dependency path in package config for '
+              'dependency: transitive_module_server'),
+        )));
   });
 
   test(

--- a/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
+++ b/tools/serverpod_cli/test/integration/util/locate_modules_test.dart
@@ -1,3 +1,4 @@
+import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/util/locate_modules.dart';
 import 'package:test/test.dart';
 
@@ -19,6 +20,7 @@ void main() {
         .construct();
 
     var moduleConfigs = loadModuleConfigs(
+      projectPubspec: projectPubspec,
       packageConfig: packageConfig,
     );
 
@@ -46,6 +48,7 @@ void main() {
             .construct();
 
     var moduleConfigs = loadModuleConfigs(
+      projectPubspec: projectPubspec,
       packageConfig: packageConfig,
     );
 
@@ -81,6 +84,7 @@ void main() {
         .construct();
 
     var moduleConfigs = loadModuleConfigs(
+      projectPubspec: projectPubspec,
       packageConfig: packageConfig,
     );
 
@@ -116,6 +120,7 @@ void main() {
             .construct();
 
     var moduleConfigs = loadModuleConfigs(
+      projectPubspec: projectPubspec,
       packageConfig: packageConfig,
     );
 
@@ -131,10 +136,56 @@ void main() {
         await ProjectDependencyStructureFactory().construct();
 
     var moduleConfigs = loadModuleConfigs(
+      projectPubspec: projectPubspec,
       packageConfig: packageConfig,
     );
 
     expect(moduleConfigs, isEmpty);
+  });
+
+  test(
+      'Given serverpod module dependency that does not exist in package config when loading modules then exception is thrown',
+      () async {
+    const module = 'module_server';
+
+    var ProjectDependencyContext(:packageConfig, :projectPubspec) =
+        await ProjectDependencyStructureFactory()
+            .addProjectDependency(module)
+            .addModuleProject(ModuleProjectBuilder().withName(module).build())
+            .construct();
+
+    expect(
+        () => loadModuleConfigs(
+              projectPubspec: projectPubspec,
+              packageConfig: packageConfig,
+            ),
+        throwsA(isA<ServerpodModulesNotFoundException>()));
+  });
+
+  test(
+      'Given serverpod module dependency with transitive module dependency that does not exist in package config when loading modules then exception is thrown',
+      () async {
+    const moduleName = 'module_server';
+    const transitiveModuleName = 'transitive_module_server';
+
+    var ProjectDependencyContext(:packageConfig, :projectPubspec) =
+        await ProjectDependencyStructureFactory()
+            .addProjectDependency(moduleName)
+            .withModuleProjects([
+              ModuleProjectBuilder()
+                  .withName(moduleName)
+                  .withPubspecDependencies([transitiveModuleName]).build(),
+              ModuleProjectBuilder().withName(transitiveModuleName).build(),
+            ])
+            .addPackageToPackageConfig(moduleName)
+            .construct();
+
+    expect(
+        () => loadModuleConfigs(
+              projectPubspec: projectPubspec,
+              packageConfig: packageConfig,
+            ),
+        throwsA(isA<ServerpodModulesNotFoundException>()));
   });
 
   test(
@@ -155,6 +206,7 @@ void main() {
             .construct();
 
     var moduleConfigs = loadModuleConfigs(
+      projectPubspec: projectPubspec,
       packageConfig: packageConfig,
     );
 
@@ -175,6 +227,7 @@ void main() {
         .construct();
 
     var moduleConfigs = loadModuleConfigs(
+      projectPubspec: projectPubspec,
       packageConfig: packageConfig,
     );
 

--- a/tools/serverpod_cli/test/test_util/builders/generator_config_file_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/generator_config_file_builder.dart
@@ -1,0 +1,88 @@
+import 'package:serverpod_cli/analyzer.dart';
+
+class ModuleConfigEntry {
+  final String _moduleName;
+  final String _nickname;
+
+  ModuleConfigEntry(this._moduleName, this._nickname);
+}
+
+class GeneratorConfigFileBuilder {
+  PackageType _type;
+  String? _nickname;
+  String _clientPackagePath;
+  String? _serverTestToolsPath;
+  List<ModuleConfigEntry> _modules;
+
+  GeneratorConfigFileBuilder()
+      : _type = PackageType.server,
+        _nickname = null,
+        _clientPackagePath = '../example_client',
+        _serverTestToolsPath = '../server_test_tools',
+        _modules = [];
+
+  GeneratorConfigFileBuilder withType(PackageType type) {
+    _type = type;
+    return this;
+  }
+
+  GeneratorConfigFileBuilder withNickname(String nickname) {
+    _nickname = nickname;
+    return this;
+  }
+
+  GeneratorConfigFileBuilder withClientPackagePath(String clientPackagePath) {
+    _clientPackagePath = clientPackagePath;
+    return this;
+  }
+
+  GeneratorConfigFileBuilder withServerTestToolsPath(
+      String? serverTestToolsPath) {
+    _serverTestToolsPath = serverTestToolsPath;
+    return this;
+  }
+
+  GeneratorConfigFileBuilder addModule(ModuleConfigEntry module) {
+    _modules.add(module);
+    return this;
+  }
+
+  GeneratorConfigFileBuilder withModules(List<ModuleConfigEntry> modules) {
+    _modules = modules;
+    return this;
+  }
+
+  String build() {
+    var buffer = StringBuffer();
+    buffer.writeln('type: ${_type.name}');
+    if (_nickname != null) {
+      buffer.writeln('nickname: $_nickname');
+    }
+
+    buffer.writeln();
+    buffer.writeln('client_package_path: $_clientPackagePath');
+
+    if (_serverTestToolsPath != null) {
+      buffer.writeln('server_test_tools_path: $_serverTestToolsPath');
+    }
+
+    if (_modules.isNotEmpty) {
+      buffer.writeln();
+      buffer.writeln('modules:');
+      for (var module in _modules) {
+        buffer.writeln('  ${module._moduleName}');
+        buffer.writeln('    nickname: ${module._nickname}');
+      }
+    }
+
+    return buffer.toString();
+  }
+}
+
+void main() {
+  var config = GeneratorConfigFileBuilder();
+  // ..addModule(ModuleConfigEntry('serverpod_auth', 'auth'))
+  // ..addModule(ModuleConfigEntry('serverpod_chat', 'chat'));
+
+  print(config.build());
+}

--- a/tools/serverpod_cli/test/test_util/builders/generator_config_file_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/generator_config_file_builder.dart
@@ -78,11 +78,3 @@ class GeneratorConfigFileBuilder {
     return buffer.toString();
   }
 }
-
-void main() {
-  var config = GeneratorConfigFileBuilder();
-  // ..addModule(ModuleConfigEntry('serverpod_auth', 'auth'))
-  // ..addModule(ModuleConfigEntry('serverpod_chat', 'chat'));
-
-  print(config.build());
-}

--- a/tools/serverpod_cli/test/test_util/builders/package_config_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/package_config_builder.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+
+class PackageBuilder {
+  String _name = 'package_name';
+  Uri _root = Directory.current.uri;
+  Uri _packageUri = Uri.directory('lib/');
+
+  /// Specifies the name of the package.
+  PackageBuilder withName(String name) {
+    _name = name;
+    return this;
+  }
+
+  /// Specifies the root URI of the package.
+  /// This must be a directory URI (ending with `/`).
+  ///
+  /// These can be built using the `Uri.directory` method.
+  PackageBuilder withRoot(Uri rootDirectory) {
+    _root = rootDirectory;
+    return this;
+  }
+
+  /// Specifies the package URI, this is the path to the package within the root.
+  /// For example, if the root is `lib/` and the package URI is `src/`, then
+  /// the package will be located at `lib/src/`.
+  PackageBuilder withPackageUri(Uri packageUri) {
+    _packageUri = packageUri;
+    return this;
+  }
+
+  Package build() {
+    return Package(
+      _name,
+      _root,
+      packageUriRoot: _root.resolveUri(_packageUri),
+      relativeRoot: false,
+    );
+  }
+}
+
+class PackageConfigBuilder {
+  final List<Package> _packages = [];
+
+  PackageConfigBuilder addPackage(Package package) {
+    _packages.add(package);
+    return this;
+  }
+
+  PackageConfigBuilder withPackages(List<Package> packages) {
+    _packages.addAll(packages);
+    return this;
+  }
+
+  PackageConfig build() {
+    return PackageConfig(_packages);
+  }
+}

--- a/tools/serverpod_cli/test/test_util/builders/project_dependency_factory.dart
+++ b/tools/serverpod_cli/test/test_util/builders/project_dependency_factory.dart
@@ -1,0 +1,171 @@
+import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p;
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'generator_config_file_builder.dart';
+import 'package_config_builder.dart';
+import 'pubspec_builder.dart';
+
+class ModuleProject {
+  final String name;
+  final Pubspec pubspec;
+  final bool includeGeneratorConfig;
+
+  ModuleProject({
+    required this.name,
+    required this.pubspec,
+    this.includeGeneratorConfig = true,
+  });
+}
+
+class ModuleProjectBuilder {
+  String _name;
+  Pubspec _pubspec;
+  bool _includeGeneratorConfig;
+
+  ModuleProjectBuilder()
+      : _pubspec = PubspecBuilder().build(),
+        _name = 'example_module',
+        _includeGeneratorConfig = true;
+
+  ModuleProjectBuilder withName(String name) {
+    _name = name;
+    return this;
+  }
+
+  ModuleProjectBuilder withPubspecDependencies(List<String> dependencies) {
+    var pubspec = PubspecBuilder()
+        .withName(_name)
+        .withDependencies(
+          dependencies
+              .map((dependency) =>
+                  PubspecDependencyBuilder().withName(dependency).build())
+              .toList(),
+        )
+        .build();
+
+    _pubspec = pubspec;
+    return this;
+  }
+
+  ModuleProjectBuilder withIncludeGeneratorConfig(bool include) {
+    _includeGeneratorConfig = include;
+    return this;
+  }
+
+  ModuleProject build() {
+    return ModuleProject(
+      name: _name,
+      pubspec: _pubspec,
+      includeGeneratorConfig: _includeGeneratorConfig,
+    );
+  }
+}
+
+/// Context object for the constructed project dependency structure.
+class ProjectDependencyContext {
+  final PackageConfig packageConfig;
+  final Pubspec projectPubspec;
+
+  ProjectDependencyContext({
+    required this.packageConfig,
+    required this.projectPubspec,
+  });
+}
+
+/// A factory class to create a project dependency structure for testing.
+class ProjectDependencyStructureFactory {
+  static const String _monoRepoDir = 'mono_repo';
+
+  String _projectName = 'example_server';
+  final List<String> _projectDependencies = [];
+  List<ModuleProject> _moduleProjects = [];
+  final List<String> _packageConfigPackages = [];
+
+  /// Sets the name of the project.
+  ProjectDependencyStructureFactory withProjectName(String name) {
+    _projectName = name;
+    return this;
+  }
+
+  /// Adds a dependency to the project.
+  ProjectDependencyStructureFactory addProjectDependency(String moduleName) {
+    _projectDependencies.add(moduleName);
+    return this;
+  }
+
+  /// Adds a module project to the factory.
+  ///
+  /// This will create a directory for the module project with the given
+  /// configuration.
+  ProjectDependencyStructureFactory addModuleProject(ModuleProject module) {
+    _moduleProjects.add(module);
+    return this;
+  }
+
+  /// Sets the module projects for the factory.
+  ///
+  /// This will create directories for each module project with the given
+  /// configuration.
+  ProjectDependencyStructureFactory withModuleProjects(
+      List<ModuleProject> modules) {
+    _moduleProjects = List.from(modules);
+    return this;
+  }
+
+  /// Adds a package to the package config (normally created when running
+  /// `pub get`).
+  ProjectDependencyStructureFactory addPackageToPackageConfig(
+      String packageName) {
+    _packageConfigPackages.add(packageName);
+    return this;
+  }
+
+  /// Constructs the project dependency structure.
+  Future<ProjectDependencyContext> construct() async {
+    var projectPubspec = PubspecBuilder()
+        .withName(_projectName)
+        .withDependencies(
+          _projectDependencies
+              .map((dependency) =>
+                  PubspecDependencyBuilder().withName(dependency).build())
+              .toList(),
+        )
+        .build();
+
+    List<d.DirectoryDescriptor> moduleDirectories = [];
+    for (var module in _moduleProjects) {
+      var moduleDir = d.dir(module.name, [
+        d.file('pubspec.yaml', PubspecBuilder.serialize(module.pubspec)),
+        if (module.includeGeneratorConfig)
+          d.dir('config', [
+            d.file(
+              'generator.yaml',
+              GeneratorConfigFileBuilder().withType(PackageType.module).build(),
+            )
+          ])
+      ]);
+
+      moduleDirectories.add(moduleDir);
+    }
+
+    await d.dir(_monoRepoDir, moduleDirectories).create();
+
+    var packageConfig = PackageConfigBuilder().withPackages([
+      ..._packageConfigPackages.map(
+        (packageName) => PackageBuilder()
+            .withName(packageName)
+            .withRoot(Uri.directory(
+                p.joinAll([d.sandbox, _monoRepoDir, packageName])))
+            .build(),
+      )
+    ]).build();
+
+    return ProjectDependencyContext(
+      packageConfig: packageConfig,
+      projectPubspec: projectPubspec,
+    );
+  }
+}

--- a/tools/serverpod_cli/test/test_util/builders/pubspec_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/pubspec_builder.dart
@@ -1,0 +1,138 @@
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+class PubspecDependency {
+  final Version version;
+  final String name;
+
+  PubspecDependency({required this.version, required this.name});
+}
+
+class PubspecDependencyBuilder {
+  String _name = 'dependency_name';
+  Version _version = Version.parse('1.0.0');
+
+  PubspecDependencyBuilder withName(String name) {
+    _name = name;
+    return this;
+  }
+
+  PubspecDependencyBuilder withVersion(Version version) {
+    _version = version;
+    return this;
+  }
+
+  PubspecDependency build() {
+    return PubspecDependency(
+      name: _name,
+      version: _version,
+    );
+  }
+}
+
+class PubspecBuilder {
+  String _name = 'package_name';
+  Version _version = Version.parse('1.0.0');
+  String _description = 'A sample package';
+  Version _sdk = Version.parse('3.6.0');
+
+  List<PubspecDependency> _dependencies = [];
+  List<PubspecDependency> _devDependencies = [];
+
+  PubspecBuilder withName(String name) {
+    _name = name;
+    return this;
+  }
+
+  PubspecBuilder withVersion(Version version) {
+    _version = version;
+    return this;
+  }
+
+  PubspecBuilder withDescription(String description) {
+    _description = description;
+    return this;
+  }
+
+  PubspecBuilder withSdk(Version sdk) {
+    _sdk = sdk;
+    return this;
+  }
+
+  PubspecBuilder addDependency(PubspecDependency dependency) {
+    _dependencies.add(dependency);
+    return this;
+  }
+
+  PubspecBuilder withDependencies(List<PubspecDependency> dependencies) {
+    _dependencies = dependencies;
+    return this;
+  }
+
+  PubspecBuilder addDevDependency(PubspecDependency dependency) {
+    _devDependencies.add(dependency);
+    return this;
+  }
+
+  PubspecBuilder withDevDependencies(List<PubspecDependency> devDependencies) {
+    _devDependencies = devDependencies;
+    return this;
+  }
+
+  Pubspec build() {
+    return Pubspec(
+      _name,
+      version: _version,
+      description: _description,
+      environment: {
+        'sdk': _sdk,
+      },
+      dependencies: {
+        for (var dep in _dependencies)
+          dep.name: HostedDependency(version: dep.version),
+      },
+      devDependencies: {
+        for (var dep in _devDependencies)
+          dep.name: HostedDependency(version: dep.version),
+      },
+    );
+  }
+
+  static String serialize(Pubspec pubspec) {
+    var output = StringBuffer();
+    output.writeln('name: ${pubspec.name}');
+    output.writeln('version: ${pubspec.version}');
+    output.writeln('description: ${pubspec.description}');
+
+    output.writeln();
+    output.writeln('environment:');
+    for (var entry in pubspec.environment.entries) {
+      output.writeln('  ${entry.key}: ${entry.value}');
+    }
+    output.writeln();
+    output.writeln('dependencies:');
+    output.write(_serializeDependencies(pubspec.dependencies));
+
+    output.writeln();
+    output.writeln('dev_dependencies:');
+    output.write(_serializeDependencies(pubspec.devDependencies));
+    return output.toString();
+  }
+
+  static StringBuffer _serializeDependencies(
+    Map<String, Dependency> dependencies,
+  ) {
+    var output = StringBuffer();
+    for (var entry in dependencies.entries) {
+      var dependency = entry.value;
+      if (dependency is! HostedDependency) {
+        throw StateError(
+          'Only serialization for HostedDependency is supported, but got ${dependency.runtimeType}',
+        );
+      }
+      output.writeln('  ${entry.key}: ${dependency.version}');
+    }
+
+    return output;
+  }
+}

--- a/tools/serverpod_cli/test/test_util/builders/pubspec_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/pubspec_builder.dart
@@ -106,7 +106,17 @@ class PubspecBuilder {
 
     output.writeln();
     output.writeln('environment:');
-    for (var entry in pubspec.environment.entries) {
+
+    /// This interface used to be nullable but is now non-nullable.
+    /// Change was introduced in this commit: https://github.com/dart-lang/tools/commit/a7ddf356ad32bd36742108d300e12484772e3fb3
+    ///
+    /// When we run downgrade we get the nullable version of the interface that
+    /// requires the null check.
+    ///
+    /// Therefore we ignore the invalid null check at this point.
+    /// ignore: invalid_null_aware_operator
+    for (var entry in pubspec.environment?.entries ??
+        <MapEntry<String, VersionConstraint>>[]) {
       output.writeln('  ${entry.key}: ${entry.value}');
     }
     output.writeln();

--- a/tools/serverpod_cli/test/test_util/builders/pubspec_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/pubspec_builder.dart
@@ -107,16 +107,7 @@ class PubspecBuilder {
     output.writeln();
     output.writeln('environment:');
 
-    /// This interface used to be nullable but is now non-nullable.
-    /// Change was introduced in this commit: https://github.com/dart-lang/tools/commit/a7ddf356ad32bd36742108d300e12484772e3fb3
-    ///
-    /// When we run downgrade we get the nullable version of the interface that
-    /// requires the null check.
-    ///
-    /// Therefore we ignore the invalid null check at this point.
-    /// ignore: invalid_null_aware_operator
-    for (var entry in pubspec.environment?.entries ??
-        <MapEntry<String, VersionConstraint>>[]) {
+    for (var entry in pubspec.environment.entries) {
       output.writeln('  ${entry.key}: ${entry.value}');
     }
     output.writeln();


### PR DESCRIPTION
Closes: #3377 

The `package_config.json` is created when a developer runs `dart pub get` and contains paths to the cached dart packages.

This file was previously inspected to find all Serverpod modules that the project depended on in order to analyze their migrations, models and endpoints.

With the introduction of workspaces in Dart, the `package_config.json` is now shared between all workspace projects. This invalidates this file as a source of truth for what is strictly a dependency on the Serverpod project.

This PR fixes this issue by adding a pre-step to loading the configs where only module configs that are strict or direct transitive dependencies of the Serverpod project are collected for investigation.

This PR also reintroduces the `ServerpodModulesNotFoundException` throw if a module is a dependency but can not be found in the `package_config.json` file. (Most likely an indication of a missed dart pub get).

### Additional information

This PR also introduces a set of new builders to ensure that the test are not strictly tied to implementation.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None - this should be a simple bugfix.