### PR TITLE
hack: Support search path configuration

### DIFF
--- a/packages/serverpod/lib/src/database/database_pool_manager.dart
+++ b/packages/serverpod/lib/src/database/database_pool_manager.dart
@@ -40,11 +40,19 @@ class DatabasePoolManager {
   /// when starting the [Server].
   DatabasePoolManager(
     SerializationManagerServer serializationManager,
-    this.config,
-  ) : _poolSettings = pg.PoolSettings(
+    this.config, {
+    List<String>? onOpenQueries,
+  }) : _poolSettings = pg.PoolSettings(
           maxConnectionCount: 10,
           queryTimeout: const Duration(minutes: 1),
           sslMode: config.requireSsl ? pg.SslMode.require : pg.SslMode.disable,
+          onOpen: onOpenQueries != null
+              ? (connection) async {
+                  for (var query in onOpenQueries) {
+                    await connection.execute(query);
+                  }
+                }
+              : null,
         ) {
     _serializationManager = serializationManager;
   }

--- a/packages/serverpod/lib/src/database/extensions.dart
+++ b/packages/serverpod/lib/src/database/extensions.dart
@@ -79,15 +79,15 @@ extension TableComparisons on TableDefinition {
       );
     }
 
-    if (other.schema != schema) {
-      mismatches.add(
-        TableComparisonWarning(
-          name: 'schema',
-          expected: schema,
-          found: other.schema,
-        ),
-      );
-    }
+    // if (other.schema != schema) {
+    //   mismatches.add(
+    //     TableComparisonWarning(
+    //       name: 'schema',
+    //       expected: schema,
+    //       found: other.schema,
+    //     ),
+    //   );
+    // }
 
     if (managed != null && other.managed != null && managed != other.managed) {
       mismatches.add(
@@ -383,15 +383,15 @@ extension ForeignKeyComparisons on ForeignKeyDefinition {
       );
     }
 
-    if (referenceTableSchema != other.referenceTableSchema) {
-      mismatches.add(
-        ForeignKeyComparisonWarning(
-          name: 'reference schema',
-          expected: referenceTableSchema,
-          found: other.referenceTableSchema,
-        ),
-      );
-    }
+    // if (referenceTableSchema != other.referenceTableSchema) {
+    //   mismatches.add(
+    //     ForeignKeyComparisonWarning(
+    //       name: 'reference schema',
+    //       expected: referenceTableSchema,
+    //       found: other.referenceTableSchema,
+    //     ),
+    //   );
+    // }
 
     if (!const ListEquality()
         .equals(referenceColumns, other.referenceColumns)) {

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -297,6 +297,8 @@ class Serverpod {
   /// Security context if the insights server is running over https.
   final SecurityContextConfig? _securityContextConfig;
 
+  final List<String>? _onOpenDatabaseQueries;
+
   /// Creates a new Serverpod.
   ///
   /// ## Experimental features
@@ -314,7 +316,9 @@ class Serverpod {
     this.httpOptionsResponseHeaders = _defaultHttpOptionsResponseHeaders,
     SecurityContextConfig? securityContextConfig,
     ExperimentalFeatures? experimentalFeatures,
+    List<String>? onOpenDatabaseQueries,
   })  : _securityContextConfig = securityContextConfig,
+        _onOpenDatabaseQueries = onOpenDatabaseQueries,
         _experimental = ExperimentalApi._(
           config: config,
           experimentalFeatures: experimentalFeatures,
@@ -381,6 +385,7 @@ class Serverpod {
       _databasePoolManager = DatabasePoolManager(
         serializationManager,
         databaseConfiguration,
+        onOpenQueries: _onOpenDatabaseQueries,
       );
 
       // TODO: Remove this when we have a better way to handle this.

--- a/packages/serverpod/test/database/extensions/table_comparison_test.dart
+++ b/packages/serverpod/test/database/extensions/table_comparison_test.dart
@@ -71,38 +71,37 @@ void main() {
     );
 
     test(
-      'when tables have different schemas then mismatches include schema mismatch',
-      () {
-        var tableA = TableDefinition(
-          name: 'test_table',
-          schema: 'schema_a',
-          columns: [],
-          foreignKeys: [],
-          indexes: [],
-          managed: true,
-        );
+        'when tables have different schemas then mismatches include schema mismatch',
+        () {
+      var tableA = TableDefinition(
+        name: 'test_table',
+        schema: 'schema_a',
+        columns: [],
+        foreignKeys: [],
+        indexes: [],
+        managed: true,
+      );
 
-        var tableB = TableDefinition(
-          name: 'test_table',
-          schema: 'schema_b',
-          columns: [],
-          foreignKeys: [],
-          indexes: [],
-          managed: true,
-        );
+      var tableB = TableDefinition(
+        name: 'test_table',
+        schema: 'schema_b',
+        columns: [],
+        foreignKeys: [],
+        indexes: [],
+        managed: true,
+      );
 
-        var mismatches = tableA.like(tableB);
+      var mismatches = tableA.like(tableB);
 
-        expect(mismatches.length, 1);
-        expect(mismatches.first.subs, isEmpty);
-        expect(mismatches.first, isA<TableComparisonWarning>());
-        expect(mismatches.first.expected, equals('schema_a'));
-        expect(mismatches.first.found, equals('schema_b'));
-        expect(mismatches.first.isMismatch, isTrue);
-        expect(mismatches.first.isMissing, isFalse);
-        expect(mismatches.first.isAdded, isFalse);
-      },
-    );
+      expect(mismatches.length, 1);
+      expect(mismatches.first.subs, isEmpty);
+      expect(mismatches.first, isA<TableComparisonWarning>());
+      expect(mismatches.first.expected, equals('schema_a'));
+      expect(mismatches.first.found, equals('schema_b'));
+      expect(mismatches.first.isMismatch, isTrue);
+      expect(mismatches.first.isMissing, isFalse);
+      expect(mismatches.first.isAdded, isFalse);
+    }, skip: 'Branch that ignores this specific validation');
 
     test(
       'when tables have different tablespaces then mismatches include tablespace mismatch',

--- a/tests/serverpod_test_server/lib/server.dart
+++ b/tests/serverpod_test_server/lib/server.dart
@@ -15,6 +15,12 @@ void run(List<String> args) async {
     Protocol(),
     Endpoints(),
     authenticationHandler: auth.authenticationHandler,
+    onOpenDatabaseQueries: [
+      // Creates the schema if it doesn't exist
+      'CREATE SCHEMA IF NOT EXISTS alex_schema;',
+      // Sets the search path to the schema for all opened connections
+      'SET search_path TO alex_schema;',
+    ],
   );
 
   // Add future calls

--- a/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
+++ b/tests/serverpod_test_server/lib/test_util/test_serverpod.dart
@@ -34,6 +34,12 @@ class IntegrationTestServer extends TestServerpod {
           authenticationHandler ?? auth.authenticationHandler,
       securityContextConfig: securityContextConfig,
       experimentalFeatures: experimentalFeatures,
+      onOpenDatabaseQueries: [
+        // Creates the schema if it doesn't exist
+        'CREATE SCHEMA IF NOT EXISTS alex_schema;',
+        // Sets the search path to the schema for all opened connections
+        'SET search_path TO alex_schema;',
+      ],
     );
   }
 }


### PR DESCRIPTION
Quick and dirty hack to support postgres search path configuration.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._